### PR TITLE
feat(templates): notary acknowledgment page verified + blank-form rule enforced (Ticket N)

### DIFF
--- a/backend/services/deed_pdf.py
+++ b/backend/services/deed_pdf.py
@@ -94,12 +94,15 @@ def build_context_from_row(row):
     }
 
 
-def render_deed_pdf(row) -> bytes:
+def render_deed_html(row) -> str:
     template_name = TEMPLATE_BY_DEED_TYPE.get(
         (row.get("deed_type") or "").strip().lower(), DEFAULT_TEMPLATE
     )
-    html = _env.get_template(template_name).render(**build_context_from_row(row))
-    return render_pdf(html)
+    return _env.get_template(template_name).render(**build_context_from_row(row))
+
+
+def render_deed_pdf(row) -> bytes:
+    return render_pdf(render_deed_html(row))
 
 
 def ensure_deed_pdfs_table(conn):

--- a/backend/tests/test_deed_pdf.py
+++ b/backend/tests/test_deed_pdf.py
@@ -77,3 +77,43 @@ def test_render_produces_pdf_bytes_for_every_mapped_deed_type():
         pdf = render_deed_pdf(minimal_row(deed_type=deed_type))
         assert pdf[:5] == b"%PDF-", f"{deed_type} did not render a PDF"
         assert len(pdf) > 1000
+
+
+# ── Ticket N: California all-purpose acknowledgment page (CC §1189) ──
+
+VERBATIM_1189 = (
+    "A notary public or other officer completing this certificate verifies only "
+    "the identity of the individual who signed the document to which this "
+    "certificate is attached, and not the truthfulness, accuracy, or validity "
+    "of that document."
+)
+
+
+def _normalized(html):
+    import re as _re
+    return _re.sub(r"\s+", " ", html)
+
+
+def test_acknowledgment_page_on_all_five_deed_types():
+    from services.deed_pdf import render_deed_html
+    for deed_type in ("grant-deed", "quitclaim-deed", "interspousal-transfer",
+                      "warranty-deed", "tax-deed"):
+        html = render_deed_html(minimal_row(deed_type=deed_type))
+        assert "California All-Purpose Acknowledgment" in html, deed_type
+        # CC 1189(a)(8): the disclaimer must appear verbatim (whitespace-normalized).
+        assert VERBATIM_1189 in _normalized(html), deed_type
+        assert "County of" in html, deed_type
+
+
+def test_acknowledgment_body_is_blank_except_county():
+    """We generate the form, never its contents: the notary's certificate
+    fields (date, notary name, signer name) must be blank lines; only the
+    venue county pre-fills from builder state."""
+    from services.deed_pdf import render_deed_html
+    html = render_deed_html(minimal_row())
+    ack = html[html.index("California All-Purpose Acknowledgment"):]
+    body = ack[ack.index("personally appeared"):ack.index("who proved")]
+    assert "JOHN DOE" not in body  # signer name never pre-filled
+    assert "____" in body          # blank line present for the notary
+    venue = ack[ack.index("County of"):ack.index("County of") + 200]
+    assert "Los Angeles" in venue  # county pre-fills from builder state

--- a/templates/_partials/notary_acknowledgment.jinja2
+++ b/templates/_partials/notary_acknowledgment.jinja2
@@ -296,10 +296,13 @@
     <!-- ACKNOWLEDGMENT BODY -->
     <div class="notary-body">
         <p>
-            On <span class="notary-field short">____________________</span> before me, 
-            <span class="notary-field long">________________________________________</span>, 
-            a Notary Public, personally appeared 
-            <span class="notary-field extra-long">{{ grantors_text or '____________________________________________' }}</span>,
+            {# Ticket N: the certificate body is the NOTARY's to complete — we
+               generate the form, never its contents. Only the venue county
+               pre-fills; the signer name line stays blank. #}
+            On <span class="notary-field short">____________________</span> before me,
+            <span class="notary-field long">________________________________________</span>,
+            a Notary Public, personally appeared
+            <span class="notary-field extra-long">____________________________________________</span>,
         </p>
         <p>
             who proved to me on the basis of satisfactory evidence to be the person(s) whose name(s) 


### PR DESCRIPTION
## Summary

Ticket N. Investigation-first result: the CC §1189 acknowledgment page **already existed** — `templates/_partials/notary_acknowledgment.jinja2`, included by all five `*_ca` deed templates, with the §1189(a)(8) disclaimer box verbatim, the State-of-California/County venue, certification, signature and seal areas, and the optional section.

**One real defect against the ticket's rule, now fixed:** the certificate's *"personally appeared ____"* line pre-filled the signer's name from `grantors_text`. That's certificate **contents** — the notary's to complete, never ours to generate. The prefill is removed; the line is a blank rule like the date and notary-name fields. Only the **venue county** pre-fills from builder state (per spec). The optional non-certificate section keeps the document-title description (it describes our form, not the notary's act).

**Testable seam:** `render_deed_html` factored out of `render_deed_pdf` (byte-identical pipeline; sha256/immutability unchanged).

## Verification (ticket checklist)
- ✅ All five deed types render the acknowledgment page — asserted in tests.
- ✅ Disclaimer text **verbatim per CC §1189(a)(8)** — whitespace-normalized exact-string assertion.
- ✅ Certificate body blank of any signer name; county pre-filled — both asserted.
- ✅ 41/41 backend tests green (six-flow snapshot unaffected — it checks PDF validity, not bytes); OpenAPI surface untouched; blocking CI runs on this PR.

## Out of scope, untouched
RON, notary data entry, recorder margin-rule changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_