### PR TITLE
fix(billing): sync users.plan in live Stripe webhook + backfill; fix AI chat proxy (T1 + B2)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -253,7 +253,6 @@ async def metrics_middleware(request: Request, call_next):
 
 # Stripe configuration
 stripe.api_key = os.getenv("STRIPE_SECRET_KEY")
-webhook_secret = os.getenv("STRIPE_WEBHOOK_SECRET")
 
 # Database connection with auto-reconnect support
 DB_URL = os.getenv("DATABASE_URL") or os.getenv("DB_URL")
@@ -776,65 +775,9 @@ async def upgrade_plan(req: UpgradeRequest, user_id: int = Depends(get_current_u
 # STRIPE WEBHOOK & PAYMENT ENDPOINTS
 # ============================================================================
 
-@app.post("/payments/webhook")
-async def stripe_webhook(request: Request):
-    """Handle Stripe webhook events"""
-    payload = await request.body()
-    sig_header = request.headers.get("stripe-signature")
-    
-    if not webhook_secret:
-        raise HTTPException(status_code=500, detail="Webhook secret not configured")
-    
-    try:
-        event = stripe.Webhook.construct_event(payload, sig_header, webhook_secret)
-    except ValueError:
-        raise HTTPException(status_code=400, detail="Invalid payload")
-    except stripe.error.SignatureVerificationError:
-        raise HTTPException(status_code=400, detail="Invalid signature")
-    
-    try:
-        if event['type'] == 'checkout.session.completed':
-            session = event['data']['object']
-            user_id = int(session['client_reference_id'])
-            plan = session['metadata']['plan']
-            
-            # Update user plan in database
-            if conn:
-                with conn.cursor() as cur:
-                    cur.execute("UPDATE users SET plan = %s WHERE id = %s", (plan, user_id))
-                    conn.commit()
-        
-        elif event['type'] == 'invoice.payment_succeeded':
-            invoice = event['data']['object']
-            customer_id = invoice['customer']
-            
-            # Update subscription status
-            if conn:
-                with conn.cursor() as cur:
-                    cur.execute("""
-                        UPDATE users SET updated_at = CURRENT_TIMESTAMP 
-                        WHERE stripe_customer_id = %s
-                    """, (customer_id,))
-                    conn.commit()
-        
-        elif event['type'] == 'customer.subscription.deleted':
-            subscription = event['data']['object']
-            customer_id = subscription['customer']
-            
-            # Downgrade to free plan
-            if conn:
-                with conn.cursor() as cur:
-                    cur.execute("""
-                        UPDATE users SET plan = 'free' 
-                        WHERE stripe_customer_id = %s
-                    """, (customer_id,))
-                    conn.commit()
-        
-        return {"status": "success"}
-        
-    except Exception as e:
-        print(f"Webhook error: {str(e)}")
-        raise HTTPException(status_code=500, detail="Webhook processing failed")
+# NOTE: POST /payments/webhook is handled by phase23_billing/router_webhook.py
+# (registered first in include_billing_routers). The legacy inline handler that
+# lived here was shadowed/dead; its users.plan sync logic has been ported there.
 
 @app.post("/payments/create-portal-session")
 async def create_portal_session(user_id: int = Depends(get_current_user_id)):

--- a/backend/phase23_billing/router_webhook.py
+++ b/backend/phase23_billing/router_webhook.py
@@ -26,7 +26,22 @@ async def stripe_webhook(request: Request, db: Session = Depends(get_db)):
 
     # --- Checkout completed ---
     if etype == "checkout.session.completed":
-        # If metadata contains user_id or subscription id, you can store it
+        # Apply the purchased plan to the user. Ported from the legacy inline
+        # webhook this router shadows — without this, paid upgrades never
+        # change users.plan. /users/upgrade sets client_reference_id and
+        # metadata={plan, user_id} on the checkout session.
+        sess = obj
+        user_id = sess.get("client_reference_id") or (sess.get("metadata") or {}).get("user_id")
+        plan = (sess.get("metadata") or {}).get("plan")
+        try:
+            uid = int(user_id) if user_id is not None else None
+        except (TypeError, ValueError):
+            uid = None
+        if uid is not None and plan:
+            db.execute(text(
+                "UPDATE users SET plan = :plan, updated_at = now() WHERE id = :uid"
+            ), {"plan": plan, "uid": uid})
+            db.commit()
         return {"ok": True}
 
     # --- Subscription lifecycle (assumes 'subscriptions' table exists) ---
@@ -46,6 +61,12 @@ async def stripe_webhook(request: Request, db: Session = Depends(get_db)):
             "mrr": (sub.get("items", {}).get("data",[{}])[0].get("price",{}).get("unit_amount") or 0),
             "sid": sub.get("id")
         })
+        if etype == "customer.subscription.deleted" and sub.get("customer"):
+            # Ported from the legacy webhook: a cancelled subscription
+            # downgrades the user back to the free plan.
+            db.execute(text(
+                "UPDATE users SET plan = 'free', updated_at = now() WHERE stripe_customer_id = :cust"
+            ), {"cust": sub.get("customer")})
         db.commit()
         return {"ok": True}
 

--- a/backend/scripts/backfill_plan_sync.py
+++ b/backend/scripts/backfill_plan_sync.py
@@ -1,0 +1,130 @@
+"""Backfill users.plan from Stripe after the plan-sync webhook gap.
+
+Background: from the moment phase23_billing's webhook shadowed the legacy
+handler, checkout.session.completed stopped updating users.plan (and
+subscription cancellations stopped downgrading). This script diffs Stripe's
+active subscriptions (the source of truth) against users.plan and reports —
+and optionally corrects — the discrepancies.
+
+Usage (run where DATABASE_URL and STRIPE_SECRET_KEY are configured, e.g. a
+Render shell):
+
+    python scripts/backfill_plan_sync.py                    # dry-run report
+    python scripts/backfill_plan_sync.py --apply            # fix missed upgrades
+    python scripts/backfill_plan_sync.py --apply-downgrades # also downgrade
+                                                            # paid-plan users
+                                                            # with no active sub
+
+Plan mapping comes from STRIPE_PROFESSIONAL_PRICE_ID / STRIPE_ENTERPRISE_PRICE_ID
+(the same env vars /users/upgrade uses).
+"""
+import argparse
+import os
+import sys
+from datetime import datetime, timezone
+
+import psycopg2
+import stripe
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true",
+                        help="write missed plan upgrades to users.plan")
+    parser.add_argument("--apply-downgrades", action="store_true",
+                        help="also downgrade paid users with no active subscription")
+    args = parser.parse_args()
+
+    db_url = os.getenv("DATABASE_URL")
+    stripe.api_key = os.getenv("STRIPE_SECRET_KEY")
+    if not db_url or not stripe.api_key:
+        sys.exit("DATABASE_URL and STRIPE_SECRET_KEY are required")
+
+    price_to_plan = {}
+    for env_var, plan in (("STRIPE_PROFESSIONAL_PRICE_ID", "professional"),
+                          ("STRIPE_ENTERPRISE_PRICE_ID", "enterprise")):
+        price_id = os.getenv(env_var)
+        if price_id:
+            price_to_plan[price_id] = plan
+    if not price_to_plan:
+        sys.exit("No STRIPE_*_PRICE_ID env vars set — cannot map prices to plans")
+
+    # Authoritative state: every active/trialing subscription in Stripe.
+    expected = {}  # stripe_customer_id -> (plan, subscription created datetime)
+    unknown_prices = set()
+    for status in ("active", "trialing"):
+        for sub in stripe.Subscription.list(status=status, limit=100).auto_paging_iter():
+            items = sub.get("items", {}).get("data", [])
+            price_id = items[0]["price"]["id"] if items else None
+            plan = price_to_plan.get(price_id)
+            if plan is None:
+                if price_id:
+                    unknown_prices.add(price_id)
+                continue
+            created = datetime.fromtimestamp(sub["created"], tz=timezone.utc)
+            customer = sub["customer"]
+            if customer not in expected or created > expected[customer][1]:
+                expected[customer] = (plan, created)
+
+    conn = psycopg2.connect(db_url)
+    missed_upgrades = []   # (user_id, email, current_plan, expected_plan, sub_created)
+    downgrade_candidates = []  # (user_id, email, current_plan)
+    with conn.cursor() as cur:
+        cur.execute("""
+            SELECT id, email, COALESCE(plan, 'free'), stripe_customer_id
+            FROM users WHERE stripe_customer_id IS NOT NULL
+        """)
+        rows = cur.fetchall()
+
+    matched_customers = set()
+    for user_id, email, current_plan, customer_id in rows:
+        if customer_id in expected:
+            matched_customers.add(customer_id)
+            expected_plan, sub_created = expected[customer_id]
+            if current_plan != expected_plan:
+                missed_upgrades.append((user_id, email, current_plan, expected_plan, sub_created))
+        elif current_plan not in ("free", None):
+            downgrade_candidates.append((user_id, email, current_plan))
+
+    orphan_customers = set(expected) - matched_customers
+
+    print(f"Active/trialing Stripe subscriptions mapped to plans: {len(expected)}")
+    print(f"Users with a stripe_customer_id: {len(rows)}")
+    print()
+    print(f"MISSED UPGRADES (Stripe says paid, users.plan disagrees): {len(missed_upgrades)}")
+    for user_id, email, cur_p, exp_p, created in sorted(missed_upgrades, key=lambda r: r[4]):
+        print(f"  user {user_id} <{email}>: '{cur_p}' -> '{exp_p}' (subscribed {created:%Y-%m-%d %H:%M UTC})")
+    if missed_upgrades:
+        window = sorted(r[4] for r in missed_upgrades)
+        print(f"  time window: {window[0]:%Y-%m-%d} .. {window[-1]:%Y-%m-%d}")
+    print()
+    print(f"DOWNGRADE CANDIDATES (paid plan, no active Stripe subscription): {len(downgrade_candidates)}")
+    for user_id, email, cur_p in downgrade_candidates:
+        print(f"  user {user_id} <{email}>: '{cur_p}' -> 'free'")
+    if unknown_prices:
+        print(f"\nWARNING: subscriptions on unmapped price IDs (ignored): {sorted(unknown_prices)}")
+    if orphan_customers:
+        print(f"WARNING: {len(orphan_customers)} paying Stripe customers have no matching "
+              f"users.stripe_customer_id row: {sorted(orphan_customers)}")
+
+    if args.apply and missed_upgrades:
+        with conn.cursor() as cur:
+            for user_id, _, _, exp_p, _ in missed_upgrades:
+                cur.execute("UPDATE users SET plan = %s, updated_at = CURRENT_TIMESTAMP WHERE id = %s",
+                            (exp_p, user_id))
+        conn.commit()
+        print(f"\nAPPLIED {len(missed_upgrades)} plan upgrades.")
+    if args.apply_downgrades and downgrade_candidates:
+        with conn.cursor() as cur:
+            for user_id, _, _ in downgrade_candidates:
+                cur.execute("UPDATE users SET plan = 'free', updated_at = CURRENT_TIMESTAMP WHERE id = %s",
+                            (user_id,))
+        conn.commit()
+        print(f"APPLIED {len(downgrade_candidates)} downgrades.")
+    if not args.apply:
+        print("\nDry run — nothing written. Re-run with --apply (and/or --apply-downgrades).")
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_phase23_webhook.py
+++ b/backend/tests/test_phase23_webhook.py
@@ -1,0 +1,116 @@
+"""Regression tests for users.plan sync in the phase23 Stripe webhook.
+
+The phase23 router owns POST /payments/webhook (it registers before main.py's
+routes). These tests pin the plan-sync behavior ported from the legacy inline
+webhook: checkout.session.completed applies the purchased plan, and
+customer.subscription.deleted downgrades the user to 'free'.
+"""
+from unittest.mock import MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from phase23_billing.router_webhook import router
+from phase23_billing.deps import get_db
+
+
+class RecordingSession:
+    """Stands in for a SQLAlchemy Session, recording every execute()."""
+
+    def __init__(self):
+        self.statements = []
+
+    def execute(self, stmt, params=None):
+        self.statements.append((str(stmt), params or {}))
+        result = MagicMock()
+        result.fetchone.return_value = None
+        return result
+
+    def commit(self):
+        pass
+
+    def close(self):
+        pass
+
+
+def make_client(session):
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_db] = lambda: session
+    return TestClient(app)
+
+
+def post_event(session, event):
+    stripe_stub = MagicMock()
+    stripe_stub.Webhook.construct_event.return_value = event
+    with patch("phase23_billing.router_webhook.init_stripe", return_value=stripe_stub):
+        client = make_client(session)
+        return client.post(
+            "/payments/webhook",
+            content=b"{}",
+            headers={"stripe-signature": "t=1,v1=stub"},
+        )
+
+
+def statements_matching(session, fragment):
+    return [(sql, params) for sql, params in session.statements if fragment in sql]
+
+
+def test_checkout_completed_applies_plan():
+    session = RecordingSession()
+    resp = post_event(session, {
+        "type": "checkout.session.completed",
+        "data": {"object": {
+            "client_reference_id": "42",
+            "metadata": {"plan": "professional", "user_id": "42"},
+        }},
+    })
+    assert resp.status_code == 200
+    updates = statements_matching(session, "UPDATE users SET plan = :plan")
+    assert len(updates) == 1
+    assert updates[0][1] == {"plan": "professional", "uid": 42}
+
+
+def test_checkout_completed_without_metadata_is_safe():
+    session = RecordingSession()
+    resp = post_event(session, {
+        "type": "checkout.session.completed",
+        "data": {"object": {"client_reference_id": None, "metadata": {}}},
+    })
+    assert resp.status_code == 200
+    assert statements_matching(session, "UPDATE users") == []
+
+
+def test_subscription_deleted_downgrades_user_to_free():
+    session = RecordingSession()
+    resp = post_event(session, {
+        "type": "customer.subscription.deleted",
+        "data": {"object": {
+            "id": "sub_123",
+            "customer": "cus_abc",
+            "status": "canceled",
+            "cancel_at_period_end": False,
+            "items": {"data": [{"price": {"unit_amount": 2999}}]},
+        }},
+    })
+    assert resp.status_code == 200
+    assert len(statements_matching(session, "UPDATE subscriptions")) == 1
+    downgrades = statements_matching(session, "UPDATE users SET plan = 'free'")
+    assert len(downgrades) == 1
+    assert downgrades[0][1] == {"cust": "cus_abc"}
+
+
+def test_subscription_updated_does_not_touch_users():
+    session = RecordingSession()
+    resp = post_event(session, {
+        "type": "customer.subscription.updated",
+        "data": {"object": {
+            "id": "sub_123",
+            "customer": "cus_abc",
+            "status": "active",
+            "cancel_at_period_end": False,
+            "items": {"data": [{"price": {"unit_amount": 2999}}]},
+        }},
+    })
+    assert resp.status_code == 200
+    assert statements_matching(session, "UPDATE users") == []

--- a/frontend/src/app/api/ai/chat/route.ts
+++ b/frontend/src/app/api/ai/chat/route.ts
@@ -14,7 +14,7 @@ export async function POST(request: NextRequest) {
     const body = await request.json()
 
     // Proxy to backend AI assist endpoint
-    const response = await fetch(`${BACKEND_URL}/api/ai-assist/chat`, {
+    const response = await fetch(`${BACKEND_URL}/api/ai/chat`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
## Summary

Hotfix ticket T1 (+ B2 riding along) from the Phase 3–4 plan.

**T1 — plan-sync bug (B1).** The phase23 billing webhook owns `POST /payments/webhook` (registered first, `main.py:46`), and it never touched `users.plan` — the upgrade/downgrade logic lived only in the shadowed dead handler. This PR:
- Applies `metadata.plan` on `checkout.session.completed` to the user from `client_reference_id`/`metadata.user_id` (exactly what `/users/upgrade` puts on the session, `main.py:753-756`), defensively skipping malformed events.
- Downgrades to `'free'` by `stripe_customer_id` on `customer.subscription.deleted`, alongside the existing `subscriptions`-table update.
- Deletes the dead inline webhook handler and its unused `webhook_secret` global.
- Adds `backend/scripts/backfill_plan_sync.py` — dry-run/apply tool that diffs Stripe's active/trialing subscriptions against `users.plan`, reports missed upgrades (with per-user detail and the time window) and downgrade candidates, and corrects them with `--apply` / `--apply-downgrades`.
- Adds `backend/tests/test_phase23_webhook.py` — 4 regression tests pinning the ported behavior. **All 4 pass locally on Python 3.11.**

**B2 — AI chat proxy.** `frontend/src/app/api/ai/chat/route.ts` forwarded to `/api/ai-assist/chat`, a path that has never existed (router mounts at `/api/ai`); the AI Help button and vesting guidance always failed. One-line fix to `/api/ai/chat`.

## Verification
- `py_compile` clean on all touched Python files; `pytest tests/test_phase23_webhook.py` → 4 passed.
- The pre-existing red `test` check (Python 3.8 pin) is unrelated; fix scheduled as T9-lite.

## Stripe events this fix depends on (owner: verify these are enabled on the webhook endpoint in the Stripe dashboard)
- `checkout.session.completed` — required for plan upgrades
- `customer.subscription.deleted` — required for downgrades
- Also consumed by the existing handler (should already be on): `customer.subscription.created/updated`, `invoice.created`, `invoice.payment_succeeded`, `payment_intent.succeeded`, `payment_intent.payment_failed`, `charge.refunded`

## Post-merge backfill (owner-run, needs prod credentials)
```bash
python scripts/backfill_plan_sync.py            # dry-run report first
python scripts/backfill_plan_sync.py --apply    # then fix missed upgrades
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_