### PR TITLE
feat(deeds): stored-PDF pipeline — render once at save, stream with auth (T2)

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -1,3 +1,4 @@
+import json
 import os
 import psycopg2
 from psycopg2.extras import RealDictCursor
@@ -215,14 +216,22 @@ def create_deed(user_id, deed_data):
                 print(f"[Database.create_deed] deed_data: {deed_data}")
                 return None
         
+        # T2: persist the builder extras (DTT, reference numbers, mail-to)
+        # into metadata JSONB so the stored PDF can render the full document.
+        extras = {
+            key: deed_data.get(key)
+            for key in ('dtt', 'title_order_no', 'escrow_no', 'return_to', 'source')
+            if deed_data.get(key)
+        }
+
         cursor.execute("""
-            INSERT INTO deeds (user_id, deed_type, property_address, apn, county, 
-                             legal_description, owner_type, sales_price, 
-                             grantor_name, grantee_name, vesting, requested_by)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            INSERT INTO deeds (user_id, deed_type, property_address, apn, county,
+                             legal_description, owner_type, sales_price,
+                             grantor_name, grantee_name, vesting, requested_by, metadata)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb)
             RETURNING *
         """, (
-            user_id, 
+            user_id,
             deed_data.get('deed_type'),
             deed_data.get('property_address') or 'Unknown',  # Fallback for empty string
             deed_data.get('apn'),
@@ -233,7 +242,8 @@ def create_deed(user_id, deed_data):
             deed_data.get('grantor_name'),  # Phase 11 Fix: Add grantor field
             deed_data.get('grantee_name'),
             deed_data.get('vesting'),
-            deed_data.get('requested_by')  # Phase 16: Add requested_by field
+            deed_data.get('requested_by'),  # Phase 16: Add requested_by field
+            json.dumps(extras)
         ))
         
         deed = cursor.fetchone()

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,5 +1,5 @@
 import os
-from fastapi import FastAPI, HTTPException, Depends, Query, Request, Body
+from fastapi import FastAPI, HTTPException, Depends, Query, Request, Body, Response
 from fastapi.middleware.cors import CORSMiddleware
 from dotenv import load_dotenv
 from pydantic import BaseModel, Field, field_validator
@@ -262,6 +262,14 @@ else:
     conn = None
     print("Warning: No database connection URL found")
 
+# T2: make sure the stored-PDF table exists (idempotent; no Alembic in this repo)
+if conn:
+    try:
+        from services.deed_pdf import ensure_deed_pdfs_table
+        ensure_deed_pdfs_table(conn)
+    except Exception as _pdf_table_error:
+        print(f"Warning: could not ensure deed_pdfs table: {_pdf_table_error}")
+
 def get_db_connection():
     """Get database connection, reconnecting if necessary"""
     global conn
@@ -400,7 +408,13 @@ class DeedCreate(BaseModel):
     vesting: Optional[str] = Field(default=None)
     requested_by: Optional[str] = Field(default=None, description="Person/company requesting the deed (e.g., escrow officer)")
     source: Optional[str] = Field(default=None, description="Data source tracking (e.g., 'modern-canonical', 'classic')")
-    
+    # T2: extras persisted into deeds.metadata so the stored PDF can render
+    # the complete document (DTT declaration, reference numbers, mail-to).
+    dtt: Optional[Dict] = Field(default=None, description="Documentary transfer tax details from the builder")
+    title_order_no: Optional[str] = Field(default=None)
+    escrow_no: Optional[str] = Field(default=None)
+    return_to: Optional[str] = Field(default=None, description="Mail-to name for the recorded deed")
+
     class Config:
         extra = "ignore"  # Ignore extra fields from frontend
 
@@ -1609,10 +1623,22 @@ def create_deed_endpoint(deed: DeedCreate, user_id: int = Depends(get_current_us
     print(f"[Backend /deeds] source: {deed_data.get('source', 'unknown')}")
     
     new_deed = create_deed(user_id, deed_data)
-    
+
     if not new_deed:
         print(f"[Backend /deeds] ❌ create_deed returned None!")
         raise HTTPException(status_code=500, detail="Failed to create deed - check backend logs")
+
+    # T2: render the deed's PDF once at generation time and store it.
+    # Non-blocking — if rendering fails the deed record still saves, and
+    # /download will retry the render on first request.
+    try:
+        from services.deed_pdf import generate_and_store
+        if conn:
+            digest = generate_and_store(conn, new_deed)
+            new_deed["pdf_url"] = f"/deeds/{new_deed['id']}/download"
+            print(f"[T2] Stored PDF for deed {new_deed['id']} (sha256 {digest[:12]}…)")
+    except Exception as pdf_error:
+        print(f"[T2] PDF generation failed for deed {new_deed.get('id')} (non-blocking): {pdf_error}")
     
     # Phase 7: Send deed completion notification
     try:
@@ -2602,13 +2628,48 @@ def delete_deed_endpoint(deed_id: int):
     return {"message": f"Deed {deed_id} deleted successfully"}
 
 @app.get("/deeds/{deed_id}/download")
-def download_deed_endpoint(deed_id: int):
-    """Generate and download deed document"""
-    # In production, generate PDF and return file
-    return {
-        "download_url": f"https://api.deedpro.io/files/deed_{deed_id}.pdf",
-        "expires_at": "2024-02-01T12:00:00Z"
-    }
+def download_deed_endpoint(deed_id: int, user_id: int = Depends(get_current_user_id)):
+    """Stream the stored deed PDF; render+store on first request for legacy rows."""
+    if not conn:
+        raise HTTPException(status_code=500, detail="Database connection not available")
+    try:
+        cursor = conn.cursor(cursor_factory=RealDictCursor)
+        cursor.execute("""
+            SELECT d.*, u.role
+            FROM deeds d
+            LEFT JOIN users u ON u.id = %s
+            WHERE d.id = %s AND (d.user_id = %s OR u.role = 'admin')
+        """, (user_id, deed_id, user_id))
+        deed = cursor.fetchone()
+        cursor.close()
+
+        if not deed:
+            raise HTTPException(status_code=404, detail="Deed not found")
+
+        with conn.cursor() as cur:
+            cur.execute("SELECT pdf_data FROM deed_pdfs WHERE deed_id = %s", (deed_id,))
+            stored = cur.fetchone()
+
+        if stored and stored[0]:
+            pdf_bytes = bytes(stored[0])
+        else:
+            # Legacy row saved before the stored-PDF pipeline: render now,
+            # store, and serve — subsequent downloads hit the stored copy.
+            from services.deed_pdf import render_deed_pdf, store_deed_pdf
+            pdf_bytes = render_deed_pdf(dict(deed))
+            store_deed_pdf(conn, deed_id, pdf_bytes)
+
+        return Response(
+            content=pdf_bytes,
+            media_type="application/pdf",
+            headers={"Content-Disposition": f'attachment; filename="deed_{deed_id}.pdf"'},
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        print(f"Error downloading deed {deed_id}: {e}")
+        conn.rollback()
+        raise HTTPException(status_code=500, detail="Failed to generate deed PDF")
 
 # Payment endpoints
 @app.post("/payment-methods")

--- a/backend/services/deed_pdf.py
+++ b/backend/services/deed_pdf.py
@@ -1,0 +1,147 @@
+"""Render and store PDFs for saved deed records (stored-PDF pipeline).
+
+A deed's PDF is rendered once at generation time, persisted in the deed_pdfs
+table (BYTEA, same pattern as api_deeds.pdf_data), and streamed by
+GET /deeds/{id}/download. Legacy rows without a stored PDF are rendered and
+stored on first download. Column names follow the live production schema:
+grantor_name/grantee_name (the phase-11 rename never ran).
+"""
+import hashlib
+import json
+import os
+from datetime import datetime, timezone
+
+import psycopg2
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+from pdf_engine import render_pdf
+
+TEMPLATE_ROOT = os.path.join(os.path.dirname(os.path.dirname(__file__)), "..", "templates")
+
+_env = Environment(
+    loader=FileSystemLoader(TEMPLATE_ROOT),
+    autoescape=select_autoescape(["html", "xml", "jinja2"]),
+)
+try:
+    from filters import shrink_to_fit, hyphenate_soft
+    _env.filters["hyphenate_soft"] = hyphenate_soft
+    _env.filters["shrink_to_fit"] = shrink_to_fit
+except ImportError:
+    pass
+
+TEMPLATE_BY_DEED_TYPE = {
+    "grant-deed": "grant_deed_ca/index.jinja2",
+    "grant_deed": "grant_deed_ca/index.jinja2",
+    "quitclaim-deed": "quitclaim_deed_ca/index.jinja2",
+    "quitclaim": "quitclaim_deed_ca/index.jinja2",
+    "interspousal-transfer": "interspousal_transfer_ca/index.jinja2",
+    "warranty-deed": "warranty_deed_ca/index.jinja2",
+    "tax-deed": "tax_deed_ca/index.jinja2",
+}
+DEFAULT_TEMPLATE = "grant_deed_ca/index.jinja2"
+
+
+def _map_dtt(raw):
+    """Map the builder's DTT shape (stored in deeds.metadata) to the template's."""
+    if not isinstance(raw, dict):
+        return None
+    amount = raw.get("calculated_amount") or raw.get("amount") or ""
+    if raw.get("is_exempt"):
+        amount = "0.00"
+    if not (amount or raw.get("city_name") or raw.get("is_exempt")):
+        return None
+    return {
+        "amount": str(amount).lstrip("$"),
+        "basis": "less_liens" if raw.get("basis") == "less_liens" else "full",
+        "area_type": raw.get("area_type") or "unincorporated",
+        "city_name": raw.get("city_name") or "",
+        "is_exempt": bool(raw.get("is_exempt")),
+        "exemption_reason": raw.get("exemption_reason") or "",
+    }
+
+
+def build_context_from_row(row):
+    """Template context from a deeds row (dict) + its metadata JSONB extras."""
+    meta = row.get("metadata") or {}
+    if isinstance(meta, str):
+        try:
+            meta = json.loads(meta)
+        except ValueError:
+            meta = {}
+
+    return_to = meta.get("return_to")
+    if isinstance(return_to, str) and return_to.strip():
+        # The builder stores return_to as a bare name; the template expects a dict.
+        return_to = {"name": return_to.strip()}
+    elif not isinstance(return_to, dict):
+        return_to = None
+
+    return {
+        "grantors_text": row.get("grantor_name") or "",
+        "grantees_text": row.get("grantee_name") or "",
+        "legal_description": row.get("legal_description") or "",
+        "county": row.get("county") or "",
+        "apn": row.get("apn") or "",
+        "vesting": row.get("vesting") or "",
+        "requested_by": row.get("requested_by") or "",
+        "title_order_no": meta.get("title_order_no") or "",
+        "escrow_no": meta.get("escrow_no") or "",
+        "return_to": return_to,
+        "dtt": _map_dtt(meta.get("dtt")),
+        "exhibit_threshold": 600,
+        "execution_date": None,
+        "now": datetime.now,
+    }
+
+
+def render_deed_pdf(row) -> bytes:
+    template_name = TEMPLATE_BY_DEED_TYPE.get(
+        (row.get("deed_type") or "").strip().lower(), DEFAULT_TEMPLATE
+    )
+    html = _env.get_template(template_name).render(**build_context_from_row(row))
+    return render_pdf(html)
+
+
+def ensure_deed_pdfs_table(conn):
+    with conn.cursor() as cur:
+        cur.execute("""
+            CREATE TABLE IF NOT EXISTS deed_pdfs (
+                deed_id INTEGER PRIMARY KEY REFERENCES deeds(id) ON DELETE CASCADE,
+                pdf_data BYTEA NOT NULL,
+                sha256 VARCHAR(64) NOT NULL,
+                generated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """)
+        conn.commit()
+
+
+def store_deed_pdf(conn, deed_id: int, pdf_bytes: bytes) -> str:
+    """Persist the PDF bytes and stamp pdf_url + sha256 on the deed row."""
+    digest = hashlib.sha256(pdf_bytes).hexdigest()
+    stamp = json.dumps({
+        "pdf_sha256": digest,
+        "pdf_generated_at": datetime.now(timezone.utc).isoformat(),
+    })
+    with conn.cursor() as cur:
+        cur.execute("""
+            INSERT INTO deed_pdfs (deed_id, pdf_data, sha256, generated_at)
+            VALUES (%s, %s, %s, CURRENT_TIMESTAMP)
+            ON CONFLICT (deed_id) DO UPDATE
+                SET pdf_data = EXCLUDED.pdf_data,
+                    sha256 = EXCLUDED.sha256,
+                    generated_at = CURRENT_TIMESTAMP
+        """, (deed_id, psycopg2.Binary(pdf_bytes), digest))
+        cur.execute("""
+            UPDATE deeds
+            SET pdf_url = %s,
+                metadata = COALESCE(metadata, '{}'::jsonb) || %s::jsonb
+            WHERE id = %s
+        """, (f"/deeds/{deed_id}/download", stamp, deed_id))
+        conn.commit()
+    return digest
+
+
+def generate_and_store(conn, row) -> str:
+    """Render the PDF for a deed row and persist it. Returns the sha256."""
+    pdf_bytes = render_deed_pdf(row)
+    return store_deed_pdf(conn, row["id"], pdf_bytes)

--- a/backend/tests/test_deed_pdf.py
+++ b/backend/tests/test_deed_pdf.py
@@ -1,0 +1,79 @@
+"""Tests for the stored-PDF pipeline (services/deed_pdf.py)."""
+import json
+
+from services.deed_pdf import (
+    TEMPLATE_BY_DEED_TYPE,
+    DEFAULT_TEMPLATE,
+    build_context_from_row,
+    render_deed_pdf,
+    _map_dtt,
+)
+
+
+def minimal_row(**overrides):
+    row = {
+        "id": 1,
+        "deed_type": "grant-deed",
+        "property_address": "123 Main St, Los Angeles, CA 90001",
+        "grantor_name": "JOHN DOE",
+        "grantee_name": "JANE ROE",
+        "legal_description": "LOT 1, BLOCK 2, TRACT 3456",
+        "county": "Los Angeles",
+        "apn": "1234-567-890",
+        "vesting": "a single woman",
+        "requested_by": "Acme Escrow",
+        "metadata": {},
+    }
+    row.update(overrides)
+    return row
+
+
+def test_context_maps_live_column_names():
+    ctx = build_context_from_row(minimal_row())
+    assert ctx["grantors_text"] == "JOHN DOE"
+    assert ctx["grantees_text"] == "JANE ROE"
+    assert ctx["county"] == "Los Angeles"
+    assert ctx["apn"] == "1234-567-890"
+    assert ctx["dtt"] is None  # no DTT in metadata -> template renders blanks
+
+
+def test_context_reads_metadata_extras_including_json_string():
+    meta = {
+        "title_order_no": "TO-1",
+        "escrow_no": "ESC-2",
+        "return_to": "JANE ROE",
+        "dtt": {
+            "calculated_amount": "550.00",
+            "basis": "less_liens",
+            "area_type": "city",
+            "city_name": "Los Angeles",
+            "is_exempt": False,
+        },
+    }
+    for stored_as in (meta, json.dumps(meta)):  # jsonb arrives as dict; be tolerant of strings
+        ctx = build_context_from_row(minimal_row(metadata=stored_as))
+        assert ctx["title_order_no"] == "TO-1"
+        assert ctx["escrow_no"] == "ESC-2"
+        assert ctx["return_to"] == {"name": "JANE ROE"}  # bare string wrapped for the template
+        assert ctx["dtt"]["amount"] == "550.00"
+        assert ctx["dtt"]["basis"] == "less_liens"
+        assert ctx["dtt"]["city_name"] == "Los Angeles"
+
+
+def test_exempt_dtt_maps_to_zero_amount():
+    dtt = _map_dtt({"is_exempt": True, "exemption_reason": "R&T 11911", "area_type": "unincorporated"})
+    assert dtt["amount"] == "0.00"
+    assert dtt["is_exempt"] is True
+
+
+def test_unknown_deed_type_falls_back_to_grant_deed_template():
+    assert TEMPLATE_BY_DEED_TYPE.get("nonsense", DEFAULT_TEMPLATE) == DEFAULT_TEMPLATE
+
+
+def test_render_produces_pdf_bytes_for_every_mapped_deed_type():
+    # WeasyPrint renders locally (no PDFShift key in the test env).
+    for deed_type in ("grant-deed", "quitclaim-deed", "interspousal-transfer",
+                      "warranty-deed", "tax-deed"):
+        pdf = render_deed_pdf(minimal_row(deed_type=deed_type))
+        assert pdf[:5] == b"%PDF-", f"{deed_type} did not render a PDF"
+        assert len(pdf) > 1000

--- a/frontend/src/app/api/deeds/generate/route.ts
+++ b/frontend/src/app/api/deeds/generate/route.ts
@@ -22,6 +22,12 @@ export async function POST(req: NextRequest) {
       vesting: payload.vesting || null,
       requested_by: payload.requested_by || null,
       source: 'deed-builder',
+      // Persisted into deeds.metadata so the stored PDF renders the full
+      // document (DTT declaration, reference numbers, mail-to).
+      dtt: payload.dtt || null,
+      title_order_no: payload.title_order_no || null,
+      escrow_no: payload.escrow_no || null,
+      return_to: payload.return_to || null,
     };
 
     const authHeader = req.headers.get('authorization');

--- a/frontend/src/app/deed-builder/[type]/success/success-content.tsx
+++ b/frontend/src/app/deed-builder/[type]/success/success-content.tsx
@@ -67,29 +67,34 @@ export function SuccessContent() {
     fetchDeed();
   }, [deedId]);
 
-  const handlePreview = () => {
-    if (deed?.pdf_url) {
-      window.open(deed.pdf_url, '_blank');
+  // The PDF is stored server-side and served by the authenticated download
+  // endpoint, so every action fetches it as a blob (a bare pdf_url can't
+  // carry the Authorization header).
+  const fetchPdfBlobUrl = async (): Promise<string | null> => {
+    if (!deedId) return null;
+    const api = process.env.NEXT_PUBLIC_API_URL || 'https://deedpro-main-api.onrender.com';
+    const token = localStorage.getItem('access_token') || localStorage.getItem('token');
+    const response = await fetch(`${api}/deeds/${deedId}/download`, {
+      headers: { 'Authorization': `Bearer ${token}` },
+    });
+    if (!response.ok) return null;
+    const blob = await response.blob();
+    return window.URL.createObjectURL(blob);
+  };
+
+  const handlePreview = async () => {
+    const url = await fetchPdfBlobUrl();
+    if (url) {
+      window.open(url, '_blank');
     } else {
       toast.error('PDF not available for preview');
     }
   };
 
   const handleDownload = async () => {
-    if (!deedId) return;
-    
     try {
-      const api = process.env.NEXT_PUBLIC_API_URL || 'https://deedpro-main-api.onrender.com';
-      const response = await fetch(`${api}/deeds/${deedId}/download`, {
-        headers: {
-          'Authorization': `Bearer ${localStorage.getItem('access_token')}`,
-        },
-      });
-      
-      if (!response.ok) throw new Error('Download failed');
-      
-      const blob = await response.blob();
-      const url = window.URL.createObjectURL(blob);
+      const url = await fetchPdfBlobUrl();
+      if (!url) throw new Error('Download failed');
       const a = document.createElement('a');
       a.href = url;
       a.download = `${DEED_LABELS[type] || 'Deed'}_${deedId}.pdf`;
@@ -97,23 +102,17 @@ export function SuccessContent() {
       a.click();
       window.URL.revokeObjectURL(url);
       document.body.removeChild(a);
-      
       toast.success('PDF downloaded successfully!');
     } catch (err) {
-      // Fallback to direct URL if download endpoint fails
-      if (deed?.pdf_url) {
-        window.open(deed.pdf_url, '_blank');
-        toast.success('PDF opened in new tab');
-      } else {
-        console.error('Download error:', err);
-        toast.error('Failed to download PDF');
-      }
+      console.error('Download error:', err);
+      toast.error('Failed to download PDF');
     }
   };
 
   const handlePrint = async () => {
-    if (deed?.pdf_url) {
-      const printWindow = window.open(deed.pdf_url, '_blank');
+    const url = await fetchPdfBlobUrl();
+    if (url) {
+      const printWindow = window.open(url, '_blank');
       if (printWindow) {
         printWindow.onload = () => {
           setTimeout(() => printWindow.print(), 500);

--- a/frontend/src/app/past-deeds/page.tsx
+++ b/frontend/src/app/past-deeds/page.tsx
@@ -88,10 +88,27 @@ export default function PastDeedsPageV0() {
     router.push(`/deed-builder/${deed.deed_type.toLowerCase().replace(" ", "-")}`)
   }
 
-  const handleDownload = (deed: Deed) => {
-    if (deed.pdf_url) {
-      window.open(deed.pdf_url, "_blank")
-    } else {
+  const handleDownload = async (deed: Deed) => {
+    // The stored PDF is served by the authenticated download endpoint; fetch
+    // it as a blob since window.open can't carry the Authorization header.
+    try {
+      const api = process.env.NEXT_PUBLIC_API_URL || "https://deedpro-main-api.onrender.com"
+      const token = localStorage.getItem("access_token") || localStorage.getItem("token")
+      const response = await fetch(`${api}/deeds/${deed.id}/download`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!response.ok) throw new Error("Download failed")
+      const blob = await response.blob()
+      const url = window.URL.createObjectURL(blob)
+      const a = document.createElement("a")
+      a.href = url
+      a.download = `${deed.deed_type || "Deed"}_${deed.id}.pdf`
+      document.body.appendChild(a)
+      a.click()
+      window.URL.revokeObjectURL(url)
+      document.body.removeChild(a)
+    } catch (err) {
+      console.error("Download error:", err)
       toast.error("PDF not available for this deed")
     }
   }


### PR DESCRIPTION
## Summary

T2 from the Phase 3–4 plan, stored-PDF version per the red-team amendment. A saved deed now produces a real, immutable, authenticated PDF.

**Pipeline:** builder save → `POST /deeds` persists the previously-dropped extras (`dtt`, `title_order_no`, `escrow_no`, `return_to`) into `deeds.metadata` JSONB → the deed's Jinja2 template renders once via `pdf_engine` (PDFShift if configured, WeasyPrint otherwise) → bytes stored in a new `deed_pdfs` table (BYTEA + sha256, mirroring the proven `api_deeds.pdf_data` pattern) → `deeds.pdf_url` + `metadata.pdf_sha256`/`pdf_generated_at` stamped → `GET /deeds/{id}/download` streams the stored bytes behind owner-or-admin auth. Legacy rows self-heal: first download renders + stores.

**Schema:** mapped against the owner-supplied live `information_schema` dump — `grantor_name`/`grantee_name` (the phase-11 rename never ran in production), `pdf_url` varchar, `metadata` jsonb. The `deed_pdfs` table is created idempotently at startup (`CREATE TABLE IF NOT EXISTS` — no Alembic in this repo).

**Frontend:** the generate proxy passes the extras through; the success page's Preview/Download/Print and past-deeds' Download all fetch the PDF as an authenticated blob (a bare `pdf_url` in `window.open` can't carry the bearer token). All five deed types map to their template set, defaulting to grant deed.

## Deviation from the amendment (flagged for owner)

The amendment specified persisting via the existing `StorageClient`. Its **local** driver writes to Render's ephemeral disk (files vanish on every deploy) and the main API has no static file server for them; S3 mode needs credentials that aren't configured. So PDFs persist as **BYTEA in managed Postgres** — durable today with zero new infrastructure, and the render-once/immutable/sha256 properties the amendment wanted are all preserved. Swapping to S3 via `StorageClient` later is a small, isolated change.

## Verification

- 5 new unit tests: live-column context mapping, metadata extras (dict and JSON-string forms), exempt-DTT → `0.00`, unknown-type fallback, and **real WeasyPrint renders of all five deed-type templates asserted to produce valid PDF bytes**. All passing locally on Python 3.11, alongside the T1 webhook regression tests.
- `py_compile` clean; frontend `tsc` error count unchanged at the 116 pre-existing baseline (zero errors in touched files).
- Pre-existing red `test` CI check is the known Python 3.8 issue (T9-lite).

## Post-merge click-through (owner)

1. Build and save a deed through the builder — success page should show Preview/Download/Print all delivering the actual PDF.
2. Check an **old** deed in Past Deeds — Download should now work too (self-heal path).
3. Confirm the DTT declaration and Order/Escrow numbers appear on the PDF for a deed that filled those sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_