### PR TITLE
feat(builder): two-stage pre-generate validation — substantive vs recorder preflight (Ticket V)

### DIFF
--- a/frontend/src/__tests__/deedValidation.test.ts
+++ b/frontend/src/__tests__/deedValidation.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for the two-stage pre-generate validation (Ticket V).
+ * Each check must be triggerable in isolation.
+ */
+import { describe, expect, it } from '@jest/globals';
+import {
+  evaluateRecorderPreflight,
+  evaluateSubstantive,
+  unresolvedPreflight,
+} from '@/lib/deedValidation';
+import { buildPreflightOverridesPayload } from '@/lib/provenance';
+import type { DeedBuilderState, PropertyData } from '@/types/builder';
+
+const property: PropertyData = {
+  address: '123 Main St', city: 'Los Angeles', county: 'Los Angeles',
+  state: 'CA', zip: '90001', apn: '1234-567-890',
+  legalDescription: 'LOT 1', owner: 'JOHN DOE',
+};
+
+const complete = (overrides: Partial<DeedBuilderState> = {}): DeedBuilderState => ({
+  deedType: 'grant-deed',
+  property,
+  grantor: 'JOHN DOE',
+  grantee: 'MARY JONES',
+  vesting: 'a single woman',
+  dtt: {
+    isExempt: false, exemptReason: '', transferValue: '500,000',
+    calculatedAmount: '550.00', basis: 'full_value', areaType: 'city', cityName: 'Los Angeles',
+  },
+  dttDecision: { source: 'user', status: 'confirmed', confirmedAt: '2026-07-23T00:00:00Z' },
+  requestedBy: 'Acme Escrow',
+  returnTo: 'grantee',
+  ...overrides,
+});
+
+const failing = (id: string, checks: { id: string; ok: boolean }[]) =>
+  checks.filter((c) => !c.ok).map((c) => c.id).includes(id);
+
+describe('substantive readiness — each check triggers in isolation', () => {
+  it('fully complete state passes every substantive check', () => {
+    expect(evaluateSubstantive(complete()).every((c) => c.ok)).toBe(true);
+  });
+
+  it.each([
+    ['grantor_present', { grantor: '' }],
+    ['grantee_present', { grantee: '' }],
+    ['legal_description_present', { property: { ...property, legalDescription: '' } }],
+    ['vesting_stated', { vesting: '' }],
+    ['dtt_decided', { dtt: null, dttDecision: undefined }],
+  ] as const)('%s fails alone', (id, override) => {
+    const results = evaluateSubstantive(complete(override as Partial<DeedBuilderState>));
+    expect(failing(id, results)).toBe(true);
+    expect(results.filter((c) => !c.ok)).toHaveLength(1);
+  });
+
+  it('surfaces the TT pending-decision state on dtt_decided', () => {
+    const results = evaluateSubstantive(complete({
+      deedType: 'interspousal-transfer',   // triggers the suggestion
+      dttDecision: undefined,
+    }));
+    const dtt = results.find((c) => c.id === 'dtt_decided')!;
+    expect(dtt.ok).toBe(false);
+    expect(dtt.detail).toContain('awaiting your decision');
+    expect(dtt.detail).toContain('will not be applied unless you accept');
+  });
+
+  it('legacy drafts: complete DTT with no record and no pending suggestion counts as decided', () => {
+    const results = evaluateSubstantive(complete({ dttDecision: undefined }));
+    expect(results.find((c) => c.id === 'dtt_decided')!.ok).toBe(true);
+  });
+});
+
+describe('recorder preflight — formatting class, never legal sufficiency', () => {
+  it('complete state passes all preflight checks', () => {
+    expect(evaluateRecorderPreflight(complete()).every((c) => c.ok)).toBe(true);
+  });
+
+  it.each([
+    ['apn_present', { property: { ...property, apn: '' } }],
+    ['county_set', { property: { ...property, county: '' } }],
+    ['return_address', { returnTo: '', requestedBy: '' }],
+  ] as const)('%s fails alone', (id, override) => {
+    const results = evaluateRecorderPreflight(complete(override as Partial<DeedBuilderState>));
+    expect(failing(id, results)).toBe(true);
+    expect(results.filter((c) => !c.ok)).toHaveLength(1);
+  });
+
+  it('static template facts (acknowledgment page, page setup) always pass', () => {
+    const results = evaluateRecorderPreflight(complete({ property: null }));
+    expect(results.find((c) => c.id === 'acknowledgment_page')!.ok).toBe(true);
+    expect(results.find((c) => c.id === 'page_setup')!.ok).toBe(true);
+  });
+});
+
+describe('overrides', () => {
+  it('an override resolves a failing preflight item', () => {
+    const s = complete({ property: { ...property, apn: '' } });
+    expect(unresolvedPreflight(s).map((c) => c.id)).toEqual(['apn_present']);
+    const overridden = { ...s, preflightOverrides: { apn_present: '2026-07-23T09:00:00Z' } };
+    expect(unresolvedPreflight(overridden)).toHaveLength(0);
+  });
+
+  it('override is recorded in the payload with its timestamp', () => {
+    const payload = buildPreflightOverridesPayload(complete({
+      preflightOverrides: { apn_present: '2026-07-23T09:00:00Z' },
+    }));
+    expect(payload).toEqual({ apn_present: { overridden_at: '2026-07-23T09:00:00Z' } });
+  });
+
+  it('no overrides -> nothing recorded', () => {
+    expect(buildPreflightOverridesPayload(complete())).toBeNull();
+  });
+});

--- a/frontend/src/components/builder/ValidationPanel.tsx
+++ b/frontend/src/components/builder/ValidationPanel.tsx
@@ -1,154 +1,130 @@
 "use client"
 
-import { CheckCircle, AlertCircle, AlertTriangle, Info } from "lucide-react"
-import { useAIAssist } from "@/contexts/AIAssistContext"
-import { validateDeedData, type ValidationIssue } from "@/lib/ai-helpers"
-import type { DeedBuilderState } from "@/types/builder"
+// Ticket V: two-stage pre-generate checklist. Substantive readiness and
+// recorder preflight are DIFFERENT QUESTIONS rendered as distinct, labeled
+// sections — never conflate recorder acceptance with legal sufficiency.
+// Copy here must not imply legal validity.
+import { AlertTriangle, ArrowRight, CheckCircle, ShieldAlert } from "lucide-react"
+import type { CheckResult } from "@/lib/deedValidation"
 
 interface ValidationPanelProps {
-  state: DeedBuilderState
-  onJumpToSection?: (section: string) => void
+  substantive: CheckResult[]
+  preflight: CheckResult[]
+  overrides: Record<string, string>
+  onOverride: (id: string) => void
+  onNavigate: (sectionId: string) => void
 }
 
-export function ValidationPanel({ state, onJumpToSection }: ValidationPanelProps) {
-  const { enabled: aiEnabled } = useAIAssist()
-
-  // Don't show validation if AI is disabled
-  if (!aiEnabled) return null
-
-  const issues = validateDeedData(state)
-
-  const errors = issues.filter((i) => i.level === "error")
-  const warnings = issues.filter((i) => i.level === "warning")
-  const infos = issues.filter((i) => i.level === "info")
-
-  // All good!
-  if (issues.length === 0) {
-    return (
-      <div className="flex items-center gap-2 text-sm text-emerald-600 bg-emerald-50 px-3 py-2 rounded-lg mb-3">
-        <CheckCircle className="w-4 h-4" />
-        <span>All sections look good</span>
-      </div>
-    )
-  }
-
+function CheckRow({
+  check,
+  overriddenAt,
+  onOverride,
+  onNavigate,
+  overridable,
+}: {
+  check: CheckResult
+  overriddenAt?: string
+  onOverride?: (id: string) => void
+  onNavigate: (sectionId: string) => void
+  overridable: boolean
+}) {
+  const resolved = check.ok || !!overriddenAt
   return (
-    <div className="space-y-2 mb-3">
-      {/* Errors - Red */}
-      {errors.map((issue, i) => (
-        <ValidationItem
-          key={`error-${i}`}
-          issue={issue}
-          icon={<AlertCircle className="w-4 h-4 text-red-500" />}
-          bgColor="bg-red-50"
-          borderColor="border-red-200"
-          textColor="text-red-800"
-          subtextColor="text-red-600"
-          onJump={onJumpToSection}
-        />
-      ))}
-
-      {/* Warnings - Amber */}
-      {warnings.map((issue, i) => (
-        <ValidationItem
-          key={`warning-${i}`}
-          issue={issue}
-          icon={<AlertTriangle className="w-4 h-4 text-amber-500" />}
-          bgColor="bg-amber-50"
-          borderColor="border-amber-200"
-          textColor="text-amber-800"
-          subtextColor="text-amber-600"
-          onJump={onJumpToSection}
-        />
-      ))}
-
-      {/* Info - Blue */}
-      {infos.map((issue, i) => (
-        <ValidationItem
-          key={`info-${i}`}
-          issue={issue}
-          icon={<Info className="w-4 h-4 text-blue-500" />}
-          bgColor="bg-blue-50"
-          borderColor="border-blue-200"
-          textColor="text-blue-800"
-          subtextColor="text-blue-600"
-          onJump={onJumpToSection}
-        />
-      ))}
+    <div
+      className={`flex items-start justify-between gap-3 px-3 py-2 rounded-md ${
+        check.ok ? "bg-emerald-50" : overriddenAt ? "bg-gray-50" : overridable ? "bg-yellow-50" : "bg-red-50"
+      }`}
+    >
+      <div className="min-w-0">
+        <div className="flex items-center gap-1.5">
+          {resolved ? (
+            <CheckCircle className={`w-4 h-4 ${check.ok ? "text-emerald-600" : "text-gray-400"}`} />
+          ) : overridable ? (
+            <AlertTriangle className="w-4 h-4 text-yellow-600" />
+          ) : (
+            <ShieldAlert className="w-4 h-4 text-red-600" />
+          )}
+          <span className="text-sm font-medium text-gray-900">{check.label}</span>
+          {overriddenAt && (
+            <span className="text-xs text-gray-500">
+              overridden {new Date(overriddenAt).toLocaleString()}
+            </span>
+          )}
+        </div>
+        {!resolved && check.detail && (
+          <p className="text-xs text-gray-600 mt-0.5">{check.detail}</p>
+        )}
+      </div>
+      {!resolved && (
+        <div className="flex items-center gap-2 flex-shrink-0">
+          {check.sectionId && (
+            <button
+              type="button"
+              onClick={() => onNavigate(check.sectionId!)}
+              className="inline-flex items-center gap-1 text-xs font-medium text-brand-600 hover:text-brand-800"
+            >
+              Fix <ArrowRight className="w-3 h-3" />
+            </button>
+          )}
+          {overridable && onOverride && (
+            <button
+              type="button"
+              onClick={() => onOverride(check.id)}
+              className="text-xs font-medium text-yellow-800 border border-yellow-400 rounded px-2 py-1 hover:bg-yellow-100"
+              title="Proceed despite this formatting warning; your override is recorded with the deed."
+            >
+              Override
+            </button>
+          )}
+        </div>
+      )}
     </div>
   )
 }
 
-interface ValidationItemProps {
-  issue: ValidationIssue
-  icon: React.ReactNode
-  bgColor: string
-  borderColor: string
-  textColor: string
-  subtextColor: string
-  onJump?: (section: string) => void
-}
-
-function ValidationItem({
-  issue,
-  icon,
-  bgColor,
-  borderColor,
-  textColor,
-  subtextColor,
-  onJump,
-}: ValidationItemProps) {
+export function ValidationPanel({
+  substantive,
+  preflight,
+  overrides,
+  onOverride,
+  onNavigate,
+}: ValidationPanelProps) {
   return (
-    <button
-      onClick={() => onJump?.(issue.section)}
-      className={`
-        w-full flex items-start gap-2 p-2 ${bgColor} border ${borderColor} rounded-lg text-sm text-left
-        hover:opacity-90 transition-opacity
-      `}
-    >
-      <div className="mt-0.5 flex-shrink-0">{icon}</div>
-      <div className="flex-1 min-w-0">
-        <p className={`font-medium ${textColor}`}>{issue.message}</p>
-        {issue.suggestion && <p className={subtextColor}>{issue.suggestion}</p>}
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-1.5">
+          Substantive readiness
+        </h3>
+        <div className="space-y-1.5">
+          {substantive.map((c) => (
+            <CheckRow key={c.id} check={c} onNavigate={onNavigate} overridable={false} />
+          ))}
+        </div>
       </div>
-    </button>
+
+      <div>
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-1.5">
+          Recorder preflight (formatting)
+        </h3>
+        <div className="space-y-1.5">
+          {preflight.map((c) => (
+            <CheckRow
+              key={c.id}
+              check={c}
+              overriddenAt={overrides[c.id]}
+              onOverride={onOverride}
+              onNavigate={onNavigate}
+              overridable
+            />
+          ))}
+        </div>
+      </div>
+
+      <p className="text-[11px] text-gray-400 leading-snug">
+        These checks verify document completeness and common recorder formatting
+        conventions. They are not legal advice, and passing them does not
+        determine the legal validity or effect of the transfer.
+      </p>
+    </div>
   )
 }
-
-// Compact version - just shows count
-export function ValidationSummary({ state }: { state: DeedBuilderState }) {
-  const { enabled: aiEnabled } = useAIAssist()
-
-  if (!aiEnabled) return null
-
-  const issues = validateDeedData(state)
-  const errors = issues.filter((i) => i.level === "error").length
-  const warnings = issues.filter((i) => i.level === "warning").length
-
-  if (errors === 0 && warnings === 0) {
-    return (
-      <span className="flex items-center gap-1 text-xs text-emerald-600">
-        <CheckCircle className="w-3 h-3" />
-        Ready
-      </span>
-    )
-  }
-
-  return (
-    <span className="flex items-center gap-2 text-xs">
-      {errors > 0 && (
-        <span className="flex items-center gap-1 text-red-600">
-          <AlertCircle className="w-3 h-3" />
-          {errors}
-        </span>
-      )}
-      {warnings > 0 && (
-        <span className="flex items-center gap-1 text-amber-600">
-          <AlertTriangle className="w-3 h-3" />
-          {warnings}
-        </span>
-      )}
-    </span>
-  )
-}
-

--- a/frontend/src/features/builder/DeedBuilder.tsx
+++ b/frontend/src/features/builder/DeedBuilder.tsx
@@ -10,12 +10,17 @@ import { PreviewPanel } from '@/components/builder/PreviewPanel';
 import { useBuilderMode } from '@/hooks/useBuilderMode';
 import { DeedBuilderState, PropertyData, Sourced } from '@/types/builder';
 import {
-  CandidateField,
   MaterialFieldKey,
+  buildPreflightOverridesPayload,
   buildProvenancePayload,
   collectCandidateFields,
 } from '@/lib/provenance';
-import { isDttSuggestionPending } from '@/lib/dttSuggestions';
+import {
+  evaluateRecorderPreflight,
+  evaluateSubstantive,
+  unresolvedPreflight,
+} from '@/lib/deedValidation';
+import { ValidationPanel } from '@/components/builder/ValidationPanel';
 
 interface DeedBuilderProps {
   deedType: string;
@@ -57,15 +62,21 @@ function DeedBuilderInner({ deedType, initialProperty }: DeedBuilderProps) {
     setState(prev => ({ ...prev, ...updates }));
   }, []);
 
-  // The generation gate: material sourced data fields (apn, legal
-  // description, owner, grantor) still in 'candidate' status block
-  // generation until confirmed. The gate sits in front of the save →
-  // render → store pipeline: a gated deed never renders, never hashes.
-  const [confirmationNeeded, setConfirmationNeeded] = useState<CandidateField[] | null>(null);
-  // Ticket TT: an undecided DTT suggestion is surfaced in the panel as a
-  // decision to make (with a link back to the section) — NEVER a
-  // confirm-all item. Confirm-all must never accept a legal choice.
-  const [dttNotePending, setDttNotePending] = useState(false);
+  // The generation gate (Tickets B + TT + V): sits in front of the save →
+  // render → store pipeline — a gated deed never renders, never hashes.
+  // Three groups, three doctrines:
+  //   1. Candidate DATA fields — confirmable (confirm-all allowed).
+  //   2. Substantive readiness — must be completed; hard block, fix links.
+  //      (Ticket V: an undecided DTT suggestion fails 'Transfer tax decided'
+  //      here — a decision to make, never a confirm-all item.)
+  //   3. Recorder preflight — formatting warnings, explicitly overridable;
+  //      overrides are recorded in metadata like other confirmations.
+  const [gateOpen, setGateOpen] = useState(false);
+
+  const gateBlocked = (s: DeedBuilderState): boolean =>
+    collectCandidateFields(s).length > 0 ||
+    evaluateSubstantive(s).some((c) => !c.ok) ||
+    unresolvedPreflight(s).length > 0;
 
   const stampConfirmed = (s: DeedBuilderState, keys: MaterialFieldKey[]): DeedBuilderState => {
     let next = s;
@@ -104,11 +115,8 @@ function DeedBuilderInner({ deedType, initialProperty }: DeedBuilderProps) {
   };
 
   const handleGenerate = () => {
-    const candidates = collectCandidateFields(state);
-    const dttPending = isDttSuggestionPending(state);
-    if (candidates.length > 0 || dttPending) {
-      setConfirmationNeeded(candidates);
-      setDttNotePending(dttPending);
+    if (gateBlocked(state)) {
+      setGateOpen(true);
       return;
     }
     performGenerate(state);
@@ -117,32 +125,33 @@ function DeedBuilderInner({ deedType, initialProperty }: DeedBuilderProps) {
   const handleConfirmField = (key: MaterialFieldKey) => {
     const next = stampConfirmed(state, [key]);
     setState(next);
-    const remaining = collectCandidateFields(next);
-    if (remaining.length > 0) {
-      setConfirmationNeeded(remaining);
-    } else {
-      setConfirmationNeeded(null);
-      setDttNotePending(false);
+    if (!gateBlocked(next)) {
+      setGateOpen(false);
       performGenerate(next);
     }
   };
 
   const handleConfirmAll = () => {
-    if (!confirmationNeeded) return;
-    // Stamps DATA fields only. A pending DTT suggestion is deliberately left
-    // untouched — generating without deciding means the deed carries only
-    // what the officer entered, never the unaccepted proposal.
-    const next = stampConfirmed(state, confirmationNeeded.map((c) => c.key));
+    // Stamps DATA fields only — never a substantive item, never a legal
+    // choice, never a preflight override.
+    const next = stampConfirmed(state, collectCandidateFields(state).map((c) => c.key));
     setState(next);
-    setConfirmationNeeded(null);
-    setDttNotePending(false);
-    performGenerate(next);
+    if (!gateBlocked(next)) {
+      setGateOpen(false);
+      performGenerate(next);
+    }
   };
 
-  const handleReviewTransferTax = () => {
-    setConfirmationNeeded(null);
-    setDttNotePending(false);
-    setExpandedSection('transferTax');
+  const handleOverridePreflight = (id: string) => {
+    setState((prev) => ({
+      ...prev,
+      preflightOverrides: { ...prev.preflightOverrides, [id]: new Date().toISOString() },
+    }));
+  };
+
+  const handleNavigateFromGate = (sectionId: string) => {
+    setGateOpen(false);
+    setExpandedSection(sectionId);
   };
 
   const performGenerate = async (genState: DeedBuilderState) => {
@@ -173,7 +182,12 @@ function DeedBuilderInner({ deedType, initialProperty }: DeedBuilderProps) {
         },
         // Who-confirmed-what-when, persisted into deeds.metadata.provenance
         // alongside the stored PDF's hash.
-        provenance: buildProvenancePayload(genState),
+        provenance: {
+          ...buildProvenancePayload(genState),
+          ...(buildPreflightOverridesPayload(genState)
+            ? { preflight_overrides: buildPreflightOverridesPayload(genState) }
+            : {}),
+        },
       };
 
       const response = await fetch('/api/deeds/generate', {
@@ -225,86 +239,100 @@ function DeedBuilderInner({ deedType, initialProperty }: DeedBuilderProps) {
 
       {/* Generation gate: unconfirmed material fields must be confirmed
           before the deed renders and freezes as an immutable PDF. */}
-      {confirmationNeeded && (confirmationNeeded.length > 0 || dttNotePending) && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
-          <div className="w-full max-w-lg bg-white rounded-xl shadow-2xl p-6">
-            <h2 className="text-lg font-semibold text-gray-900 mb-1">
-              {confirmationNeeded.length > 0
-                ? `${confirmationNeeded.length} field${confirmationNeeded.length === 1 ? '' : 's'} need${confirmationNeeded.length === 1 ? 's' : ''} confirmation`
-                : 'Transfer tax decision pending'}
-            </h2>
-            {confirmationNeeded.length > 0 && (
+      {gateOpen && (() => {
+        const candidates = collectCandidateFields(state);
+        const substantive = evaluateSubstantive(state);
+        const preflight = evaluateRecorderPreflight(state);
+        const overrides = state.preflightOverrides ?? {};
+        const substantiveBlocked = substantive.some((c) => !c.ok);
+        const preflightBlocked = unresolvedPreflight(state).length > 0;
+        const primaryLabel = candidates.length > 0 ? 'Confirm all & generate' : 'Generate';
+        const primaryDisabled = substantiveBlocked || (candidates.length === 0 && preflightBlocked);
+        return (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
+            <div className="w-full max-w-xl bg-white rounded-xl shadow-2xl p-6 max-h-[85vh] overflow-y-auto">
+              <h2 className="text-lg font-semibold text-gray-900 mb-1">Ready to generate?</h2>
               <p className="text-sm text-gray-500 mb-4">
-                These values were pulled from external records. Confirm each one is
-                correct before the deed is generated — the generated document is final.
+                The generated document is final and stored immutably. Resolve the
+                items below first.
               </p>
-            )}
 
-            {/* Ticket TT: a pending legal-choice suggestion is a DECISION,
-                not a confirmable value — link back to the section only. */}
-            {dttNotePending && (
-              <div className="p-3 mb-3 rounded-lg border-2 border-dashed border-violet-300 bg-violet-50">
-                <p className="text-sm text-gray-900 font-medium">
-                  A suggested transfer-tax exemption is awaiting your decision.
-                </p>
-                <p className="text-xs text-gray-600 mt-1">
-                  It will not be applied unless you accept it in the Transfer Tax
-                  section. Generating now uses only what you entered.
-                </p>
-                <button
-                  type="button"
-                  onClick={handleReviewTransferTax}
-                  className="mt-2 text-sm font-medium text-violet-700 hover:text-violet-900 underline"
-                >
-                  Review transfer tax section
-                </button>
-              </div>
-            )}
+              <ValidationPanel
+                substantive={substantive}
+                preflight={preflight}
+                overrides={overrides}
+                onOverride={handleOverridePreflight}
+                onNavigate={handleNavigateFromGate}
+              />
 
-            <div className="space-y-3 max-h-72 overflow-y-auto">
-              {confirmationNeeded.map(({ key, label, field }) => (
-                <div key={key} className="p-3 bg-amber-50 border border-amber-200 rounded-lg">
-                  <div className="flex items-center justify-between gap-3">
-                    <div className="min-w-0">
-                      <p className="text-xs font-medium text-amber-700 uppercase tracking-wide">
-                        {label} · {SOURCE_LABELS[field.source] || field.source}
-                      </p>
-                      <p className="text-sm text-gray-900 break-words">{field.value}</p>
-                    </div>
-                    <button
-                      type="button"
-                      onClick={() => handleConfirmField(key)}
-                      className="flex-shrink-0 bg-emerald-600 text-white px-3 py-1.5 rounded-md text-sm font-medium hover:bg-emerald-700"
-                    >
-                      Confirm
-                    </button>
+              {candidates.length > 0 && (
+                <div className="mt-4">
+                  <h3 className="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-1.5">
+                    External data awaiting confirmation
+                  </h3>
+                  <div className="space-y-2 max-h-60 overflow-y-auto">
+                    {candidates.map(({ key, label, field }) => (
+                      <div key={key} className="p-3 bg-amber-50 border border-amber-200 rounded-lg">
+                        <div className="flex items-center justify-between gap-3">
+                          <div className="min-w-0">
+                            <p className="text-xs font-medium text-amber-700 uppercase tracking-wide">
+                              {label} · {SOURCE_LABELS[field.source] || field.source}
+                            </p>
+                            <p className="text-sm text-gray-900 break-words">{field.value}</p>
+                          </div>
+                          <button
+                            type="button"
+                            onClick={() => handleConfirmField(key)}
+                            className="flex-shrink-0 bg-emerald-600 text-white px-3 py-1.5 rounded-md text-sm font-medium hover:bg-emerald-700"
+                          >
+                            Confirm
+                          </button>
+                        </div>
+                      </div>
+                    ))}
                   </div>
                 </div>
-              ))}
-            </div>
+              )}
 
-            <div className="flex items-center justify-end gap-3 mt-5">
-              <button
-                type="button"
-                onClick={() => {
-                  setConfirmationNeeded(null);
-                  setDttNotePending(false);
-                }}
-                className="text-sm text-gray-500 hover:text-gray-700 px-3 py-2"
-              >
-                Cancel
-              </button>
-              <button
-                type="button"
-                onClick={handleConfirmAll}
-                className="bg-[#7C4DFF] hover:bg-[#6a3de8] text-white px-4 py-2 rounded-lg text-sm font-semibold"
-              >
-                {confirmationNeeded.length > 0 ? 'Confirm all & generate' : 'Generate as entered'}
-              </button>
+              <div className="flex items-center justify-end gap-3 mt-5">
+                <button
+                  type="button"
+                  onClick={() => setGateOpen(false)}
+                  className="text-sm text-gray-500 hover:text-gray-700 px-3 py-2"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  disabled={primaryDisabled}
+                  onClick={() => {
+                    if (candidates.length > 0) {
+                      handleConfirmAll();
+                    } else if (!gateBlocked(state)) {
+                      setGateOpen(false);
+                      performGenerate(state);
+                    }
+                  }}
+                  className={`px-4 py-2 rounded-lg text-sm font-semibold text-white ${
+                    primaryDisabled
+                      ? 'bg-gray-300 cursor-not-allowed'
+                      : 'bg-[#7C4DFF] hover:bg-[#6a3de8]'
+                  }`}
+                  title={
+                    substantiveBlocked
+                      ? 'Complete the substantive items first'
+                      : preflightBlocked && candidates.length === 0
+                        ? 'Fix or override the preflight items first'
+                        : undefined
+                  }
+                >
+                  {primaryLabel}
+                </button>
+              </div>
             </div>
           </div>
-        </div>
-      )}
+        );
+      })()}
     </div>
   );
 }

--- a/frontend/src/lib/deedValidation.ts
+++ b/frontend/src/lib/deedValidation.ts
@@ -1,0 +1,120 @@
+/**
+ * Two-stage pre-generate validation (Ticket V).
+ *
+ * Stage 1 — SUBSTANTIVE READINESS: is the document complete as a document
+ * (parties, legal description, transfer-tax decision, vesting)? Failures
+ * block generation like unconfirmed data.
+ *
+ * Stage 2 — RECORDER PREFLIGHT (CA / LA County formatting conventions):
+ * will the recorder's intake likely accept the formatting? Failures are
+ * warnings the officer may explicitly override; overrides are recorded in
+ * metadata like other confirmations.
+ *
+ * Doctrine: never conflate recorder acceptance with legal sufficiency.
+ * Copy in this module must not imply legal validity — these are
+ * completeness and formatting checks, not legal advice.
+ */
+import type { DeedBuilderState } from '@/types/builder';
+import { isDttSuggestionPending } from '@/lib/dttSuggestions';
+
+export interface CheckResult {
+  id: string;
+  label: string;
+  ok: boolean;
+  detail?: string;
+  /** Builder section to open when the officer clicks through to fix it. */
+  sectionId?: string;
+}
+
+const dttComplete = (state: DeedBuilderState): boolean => {
+  const dtt = state.dtt;
+  if (!dtt) return false;
+  return (dtt.isExempt && !!dtt.exemptReason) || !!dtt.transferValue;
+};
+
+export function evaluateSubstantive(state: DeedBuilderState): CheckResult[] {
+  const pending = isDttSuggestionPending(state);
+  // Decided = a recorded instruction exists, or (legacy drafts predating the
+  // decision record) the section is complete with no suggestion pending.
+  const dttDecided = !!state.dttDecision || (dttComplete(state) && !pending);
+  return [
+    {
+      id: 'grantor_present',
+      label: 'Grantor stated',
+      ok: !!state.grantor?.trim(),
+      sectionId: 'grantor',
+    },
+    {
+      id: 'grantee_present',
+      label: 'Grantee stated',
+      ok: !!state.grantee?.trim(),
+      sectionId: 'grantee',
+    },
+    {
+      id: 'legal_description_present',
+      label: 'Legal description present',
+      ok: !!state.property?.legalDescription?.trim(),
+      sectionId: 'property',
+    },
+    {
+      id: 'vesting_stated',
+      label: 'Vesting stated',
+      ok: !!state.vesting?.trim(),
+      sectionId: 'vesting',
+    },
+    {
+      id: 'dtt_decided',
+      label: 'Transfer tax decided',
+      ok: dttDecided,
+      detail: pending
+        ? 'A suggested exemption is awaiting your decision. It will not be applied unless you accept it.'
+        : dttDecided ? undefined : 'Enter the transfer-tax treatment or exemption.',
+      sectionId: 'transferTax',
+    },
+  ];
+}
+
+export function evaluateRecorderPreflight(state: DeedBuilderState): CheckResult[] {
+  return [
+    {
+      id: 'apn_present',
+      label: 'APN present',
+      ok: !!state.property?.apn?.trim(),
+      detail: 'Recorder intake conventions expect an Assessor’s Parcel Number.',
+      sectionId: 'property',
+    },
+    {
+      id: 'county_set',
+      label: 'County set',
+      ok: !!state.property?.county?.trim(),
+      sectionId: 'property',
+    },
+    {
+      id: 'return_address',
+      label: 'Return address block',
+      ok: !!state.returnTo?.trim() || !!state.requestedBy?.trim(),
+      detail: 'The "when recorded mail to" block should identify a recipient.',
+      sectionId: 'recording',
+    },
+    {
+      id: 'acknowledgment_page',
+      label: 'Acknowledgment page (CC §1189)',
+      ok: true, // included by every deed template (Ticket N); static template fact
+      detail: 'Included automatically in the generated document.',
+    },
+    {
+      id: 'page_setup',
+      label: 'Page size and recorder box',
+      ok: true, // letter size + recorder-box margins are fixed in the templates
+      detail: 'Letter size with recorder-box clearance per template.',
+    },
+  ];
+}
+
+/** Preflight failures that the officer has not explicitly overridden. */
+export function unresolvedPreflight(
+  state: DeedBuilderState,
+): CheckResult[] {
+  const overrides = state.preflightOverrides ?? {};
+  return evaluateRecorderPreflight(state).filter((c) => !c.ok && !overrides[c.id]);
+}

--- a/frontend/src/lib/provenance.ts
+++ b/frontend/src/lib/provenance.ts
@@ -114,3 +114,20 @@ export function buildProvenancePayload(
   }
   return payload;
 }
+
+/**
+ * Recorder-preflight overrides (Ticket V): id -> {overridden_at}. Included in
+ * the generation payload beside the field/legal-choice records so the stored
+ * deed carries the officer's explicit acknowledgments.
+ */
+export function buildPreflightOverridesPayload(
+  state: DeedBuilderState,
+): Record<string, { overridden_at: string }> | null {
+  const overrides = state.preflightOverrides;
+  if (!overrides || Object.keys(overrides).length === 0) return null;
+  const out: Record<string, { overridden_at: string }> = {};
+  for (const [id, ts] of Object.entries(overrides)) {
+    out[id] = { overridden_at: ts };
+  }
+  return out;
+}

--- a/frontend/src/types/builder.ts
+++ b/frontend/src/types/builder.ts
@@ -85,6 +85,12 @@ export interface DeedBuilderState {
   dttDecision?: LegalChoiceRecord;
   /** Officer dismissed the pending DTT suggestion (reject leaves manual entry). */
   dttSuggestionDismissed?: boolean;
+  /**
+   * Recorder-preflight warnings the officer explicitly overrode, id -> ISO
+   * timestamp of the override (Ticket V). Recorded in metadata like other
+   * confirmations.
+   */
+  preflightOverrides?: Record<string, string>;
   requestedBy: string;
   returnTo: string;
   titleOrderNo?: string;


### PR DESCRIPTION
## Summary

Ticket V. *Legally complete* and *recordable* are now visually and mechanically different questions in the generation gate — per the doctrine that recorder acceptance must never be conflated with legal sufficiency.

**Stage 1 — Substantive readiness (hard block, per-item Fix links):** grantor, grantee, legal description, vesting, and **transfer tax decided** — Ticket TT's pending-suggestion state surfaces here as the reason `dtt_decided` fails, with copy reiterating the suggestion will never be applied without acceptance. Legacy drafts with complete DTT and no decision record (pre-TT) count as decided.

**Stage 2 — Recorder preflight (warnings with explicit override):** APN, county, return-address block, acknowledgment page (from Ticket N), page setup — the last two are static template facts rendered as passing context. Each failing item requires an individual, deliberate **Override** click; overrides are recorded as `{id → ISO timestamp}` and persisted into `deeds.metadata.provenance.preflight_overrides` beside the field and legal-choice records.

**The orphaned `ValidationPanel` is finally alive** — rewritten as the two-labeled-sections renderer and wired into the live gate (it had zero importers since the original audit). Disclaimer copy: completeness/formatting checks only, not legal advice, no bearing on legal validity.

**Confirm-all discipline holds:** it stamps candidate *data* fields only — never a substantive item, never a legal choice, never an override. Panel lists recompute live as items are resolved.

**Flagged supersession:** TT's "Generate as entered" escape for an undecided DTT suggestion is replaced by V's substantive block, per this ticket's spec (`dtt_decided` is substantive readiness).

## Verification (ticket checklist)
- ✅ 16 new Jest tests: every check triggerable **in isolation** (parameterized single-failure assertions), TT pending surfacing, static-fact passes, override resolution, and override payload recording with timestamp. **51/51 frontend tests green.**
- ✅ `tsc` at the 114 baseline; zero errors in touched files.
- ✅ No backend changes; OpenAPI route surface untouched; blocking CI runs on this PR.

## Out of scope, untouched
Recorder-specific margin rules beyond the template's static facts; vesting suggestions; `validateDeedData` in `ai-helpers.ts` (now fully orphaned — flagged for consolidation in the vesting ticket).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_