### PR TITLE
feat(builder): grantor provenance + generation-time confirmation gate (Ticket B)

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -220,7 +220,7 @@ def create_deed(user_id, deed_data):
         # into metadata JSONB so the stored PDF can render the full document.
         extras = {
             key: deed_data.get(key)
-            for key in ('dtt', 'title_order_no', 'escrow_no', 'return_to', 'source')
+            for key in ('dtt', 'title_order_no', 'escrow_no', 'return_to', 'source', 'provenance')
             if deed_data.get(key)
         }
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -414,6 +414,7 @@ class DeedCreate(BaseModel):
     title_order_no: Optional[str] = Field(default=None)
     escrow_no: Optional[str] = Field(default=None)
     return_to: Optional[str] = Field(default=None, description="Mail-to name for the recorded deed")
+    provenance: Optional[Dict] = Field(default=None, description="Per-field source + confirmation timestamps (Ticket B)")
 
     class Config:
         extra = "ignore"  # Ignore extra fields from frontend

--- a/frontend/src/__tests__/provenance.test.ts
+++ b/frontend/src/__tests__/provenance.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for the generation-time confirmation gate helpers (Ticket B).
+ */
+import { describe, expect, it } from '@jest/globals';
+import {
+  buildProvenancePayload,
+  collectCandidateFields,
+  grantorFieldProvenance,
+  propertyFieldProvenance,
+} from '@/lib/provenance';
+import type { DeedBuilderState, PropertyData } from '@/types/builder';
+
+const baseProperty: PropertyData = {
+  address: '123 Main St, Los Angeles, CA 90001',
+  city: 'Los Angeles',
+  county: 'Los Angeles',
+  state: 'CA',
+  zip: '90001',
+  apn: '1234-567-890',
+  legalDescription: 'LOT 1, BLOCK 2, TRACT 3456',
+  owner: 'JOHN DOE',
+};
+
+const baseState = (overrides: Partial<DeedBuilderState> = {}): DeedBuilderState => ({
+  deedType: 'grant-deed',
+  property: baseProperty,
+  grantor: '',
+  grantee: '',
+  vesting: '',
+  dtt: null,
+  requestedBy: '',
+  returnTo: '',
+  ...overrides,
+});
+
+describe('collectCandidateFields', () => {
+  it('treats unstamped SiteX-loaded property fields as candidates (backfill rule)', () => {
+    const candidates = collectCandidateFields(baseState());
+    const keys = candidates.map((c) => c.key);
+    expect(keys).toEqual(expect.arrayContaining(['apn', 'legalDescription', 'owner']));
+  });
+
+  it('flags a SiteX-prefilled grantor as a candidate', () => {
+    const state = baseState({ grantor: 'JOHN DOE' }); // equals property.owner, no stamp
+    const keys = collectCandidateFields(state).map((c) => c.key);
+    expect(keys).toContain('grantor');
+  });
+
+  it('passes a user-typed grantor without the panel', () => {
+    const state = baseState({
+      grantor: 'SOMEONE ELSE',
+      grantorProvenance: {
+        value: 'SOMEONE ELSE',
+        source: 'user',
+        status: 'confirmed',
+        confirmedAt: '2026-07-23T00:00:00Z',
+      },
+    });
+    expect(collectCandidateFields(state).map((c) => c.key)).not.toContain('grantor');
+  });
+
+  it('opens the gate when every material field is confirmed', () => {
+    const confirmedAt = '2026-07-23T00:00:00Z';
+    const state = baseState({
+      grantor: 'JOHN DOE',
+      grantorProvenance: { value: 'JOHN DOE', source: 'sitex', status: 'confirmed', confirmedAt },
+      property: {
+        ...baseProperty,
+        provenance: {
+          apn: { value: baseProperty.apn, source: 'sitex', status: 'confirmed', confirmedAt },
+          legalDescription: { value: baseProperty.legalDescription, source: 'sitex', status: 'confirmed', confirmedAt },
+          owner: { value: 'JOHN DOE', source: 'sitex', status: 'confirmed', confirmedAt },
+        },
+      },
+    });
+    expect(collectCandidateFields(state)).toHaveLength(0);
+  });
+
+  it('skips empty fields — nothing to confirm', () => {
+    const state = baseState({
+      property: { ...baseProperty, apn: '', legalDescription: '', owner: undefined },
+    });
+    expect(collectCandidateFields(state)).toHaveLength(0);
+  });
+
+  it('handles a state with no property at all', () => {
+    expect(collectCandidateFields(baseState({ property: null }))).toHaveLength(0);
+  });
+});
+
+describe('field provenance accessors', () => {
+  it('prefers the stamped provenance but syncs the bare value', () => {
+    const state = baseState({
+      property: {
+        ...baseProperty,
+        apn: '9999-999-999', // bare value edited after stamping
+        provenance: {
+          apn: { value: '1234-567-890', source: 'sitex', status: 'confirmed', confirmedAt: 'x' },
+        },
+      },
+    });
+    expect(propertyFieldProvenance(state, 'apn')).toMatchObject({
+      value: '9999-999-999',
+      status: 'confirmed',
+    });
+  });
+
+  it('marks an unstamped grantor differing from the owner as user-confirmed', () => {
+    const state = baseState({ grantor: 'TYPED BEFORE STAMPING' });
+    expect(grantorFieldProvenance(state)).toMatchObject({ source: 'user', status: 'confirmed' });
+  });
+});
+
+describe('buildProvenancePayload', () => {
+  it('emits source + confirmed_at per material field', () => {
+    const confirmedAt = '2026-07-23T01:02:03Z';
+    const state = baseState({
+      grantor: 'JOHN DOE',
+      grantorProvenance: { value: 'JOHN DOE', source: 'sitex', status: 'confirmed', confirmedAt },
+    });
+    const payload = buildProvenancePayload(state);
+    expect(payload.grantor).toEqual({ source: 'sitex', confirmed_at: confirmedAt });
+    expect(payload.apn).toEqual({ source: 'sitex', confirmed_at: null });
+    expect(Object.keys(payload).sort()).toEqual(['apn', 'grantor', 'legalDescription', 'owner']);
+  });
+});

--- a/frontend/src/app/api/deeds/generate/route.ts
+++ b/frontend/src/app/api/deeds/generate/route.ts
@@ -28,6 +28,7 @@ export async function POST(req: NextRequest) {
       title_order_no: payload.title_order_no || null,
       escrow_no: payload.escrow_no || null,
       return_to: payload.return_to || null,
+      provenance: payload.provenance || null,
     };
 
     const authHeader = req.headers.get('authorization');

--- a/frontend/src/components/builder/ConfirmableField.tsx
+++ b/frontend/src/components/builder/ConfirmableField.tsx
@@ -1,0 +1,133 @@
+'use client'
+
+// ─────────────────────────────────────────────────────────────────
+// ConfirmableField — renders a Sourced<string> value the officer must
+// confirm or edit before it is treated as authorized. Shared by
+// PropertySection (apn / legal description / owner) and GrantorSection.
+// ─────────────────────────────────────────────────────────────────
+import { useState } from 'react'
+import { AlertCircle, Check, Pencil, ShieldCheck } from 'lucide-react'
+import type { Sourced } from '@/types/builder'
+
+export interface ConfirmableFieldProps {
+  label: string
+  field: Sourced<string>
+  multiline?: boolean
+  onConfirm: () => void
+  onEdit: (newValue: string) => void
+}
+
+export function ConfirmableField({ label, field, multiline, onConfirm, onEdit }: ConfirmableFieldProps) {
+  const [isEditing, setIsEditing] = useState(false)
+  const [draft, setDraft] = useState(field.value)
+
+  const isConfirmed = field.status === 'confirmed'
+  const isUserSourced = field.source === 'user'
+
+  const startEdit = () => {
+    setDraft(field.value)
+    setIsEditing(true)
+  }
+
+  const saveEdit = () => {
+    onEdit(draft)
+    setIsEditing(false)
+  }
+
+  return (
+    <div
+      className={`p-3 rounded-lg border ${
+        isConfirmed ? 'bg-emerald-50 border-emerald-200' : 'bg-amber-50 border-amber-200'
+      }`}
+    >
+      <div className="flex items-center justify-between mb-1">
+        <label className="text-sm font-medium text-gray-700">{label}</label>
+        {isConfirmed ? (
+          <span className="inline-flex items-center gap-1 text-xs font-medium text-emerald-700">
+            <ShieldCheck className="w-3.5 h-3.5" />
+            {isUserSourced ? 'Edited & confirmed' : 'Confirmed'}
+          </span>
+        ) : (
+          <span className="inline-flex items-center gap-1 text-xs font-medium text-amber-700">
+            <AlertCircle className="w-3.5 h-3.5" />
+            From SiteX — needs confirmation
+          </span>
+        )}
+      </div>
+
+      {isEditing ? (
+        <div className="space-y-2">
+          {multiline ? (
+            <textarea
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              rows={3}
+              className="w-full p-2 text-sm border border-gray-300 rounded-md focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+              autoFocus
+            />
+          ) : (
+            <input
+              type="text"
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              className="w-full p-2 text-sm border border-gray-300 rounded-md focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+              autoFocus
+            />
+          )}
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              onClick={saveEdit}
+              className="inline-flex items-center gap-1 bg-brand-500 text-white px-3 py-1.5 rounded-md text-sm font-medium hover:bg-brand-600"
+            >
+              <Check className="w-4 h-4" />
+              Save &amp; confirm
+            </button>
+            <button
+              type="button"
+              onClick={() => setIsEditing(false)}
+              className="text-sm text-gray-500 hover:text-gray-700 px-2 py-1.5"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <p
+            className={`text-sm text-gray-900 break-words ${
+              multiline ? 'max-h-32 overflow-y-auto' : ''
+            }`}
+          >
+            {field.value || <span className="text-gray-400 italic">No value</span>}
+          </p>
+          <div className="flex items-center gap-2 mt-2">
+            {!isConfirmed && (
+              <button
+                type="button"
+                onClick={onConfirm}
+                className="inline-flex items-center gap-1 bg-emerald-600 text-white px-3 py-1.5 rounded-md text-sm font-medium hover:bg-emerald-700"
+              >
+                <Check className="w-4 h-4" />
+                Confirm
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={startEdit}
+              className="inline-flex items-center gap-1 text-sm text-gray-600 hover:text-gray-900 px-2 py-1.5"
+            >
+              <Pencil className="w-3.5 h-3.5" />
+              Edit
+            </button>
+          </div>
+          {isConfirmed && field.confirmedAt && (
+            <p className="text-xs text-gray-400 mt-1">
+              Confirmed {new Date(field.confirmedAt).toLocaleString()}
+            </p>
+          )}
+        </>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/builder/InputPanel.tsx
+++ b/frontend/src/components/builder/InputPanel.tsx
@@ -127,8 +127,9 @@ export function InputPanel({
         >
           <GrantorSection
             value={state.grantor}
-            onChange={(grantor) => onChange({ grantor })}
+            onChange={(grantor, grantorProvenance) => onChange({ grantor, grantorProvenance })}
             suggestedName={state.property?.owner}
+            provenance={state.grantorProvenance}
           />
         </InputSection>
 

--- a/frontend/src/components/builder/sections/GrantorSection.tsx
+++ b/frontend/src/components/builder/sections/GrantorSection.tsx
@@ -1,25 +1,55 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { User, Sparkles } from 'lucide-react';
+import { User } from 'lucide-react';
 import { useAIAssist } from '@/contexts/AIAssistContext';
 import { AISuggestion } from '../AISuggestion';
+import { ConfirmableField } from '../ConfirmableField';
+import type { Sourced } from '@/types/builder';
 
 interface GrantorSectionProps {
   value: string;
-  onChange: (grantor: string) => void;
+  onChange: (grantor: string, provenance: Sourced<string>) => void;
   suggestedName?: string;
+  provenance?: Sourced<string>;
 }
 
-export function GrantorSection({ value, onChange, suggestedName }: GrantorSectionProps) {
+export function GrantorSection({ value, onChange, suggestedName, provenance }: GrantorSectionProps) {
   const { enabled: aiEnabled } = useAIAssist();
   const [guidanceDismissed, setGuidanceDismissed] = useState(false);
 
   useEffect(() => {
     if (!value && suggestedName) {
-      onChange(suggestedName);
+      // SiteX-derived prefill: an unverified candidate until the officer
+      // confirms it — same rule as the property owner field.
+      onChange(suggestedName, { value: suggestedName, source: 'sitex', status: 'candidate' });
     }
   }, [suggestedName, value, onChange]);
+
+  const handleConfirm = () => {
+    onChange(value, {
+      value,
+      source: provenance?.source ?? 'sitex',
+      status: 'confirmed',
+      confirmedAt: new Date().toISOString(),
+    });
+  };
+
+  const handleEdit = (newValue: string) => {
+    const upper = newValue.toUpperCase();
+    // Manual entry is user-sourced and confirmed on entry.
+    onChange(upper, {
+      value: upper,
+      source: 'user',
+      status: 'confirmed',
+      confirmedAt: new Date().toISOString(),
+    });
+  };
+
+  // SiteX-sourced values (candidate or confirmed) render through the
+  // confirm/edit affordance; user-typed values use the plain input.
+  const showConfirmable = !!value && (provenance?.source ?? 'sitex') === 'sitex' &&
+    (!!provenance || value === suggestedName);
 
   return (
     <div className="space-y-4">
@@ -32,32 +62,33 @@ export function GrantorSection({ value, onChange, suggestedName }: GrantorSectio
         />
       )}
 
-      {suggestedName && value === suggestedName && (
-        <div className="flex items-center gap-2 text-sm text-emerald-600 bg-emerald-50 px-3 py-2 rounded-lg">
-          <Sparkles className="w-4 h-4" />
-          Auto-filled from county records
+      {showConfirmable ? (
+        <ConfirmableField
+          label="Grantor Name (Current Owner)"
+          field={provenance ?? { value, source: 'sitex', status: 'candidate' }}
+          onConfirm={handleConfirm}
+          onEdit={handleEdit}
+        />
+      ) : (
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Grantor Name (Current Owner)
+          </label>
+          <div className="relative">
+            <User className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
+            <input
+              type="text"
+              value={value}
+              onChange={(e) => handleEdit(e.target.value)}
+              placeholder="JOHN SMITH"
+              className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500 uppercase"
+            />
+          </div>
+          <p className="text-xs text-gray-500 mt-1">
+            For multiple grantors, use &quot;and&quot; (e.g., JOHN SMITH AND JANE SMITH)
+          </p>
         </div>
       )}
-
-      <div>
-        <label className="block text-sm font-medium text-gray-700 mb-1">
-          Grantor Name (Current Owner)
-        </label>
-        <div className="relative">
-          <User className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
-          <input
-            type="text"
-            value={value}
-            onChange={(e) => onChange(e.target.value.toUpperCase())}
-            placeholder="JOHN SMITH"
-            className="w-full pl-10 pr-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500 uppercase"
-          />
-        </div>
-        <p className="text-xs text-gray-500 mt-1">
-          For multiple grantors, use &quot;and&quot; (e.g., JOHN SMITH AND JANE SMITH)
-        </p>
-      </div>
     </div>
   );
 }
-

--- a/frontend/src/components/builder/sections/PropertySection.tsx
+++ b/frontend/src/components/builder/sections/PropertySection.tsx
@@ -5,6 +5,7 @@ import { MapPin, Search, Check, Loader2, AlertCircle, Building2, ChevronRight, P
 import type { PropertyData, PropertyProvenance, Sourced } from "@/types/builder"
 import { useAIAssist } from "@/contexts/AIAssistContext"
 import { AISuggestion } from "../AISuggestion"
+import { ConfirmableField } from "../ConfirmableField"
 
 interface PropertySectionProps {
   value: PropertyData | null
@@ -175,128 +176,8 @@ function parseGoogleAddress(fullAddress: string): ParsedAddress {
 // Suggest → confirm → record: one SiteX-sourced field the officer must
 // confirm or edit before it is treated as authorized.
 // ─────────────────────────────────────────────────────────────────
-interface ConfirmableFieldProps {
-  label: string
-  field: Sourced<string>
-  multiline?: boolean
-  onConfirm: () => void
-  onEdit: (newValue: string) => void
-}
-
-function ConfirmableField({ label, field, multiline, onConfirm, onEdit }: ConfirmableFieldProps) {
-  const [isEditing, setIsEditing] = useState(false)
-  const [draft, setDraft] = useState(field.value)
-
-  const isConfirmed = field.status === 'confirmed'
-  const isUserSourced = field.source === 'user'
-
-  const startEdit = () => {
-    setDraft(field.value)
-    setIsEditing(true)
-  }
-
-  const saveEdit = () => {
-    onEdit(draft)
-    setIsEditing(false)
-  }
-
-  return (
-    <div
-      className={`p-3 rounded-lg border ${
-        isConfirmed ? 'bg-emerald-50 border-emerald-200' : 'bg-amber-50 border-amber-200'
-      }`}
-    >
-      <div className="flex items-center justify-between mb-1">
-        <label className="text-sm font-medium text-gray-700">{label}</label>
-        {isConfirmed ? (
-          <span className="inline-flex items-center gap-1 text-xs font-medium text-emerald-700">
-            <ShieldCheck className="w-3.5 h-3.5" />
-            {isUserSourced ? 'Edited & confirmed' : 'Confirmed'}
-          </span>
-        ) : (
-          <span className="inline-flex items-center gap-1 text-xs font-medium text-amber-700">
-            <AlertCircle className="w-3.5 h-3.5" />
-            From SiteX — needs confirmation
-          </span>
-        )}
-      </div>
-
-      {isEditing ? (
-        <div className="space-y-2">
-          {multiline ? (
-            <textarea
-              value={draft}
-              onChange={(e) => setDraft(e.target.value)}
-              rows={3}
-              className="w-full p-2 text-sm border border-gray-300 rounded-md focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
-              autoFocus
-            />
-          ) : (
-            <input
-              type="text"
-              value={draft}
-              onChange={(e) => setDraft(e.target.value)}
-              className="w-full p-2 text-sm border border-gray-300 rounded-md focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
-              autoFocus
-            />
-          )}
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={saveEdit}
-              className="inline-flex items-center gap-1 bg-brand-500 text-white px-3 py-1.5 rounded-md text-sm font-medium hover:bg-brand-600"
-            >
-              <Check className="w-4 h-4" />
-              Save &amp; confirm
-            </button>
-            <button
-              type="button"
-              onClick={() => setIsEditing(false)}
-              className="text-sm text-gray-500 hover:text-gray-700 px-2 py-1.5"
-            >
-              Cancel
-            </button>
-          </div>
-        </div>
-      ) : (
-        <>
-          <p
-            className={`text-sm text-gray-900 break-words ${
-              multiline ? 'max-h-32 overflow-y-auto' : ''
-            }`}
-          >
-            {field.value || <span className="text-gray-400 italic">No value</span>}
-          </p>
-          <div className="flex items-center gap-2 mt-2">
-            {!isConfirmed && (
-              <button
-                type="button"
-                onClick={onConfirm}
-                className="inline-flex items-center gap-1 bg-emerald-600 text-white px-3 py-1.5 rounded-md text-sm font-medium hover:bg-emerald-700"
-              >
-                <Check className="w-4 h-4" />
-                Confirm
-              </button>
-            )}
-            <button
-              type="button"
-              onClick={startEdit}
-              className="inline-flex items-center gap-1 text-sm text-gray-600 hover:text-gray-900 px-2 py-1.5"
-            >
-              <Pencil className="w-3.5 h-3.5" />
-              Edit
-            </button>
-          </div>
-          {isConfirmed && field.confirmedAt && (
-            <p className="text-xs text-gray-400 mt-1">
-              Confirmed {new Date(field.confirmedAt).toLocaleString()}
-            </p>
-          )}
-        </>
-      )}
-    </div>
-  )
-}
+// ConfirmableField now lives in components/builder/ConfirmableField.tsx,
+// shared with GrantorSection.
 
 export function PropertySection({ value, onChange, onComplete }: PropertySectionProps) {
   const { enabled: aiEnabled } = useAIAssist()

--- a/frontend/src/features/builder/DeedBuilder.tsx
+++ b/frontend/src/features/builder/DeedBuilder.tsx
@@ -8,7 +8,13 @@ import { BuilderHeader } from '@/components/builder/BuilderHeader';
 import { InputPanel } from '@/components/builder/InputPanel';
 import { PreviewPanel } from '@/components/builder/PreviewPanel';
 import { useBuilderMode } from '@/hooks/useBuilderMode';
-import { DeedBuilderState, PropertyData } from '@/types/builder';
+import { DeedBuilderState, PropertyData, Sourced } from '@/types/builder';
+import {
+  CandidateField,
+  MaterialFieldKey,
+  buildProvenancePayload,
+  collectCandidateFields,
+} from '@/lib/provenance';
 
 interface DeedBuilderProps {
   deedType: string;
@@ -31,6 +37,9 @@ function DeedBuilderInner({ deedType, initialProperty }: DeedBuilderProps) {
     deedType,
     property: initialProperty || null,
     grantor: initialProperty?.owner || '',
+    grantorProvenance: initialProperty?.owner
+      ? { value: initialProperty.owner, source: 'sitex', status: 'candidate' }
+      : undefined,
     grantee: '',
     vesting: '',
     dtt: null,
@@ -47,32 +56,106 @@ function DeedBuilderInner({ deedType, initialProperty }: DeedBuilderProps) {
     setState(prev => ({ ...prev, ...updates }));
   }, []);
 
-  const handleGenerate = async () => {
+  // The generation gate: material sourced data fields (apn, legal
+  // description, owner, grantor) still in 'candidate' status block
+  // generation until confirmed. The gate sits in front of the save →
+  // render → store pipeline: a gated deed never renders, never hashes.
+  const [confirmationNeeded, setConfirmationNeeded] = useState<CandidateField[] | null>(null);
+
+  const stampConfirmed = (s: DeedBuilderState, keys: MaterialFieldKey[]): DeedBuilderState => {
+    let next = s;
+    for (const key of keys) {
+      // Each field gets its own recorded confirmation timestamp.
+      const confirmedAt = new Date().toISOString();
+      if (key === 'grantor') {
+        next = {
+          ...next,
+          grantorProvenance: {
+            value: next.grantor,
+            source: next.grantorProvenance?.source ?? 'sitex',
+            status: 'confirmed',
+            confirmedAt,
+          },
+        };
+      } else if (next.property) {
+        const existing: Sourced<string> = next.property.provenance?.[key] ?? {
+          value: (next.property[key] ?? '') as string,
+          source: 'sitex',
+          status: 'candidate',
+        };
+        next = {
+          ...next,
+          property: {
+            ...next.property,
+            provenance: {
+              ...next.property.provenance,
+              [key]: { ...existing, status: 'confirmed', confirmedAt },
+            },
+          },
+        };
+      }
+    }
+    return next;
+  };
+
+  const handleGenerate = () => {
+    const candidates = collectCandidateFields(state);
+    if (candidates.length > 0) {
+      setConfirmationNeeded(candidates);
+      return;
+    }
+    performGenerate(state);
+  };
+
+  const handleConfirmField = (key: MaterialFieldKey) => {
+    const next = stampConfirmed(state, [key]);
+    setState(next);
+    const remaining = collectCandidateFields(next);
+    if (remaining.length > 0) {
+      setConfirmationNeeded(remaining);
+    } else {
+      setConfirmationNeeded(null);
+      performGenerate(next);
+    }
+  };
+
+  const handleConfirmAll = () => {
+    if (!confirmationNeeded) return;
+    const next = stampConfirmed(state, confirmationNeeded.map((c) => c.key));
+    setState(next);
+    setConfirmationNeeded(null);
+    performGenerate(next);
+  };
+
+  const performGenerate = async (genState: DeedBuilderState) => {
     setIsGenerating(true);
     try {
       // Build the payload to match backend expectations
       const payload = {
-        doc_type: state.deedType,
-        county: state.property?.county || '',
-        apn: state.property?.apn || '',
-        property_address: state.property?.address || '',
-        legal_description: state.property?.legalDescription || '',
-        grantors_text: state.grantor,
-        grantees_text: state.grantee,
-        vesting: state.vesting,
-        requested_by: state.requestedBy,
-        return_to: state.returnTo === 'grantee' ? state.grantee : state.requestedBy,
-        title_order_no: state.titleOrderNo || '',
-        escrow_no: state.escrowNo || '',
+        doc_type: genState.deedType,
+        county: genState.property?.county || '',
+        apn: genState.property?.apn || '',
+        property_address: genState.property?.address || '',
+        legal_description: genState.property?.legalDescription || '',
+        grantors_text: genState.grantor,
+        grantees_text: genState.grantee,
+        vesting: genState.vesting,
+        requested_by: genState.requestedBy,
+        return_to: genState.returnTo === 'grantee' ? genState.grantee : genState.requestedBy,
+        title_order_no: genState.titleOrderNo || '',
+        escrow_no: genState.escrowNo || '',
         dtt: {
-          transfer_value: state.dtt?.transferValue?.replace(/[^0-9]/g, '') || '',
-          is_exempt: state.dtt?.isExempt || false,
-          exemption_reason: state.dtt?.exemptReason || '',
-          basis: state.dtt?.basis || 'full_value',
-          area_type: state.dtt?.areaType || 'unincorporated',
-          city_name: state.dtt?.cityName || '',
-          calculated_amount: state.dtt?.calculatedAmount || '',
+          transfer_value: genState.dtt?.transferValue?.replace(/[^0-9]/g, '') || '',
+          is_exempt: genState.dtt?.isExempt || false,
+          exemption_reason: genState.dtt?.exemptReason || '',
+          basis: genState.dtt?.basis || 'full_value',
+          area_type: genState.dtt?.areaType || 'unincorporated',
+          city_name: genState.dtt?.cityName || '',
+          calculated_amount: genState.dtt?.calculatedAmount || '',
         },
+        // Who-confirmed-what-when, persisted into deeds.metadata.provenance
+        // alongside the stored PDF's hash.
+        provenance: buildProvenancePayload(genState),
       };
 
       const response = await fetch('/api/deeds/generate', {
@@ -121,9 +204,71 @@ function DeedBuilderInner({ deedType, initialProperty }: DeedBuilderProps) {
           <PreviewPanel state={state} activeSection={expandedSection} />
         </div>
       </div>
+
+      {/* Generation gate: unconfirmed material fields must be confirmed
+          before the deed renders and freezes as an immutable PDF. */}
+      {confirmationNeeded && confirmationNeeded.length > 0 && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+          <div className="w-full max-w-lg bg-white rounded-xl shadow-2xl p-6">
+            <h2 className="text-lg font-semibold text-gray-900 mb-1">
+              {confirmationNeeded.length} field{confirmationNeeded.length === 1 ? '' : 's'} need{confirmationNeeded.length === 1 ? 's' : ''} confirmation
+            </h2>
+            <p className="text-sm text-gray-500 mb-4">
+              These values were pulled from external records. Confirm each one is
+              correct before the deed is generated — the generated document is final.
+            </p>
+
+            <div className="space-y-3 max-h-72 overflow-y-auto">
+              {confirmationNeeded.map(({ key, label, field }) => (
+                <div key={key} className="p-3 bg-amber-50 border border-amber-200 rounded-lg">
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="text-xs font-medium text-amber-700 uppercase tracking-wide">
+                        {label} · {SOURCE_LABELS[field.source] || field.source}
+                      </p>
+                      <p className="text-sm text-gray-900 break-words">{field.value}</p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => handleConfirmField(key)}
+                      className="flex-shrink-0 bg-emerald-600 text-white px-3 py-1.5 rounded-md text-sm font-medium hover:bg-emerald-700"
+                    >
+                      Confirm
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="flex items-center justify-end gap-3 mt-5">
+              <button
+                type="button"
+                onClick={() => setConfirmationNeeded(null)}
+                className="text-sm text-gray-500 hover:text-gray-700 px-3 py-2"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleConfirmAll}
+                className="bg-[#7C4DFF] hover:bg-[#6a3de8] text-white px-4 py-2 rounded-lg text-sm font-semibold"
+              >
+                Confirm all &amp; generate
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }
+
+const SOURCE_LABELS: Record<string, string> = {
+  sitex: 'From SiteX (county records)',
+  google: 'From Google',
+  titlepoint: 'From TitlePoint',
+  user: 'Entered by you',
+};
 
 // Wrap with AIAssistProvider
 export function DeedBuilder(props: DeedBuilderProps) {

--- a/frontend/src/lib/provenance.ts
+++ b/frontend/src/lib/provenance.ts
@@ -1,0 +1,99 @@
+/**
+ * Generation-time confirmation gate over the material sourced data fields:
+ * apn, legalDescription, owner (property.provenance) and grantor
+ * (state.grantorProvenance). A field still in 'candidate' status blocks
+ * generation until the officer confirms it — nothing unconfirmed may enter
+ * the immutable stored PDF. Legal choices (vesting, transfer tax) gate at
+ * the point of decision, not here.
+ */
+import type { DeedBuilderState, PropertyProvenance, Sourced } from '@/types/builder';
+
+export type MaterialFieldKey = 'apn' | 'legalDescription' | 'owner' | 'grantor';
+
+export interface CandidateField {
+  key: MaterialFieldKey;
+  label: string;
+  field: Sourced<string>;
+}
+
+export const MATERIAL_FIELD_LABELS: Record<MaterialFieldKey, string> = {
+  apn: 'APN',
+  legalDescription: 'Legal Description',
+  owner: 'Current Owner (per county records)',
+  grantor: 'Grantor Name',
+};
+
+const PROPERTY_KEYS: Array<keyof PropertyProvenance> = ['apn', 'legalDescription', 'owner'];
+
+/**
+ * Provenance for one property field. Values without a stamp were loaded
+ * from SiteX before provenance existed — treated as unconfirmed candidates,
+ * matching PropertySection's provenanceFor backfill. Empty fields have
+ * nothing to confirm and return null.
+ */
+export function propertyFieldProvenance(
+  state: DeedBuilderState,
+  key: keyof PropertyProvenance,
+): Sourced<string> | null {
+  const bare = (state.property?.[key] ?? '') as string;
+  if (!bare.trim()) return null;
+  const stamped = state.property?.provenance?.[key];
+  if (stamped) return { ...stamped, value: bare };
+  return { value: bare, source: 'sitex', status: 'candidate' };
+}
+
+/**
+ * Provenance for the grantor. Unstamped non-empty values only occur via the
+ * SiteX owner prefill path (typing always stamps): equal to property.owner
+ * means SiteX candidate; anything else predates stamping and is treated as
+ * user-entered (confirmed on entry, per the provenance rule).
+ */
+export function grantorFieldProvenance(state: DeedBuilderState): Sourced<string> | null {
+  const bare = state.grantor?.trim() ?? '';
+  if (!bare) return null;
+  if (state.grantorProvenance) return { ...state.grantorProvenance, value: state.grantor };
+  if (state.property?.owner && state.grantor === state.property.owner) {
+    return { value: state.grantor, source: 'sitex', status: 'candidate' };
+  }
+  return { value: state.grantor, source: 'user', status: 'confirmed' };
+}
+
+function materialFieldProvenance(
+  state: DeedBuilderState,
+  key: MaterialFieldKey,
+): Sourced<string> | null {
+  return key === 'grantor'
+    ? grantorFieldProvenance(state)
+    : propertyFieldProvenance(state, key);
+}
+
+/** Every material field still awaiting confirmation. Empty array = gate open. */
+export function collectCandidateFields(state: DeedBuilderState): CandidateField[] {
+  const keys: MaterialFieldKey[] = [...PROPERTY_KEYS, 'grantor'];
+  const candidates: CandidateField[] = [];
+  for (const key of keys) {
+    const field = materialFieldProvenance(state, key);
+    if (field && field.status === 'candidate') {
+      candidates.push({ key, label: MATERIAL_FIELD_LABELS[key], field });
+    }
+  }
+  return candidates;
+}
+
+/**
+ * Snapshot of who-confirmed-what-when for the generation payload; persisted
+ * into deeds.metadata.provenance next to the stored PDF's hash.
+ */
+export function buildProvenancePayload(
+  state: DeedBuilderState,
+): Record<string, { source: string; confirmed_at: string | null }> {
+  const payload: Record<string, { source: string; confirmed_at: string | null }> = {};
+  const keys: MaterialFieldKey[] = [...PROPERTY_KEYS, 'grantor'];
+  for (const key of keys) {
+    const field = materialFieldProvenance(state, key);
+    if (field) {
+      payload[key] = { source: field.source, confirmed_at: field.confirmedAt ?? null };
+    }
+  }
+  return payload;
+}

--- a/frontend/src/types/builder.ts
+++ b/frontend/src/types/builder.ts
@@ -56,6 +56,13 @@ export interface DeedBuilderState {
   deedType: string;
   property: PropertyData | null;
   grantor: string;
+  /**
+   * Provenance for the grantor name, mirroring property.provenance: SiteX
+   * prefill arrives as a candidate the officer confirms; manual entry is
+   * user-sourced and confirmed on entry. Optional so the bare grantor value
+   * and the generation payload keep working unchanged.
+   */
+  grantorProvenance?: Sourced<string>;
   grantee: string;
   vesting: string;
   dtt: DTTData | null;


### PR DESCRIPTION
## Summary

Ticket B — the data-field half of the two-tier confirmation rule, placed directly in front of the T2 render/persist pipeline: **a gated deed never renders, never stores, never hashes.**

**1. Grantor provenance.** The `Sourced<T>`/`ConfirmableField` pattern from `PropertySection` (commit `270425a`) now covers the grantor name. SiteX owner prefill arrives `{source:'sitex', status:'candidate'}` with the confirm/edit affordance; confirming stamps `confirmedAt`; manual typing is `{source:'user', status:'confirmed'}` on entry. `ConfirmableField` was extracted to `components/builder/ConfirmableField.tsx` (shared, byte-identical UI). Bare values stay in sync; the generation payload shape is unchanged; state stays in the existing `useState` prop-drill.

**2. Generation gate.** `handleGenerate` collects material sourced fields — `{apn, legalDescription, owner, grantor}` — still in `candidate` status. Any candidates → generation blocks and a panel lists each field with its value and source, offering per-field **Confirm** and **Confirm all & generate**. Unstamped legacy values follow the backfill rule (SiteX-loaded → candidate; user-typed → confirmed). Empty fields have nothing to confirm and don't block.

**3. Confirm-all = real confirmations.** Each field gets its own `confirmedAt` stamp — no bypass flag — and generation proceeds in the same interaction. All-confirmed-already → zero extra clicks (fast path straight to the T2 pipeline).

**4. Navigation untouched.** Section auto-advance and the 6/6 completion gate are unmodified; the only new block is at generate. Legal-choice sections (vesting, transfer tax) behaviorally untouched per the two-tier rule.

**5. Provenance into the record.** The payload adds a `provenance` object (per material field: `source`, `confirmed_at`), passed through the proxy and persisted via the T2 extras path into `deeds.metadata.provenance` — the immutable PDF and its sha256 are now paired with who-confirmed-what-when. Additive JSONB; no schema or template change.

## Verification

- 9 Jest tests on the gate helpers: candidate collection (SiteX backfill, prefilled grantor), user-typed fast path, all-confirmed gate-open, empty-field/no-property safety, payload shape. All passing.
- `tsc` error count unchanged at the 116 pre-existing baseline (zero new errors in changed files; the test file imports from `@jest/globals` since the project lacks jest type definitions).
- `py_compile` clean on the two backend files (one field on `DeedCreate`, one key in the extras list).

## Out of scope (untouched, per ticket)

Legal-choice gating, `ValidationPanel`, PDF templates and T2 render internals, Google-sourced address fields, Zustand.

## Click-through (combined with T2's, same flow)

SiteX-load a property → property fields **and grantor** show amber "needs confirmation" → hit Generate with some unconfirmed → panel shows accurate count/values/sources → Confirm all → deed generates, PDF renders/stores/hashes → check `deeds.metadata.provenance` on the new row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_