### PR TITLE
fix(users): un-shadow database.get_user_profile — two endpoints work again

### DIFF
--- a/backend/routers/property_cache_routes.py
+++ b/backend/routers/property_cache_routes.py
@@ -1,9 +1,6 @@
 """Property cache + AI deed-suggestion endpoints (T8 split — moved verbatim from main.py).
 
-NOTE on ``get_user_profile``: in the pre-split main.py the /users/profile
-route handler shadowed the ``database.get_user_profile`` import, so these
-endpoints called the route handler (a coroutine function) rather than the
-database helper. That handler now lives in routers.users_auth and is
+get_user_profile here is the real database helper (name-shadowing fixed).
 imported from there to preserve the exact pre-split behavior.
 """
 from fastapi import APIRouter, Body, Depends, HTTPException, Query
@@ -12,7 +9,7 @@ import db  # noqa: F401  (kept for parity with the other split routers)
 from ai_assist import suggest_defaults, validate_deed_data
 from auth import get_current_user_id
 from database import get_cached_property, cache_property_data, get_recent_properties
-from routers.users_auth import get_user_profile
+from database import get_user_profile
 
 router = APIRouter()
 

--- a/backend/routers/users_auth.py
+++ b/backend/routers/users_auth.py
@@ -1,9 +1,8 @@
 """User auth/profile/billing-session endpoints (T8 split — moved verbatim from main.py).
 
 NOTE: the /users/profile handler below is intentionally named
-``get_user_profile`` and (exactly as in the pre-split main.py) shadows the
-``database.get_user_profile`` import for everything defined after it —
-including the /users/profile/enhanced endpoints. Do not "fix" this here;
+the route handler was renamed get_user_profile_endpoint so it no longer
+shadows the database.get_user_profile helper (name-shadowing fix).
 it is the preserved pre-split behavior.
 """
 import os
@@ -213,7 +212,7 @@ async def login_user(credentials: UserLogin = Body(...)):
         raise HTTPException(status_code=500, detail=f"Login failed: {str(e)}")
 
 @router.get("/users/profile")
-async def get_user_profile(user_id: int = Depends(get_current_user_id)):
+async def get_user_profile_endpoint(user_id: int = Depends(get_current_user_id)):
     """Get current user's profile information"""
     try:
         if not db.conn:

--- a/backend/tests/test_name_shadowing_fix.py
+++ b/backend/tests/test_name_shadowing_fix.py
@@ -1,0 +1,21 @@
+"""The name-shadowing fix: /users/profile/enhanced and /ai/deed-suggestions
+must call database.get_user_profile (the DB helper), not the /users/profile
+route handler that used to shadow it (returning an un-awaited coroutine)."""
+import inspect
+
+import database
+from routers import property_cache_routes, users_auth
+
+
+def test_both_modules_bind_the_database_helper():
+    assert users_auth.get_user_profile is database.get_user_profile
+    assert property_cache_routes.get_user_profile is database.get_user_profile
+    assert not inspect.iscoroutinefunction(users_auth.get_user_profile)
+
+
+def test_users_profile_route_still_registered():
+    from main import app
+    routes = {(m, r.path) for r in app.routes for m in (getattr(r, "methods", None) or set())}
+    assert ("GET", "/users/profile") in routes
+    assert ("GET", "/users/profile/enhanced") in routes
+    assert ("POST", "/ai/deed-suggestions") in routes


### PR DESCRIPTION
## Summary

The approved name-shadowing fix (flagged during T8, preserved byte-identically there per its behavioral-identity gate). The `/users/profile` handler was named `get_user_profile`, shadowing the `database.get_user_profile` import — so `GET /users/profile/enhanced` and `POST /ai/deed-suggestions` were calling the **async route handler** and receiving an un-awaited coroutine: the former 500'd on `profile.get()`, the latter fed a coroutine into `suggest_defaults`. Broken since long before the split.

**Fix:** handler renamed `get_user_profile_endpoint` (route path unchanged); `property_cache_routes` imports the helper from `database` directly; shadow-preservation comments retired.

## Verification
- New tests pin the identity (`users_auth.get_user_profile is database.get_user_profile`, same for `property_cache_routes`, not-a-coroutine-function) and the three routes present.
- **43/43 backend tests green** including the OpenAPI route contract (byte-identical surface — the rename touches only the Python symbol).
- Deliberate behavior change, which is the ticket: two broken endpoints now function. Bug ledger: this was flagged item #5 from the T8 report.

## Tier-2 status
Zero deviations, zero new discoveries (the bug and mechanism were already on the ledger). Eligible to roll to the final queue item — the `backend.`-import follow-up, which per `docs/EXECUTION_POLICY.md` is **Tier 3** (deploy topology) and will end in prepare-and-report, not auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_