### PR TITLE
docs: standing execution policy wired into every agent entry point (Ticket P)

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,19 @@
+# Cursor agent rules — digest only
+
+Read docs/EXECUTION_POLICY.md before executing any ticket. It is the single
+canonical policy; do not rely on this digest alone.
+
+- Tier 1: free inside a ticket; re-run every gate yourself before reporting.
+- Tier 2: continue to the next approved ticket ONLY if the finished one had
+  zero deviations, zero discoveries, and all gates green; otherwise stop
+  and report. When in doubt, treat it as Tier 3.
+- Tier 3 (owner-only): DROP TABLE / irreversible data operations;
+  credentials (Render env vars only — never commit or paste them);
+  deploy-topology changes; production click-throughs; anything touching
+  money or customer communication.
+- Flag letter-vs-intent deviations and hold for review; never silently
+  decide them either way.
+- Never weaken CI (no `|| true`); keep the OpenAPI route contract and
+  six-flow baseline green without re-recording; tsc error count (114) may
+  only go down. Legal choices are never auto-applied — suggest, confirm,
+  record.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,16 @@
+# Agent execution digest
+
+**Read `docs/EXECUTION_POLICY.md` before executing any ticket — it is the
+canonical policy; this is only the digest.**
+
+- Tier 1: free inside a ticket; re-verify your own gates before reporting.
+- Tier 2: auto-proceed to the next approved ticket ONLY on zero deviations,
+  zero discoveries, all gates green. Otherwise stop and report.
+- Tier 3 (owner-only, never delegated): DROP TABLE / irreversible data ops;
+  credentials (env vars on Render only, never committed or pasted);
+  deploy-topology changes; production click-throughs; money or customer
+  communication.
+- Deviation doctrine: letter-vs-intent conflicts are flagged and held —
+  never silently decided in either direction.
+- Invariants: blocking CI (no `|| true`), OpenAPI + six-flow baselines stay
+  green, tsc baseline only goes down. Legal choices are never auto-applied.

--- a/README.md
+++ b/README.md
@@ -55,4 +55,8 @@ App at http://localhost:3000. Register/login stores a JWT (localStorage + cookie
 - **External partner API** → Render `deedpro-external-api`: `uvicorn external_api.app:app`
 - **DB** → Render Postgres `deedpro-db`
 
-CI in `.github/workflows/` (note: `ci.yml` steps are non-blocking `|| true`; `test.yml` still pins Python 3.8 vs. the 3.11 runtime).
+CI in `.github/workflows/` — blocking: backend tests (incl. the OpenAPI route contract), frontend build, plus a non-blocking `tsc` report job.
+
+## For agents & contributors
+
+All agent work in this repo — from any tool — is governed by [`docs/EXECUTION_POLICY.md`](docs/EXECUTION_POLICY.md). Read it before executing any ticket.

--- a/docs/EXECUTION_POLICY.md
+++ b/docs/EXECUTION_POLICY.md
@@ -1,0 +1,84 @@
+# Execution Policy — canonical
+
+> This document governs all agent work in this repository, from any tool
+> (Claude Code, Cursor, or anything else). It is the single source of truth;
+> `CLAUDE.md` and `.cursorrules` carry only a digest and a pointer here.
+> Established 2026-07-23 (Ticket P), distilled from the three-week cleanup
+> and launch-set execution record (PRs #17–#36).
+
+## Autonomy tiers
+
+**Tier 1 — Free inside a ticket.** Build, self-review, independently re-run
+all gates, recap. Every ticket ends with the executing agent re-verifying its
+own gate conditions before reporting. When work is delegated, the T8 pattern
+applies: the executor verifies, then the orchestrator independently
+re-verifies — a gate is not "passed" on one party's word.
+
+**Tier 2 — Conditional auto-proceed across tickets.** Rolling into the next
+approved ticket without waiting is permitted only when the completed ticket
+had **zero deviations, zero discoveries, zero surprises, and all gates
+green**. Any flagged item, any "interesting find," any letter-vs-intent
+judgment → stop and report instead. When in doubt, it's Tier 3.
+
+**Tier 3 — Owner gates, never delegated.**
+- `DROP TABLE` and any irreversible data operation (dumps first, drops by
+  the owner's hand or explicit per-statement approval).
+- Credentials: never committed, never pasted into any agent session —
+  environment variables on Render only. Uploaded documents containing
+  secrets get redacted before anything is committed.
+- Deploy-topology changes (start commands, service layout, root dirs).
+- Production click-throughs.
+- Anything touching money or customer communication.
+
+## Deviation doctrine
+
+Letter-vs-intent deviations are **flagged and held for review, never
+silently decided in either direction** — neither silent compliance with a
+letter that violates the intent, nor silent improvisation past the letter.
+Precedents, both correct *because they were flagged*: the
+StorageClient→Postgres BYTEA storage call (T2 — ephemeral disk would have
+silently violated the immutability requirement) and the flat-import call
+(T8 — `backend.`-prefixing would have forced a deploy-topology change
+mid-refactor). Recorded correction: `dtt_decided` (Ticket V) superseding
+Ticket TT's "Generate as entered" — an undecided DTT was a path to a
+substantively incomplete deed; the legal-choice doctrine was unchanged.
+
+## Ticket protocol
+
+- One concern per PR.
+- Tickets name the agent type, verification steps, and explicit
+  out-of-scope items ("flag, don't touch").
+- Stop-and-report gates are non-negotiable.
+- Evidence claims carry `file:line` citations.
+
+## Verification invariants
+
+- Honest CI stays blocking. No `|| true`, ever again.
+- The OpenAPI route-contract test and the six-flow behavioral baseline
+  (`backend/scripts/six_flow_baseline.py`) must stay green. Neither is
+  re-recorded to make a failure pass without an approved, documented reason
+  in the PR that re-records it.
+- The frontend `tsc` error baseline (currently **114**) may only go down.
+
+## Product doctrine (the why)
+
+**The two-tier rule.**
+- *Data fields* (APN, legal description, owner, grantor) carry `Sourced<T>`
+  provenance and gate at generation with confirm-all; unstamped SiteX-loaded
+  values are candidates, user-typed values are confirmed on entry.
+- *Legal choices* (transfer-tax exemption, vesting) are **never
+  auto-applied, never candidate-state inside the deed**. They gate at the
+  point of decision by explicit officer acceptance and are recorded as the
+  authorized instruction with source, timestamp, and the basis text the
+  officer was shown. Suggest → confirm → record; the system proposes, the
+  officer decides, we keep the record.
+- *We generate the form, never its contents*: fields that belong to another
+  party's legal act (e.g. the notary's certificate) are rendered blank.
+
+**Immutability.** Generated PDFs are rendered once, stored once, and
+sha256-stamped; `deeds.metadata.provenance` carries the
+who-confirmed-what-when(-told-what) record beside the hash. Downloads
+stream the stored bytes.
+
+**Any code change that would violate these is wrong even if requested —
+flag it.**


### PR DESCRIPTION
## Summary

Ticket P. `docs/EXECUTION_POLICY.md` becomes the single canonical governance document for all agent work in this repo, from any tool. Contents per spec: the three autonomy tiers (with the T8 executor-verifies/orchestrator-re-verifies pattern in Tier 1 and the full Tier-3 owner-only list), the deviation doctrine with its two precedents plus the blessed `dtt_decided` supersession recorded as a correction, the ticket protocol, the verification invariants (blocking CI forever, OpenAPI + six-flow baselines never re-recorded without documented approval, tsc baseline 114 only goes down), and the product doctrine — the two-tier rule, form-never-contents, and PDF immutability — with the standing instruction that violating changes are wrong even if requested.

**Entry points (digest + pointer only, so the policy has one home and can't drift):**
- `CLAUDE.md` (new, repo root) — ~10-line digest for Claude agents.
- `.cursorrules` (new, repo root) — same digest phrased for Cursor agents.
- `README.md` — one-line agents section pointing at the canonical doc.

**Rode-along accuracy fix, flagged per protocol:** README's closing CI sentence still described the pre-T9 `|| true` era; it now describes the blocking CI. Docs-only, no policy content beyond spec.

## Verification
- All three entry-point files reference `docs/EXECUTION_POLICY.md`; no duplicated full text.
- Docs-only change; blocking CI runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_