### PR TITLE
F1: fix the partner pipeline (dropdown blocker, bugs #12a/#12b)

### DIFF
--- a/backend/routers/partners.py
+++ b/backend/routers/partners.py
@@ -98,6 +98,32 @@ async def create_my_partner(
         raise HTTPException(status_code=500, detail=f"Failed to create partner: {str(e)}")
 
 
+# Registered BEFORE /{partner_id}: a slash-less /partners/selectlist must
+# never match the id route ('selectlist'::uuid cast). The proxy's trailing
+# slash is no longer load-bearing.
+@router.get("/selectlist/", response_model=List[Dict])
+@router.get("/selectlist", response_model=List[Dict], include_in_schema=False)
+async def get_partners_selectlist(
+    user_id: int = Depends(get_current_user_id)
+):
+    """Get simplified partner list for dropdowns (id, name, category)"""
+    try:
+        organization_id = get_user_organization(user_id)
+        partners = list_partners(organization_id, active_only=True)
+
+        # Simplify for dropdown
+        return [
+            {
+                'id': p['id'],
+                'name': p['company_name'],
+                'category': p.get('category', 'other')
+            }
+            for p in partners
+        ]
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to get partners: {str(e)}")
+
+
 @router.get("/{partner_id}", response_model=Dict)
 async def get_my_partner(
     partner_id: str,
@@ -163,25 +189,3 @@ async def delete_my_partner(
         raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to delete partner: {str(e)}")
-
-
-@router.get("/selectlist/", response_model=List[Dict])
-async def get_partners_selectlist(
-    user_id: int = Depends(get_current_user_id)
-):
-    """Get simplified partner list for dropdowns (id, name, category)"""
-    try:
-        organization_id = get_user_organization(user_id)
-        partners = list_partners(organization_id, active_only=True)
-        
-        # Simplify for dropdown
-        return [
-            {
-                'id': p['id'],
-                'name': p['company_name'],
-                'category': p.get('category', 'other')
-            }
-            for p in partners
-        ]
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Failed to get partners: {str(e)}")

--- a/backend/tests/snapshots/openapi_routes.json
+++ b/backend/tests/snapshots/openapi_routes.json
@@ -213,6 +213,10 @@
  ],
  [
   "GET",
+  "/partners/selectlist"
+ ],
+ [
+  "GET",
   "/partners/selectlist/"
  ],
  [

--- a/backend/tests/test_partners_routes.py
+++ b/backend/tests/test_partners_routes.py
@@ -1,0 +1,52 @@
+"""F1 regression: /partners/selectlist must never fall into /partners/{partner_id}.
+
+The selectlist route was registered after the id route, so any request that
+didn't carry the exact trailing slash matched /{partner_id} and died on the
+'selectlist'::uuid cast. Route order inside a FastAPI router is registration
+order — these tests pin the fixed order and both path spellings.
+"""
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from auth import get_current_user_id
+from main import app
+
+FAKE_PARTNERS = [
+    {"id": "11111111-1111-1111-1111-111111111111",
+     "company_name": "Pacific Coast Title", "category": "title"},
+]
+
+
+@pytest.fixture
+def client():
+    app.dependency_overrides[get_current_user_id] = lambda: 1
+    try:
+        yield TestClient(app)
+    finally:
+        app.dependency_overrides.pop(get_current_user_id, None)
+
+
+def _route_index(method, path):
+    for i, r in enumerate(app.routes):
+        if r.path == path and method in (getattr(r, "methods", None) or set()):
+            return i
+    raise AssertionError(f"route {method} {path} not registered")
+
+
+def test_selectlist_registered_before_partner_id():
+    id_route = _route_index("GET", "/partners/{partner_id}")
+    assert _route_index("GET", "/partners/selectlist/") < id_route
+    assert _route_index("GET", "/partners/selectlist") < id_route
+
+
+@pytest.mark.parametrize("path", ["/partners/selectlist/", "/partners/selectlist"])
+def test_selectlist_resolves_to_selectlist_handler(client, path):
+    with patch("routers.partners.list_partners", return_value=FAKE_PARTNERS):
+        res = client.get(path, headers={"Authorization": "Bearer x"})
+    assert res.status_code == 200
+    assert res.json() == [
+        {"id": "11111111-1111-1111-1111-111111111111",
+         "name": "Pacific Coast Title", "category": "title"},
+    ]

--- a/frontend/src/app/api/partners/[id]/route.ts
+++ b/frontend/src/app/api/partners/[id]/route.ts
@@ -5,6 +5,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
+import { PARTNERS_BACKEND } from '../_backend';
 
 export async function PUT(
   request: NextRequest,
@@ -15,7 +16,7 @@ export async function PUT(
     const authHeader = request.headers.get('authorization');
     const { id } = params;
     
-    const backendUrl = process.env.NEXT_PUBLIC_API_URL || 'https://deedpro-main-api.onrender.com';
+    const backendUrl = PARTNERS_BACKEND;
     const res = await fetch(`${backendUrl}/partners/${id}`, {
       method: 'PUT',
       headers: {
@@ -55,7 +56,7 @@ export async function DELETE(
     const authHeader = request.headers.get('authorization');
     const { id } = params;
     
-    const backendUrl = process.env.NEXT_PUBLIC_API_URL || 'https://deedpro-main-api.onrender.com';
+    const backendUrl = PARTNERS_BACKEND;
     const res = await fetch(`${backendUrl}/partners/${id}`, {
       method: 'DELETE',
       headers: {

--- a/frontend/src/app/api/partners/_backend.ts
+++ b/frontend/src/app/api/partners/_backend.ts
@@ -1,0 +1,10 @@
+// Single source of truth for the partners proxies' backend origin.
+// Bug #12a: the create proxy resolved NEXT_PUBLIC_API_URL while the
+// selectlist proxy resolved BACKEND_BASE_URL first — with different env
+// configs, a partner could be written to one backend and listed from
+// another. Every partners proxy imports this constant now.
+export const PARTNERS_BACKEND =
+  process.env.BACKEND_BASE_URL ||
+  process.env.NEXT_PUBLIC_BACKEND_BASE_URL ||
+  process.env.NEXT_PUBLIC_API_URL ||
+  'https://deedpro-main-api.onrender.com';

--- a/frontend/src/app/api/partners/route.ts
+++ b/frontend/src/app/api/partners/route.ts
@@ -5,6 +5,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
+import { PARTNERS_BACKEND } from './_backend';
 
 export async function POST(request: NextRequest) {
   try {
@@ -12,7 +13,7 @@ export async function POST(request: NextRequest) {
     const authHeader = request.headers.get('authorization');
     
     // Proxy to backend
-    const backendUrl = process.env.NEXT_PUBLIC_API_URL || 'https://deedpro-main-api.onrender.com';
+    const backendUrl = PARTNERS_BACKEND;
     const res = await fetch(`${backendUrl}/partners`, {
       method: 'POST',
       headers: {
@@ -53,7 +54,7 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url);
     const activeOnly = searchParams.get('active_only') || 'true';
     
-    const backendUrl = process.env.NEXT_PUBLIC_API_URL || 'https://deedpro-main-api.onrender.com';
+    const backendUrl = PARTNERS_BACKEND;
     const res = await fetch(`${backendUrl}/partners?active_only=${activeOnly}`, {
       method: 'GET',
       headers: {

--- a/frontend/src/app/api/partners/selectlist/route.ts
+++ b/frontend/src/app/api/partners/selectlist/route.ts
@@ -5,7 +5,7 @@ import { NextRequest, NextResponse } from 'next/server';
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-const API_BASE = process.env.BACKEND_BASE_URL || process.env.NEXT_PUBLIC_BACKEND_BASE_URL || process.env.NEXT_PUBLIC_API_URL || 'https://deedpro-main-api.onrender.com';
+import { PARTNERS_BACKEND as API_BASE } from '../_backend';
 
 export async function GET(req: NextRequest) {
   try {
@@ -31,16 +31,13 @@ export async function GET(req: NextRequest) {
     // Get response text
     const text = await res.text();
     
-    // If backend returns error, return empty array to unblock UI
+    // Bug #12b fix: forward the real failure — a swallowed error rendered
+    // identically to "no partners yet" and hid the actual cause.
     if (!res.ok) {
-      console.error(`[partners/selectlist] Backend error ${res.status}`);
-      return NextResponse.json([], { 
-        status: 200,
-        headers: { 
-          'content-type': 'application/json',
-          'x-partners-fallback': 'true',
-        }
-      });
+      console.error(`[partners/selectlist] Backend error ${res.status}: ${text.slice(0, 200)}`);
+      let body: unknown;
+      try { body = JSON.parse(text); } catch { body = { detail: text || `Backend returned ${res.status}` }; }
+      return NextResponse.json(body, { status: res.status });
     }
     
     // Parse response
@@ -49,13 +46,7 @@ export async function GET(req: NextRequest) {
       data = JSON.parse(text);
     } catch (parseError) {
       console.error('[partners/selectlist] JSON parse error');
-      return NextResponse.json([], { 
-        status: 200,
-        headers: { 
-          'content-type': 'application/json',
-          'x-partners-fallback': 'parse-error'
-        }
-      });
+      return NextResponse.json({ detail: 'Invalid response from partners backend' }, { status: 502 });
     }
     
     // Success - return the data
@@ -70,14 +61,6 @@ export async function GET(req: NextRequest) {
     
   } catch (e: any) {
     console.error('[partners/selectlist] Exception:', e.message);
-    
-    // Return empty array on exception to unblock UI
-    return NextResponse.json([], { 
-      status: 200,
-      headers: { 
-        'content-type': 'application/json',
-        'x-partners-fallback': 'exception',
-      }
-    });
+    return NextResponse.json({ detail: `Partners proxy error: ${e.message}` }, { status: 502 });
   }
 }

--- a/frontend/src/components/builder/sections/RecordingSection.tsx
+++ b/frontend/src/components/builder/sections/RecordingSection.tsx
@@ -19,7 +19,7 @@ export function RecordingSection({ requestedBy, returnTo, titleOrderNo, escrowNo
   const { enabled: aiEnabled } = useAIAssist();
   const [guidanceDismissed, setGuidanceDismissed] = useState(false);
   const [showAddModal, setShowAddModal] = useState(false);
-  const { partners, create: createPartner } = usePartners();
+  const { partners, create: createPartner, error: partnersError, refresh: refreshPartners } = usePartners();
   
   useEffect(() => {
     if (!requestedBy && partners.length > 0) {
@@ -110,12 +110,24 @@ export function RecordingSection({ requestedBy, returnTo, titleOrderNo, escrowNo
           </select>
         </div>
         
-        {/* Helper text for empty state */}
-        {partners.length === 0 && (
+        {/* Bug #12b: a failed partners fetch used to render exactly like an
+            empty list. Failures now surface with a retry. */}
+        {partnersError ? (
+          <div className="mt-1 flex items-center gap-2 text-xs text-red-600">
+            <span>Couldn&apos;t load your partners: {partnersError}</span>
+            <button
+              type="button"
+              onClick={() => refreshPartners()}
+              className="underline font-medium hover:text-red-800"
+            >
+              Retry
+            </button>
+          </div>
+        ) : partners.length === 0 ? (
           <p className="mt-1 text-xs text-gray-500">
-            No partners yet. Select "➕ Add New Partner" to create one.
+            No partners yet. Select &quot;➕ Add New Partner&quot; to create one.
           </p>
-        )}
+        ) : null}
       </div>
 
       {/* Add Partner Modal */}


### PR DESCRIPTION
## What

Fixes the live blocker on deed generation: the Recording step's partner dropdown could show "No partners yet" forever, even right after creating a partner.

**Bug #12a — origin split.** The three partners proxies resolved their backend origin differently: the create proxy tried `NEXT_PUBLIC_API_URL` first while the selectlist proxy tried `BACKEND_BASE_URL` first. In any deployment where those differ, a partner is created on one backend and listed from another. New `frontend/src/app/api/partners/_backend.ts` is the single resolver; all three proxies import it.

**Bug #12b — silent 200-`[]`.** The selectlist proxy swallowed every failure (backend non-OK, JSON parse error, thrown exception) into a `200 []`, so the UI rendered the empty state over real errors. Non-OK responses now forward the backend's real status + body; parse errors and exceptions return `502` with a `detail`. `RecordingSection` now surfaces the load error with a Retry button instead of showing "No partners yet" over a failure.

**Backend route shadowing.** `GET /partners/selectlist/` was registered *after* `GET /partners/{partner_id}`, so a slash-less `/partners/selectlist` matched the id route and died on the `'selectlist'::uuid` cast. The selectlist route now registers first, with a slash-less alias (hidden from the schema) so the proxy's trailing slash is no longer load-bearing.

## Route snapshot re-record (justification)

`backend/tests/snapshots/openapi_routes.json` diff is exactly one intentional addition: `["GET", "/partners/selectlist"]` — the slash-less alias. No routes removed; the reorder itself doesn't affect the sorted snapshot.

## Tests

- New `backend/tests/test_partners_routes.py`: asserts selectlist (both spellings) registers before `/{partner_id}`, and that both path spellings resolve to the selectlist handler (200 with the simplified shape).

## Gates

- Backend: 48 passed
- Six-flow behavioral baseline: all flows match ✔
- Frontend: tsc 98 errors (baseline held), jest 56 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_