### PR TITLE
F2: auto-login on registration

### DIFF
--- a/backend/routers/users_auth.py
+++ b/backend/routers/users_auth.py
@@ -116,10 +116,29 @@ async def register_user(user: UserRegister = Body(...)):
             # Don't fail registration if notification fails
             print(f"[Phase 7] ⚠️ Admin notification error (non-blocking): {notif_error}")
 
+        # F2: mint the session at registration so signup lands in the app
+        # logged in. Claims are identical to /users/login's token (sub, email,
+        # role) — same storage contract on the client, no fourth pattern.
+        access_token = create_access_token(
+            data={
+                "sub": str(new_user_id),
+                "email": user.email.lower(),
+                "role": user.role or "user"
+            }
+        )
+
         return {
             "message": "User registered successfully",
             "email": user.email,
-            "plan": "free"
+            "plan": "free",
+            "access_token": access_token,
+            "token_type": "bearer",
+            "user": {
+                "id": new_user_id,
+                "email": user.email.lower(),
+                "full_name": user.full_name,
+                "plan": "free"
+            }
         }
 
     except psycopg2.IntegrityError as ie:

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -6,6 +6,7 @@ import { useState } from "react"
 import { useRouter } from "next/navigation"
 import Link from "next/link"
 import { Eye, EyeOff, CheckCircle2, Zap, Shield } from "lucide-react"
+import { AuthManager } from "@/utils/auth"
 
 const states = [
   { code: "AL", name: "Alabama" },
@@ -176,7 +177,17 @@ export default function RegisterPage() {
       )
 
       if (response.ok) {
-        router.push(`/login?registered=true&email=${encodeURIComponent(formData.email)}`)
+        // F2: register now returns a session token (same claims as login) —
+        // store it exactly like login does and land in the app signed in.
+        const data = await response.json()
+        const token = data.access_token
+        if (token) {
+          AuthManager.setAuth(token, data.user)
+          router.push("/dashboard")
+        } else {
+          // Backend without F2 yet: fall back to the old login hand-off.
+          router.push(`/login?registered=true&email=${encodeURIComponent(formData.email)}`)
+        }
       } else {
         const errorData = await response.json()
         setError(errorData.detail || "Registration failed. Please try again.")


### PR DESCRIPTION
## What

Fixes the signup dead-end: creating an account dumped the user back on `/login` to type the same credentials again.

**Backend** — `/users/register` now mints an access token with claims **identical** to `/users/login` (`sub`, `email`, `role`) and returns the same session shape (`access_token`, `token_type`, `user{id,email,full_name,plan}`). The existing `message`/`email`/`plan` keys are kept for compatibility.

**Frontend** — the register success handler stores the session exactly the way login does — `AuthManager.setAuth` (localStorage `access_token` + `user_data` + the middleware-read `access_token` cookie; no fourth storage pattern) — then routes straight to `/dashboard`. If the backend response carries no token (stale deploy window), it falls back to the old `/login?registered=true&email=` hand-off, which still works.

## Gates

- Backend: 48 passed
- Six-flow behavioral baseline: all flows match ✔ (snapshot captures register *status* and login keys only — both unchanged, no re-record)
- Frontend: tsc 98 errors (baseline held), jest 56 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_