### PR TITLE
feat(builder): transfer-tax helper on suggest → confirm → record (Ticket TT)

### DIFF
--- a/frontend/src/__tests__/dttSuggestions.test.ts
+++ b/frontend/src/__tests__/dttSuggestions.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for the transfer-tax legal-choice gate (Ticket TT).
+ */
+import { describe, expect, it } from '@jest/globals';
+import { detectDttSuggestion, isDttSuggestionPending } from '@/lib/dttSuggestions';
+import { buildProvenancePayload } from '@/lib/provenance';
+import type { DeedBuilderState } from '@/types/builder';
+
+const state = (overrides: Partial<DeedBuilderState> = {}): DeedBuilderState => ({
+  deedType: 'grant-deed',
+  property: null,
+  grantor: '',
+  grantee: '',
+  vesting: '',
+  dtt: null,
+  requestedBy: '',
+  returnTo: '',
+  ...overrides,
+});
+
+describe('detectDttSuggestion (deterministic, never guesses)', () => {
+  it('interspousal deed type proposes R&T 11927 citing the deed type', () => {
+    const s = detectDttSuggestion('interspousal-transfer', 'JOHN DOE', 'JANE DOE');
+    expect(s?.codeSection).toBe('R&T 11927');
+    expect(s?.explanation).toContain('Interspousal Transfer Deed');
+    expect(s?.proposed).toEqual({ isExempt: true, exemptReason: 'R&T 11927' });
+  });
+
+  it('transfer to own trust proposes R&T 11930 citing the shared name', () => {
+    const s = detectDttSuggestion('grant-deed', 'JOHN SMITH', 'THE SMITH FAMILY TRUST');
+    expect(s?.codeSection).toBe('R&T 11930');
+    expect(s?.explanation).toContain('SMITH');
+    expect(s?.explanation).toContain('THE SMITH FAMILY TRUST');
+  });
+
+  it('trust grantee with NO name link yields no suggestion — never guess', () => {
+    expect(detectDttSuggestion('grant-deed', 'JOHN SMITH', 'THE WILSON FAMILY TRUST')).toBeNull();
+  });
+
+  it('identical grantor/grantee proposes R&T 11911', () => {
+    const s = detectDttSuggestion('grant-deed', 'JOHN SMITH', 'JOHN SMITH');
+    expect(s?.codeSection).toBe('R&T 11911');
+  });
+
+  it('ordinary sale pattern yields no suggestion', () => {
+    expect(detectDttSuggestion('grant-deed', 'JOHN SMITH', 'MARY JONES')).toBeNull();
+  });
+});
+
+describe('isDttSuggestionPending', () => {
+  const interspousal = { deedType: 'interspousal-transfer', grantor: 'A B', grantee: 'C D' };
+
+  it('pending when surfaced and undecided', () => {
+    expect(isDttSuggestionPending(state(interspousal))).toBe(true);
+  });
+
+  it('not pending after acceptance (decision recorded)', () => {
+    expect(isDttSuggestionPending(state({
+      ...interspousal,
+      dttDecision: { source: 'ai_suggested', status: 'confirmed', confirmedAt: 'x', codeSection: 'R&T 11927' },
+    }))).toBe(false);
+  });
+
+  it('not pending after dismissal', () => {
+    expect(isDttSuggestionPending(state({ ...interspousal, dttSuggestionDismissed: true }))).toBe(false);
+  });
+
+  it('not pending after manual entry (any manual edit records a user decision)', () => {
+    expect(isDttSuggestionPending(state({
+      ...interspousal,
+      dttDecision: { source: 'user', status: 'confirmed', confirmedAt: 'x' },
+    }))).toBe(false);
+  });
+});
+
+describe('provenance payload carries the legal-choice record', () => {
+  it('accepted suggestion records ai_suggested with code section and basis', () => {
+    const payload = buildProvenancePayload(state({
+      dttDecision: {
+        source: 'ai_suggested', status: 'confirmed',
+        confirmedAt: '2026-07-23T12:00:00Z',
+        codeSection: 'R&T 11927', basis: 'Interspousal transfer …',
+      },
+    }));
+    expect(payload.dtt).toEqual({
+      source: 'ai_suggested',
+      confirmed_at: '2026-07-23T12:00:00Z',
+      code_section: 'R&T 11927',
+      basis: 'Interspousal transfer …',
+    });
+  });
+
+  it('manual entry records source user without code section', () => {
+    const payload = buildProvenancePayload(state({
+      dttDecision: { source: 'user', status: 'confirmed', confirmedAt: '2026-07-23T12:00:00Z' },
+    }));
+    expect(payload.dtt).toEqual({ source: 'user', confirmed_at: '2026-07-23T12:00:00Z' });
+  });
+
+  it('no decision -> no dtt entry (nothing unauthorized in the record)', () => {
+    expect(buildProvenancePayload(state()).dtt).toBeUndefined();
+  });
+});

--- a/frontend/src/components/builder/InputPanel.tsx
+++ b/frontend/src/components/builder/InputPanel.tsx
@@ -181,11 +181,16 @@ export function InputPanel({
         >
           <TransferTaxSection
             value={state.dtt}
-            onChange={(dtt) => onChange({ dtt })}
+            onChange={(dtt, dttDecision) =>
+              onChange(dttDecision ? { dtt, dttDecision } : { dtt })
+            }
             city={state.property?.city}
             deedType={state.deedType}
             grantor={state.grantor}
             grantee={state.grantee}
+            decision={state.dttDecision}
+            suggestionDismissed={state.dttSuggestionDismissed}
+            onDismissSuggestion={() => onChange({ dttSuggestionDismissed: true })}
           />
         </InputSection>
 

--- a/frontend/src/components/builder/sections/TransferTaxSection.tsx
+++ b/frontend/src/components/builder/sections/TransferTaxSection.tsx
@@ -1,19 +1,28 @@
 "use client"
 
-import { useMemo, useEffect, useState } from "react"
-import { Calculator } from "lucide-react"
+import { useMemo, useEffect } from "react"
+import { Calculator, Scale, ShieldCheck, X } from "lucide-react"
 import { useAIAssist } from "@/contexts/AIAssistContext"
-import { AIApplied, AISuggestion } from "../AISuggestion"
-import { getTransferTaxSuggestion } from "@/lib/ai-helpers"
-import type { DTTData } from "@/types/builder"
+import { AISuggestion } from "../AISuggestion"
+import { detectDttSuggestion } from "@/lib/dttSuggestions"
+import type { DTTData, LegalChoiceRecord } from "@/types/builder"
 
 interface TransferTaxSectionProps {
   value: DTTData | null
-  onChange: (dtt: DTTData) => void
+  /**
+   * Ticket TT: legal-choice rule. onChange carries the officer's recorded
+   * instruction when (and only when) the change IS an officer action —
+   * accepting a proposal or entering values manually. Derived recalculations
+   * and neutral initialization pass no decision.
+   */
+  onChange: (dtt: DTTData, decision?: LegalChoiceRecord) => void
   city?: string
   deedType: string
   grantor: string
   grantee: string
+  decision?: LegalChoiceRecord
+  suggestionDismissed?: boolean
+  onDismissSuggestion: () => void
 }
 
 // Cities with their own DTT rates
@@ -53,49 +62,66 @@ export function TransferTaxSection({
   deedType,
   grantor,
   grantee,
+  decision,
+  suggestionDismissed,
+  onDismissSuggestion,
 }: TransferTaxSectionProps) {
   const { enabled: aiEnabled } = useAIAssist()
-  const [aiAppliedMessage, setAiAppliedMessage] = useState<string | null>(null)
-  const [suggestionDismissed, setSuggestionDismissed] = useState(false)
 
-  // Get AI suggestion
-  const suggestion = useMemo(() => {
-    if (!aiEnabled) return null
-    return getTransferTaxSuggestion(deedType, grantor, grantee)
-  }, [deedType, grantor, grantee, aiEnabled])
+  // Deterministic detection. Proposes only — never writes state.
+  const suggestion = useMemo(
+    () => detectDttSuggestion(deedType, grantor, grantee),
+    [deedType, grantor, grantee]
+  )
+  const suggestionPending = !!suggestion && !decision && !suggestionDismissed
 
-  // Initialize with smart defaults
+  // Neutral initialization only. A legal choice is NEVER auto-applied —
+  // the exemption fields stay unset until the officer explicitly accepts
+  // or enters values manually (the pre-TT auto-apply behavior is removed).
   useEffect(() => {
     if (!value) {
       const isInCity = city && CITIES_WITH_OWN_DTT.some((c) => city.toLowerCase().includes(c))
-
-      // If AI is enabled and we have a high-confidence suggestion, auto-apply
-      if (aiEnabled && suggestion && suggestion.confidence === "high") {
-        onChange({
-          isExempt: suggestion.isExempt,
-          exemptReason: suggestion.exemptReason,
-          transferValue: "",
-          calculatedAmount: "",
-          basis: "full_value",
-          areaType: isInCity ? "city" : "unincorporated",
-          cityName: isInCity ? city : "",
-        })
-        setAiAppliedMessage(suggestion.reason)
-      } else {
-        // Default initialization without AI
-        onChange({
-          isExempt: false,
-          exemptReason: "",
-          transferValue: "",
-          calculatedAmount: "",
-          basis: "full_value",
-          areaType: isInCity ? "city" : "unincorporated",
-          cityName: isInCity ? city : "",
-        })
-      }
+      onChange({
+        isExempt: false,
+        exemptReason: "",
+        transferValue: "",
+        calculatedAmount: "",
+        basis: "full_value",
+        areaType: isInCity ? "city" : "unincorporated",
+        cityName: isInCity ? city : "",
+      })
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [city, value === null])
+
+  // Any manual edit is the officer's instruction: record source 'user'.
+  const manual = (dtt: DTTData) => {
+    onChange(dtt, {
+      source: "user",
+      status: "confirmed",
+      confirmedAt: new Date().toISOString(),
+    })
+  }
+
+  const handleAccept = () => {
+    if (!suggestion || !value) return
+    onChange(
+      {
+        ...value,
+        isExempt: suggestion.proposed.isExempt,
+        exemptReason: suggestion.proposed.exemptReason,
+        transferValue: "",
+        calculatedAmount: "",
+      },
+      {
+        source: "ai_suggested",
+        status: "confirmed",
+        confirmedAt: new Date().toISOString(),
+        codeSection: suggestion.codeSection,
+        basis: suggestion.explanation,
+      }
+    )
+  }
 
   // Calculate DTT when values change
   const calculatedAmount = useMemo(() => {
@@ -126,7 +152,7 @@ export function TransferTaxSection({
     return (countyTax + cityTax).toFixed(2)
   }, [value])
 
-  // Update calculated amount when it changes
+  // Derived recalculation — not an officer action, no decision stamp.
   useEffect(() => {
     if (value && calculatedAmount !== value.calculatedAmount) {
       onChange({ ...value, calculatedAmount })
@@ -134,50 +160,63 @@ export function TransferTaxSection({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [calculatedAmount])
 
-  // Handle applying AI suggestion manually
-  const handleApplySuggestion = () => {
-    if (suggestion && value) {
-      onChange({
-        ...value,
-        isExempt: suggestion.isExempt,
-        exemptReason: suggestion.exemptReason,
-        transferValue: "",
-        calculatedAmount: "",
-      })
-      setAiAppliedMessage(suggestion.reason)
-      setSuggestionDismissed(true)
-    }
-  }
-
   if (!value) return null
-
-  // General AI guidance when no specific suggestion exists
-  const showGeneralGuidance = aiEnabled && !suggestion && !value.isExempt && !suggestionDismissed
 
   return (
     <div className="space-y-4">
-      {/* AI Applied Message (for auto-applied high-confidence suggestions) */}
-      {aiAppliedMessage && value.isExempt && <AIApplied message={aiAppliedMessage} />}
+      {/* ── PROPOSED treatment — visually distinct from applied/candidate data.
+             Nothing below is written to the deed until Accept is clicked. ── */}
+      {suggestionPending && suggestion && (
+        <div className="p-4 rounded-lg border-2 border-dashed border-violet-300 bg-violet-50">
+          <div className="flex items-center justify-between mb-1">
+            <span className="inline-flex items-center gap-1.5 text-xs font-semibold text-violet-700 uppercase tracking-wide">
+              <Scale className="w-3.5 h-3.5" />
+              Proposed — not applied
+            </span>
+            <span className="text-xs font-mono text-violet-700">{suggestion.codeSection}</span>
+          </div>
+          <p className="text-sm font-semibold text-gray-900">{suggestion.title}</p>
+          <p className="text-sm text-gray-700 mt-1">{suggestion.explanation}</p>
+          <p className="text-xs text-gray-500 mt-2">
+            The exemption is not part of this deed unless you accept it. You remain
+            responsible for the tax treatment.
+          </p>
+          <div className="flex items-center gap-2 mt-3">
+            <button
+              type="button"
+              onClick={handleAccept}
+              className="inline-flex items-center gap-1 bg-violet-600 text-white px-3 py-1.5 rounded-md text-sm font-medium hover:bg-violet-700"
+            >
+              <ShieldCheck className="w-4 h-4" />
+              Accept &amp; apply {suggestion.codeSection}
+            </button>
+            <button
+              type="button"
+              onClick={onDismissSuggestion}
+              className="inline-flex items-center gap-1 text-sm text-gray-600 hover:text-gray-900 px-2 py-1.5"
+            >
+              <X className="w-3.5 h-3.5" />
+              Dismiss — I&apos;ll decide manually
+            </button>
+          </div>
+        </div>
+      )}
 
-      {/* AI Suggestion (for medium-confidence, show as dismissible suggestion) */}
-      {suggestion &&
-        suggestion.confidence === "medium" &&
-        !value.isExempt &&
-        !suggestionDismissed && (
-          <AISuggestion
-            message={suggestion.reason}
-            action="Mark as exempt"
-            onApply={handleApplySuggestion}
-            onDismiss={() => setSuggestionDismissed(true)}
-          />
-        )}
+      {/* Recorded instruction indicator */}
+      {decision?.source === "ai_suggested" && value.isExempt && (
+        <div className="flex items-center gap-2 text-sm text-violet-700 bg-violet-50 border border-violet-200 px-3 py-2 rounded-lg">
+          <ShieldCheck className="w-4 h-4" />
+          Exemption {decision.codeSection} accepted by you
+          {decision.confirmedAt ? ` · ${new Date(decision.confirmedAt).toLocaleString()}` : ""}
+        </div>
+      )}
 
-      {/* General AI Guidance (when AI is on but no specific suggestion) */}
-      {showGeneralGuidance && (
+      {/* General AI guidance when there is no confident suggestion */}
+      {aiEnabled && !suggestion && !value.isExempt && !suggestionDismissed && (
         <AISuggestion
-          message={`For a ${deedType.replace(/-/g, ' ')}, documentary transfer tax is typically calculated on the full transfer value.`}
+          message={`For a ${deedType.replace(/-/g, " ")}, documentary transfer tax is typically calculated on the full transfer value.`}
           details="California DTT is $1.10 per $1,000 of transfer value. Some cities add their own tax (e.g., LA adds $4.50/1,000). Common exemptions: R&T 11911 (gift), R&T 11927 (interspousal), R&T 11930 (trust transfer). If the transfer involves no cash exchange (like adding a spouse), it may be exempt."
-          onDismiss={() => setSuggestionDismissed(true)}
+          onDismiss={onDismissSuggestion}
         />
       )}
 
@@ -187,10 +226,7 @@ export function TransferTaxSection({
           <input
             type="radio"
             checked={!value.isExempt}
-            onChange={() => {
-              onChange({ ...value, isExempt: false, exemptReason: "" })
-              setAiAppliedMessage(null)
-            }}
+            onChange={() => manual({ ...value, isExempt: false, exemptReason: "" })}
             className="w-4 h-4 text-brand-500 focus:ring-brand-500"
           />
           <span className="font-medium text-gray-900">Calculate Tax</span>
@@ -199,9 +235,7 @@ export function TransferTaxSection({
           <input
             type="radio"
             checked={value.isExempt}
-            onChange={() => {
-              onChange({ ...value, isExempt: true, transferValue: "", calculatedAmount: "" })
-            }}
+            onChange={() => manual({ ...value, isExempt: true, transferValue: "", calculatedAmount: "" })}
             className="w-4 h-4 text-brand-500 focus:ring-brand-500"
           />
           <span className="font-medium text-gray-900">Exempt</span>
@@ -216,7 +250,7 @@ export function TransferTaxSection({
           </label>
           <select
             value={value.exemptReason}
-            onChange={(e) => onChange({ ...value, exemptReason: e.target.value })}
+            onChange={(e) => manual({ ...value, exemptReason: e.target.value })}
             className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
           >
             <option value="">Select reason...</option>
@@ -243,7 +277,7 @@ export function TransferTaxSection({
                 onChange={(e) => {
                   const raw = e.target.value.replace(/[^0-9]/g, "")
                   const formatted = raw ? parseInt(raw).toLocaleString() : ""
-                  onChange({ ...value, transferValue: formatted })
+                  manual({ ...value, transferValue: formatted })
                 }}
                 placeholder="500,000"
                 className="w-full pl-8 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
@@ -257,7 +291,7 @@ export function TransferTaxSection({
               <input
                 type="radio"
                 checked={value.basis === "full_value"}
-                onChange={() => onChange({ ...value, basis: "full_value" })}
+                onChange={() => manual({ ...value, basis: "full_value" })}
                 className="w-4 h-4 text-brand-500"
               />
               <span className="text-sm text-gray-700">Full value</span>
@@ -266,7 +300,7 @@ export function TransferTaxSection({
               <input
                 type="radio"
                 checked={value.basis === "less_liens"}
-                onChange={() => onChange({ ...value, basis: "less_liens" })}
+                onChange={() => manual({ ...value, basis: "less_liens" })}
                 className="w-4 h-4 text-brand-500"
               />
               <span className="text-sm text-gray-700">Less liens/encumbrances</span>
@@ -279,7 +313,7 @@ export function TransferTaxSection({
               <input
                 type="radio"
                 checked={value.areaType === "city"}
-                onChange={() => onChange({ ...value, areaType: "city" })}
+                onChange={() => manual({ ...value, areaType: "city" })}
                 className="w-4 h-4 text-brand-500"
               />
               <span className="text-sm text-gray-700">
@@ -290,7 +324,7 @@ export function TransferTaxSection({
               <input
                 type="radio"
                 checked={value.areaType === "unincorporated"}
-                onChange={() => onChange({ ...value, areaType: "unincorporated" })}
+                onChange={() => manual({ ...value, areaType: "unincorporated" })}
                 className="w-4 h-4 text-brand-500"
               />
               <span className="text-sm text-gray-700">Unincorporated</span>

--- a/frontend/src/features/builder/DeedBuilder.tsx
+++ b/frontend/src/features/builder/DeedBuilder.tsx
@@ -15,6 +15,7 @@ import {
   buildProvenancePayload,
   collectCandidateFields,
 } from '@/lib/provenance';
+import { isDttSuggestionPending } from '@/lib/dttSuggestions';
 
 interface DeedBuilderProps {
   deedType: string;
@@ -61,6 +62,10 @@ function DeedBuilderInner({ deedType, initialProperty }: DeedBuilderProps) {
   // generation until confirmed. The gate sits in front of the save →
   // render → store pipeline: a gated deed never renders, never hashes.
   const [confirmationNeeded, setConfirmationNeeded] = useState<CandidateField[] | null>(null);
+  // Ticket TT: an undecided DTT suggestion is surfaced in the panel as a
+  // decision to make (with a link back to the section) — NEVER a
+  // confirm-all item. Confirm-all must never accept a legal choice.
+  const [dttNotePending, setDttNotePending] = useState(false);
 
   const stampConfirmed = (s: DeedBuilderState, keys: MaterialFieldKey[]): DeedBuilderState => {
     let next = s;
@@ -100,8 +105,10 @@ function DeedBuilderInner({ deedType, initialProperty }: DeedBuilderProps) {
 
   const handleGenerate = () => {
     const candidates = collectCandidateFields(state);
-    if (candidates.length > 0) {
+    const dttPending = isDttSuggestionPending(state);
+    if (candidates.length > 0 || dttPending) {
       setConfirmationNeeded(candidates);
+      setDttNotePending(dttPending);
       return;
     }
     performGenerate(state);
@@ -115,16 +122,27 @@ function DeedBuilderInner({ deedType, initialProperty }: DeedBuilderProps) {
       setConfirmationNeeded(remaining);
     } else {
       setConfirmationNeeded(null);
+      setDttNotePending(false);
       performGenerate(next);
     }
   };
 
   const handleConfirmAll = () => {
     if (!confirmationNeeded) return;
+    // Stamps DATA fields only. A pending DTT suggestion is deliberately left
+    // untouched — generating without deciding means the deed carries only
+    // what the officer entered, never the unaccepted proposal.
     const next = stampConfirmed(state, confirmationNeeded.map((c) => c.key));
     setState(next);
     setConfirmationNeeded(null);
+    setDttNotePending(false);
     performGenerate(next);
+  };
+
+  const handleReviewTransferTax = () => {
+    setConfirmationNeeded(null);
+    setDttNotePending(false);
+    setExpandedSection('transferTax');
   };
 
   const performGenerate = async (genState: DeedBuilderState) => {
@@ -207,16 +225,41 @@ function DeedBuilderInner({ deedType, initialProperty }: DeedBuilderProps) {
 
       {/* Generation gate: unconfirmed material fields must be confirmed
           before the deed renders and freezes as an immutable PDF. */}
-      {confirmationNeeded && confirmationNeeded.length > 0 && (
+      {confirmationNeeded && (confirmationNeeded.length > 0 || dttNotePending) && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
           <div className="w-full max-w-lg bg-white rounded-xl shadow-2xl p-6">
             <h2 className="text-lg font-semibold text-gray-900 mb-1">
-              {confirmationNeeded.length} field{confirmationNeeded.length === 1 ? '' : 's'} need{confirmationNeeded.length === 1 ? 's' : ''} confirmation
+              {confirmationNeeded.length > 0
+                ? `${confirmationNeeded.length} field${confirmationNeeded.length === 1 ? '' : 's'} need${confirmationNeeded.length === 1 ? 's' : ''} confirmation`
+                : 'Transfer tax decision pending'}
             </h2>
-            <p className="text-sm text-gray-500 mb-4">
-              These values were pulled from external records. Confirm each one is
-              correct before the deed is generated — the generated document is final.
-            </p>
+            {confirmationNeeded.length > 0 && (
+              <p className="text-sm text-gray-500 mb-4">
+                These values were pulled from external records. Confirm each one is
+                correct before the deed is generated — the generated document is final.
+              </p>
+            )}
+
+            {/* Ticket TT: a pending legal-choice suggestion is a DECISION,
+                not a confirmable value — link back to the section only. */}
+            {dttNotePending && (
+              <div className="p-3 mb-3 rounded-lg border-2 border-dashed border-violet-300 bg-violet-50">
+                <p className="text-sm text-gray-900 font-medium">
+                  A suggested transfer-tax exemption is awaiting your decision.
+                </p>
+                <p className="text-xs text-gray-600 mt-1">
+                  It will not be applied unless you accept it in the Transfer Tax
+                  section. Generating now uses only what you entered.
+                </p>
+                <button
+                  type="button"
+                  onClick={handleReviewTransferTax}
+                  className="mt-2 text-sm font-medium text-violet-700 hover:text-violet-900 underline"
+                >
+                  Review transfer tax section
+                </button>
+              </div>
+            )}
 
             <div className="space-y-3 max-h-72 overflow-y-auto">
               {confirmationNeeded.map(({ key, label, field }) => (
@@ -243,7 +286,10 @@ function DeedBuilderInner({ deedType, initialProperty }: DeedBuilderProps) {
             <div className="flex items-center justify-end gap-3 mt-5">
               <button
                 type="button"
-                onClick={() => setConfirmationNeeded(null)}
+                onClick={() => {
+                  setConfirmationNeeded(null);
+                  setDttNotePending(false);
+                }}
                 className="text-sm text-gray-500 hover:text-gray-700 px-3 py-2"
               >
                 Cancel
@@ -253,7 +299,7 @@ function DeedBuilderInner({ deedType, initialProperty }: DeedBuilderProps) {
                 onClick={handleConfirmAll}
                 className="bg-[#7C4DFF] hover:bg-[#6a3de8] text-white px-4 py-2 rounded-lg text-sm font-semibold"
               >
-                Confirm all &amp; generate
+                {confirmationNeeded.length > 0 ? 'Confirm all & generate' : 'Generate as entered'}
               </button>
             </div>
           </div>

--- a/frontend/src/lib/dttSuggestions.ts
+++ b/frontend/src/lib/dttSuggestions.ts
@@ -1,0 +1,112 @@
+/**
+ * Deterministic transfer-tax exemption detection (Ticket TT).
+ *
+ * Pattern-matches builder state against clearly recognizable CA R&T
+ * exemption fact patterns. Detection PROPOSES only — nothing here writes
+ * builder state. The explanation must cite the specific builder facts that
+ * triggered the match. If nothing matches confidently, return null — never
+ * guess. No LLM involved: the treatment logic is fully deterministic.
+ */
+import type { DTTData, DeedBuilderState } from '@/types/builder';
+
+export interface DttSuggestion {
+  codeSection: string;      // e.g. 'R&T 11927'
+  title: string;
+  explanation: string;      // grounded in the actual builder facts
+  /** The treatment applied to state ONLY if the officer accepts. */
+  proposed: Pick<DTTData, 'isExempt' | 'exemptReason'>;
+}
+
+const overlapName = (a: string, b: string): string | null => {
+  const parts = a.toUpperCase().replace(/,/g, ' ').split(/\s+/).filter(w => w.length > 2 && w !== 'AND' && w !== 'THE');
+  return parts.find(w => b.toUpperCase().includes(w)) ?? null;
+};
+
+export function detectDttSuggestion(
+  deedType: string,
+  grantor: string,
+  grantee: string,
+): DttSuggestion | null {
+  const g1 = (grantor || '').trim();
+  const g2 = (grantee || '').trim();
+
+  // ── Interspousal transfer: the deed type itself is the fact pattern ──
+  if (deedType === 'interspousal-transfer') {
+    return {
+      codeSection: 'R&T 11927',
+      title: 'Interspousal transfer exemption',
+      explanation:
+        'This deed is an Interspousal Transfer Deed. Transfers between spouses ' +
+        'are exempt from documentary transfer tax under Revenue & Taxation Code ' +
+        '§11927. This suggestion is based solely on the deed type you selected.',
+      proposed: { isExempt: true, exemptReason: 'R&T 11927' },
+    };
+  }
+
+  // ── Transfer into the grantor's own revocable trust ──────────────────
+  if (g1 && g2 && (g2.toUpperCase().includes('TRUST') || g2.toUpperCase().includes('TRUSTEE'))) {
+    const shared = overlapName(g1, g2);
+    if (shared) {
+      return {
+        codeSection: 'R&T 11930',
+        title: 'Transfer to own revocable trust',
+        explanation:
+          `The grantee "${g2}" is a trust, and it shares the name "${shared}" with ` +
+          `the grantor "${g1}". A transfer by a grantor into their own revocable ` +
+          'trust is exempt under Revenue & Taxation Code §11930 because beneficial ' +
+          'ownership does not change.',
+        proposed: { isExempt: true, exemptReason: 'R&T 11930' },
+      };
+    }
+    return null; // trust grantee without a name link: not confident — never guess
+  }
+
+  // ── Transfer out of a trust to a same-named beneficiary ───────────────
+  if (g1 && g2 && (g1.toUpperCase().includes('TRUST') || g1.toUpperCase().includes('TRUSTEE'))) {
+    const shared = overlapName(g2, g1);
+    if (shared) {
+      return {
+        codeSection: 'R&T 11930',
+        title: 'Distribution from trust to beneficiary',
+        explanation:
+          `The grantor "${g1}" is a trust sharing the name "${shared}" with the ` +
+          `grantee "${g2}". A distribution from a revocable trust back to the ` +
+          'trustor/beneficiary is exempt under Revenue & Taxation Code §11930.',
+        proposed: { isExempt: true, exemptReason: 'R&T 11930' },
+      };
+    }
+    return null;
+  }
+
+  // ── Identical grantor and grantee: no change in ownership ─────────────
+  if (g1 && g2 && g1.toUpperCase() === g2.toUpperCase()) {
+    return {
+      codeSection: 'R&T 11911',
+      title: 'No change in ownership',
+      explanation:
+        `The grantor and grantee are identical ("${g1}"), indicating a name ` +
+        'correction or confirmation with no consideration. Zero-consideration ' +
+        'transfers have no documentary transfer tax basis under Revenue & ' +
+        'Taxation Code §11911.',
+      proposed: { isExempt: true, exemptReason: 'R&T 11911' },
+    };
+  }
+
+  return null;
+}
+
+/**
+ * A suggestion is "pending" when it was surfaced but the officer has neither
+ * accepted it, dismissed it, nor overridden it with a manual entry (any
+ * manual DTT edit records a dttDecision). The generation panel surfaces this
+ * as a decision to make — never as a confirm-all item.
+ */
+export function isDttSuggestionPending(
+  state: Pick<DeedBuilderState, 'deedType' | 'grantor' | 'grantee' | 'dttDecision' | 'dttSuggestionDismissed'>,
+): boolean {
+  return (
+    !!detectDttSuggestion(state.deedType, state.grantor, state.grantee) &&
+    !state.dttDecision &&
+    !state.dttSuggestionDismissed
+  );
+}

--- a/frontend/src/lib/provenance.ts
+++ b/frontend/src/lib/provenance.ts
@@ -84,16 +84,33 @@ export function collectCandidateFields(state: DeedBuilderState): CandidateField[
  * Snapshot of who-confirmed-what-when for the generation payload; persisted
  * into deeds.metadata.provenance next to the stored PDF's hash.
  */
+export interface ProvenanceEntry {
+  source: string;
+  confirmed_at: string | null;
+  code_section?: string;
+  basis?: string;
+}
+
 export function buildProvenancePayload(
   state: DeedBuilderState,
-): Record<string, { source: string; confirmed_at: string | null }> {
-  const payload: Record<string, { source: string; confirmed_at: string | null }> = {};
+): Record<string, ProvenanceEntry> {
+  const payload: Record<string, ProvenanceEntry> = {};
   const keys: MaterialFieldKey[] = [...PROPERTY_KEYS, 'grantor'];
   for (const key of keys) {
     const field = materialFieldProvenance(state, key);
     if (field) {
       payload[key] = { source: field.source, confirmed_at: field.confirmedAt ?? null };
     }
+  }
+  // Legal-choice record (Ticket TT): the officer's transfer-tax instruction,
+  // with the code section and basis exactly as shown when they decided.
+  if (state.dttDecision) {
+    payload.dtt = {
+      source: state.dttDecision.source,
+      confirmed_at: state.dttDecision.confirmedAt ?? null,
+      ...(state.dttDecision.codeSection ? { code_section: state.dttDecision.codeSection } : {}),
+      ...(state.dttDecision.basis ? { basis: state.dttDecision.basis } : {}),
+    };
   }
   return payload;
 }

--- a/frontend/src/types/builder.ts
+++ b/frontend/src/types/builder.ts
@@ -5,8 +5,23 @@
  * confirms; we record the confirmation. AI/auto-fill never silently writes a
  * confirmed legal value.
  */
-export type FieldSource = 'sitex' | 'google' | 'user' | 'titlepoint';
+export type FieldSource = 'sitex' | 'google' | 'user' | 'titlepoint' | 'ai_suggested';
 export type FieldStatus = 'candidate' | 'confirmed';
+
+/**
+ * Record of a LEGAL CHOICE (e.g. the DTT exemption). The rule differs from
+ * data fields: a legal choice is never auto-applied and never exists in
+ * 'candidate' state inside the deed. The AI may propose; the field stays
+ * unset until the escrow officer explicitly accepts; acceptance IS the
+ * authorized instruction, recorded with the code section and basis shown.
+ */
+export interface LegalChoiceRecord {
+  source: FieldSource;       // 'ai_suggested' (accepted proposal) | 'user' (manual entry)
+  status: 'confirmed';       // legal choices are only ever recorded as confirmed
+  confirmedAt: string;       // ISO timestamp of the officer's action
+  codeSection?: string;      // e.g. 'R&T 11927' — the section proposed/accepted
+  basis?: string;            // the plain-English basis shown to the officer
+}
 
 export interface Sourced<T> {
   value: T;
@@ -66,6 +81,10 @@ export interface DeedBuilderState {
   grantee: string;
   vesting: string;
   dtt: DTTData | null;
+  /** The officer's recorded transfer-tax instruction (Ticket TT). */
+  dttDecision?: LegalChoiceRecord;
+  /** Officer dismissed the pending DTT suggestion (reject leaves manual entry). */
+  dttSuggestionDismissed?: boolean;
   requestedBy: string;
   returnTo: string;
   titleOrderNo?: string;


### PR DESCRIPTION
## Summary

Ticket TT — the legal-choice half of the two-tier rule, on the documentary transfer tax exemption. The rule inverts from data fields: **never auto-applied, never candidate-state inside the deed.** The AI detects and explains; the fields stay unset until the officer explicitly accepts; acceptance is the recorded, authorized instruction.

**The headline find:** the pre-existing `TransferTaxSection` was *already crossing the line this ticket draws* — on "high-confidence" matches it silently prefilled `isExempt` + `exemptReason` with no officer action (`useEffect` auto-apply). That behavior is removed; initialization is now always neutral.

**What shipped:**
1. **Deterministic detection** (`lib/dttSuggestions.ts`, no LLM): interspousal deed type → R&T 11927; transfer to/from the grantor's own trust via name-overlap → R&T 11930; identical grantor/grantee → R&T 11911. Every explanation cites the specific builder facts that triggered it (deed type, the shared name, the actual party strings). Trust grantee with no name link → `null` — never guess.
2. **The decision gate:** a dashed-violet **"PROPOSED — NOT APPLIED"** card (visually distinct from the amber candidate-data affordance), with `Accept & apply` and `Dismiss — I'll decide manually`. Nothing touches builder state until Accept.
3. **Recording:** Accept → `LegalChoiceRecord {source:'ai_suggested', status:'confirmed', confirmedAt, codeSection, basis}` (`FieldSource` extended); any manual DTT edit → `{source:'user', confirmedAt}`; derived recalculation and neutral init record **nothing**. The record flows into `deeds.metadata.provenance.dtt` beside the data-field records and the stored PDF's sha256.
4. **Generation interplay:** an undecided suggestion appears in the gate panel as a *decision to make* — dashed-violet note with a "Review transfer tax section" link — never a confirm-all item. **Confirm-all stamps data fields only and can never accept a legal choice.** With no candidates and only the pending note, the button reads "Generate as entered" — the deed carries only what the officer entered.

## Verification (ticket checklist)
- ✅ 12 new Jest tests: all three detection patterns + the never-guess case, the pending lifecycle (surfaced/accepted/dismissed/manually-overridden), and all three provenance payload shapes (ai_suggested with code+basis, user without, absent when undecided). Full frontend suite: **35/35 green.**
- ✅ `tsc` error count identical to `main`'s measured baseline (verified by stash-compare on a clean tree — zero new errors). Note: today's true baseline measures 114, not the 110 recorded in T10's PR; the delta is a measurement artifact between branches, not new debt from either PR.
- ✅ No backend changes; OpenAPI route surface untouched (the existing `provenance` Dict pass-through carries the new record).

## Out of scope, flagged not touched
Vesting suggestions (next ticket, same pattern), ValidationPanel split, recorder-specific DTT formatting, name-shadowing bug, LLM infrastructure. `ai-helpers.ts`'s now-orphaned `getTransferTaxSuggestion` left in place for the vesting ticket to consolidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_