### PR TITLE
fix(security): real admin auth on phase23 billing + usage routers (bug #7)

### DIFF
--- a/backend/phase23_billing/router_admin.py
+++ b/backend/phase23_billing/router_admin.py
@@ -5,16 +5,16 @@ import csv, io
 
 from .deps import get_db
 from .services.revenue import get_revenue_overview, monthly_breakdown, mrr_arr
+from auth import get_current_admin
 
-router = APIRouter(prefix="/admin", tags=["admin-billing"])
-
-def require_admin():
-    # TODO: wire to real RBAC
-    return True
+# Bug #7 fix: real admin JWT enforcement at the router level — the previous
+# require_admin() was a `return True` stub (the same disease as the original
+# verify_admin(), PR #17).
+router = APIRouter(prefix="/admin", tags=["admin-billing"],
+                   dependencies=[Depends(get_current_admin)])
 
 @router.get("/revenue")
 def revenue(db: Session = Depends(get_db)):
-    require_admin()
     return {
         "overview": get_revenue_overview(db),
         "monthly_breakdown": monthly_breakdown(db),
@@ -23,7 +23,6 @@ def revenue(db: Session = Depends(get_db)):
 
 @router.get("/invoices")
 def list_invoices(limit: int = 100, db: Session = Depends(get_db)):
-    require_admin()
     rows = db.execute(text("""
         SELECT id, invoice_number, status, total_cents, amount_due_cents, invoice_pdf_url, billing_period_start, billing_period_end, created_at
         FROM invoices ORDER BY id DESC LIMIT :lim
@@ -41,7 +40,6 @@ def list_invoices(limit: int = 100, db: Session = Depends(get_db)):
 
 @router.get("/payments")
 def list_payments(limit: int = 200, db: Session = Depends(get_db)):
-    require_admin()
     rows = db.execute(text("""
         SELECT id, invoice_id, user_id, amount_cents, currency, status, stripe_fee_cents, net_amount_cents, created_at
         FROM payment_history ORDER BY id DESC LIMIT :lim
@@ -54,7 +52,6 @@ def list_payments(limit: int = 200, db: Session = Depends(get_db)):
 
 @router.get("/exports/payments.csv")
 def export_payments_csv(db: Session = Depends(get_db)):
-    require_admin()
     buf = io.StringIO()
     wr = csv.writer(buf)
     wr.writerow(["id","invoice_id","user_id","amount_cents","currency","status","stripe_fee_cents","net_amount_cents","created_at"])

--- a/backend/phase23_billing/router_usage.py
+++ b/backend/phase23_billing/router_usage.py
@@ -3,7 +3,13 @@ from sqlalchemy.orm import Session
 from sqlalchemy import text
 from .deps import get_db, get_settings
 
-router = APIRouter(prefix="/usage", tags=["usage"])
+from auth import get_current_admin
+
+# Locked down with bug #7: these metering endpoints (including billable-event
+# injection via POST /events) had no auth. No known caller uses them over
+# HTTP; internal metering calls the service functions directly.
+router = APIRouter(prefix="/usage", tags=["usage"],
+                   dependencies=[Depends(get_current_admin)])
 
 @router.post("/events")
 def log_event(event_type: str, user_id: int | None = None, api_key_prefix: str | None = None, billable: bool = False, cost_units: int = 1, unit_price_cents: int | None = None, resource_id: int | None = None, db: Session = Depends(get_db)):

--- a/backend/tests/test_admin_auth_coverage.py
+++ b/backend/tests/test_admin_auth_coverage.py
@@ -1,0 +1,52 @@
+"""Bug #7 class-killer: EVERY /admin/* and /usage/* route, across every
+router, must carry a real admin-auth dependency. This is the third time an
+always-true auth stub was found guarding admin surfaces (verify_admin in
+PR #17, phase23's require_admin here) — this test makes a fourth impossible
+to ship silently."""
+import inspect
+
+from main import app
+import auth
+from routers import admin_partners
+
+
+REAL_ADMIN_DEPS = {auth.get_current_admin, admin_partners.require_admin}
+
+
+def flatten_dependencies(dependant, acc=None):
+    acc = acc if acc is not None else set()
+    for dep in dependant.dependencies:
+        if dep.call is not None:
+            acc.add(dep.call)
+        flatten_dependencies(dep, acc)
+    return acc
+
+
+def admin_routes():
+    for route in app.routes:
+        path = getattr(route, "path", "")
+        if path.startswith("/admin") or path.startswith("/usage"):
+            if getattr(route, "dependant", None) is not None:
+                yield route
+
+
+def test_every_admin_and_usage_route_has_real_admin_auth():
+    unprotected = []
+    for route in admin_routes():
+        deps = flatten_dependencies(route.dependant)
+        if not (deps & REAL_ADMIN_DEPS):
+            unprotected.append(sorted(route.methods)[0] + " " + route.path)
+    assert not unprotected, (
+        "Routes lacking real admin auth (get_current_admin or "
+        f"admin_partners.require_admin): {unprotected}"
+    )
+
+
+def test_the_guards_are_not_stubs():
+    # A guard that never touches its arguments or raises is the disease.
+    for guard in REAL_ADMIN_DEPS:
+        source = inspect.getsource(guard)
+        assert "return True" not in source, f"{guard.__name__} looks like a stub"
+        assert "403" in source or "HTTPException" in source, (
+            f"{guard.__name__} never rejects anyone"
+        )


### PR DESCRIPTION
## Summary

Bug #7 from the admin investigation — security riding alone per policy.

`phase23_billing/router_admin.py` guarded `/admin/revenue`, `/admin/invoices`, `/admin/payments`, and the payments CSV with a `require_admin()` that was a bare `return True` — the same always-true-stub disease as the original `verify_admin()` (PR #17), one router over. Worse: because phase23 registers **first**, its unauthenticated `/admin/revenue` is the handler that *wins the path* — the admin Revenue tab has been served by an endpoint anyone could call.

**Fixes:**
- Both phase23 routers now enforce `Depends(get_current_admin)` at the **router level**; the stub is deleted.
- **Flagged same-class discovery, fixed in the same pass:** `router_usage.py`'s metering endpoints — including billable-event injection via `POST /usage/events` — had no auth. No known HTTP caller exists (internal metering calls the service functions directly); locked down with the same router-level dependency.

**The class-killer, per owner instruction:** `tests/test_admin_auth_coverage.py` walks every route in the app and asserts each `/admin/*` and `/usage/*` path carries a real admin dependency (`get_current_admin` or `admin_partners.require_admin`, discovered by flattening the dependency tree) — and source-inspects the guards themselves for the `return True` pattern. A third always-true stub cannot ship silently.

## Verification
- **45/45 backend tests green**; OpenAPI route surface unchanged (auth is dependency-level, paths untouched).
- Blocking CI runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_