### PR TITLE
F3: onboarding rebuild — single county question, server-truth completion gate

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -90,6 +90,13 @@ def create_tables():
             )
         """)
         
+        # F3: server-truth onboarding flag (additive, idempotent — this runs
+        # at startup, which is how this schema is managed).
+        cursor.execute("""
+            ALTER TABLE user_profiles
+            ADD COLUMN IF NOT EXISTS onboarding_completed BOOLEAN DEFAULT FALSE
+        """)
+
         # Create property_cache table for intelligent suggestions
         cursor.execute("""
             CREATE TABLE IF NOT EXISTS property_cache (

--- a/backend/routers/users_auth.py
+++ b/backend/routers/users_auth.py
@@ -257,7 +257,25 @@ async def get_user_profile_endpoint(user_id: int = Depends(get_current_user_id))
             """, (user[8],))  # user[8] is plan
             limits = cur.fetchone()
 
+        # F3: server-truth onboarding state — the dashboard gate reads these
+        # from this response, never from localStorage alone (bug #10).
+        with db.conn.cursor() as cur:
+            cur.execute("""
+                SELECT default_county, onboarding_completed
+                FROM user_profiles WHERE user_id = %s
+            """, (user_id,))
+            prof = cur.fetchone()
+        with db.conn.cursor() as cur:
+            cur.execute("""
+                SELECT COUNT(*) FROM deeds
+                WHERE user_id = %s AND COALESCE(status, '') != 'deleted'
+            """, (user_id,))
+            total_deeds = cur.fetchone()[0]
+
         return {
+            "default_county": prof[0] if prof else None,
+            "onboarding_completed": bool(prof[1]) if prof else False,
+            "total_deeds": total_deeds,
             "id": user[0],
             "email": user[1],
             "full_name": user[2],
@@ -283,6 +301,49 @@ async def get_user_profile_endpoint(user_id: int = Depends(get_current_user_id))
     except Exception as e:
         db.conn.rollback()  # Phase 14-B: Prevent transaction cascade failures
         raise HTTPException(status_code=500, detail=f"Failed to get profile: {str(e)}")
+
+class ProfilePatch(BaseModel):
+    default_county: Optional[str] = None
+    onboarding_completed: Optional[bool] = None
+
+@router.patch("/users/profile")
+async def patch_user_profile(
+    patch: ProfilePatch = Body(...),
+    user_id: int = Depends(get_current_user_id)
+):
+    """Partial profile update (F3 — the endpoint onboarding used to PATCH
+    didn't exist, bug #9). Only touches the fields provided; unlike
+    POST /users/profile/enhanced it never clobbers unspecified columns."""
+    if patch.default_county is None and patch.onboarding_completed is None:
+        raise HTTPException(status_code=400, detail="No fields to update")
+    conn = None
+    try:
+        conn = db.get_db_connection()
+        with conn.cursor() as cur:
+            cur.execute("""
+                INSERT INTO user_profiles (user_id, default_county, onboarding_completed)
+                VALUES (%s, %s, COALESCE(%s, FALSE))
+                ON CONFLICT (user_id) DO UPDATE SET
+                    default_county = COALESCE(EXCLUDED.default_county,
+                                              user_profiles.default_county),
+                    onboarding_completed = COALESCE(%s,
+                                              user_profiles.onboarding_completed),
+                    updated_at = CURRENT_TIMESTAMP
+            """, (user_id, patch.default_county, patch.onboarding_completed,
+                  patch.onboarding_completed))
+            conn.commit()
+        return {
+            "status": "updated",
+            "default_county": patch.default_county,
+            "onboarding_completed": patch.onboarding_completed,
+        }
+    except Exception as e:
+        try:
+            if conn and not conn.closed:
+                conn.rollback()
+        except Exception as rollback_error:
+            print(f"[PROFILE PATCH ROLLBACK ERROR] {rollback_error}")
+        raise HTTPException(status_code=500, detail=f"Profile update failed: {str(e)}")
 
 @router.post("/users/upgrade")
 async def upgrade_plan(req: UpgradeRequest, user_id: int = Depends(get_current_user_id)):

--- a/backend/scripts/six_flow_baseline.py
+++ b/backend/scripts/six_flow_baseline.py
@@ -82,6 +82,12 @@ def ensure_schema(db_url):
     cur.execute("DELETE FROM deed_shares")
     cur.execute("DELETE FROM deed_pdfs") if _table_exists(cur, "deed_pdfs") else None
     cur.execute("DELETE FROM deeds")
+    # user_profiles references users (F3 onboarding writes it) — clear the
+    # baseline user's row first or the users delete hits the FK.
+    cur.execute(
+        "DELETE FROM user_profiles WHERE user_id IN (SELECT id FROM users WHERE email = %s)",
+        (BASELINE_EMAIL,),
+    )
     cur.execute("DELETE FROM users WHERE email = %s", (BASELINE_EMAIL,))
     conn.close()
 

--- a/backend/tests/snapshots/openapi_routes.json
+++ b/backend/tests/snapshots/openapi_routes.json
@@ -284,6 +284,10 @@
   "/admin/api-keys/{key_id}"
  ],
  [
+  "PATCH",
+  "/users/profile"
+ ],
+ [
   "POST",
   "/admin/api-keys"
  ],

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -24,6 +24,7 @@ function isDeedProToken(token: string): boolean {
 // Define protected routes that require authentication
 const protectedRoutes = [
   '/dashboard',
+  '/onboarding',
   '/deed-builder',
   '/past-deeds',
   '/shared-deeds',

--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -1,9 +1,8 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState } from "react"
 import { useRouter } from "next/navigation"
-import { Sparkles, Building2, Scale, Home, Briefcase, ArrowRight, ArrowLeft, Check, MapPin } from "lucide-react"
-import { AuthManager } from "@/utils/auth"
+import { Sparkles, MapPin, ArrowRight } from "lucide-react"
 
 // California counties for the dropdown
 const CA_COUNTIES = [
@@ -17,127 +16,63 @@ const CA_COUNTIES = [
   "Ventura", "Yolo", "Yuba"
 ]
 
-const ROLES = [
-  { id: "escrow_officer", label: "Escrow Officer", icon: Building2, description: "I prepare deeds for closings" },
-  { id: "title_officer", label: "Title Officer", icon: Scale, description: "I handle title and document preparation" },
-  { id: "attorney", label: "Attorney / Paralegal", icon: Scale, description: "I prepare legal documents for clients" },
-  { id: "real_estate", label: "Real Estate Professional", icon: Home, description: "I assist with property transactions" },
-  { id: "other", label: "Other", icon: Briefcase, description: "I have a different role" },
-]
-
-interface OnboardingData {
-  fullName: string
-  role: string
-  defaultCounty: string
-}
-
+/**
+ * Single-question onboarding (F3). Name and role are collected at signup —
+ * the only thing worth asking here is the default county, and it persists
+ * server-side via PATCH /users/profile so the completion gate is server
+ * truth, never a localStorage-only flag (bugs #9/#10).
+ */
 export default function OnboardingPage() {
   const router = useRouter()
-  const [step, setStep] = useState(1)
+  const [county, setCounty] = useState("Los Angeles")
   const [loading, setLoading] = useState(false)
-  const [data, setData] = useState<OnboardingData>({
-    fullName: "",
-    role: "",
-    defaultCounty: "Los Angeles",
-  })
-  const [animateIn, setAnimateIn] = useState(true)
+  const [error, setError] = useState("")
 
-  // Check authentication
-  useEffect(() => {
+  const saveProfile = async (body: { default_county?: string; onboarding_completed: boolean }) => {
     const token = localStorage.getItem("access_token")
-    if (!token) {
-      router.push("/login?redirect=/onboarding")
-      return
-    }
-
-    // Pre-fill name from existing user data
-    const user = AuthManager.getUser()
-    if (user?.full_name) {
-      setData(prev => ({ ...prev, fullName: user.full_name }))
-    }
-  }, [router])
-
-  const handleNext = () => {
-    setAnimateIn(false)
-    setTimeout(() => {
-      setStep(step + 1)
-      setAnimateIn(true)
-    }, 200)
-  }
-
-  const handleBack = () => {
-    setAnimateIn(false)
-    setTimeout(() => {
-      setStep(step - 1)
-      setAnimateIn(true)
-    }, 200)
-  }
-
-  const handleComplete = async () => {
-    setLoading(true)
-    try {
-      const token = localStorage.getItem("access_token")
-      
-      // Save onboarding data to backend
-      const response = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL || "https://deedpro-main-api.onrender.com"}/users/profile`,
-        {
-          method: "PATCH",
-          headers: {
-            "Authorization": `Bearer ${token}`,
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            full_name: data.fullName,
-            role: data.role,
-            default_county: data.defaultCounty,
-            onboarding_completed: true,
-          }),
-        }
-      )
-
-      // Update local storage
-      const user = AuthManager.getUser()
-      if (user) {
-        AuthManager.setAuth(token!, {
-          ...user,
-          full_name: data.fullName,
-          role: data.role,
-        })
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL || "https://deedpro-main-api.onrender.com"}/users/profile`,
+      {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(body),
       }
+    )
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}))
+      throw new Error(data.detail || `Save failed (${response.status})`)
+    }
+  }
 
-      // Store onboarding flag
+  const handleComplete = async (destination: string) => {
+    setLoading(true)
+    setError("")
+    try {
+      await saveProfile({ default_county: county, onboarding_completed: true })
       localStorage.setItem("onboarding_completed", "true")
-      localStorage.setItem("default_county", data.defaultCounty)
-
-      // Redirect to dashboard or create first deed
-      router.push("/dashboard")
-    } catch (error) {
-      console.error("Failed to save onboarding data:", error)
-      // Still redirect even if save fails
-      localStorage.setItem("onboarding_completed", "true")
-      router.push("/dashboard")
+      localStorage.setItem("default_county", county)
+      router.push(destination)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Couldn't save your county. Please try again.")
     } finally {
       setLoading(false)
     }
   }
 
-  const handleSkipToDashboard = () => {
+  const handleSkip = async () => {
+    // Skip still records completion server-side so the dashboard gate stops
+    // re-prompting; if the save fails, this device passes via localStorage
+    // and a fresh device gets asked again — which is the honest outcome.
+    try {
+      await saveProfile({ onboarding_completed: true })
+    } catch {
+      // non-blocking: skip means "get me out of here"
+    }
     localStorage.setItem("onboarding_completed", "true")
     router.push("/dashboard")
-  }
-
-  const canProceed = () => {
-    switch (step) {
-      case 1:
-        return data.fullName.trim().length >= 2
-      case 2:
-        return data.role !== ""
-      case 3:
-        return data.defaultCounty !== ""
-      default:
-        return true
-    }
   }
 
   return (
@@ -151,8 +86,8 @@ export default function OnboardingPage() {
             </div>
             <span className="font-bold text-gray-900">DeedPro</span>
           </div>
-          <button 
-            onClick={handleSkipToDashboard}
+          <button
+            onClick={handleSkip}
             className="text-sm text-gray-500 hover:text-gray-700"
           >
             Skip for now
@@ -163,263 +98,71 @@ export default function OnboardingPage() {
       {/* Main Content */}
       <main className="flex-1 flex items-center justify-center p-6">
         <div className="w-full max-w-xl">
-          {/* Step 1: Name */}
-          {step === 1 && (
-            <div className={`transition-all duration-200 ${animateIn ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-4'}`}>
-              <div className="bg-emerald-50 border border-emerald-200 rounded-2xl p-6 mb-8">
-                <div className="flex items-start gap-4">
-                  <div className="w-10 h-10 rounded-full bg-emerald-100 flex items-center justify-center flex-shrink-0">
-                    <Sparkles className="w-5 h-5 text-emerald-600 animate-pulse" />
-                  </div>
-                  <div>
-                    <h1 className="text-xl font-bold text-emerald-800 mb-1">Welcome to DeedPro!</h1>
-                    <p className="text-emerald-700">
-                      I'm here to help you create California deeds in minutes. Let me learn a bit about you so I can assist better.
-                    </p>
-                  </div>
-                </div>
+          <div className="bg-emerald-50 border border-emerald-200 rounded-2xl p-6 mb-8">
+            <div className="flex items-start gap-4">
+              <div className="w-10 h-10 rounded-full bg-emerald-100 flex items-center justify-center flex-shrink-0">
+                <Sparkles className="w-5 h-5 text-emerald-600" />
               </div>
-
-              <div className="bg-white rounded-2xl border border-gray-200 p-8">
-                <label className="block text-lg font-semibold text-gray-900 mb-2">
-                  What's your name?
-                </label>
-                <input
-                  type="text"
-                  value={data.fullName}
-                  onChange={(e) => setData({ ...data, fullName: e.target.value })}
-                  placeholder="John Smith"
-                  className="w-full px-4 py-4 text-lg border border-gray-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
-                  autoFocus
-                />
-                <p className="text-sm text-gray-500 mt-2">
-                  This is how I'll greet you in the app.
+              <div>
+                <h1 className="text-xl font-bold text-emerald-800 mb-1">Welcome to DeedPro!</h1>
+                <p className="text-emerald-700">
+                  One quick question and you&apos;re in: which county do you work in most often?
+                  We&apos;ll use it as your default.
                 </p>
               </div>
             </div>
-          )}
+          </div>
 
-          {/* Step 2: Role */}
-          {step === 2 && (
-            <div className={`transition-all duration-200 ${animateIn ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-4'}`}>
-              <div className="bg-emerald-50 border border-emerald-200 rounded-2xl p-6 mb-8">
-                <div className="flex items-start gap-4">
-                  <div className="w-10 h-10 rounded-full bg-emerald-100 flex items-center justify-center flex-shrink-0">
-                    <Sparkles className="w-5 h-5 text-emerald-600 animate-pulse" />
-                  </div>
-                  <div>
-                    <h1 className="text-xl font-bold text-emerald-800 mb-1">
-                      Nice to meet you, {data.fullName.split(' ')[0]}!
-                    </h1>
-                    <p className="text-emerald-700">
-                      What best describes your role? This helps me tailor my suggestions.
-                    </p>
-                  </div>
-                </div>
+          <div className="bg-white rounded-2xl border border-gray-200 p-8">
+            <label className="block text-lg font-semibold text-gray-900 mb-2">
+              <MapPin className="w-5 h-5 inline mr-2 text-gray-400" />
+              Default County
+            </label>
+            <select
+              value={county}
+              onChange={(e) => setCounty(e.target.value)}
+              className="w-full px-4 py-4 text-lg border border-gray-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
+              autoFocus
+            >
+              {CA_COUNTIES.map((c) => (
+                <option key={c} value={c}>{c}</option>
+              ))}
+            </select>
+
+            {county === "Los Angeles" && (
+              <div className="mt-4 p-4 bg-amber-50 border border-amber-200 rounded-xl">
+                <p className="text-sm text-amber-800">
+                  <strong>💡 Tip:</strong> Los Angeles has both county ($1.10/1000) and city
+                  transfer taxes. We&apos;ll help you calculate the right amount for each property.
+                </p>
               </div>
+            )}
 
-              <div className="space-y-3">
-                {ROLES.map((role) => {
-                  const Icon = role.icon
-                  const isSelected = data.role === role.id
-                  return (
-                    <button
-                      key={role.id}
-                      onClick={() => setData({ ...data, role: role.id })}
-                      className={`w-full flex items-center gap-4 p-4 rounded-xl border-2 transition-all text-left ${
-                        isSelected 
-                          ? 'border-emerald-500 bg-emerald-50' 
-                          : 'border-gray-200 bg-white hover:border-gray-300'
-                      }`}
-                    >
-                      <div className={`w-12 h-12 rounded-xl flex items-center justify-center ${
-                        isSelected ? 'bg-emerald-500 text-white' : 'bg-gray-100 text-gray-600'
-                      }`}>
-                        <Icon className="w-6 h-6" />
-                      </div>
-                      <div className="flex-1">
-                        <p className={`font-semibold ${isSelected ? 'text-emerald-800' : 'text-gray-900'}`}>
-                          {role.label}
-                        </p>
-                        <p className={`text-sm ${isSelected ? 'text-emerald-600' : 'text-gray-500'}`}>
-                          {role.description}
-                        </p>
-                      </div>
-                      {isSelected && (
-                        <div className="w-6 h-6 rounded-full bg-emerald-500 flex items-center justify-center">
-                          <Check className="w-4 h-4 text-white" />
-                        </div>
-                      )}
-                    </button>
-                  )
-                })}
+            {error && (
+              <div className="mt-4 p-4 bg-red-50 border border-red-200 rounded-xl">
+                <p className="text-sm text-red-800">{error}</p>
               </div>
-            </div>
-          )}
+            )}
+          </div>
 
-          {/* Step 3: County */}
-          {step === 3 && (
-            <div className={`transition-all duration-200 ${animateIn ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-4'}`}>
-              <div className="bg-emerald-50 border border-emerald-200 rounded-2xl p-6 mb-8">
-                <div className="flex items-start gap-4">
-                  <div className="w-10 h-10 rounded-full bg-emerald-100 flex items-center justify-center flex-shrink-0">
-                    <Sparkles className="w-5 h-5 text-emerald-600 animate-pulse" />
-                  </div>
-                  <div>
-                    <h1 className="text-xl font-bold text-emerald-800 mb-1">
-                      Great! As a{data.role === 'attorney' ? 'n' : ''} {ROLES.find(r => r.id === data.role)?.label || 'professional'}, you'll love how fast DeedPro works.
-                    </h1>
-                    <p className="text-emerald-700">
-                      Which county do you work in most often? I'll set this as your default.
-                    </p>
-                  </div>
-                </div>
-              </div>
-
-              <div className="bg-white rounded-2xl border border-gray-200 p-8">
-                <label className="block text-lg font-semibold text-gray-900 mb-2">
-                  <MapPin className="w-5 h-5 inline mr-2 text-gray-400" />
-                  Default County
-                </label>
-                <select
-                  value={data.defaultCounty}
-                  onChange={(e) => setData({ ...data, defaultCounty: e.target.value })}
-                  className="w-full px-4 py-4 text-lg border border-gray-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
-                >
-                  {CA_COUNTIES.map((county) => (
-                    <option key={county} value={county}>{county}</option>
-                  ))}
-                </select>
-                
-                {data.defaultCounty === "Los Angeles" && (
-                  <div className="mt-4 p-4 bg-amber-50 border border-amber-200 rounded-xl">
-                    <p className="text-sm text-amber-800">
-                      <strong>💡 Tip:</strong> Los Angeles has both county ($1.10/1000) and city transfer taxes. I'll help you calculate the right amount for each property.
-                    </p>
-                  </div>
-                )}
-              </div>
-            </div>
-          )}
-
-          {/* Step 4: Complete */}
-          {step === 4 && (
-            <div className={`transition-all duration-200 ${animateIn ? 'opacity-100 translate-y-0' : 'opacity-0 -translate-y-4'}`}>
-              <div className="bg-emerald-50 border border-emerald-200 rounded-2xl p-6 mb-8">
-                <div className="flex items-start gap-4">
-                  <div className="w-10 h-10 rounded-full bg-emerald-100 flex items-center justify-center flex-shrink-0">
-                    <Sparkles className="w-5 h-5 text-emerald-600 animate-pulse" />
-                  </div>
-                  <div>
-                    <h1 className="text-xl font-bold text-emerald-800 mb-1">
-                      You're all set, {data.fullName.split(' ')[0]}!
-                    </h1>
-                    <p className="text-emerald-700">
-                      Here's what I can help you with:
-                    </p>
-                  </div>
-                </div>
-              </div>
-
-              <div className="bg-white rounded-2xl border border-gray-200 p-8 mb-6">
-                <div className="space-y-4">
-                  <div className="flex items-center gap-3">
-                    <div className="w-8 h-8 rounded-full bg-emerald-100 flex items-center justify-center">
-                      <Check className="w-4 h-4 text-emerald-600" />
-                    </div>
-                    <p className="text-gray-700">Create deeds in under 2 minutes</p>
-                  </div>
-                  <div className="flex items-center gap-3">
-                    <div className="w-8 h-8 rounded-full bg-emerald-100 flex items-center justify-center">
-                      <Check className="w-4 h-4 text-emerald-600" />
-                    </div>
-                    <p className="text-gray-700">Auto-fill property data from county records</p>
-                  </div>
-                  <div className="flex items-center gap-3">
-                    <div className="w-8 h-8 rounded-full bg-emerald-100 flex items-center justify-center">
-                      <Check className="w-4 h-4 text-emerald-600" />
-                    </div>
-                    <p className="text-gray-700">Calculate transfer tax (including city rates)</p>
-                  </div>
-                  <div className="flex items-center gap-3">
-                    <div className="w-8 h-8 rounded-full bg-emerald-100 flex items-center justify-center">
-                      <Check className="w-4 h-4 text-emerald-600" />
-                    </div>
-                    <p className="text-gray-700">Ensure California compliance</p>
-                  </div>
-                </div>
-              </div>
-
-              <p className="text-center text-gray-600 mb-6">
-                Ready to create your first deed?
-              </p>
-
-              <div className="space-y-3">
-                <button
-                  onClick={() => {
-                    handleComplete()
-                    setTimeout(() => router.push('/deed-builder'), 100)
-                  }}
-                  disabled={loading}
-                  className="w-full bg-emerald-600 hover:bg-emerald-700 text-white font-semibold py-4 rounded-xl transition-all flex items-center justify-center gap-2 shadow-lg shadow-emerald-500/20"
-                >
-                  <Sparkles className="w-5 h-5" />
-                  {loading ? 'Setting up...' : 'Create My First Deed'}
-                </button>
-                <button
-                  onClick={handleComplete}
-                  disabled={loading}
-                  className="w-full text-gray-600 hover:text-gray-800 font-medium py-3 transition-colors"
-                >
-                  Take me to my dashboard
-                </button>
-              </div>
-            </div>
-          )}
-
-          {/* Navigation */}
-          {step < 4 && (
-            <div className="flex items-center justify-between mt-8">
-              <button
-                onClick={handleBack}
-                disabled={step === 1}
-                className={`flex items-center gap-2 px-4 py-2 rounded-lg font-medium transition-colors ${
-                  step === 1 
-                    ? 'text-gray-300 cursor-not-allowed' 
-                    : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
-                }`}
-              >
-                <ArrowLeft className="w-4 h-4" />
-                Back
-              </button>
-
-              {/* Step indicator */}
-              <div className="flex items-center gap-2">
-                {[1, 2, 3, 4].map((s) => (
-                  <div
-                    key={s}
-                    className={`w-2 h-2 rounded-full transition-colors ${
-                      s === step ? 'bg-emerald-500' : s < step ? 'bg-emerald-300' : 'bg-gray-300'
-                    }`}
-                  />
-                ))}
-                <span className="text-sm text-gray-500 ml-2">Step {step} of 4</span>
-              </div>
-
-              <button
-                onClick={handleNext}
-                disabled={!canProceed()}
-                className={`flex items-center gap-2 px-6 py-2 rounded-lg font-medium transition-all ${
-                  canProceed()
-                    ? 'bg-emerald-600 hover:bg-emerald-700 text-white'
-                    : 'bg-gray-200 text-gray-400 cursor-not-allowed'
-                }`}
-              >
-                Continue
-                <ArrowRight className="w-4 h-4" />
-              </button>
-            </div>
-          )}
+          <div className="space-y-3 mt-8">
+            <button
+              onClick={() => handleComplete("/deed-builder")}
+              disabled={loading}
+              className="w-full bg-emerald-600 hover:bg-emerald-700 text-white font-semibold py-4 rounded-xl transition-all flex items-center justify-center gap-2 shadow-lg shadow-emerald-500/20 disabled:opacity-60"
+            >
+              <Sparkles className="w-5 h-5" />
+              {loading ? "Saving..." : "Take me to my first deed"}
+              <ArrowRight className="w-4 h-4" />
+            </button>
+            <button
+              onClick={() => handleComplete("/dashboard")}
+              disabled={loading}
+              className="w-full text-gray-600 hover:text-gray-800 font-medium py-3 transition-colors disabled:opacity-60"
+            >
+              Take me to my dashboard
+            </button>
+          </div>
         </div>
       </main>
     </div>


### PR DESCRIPTION
## What

Fixes the onboarding dead-ends (bugs #9 and #10) and kills the redundant questions.

**Bug #9 — PATCH to a nonexistent endpoint.** Onboarding PATCHed `/users/profile`, which didn't exist; the failure was swallowed and the county silently discarded. There is now a real `PATCH /users/profile` doing a *targeted* upsert into `user_profiles` (`default_county`, `onboarding_completed` only) — unlike the legacy `POST /users/profile/enhanced`, it never clobbers columns you didn't send.

**Bug #10 — localStorage-only gate.** The dashboard gate already reads `profileData.onboarding_completed` and `profileData.total_deeds` — but `GET /users/profile` never returned them, so the localStorage flag was the entire gate and a fresh device bounced completed users back into onboarding forever. The profile response now carries `default_county`, `onboarding_completed` (server truth, from `user_profiles`) and `total_deeds` (non-deleted count).

**Redundant questions gone.** Onboarding is now a single county question. Name and role are collected at signup; the duplicate role question — whose snake_case ids drifted from the signup form's values and overwrote `user_data.role` — is deleted. The signup form's format is canonical. Save failures now show an error with the user still on the page instead of silently redirecting; Skip records completion server-side. `/onboarding` joined the middleware's protected routes.

## Schema & snapshots

- `user_profiles` gains `onboarding_completed BOOLEAN DEFAULT FALSE` via idempotent `ALTER ... ADD COLUMN IF NOT EXISTS` in `create_tables` (additive; this codebase manages schema at startup).
- OpenAPI route snapshot re-recorded: exactly one addition, `PATCH /users/profile`.
- Six-flow baseline script: cleanup now clears the baseline user's `user_profiles` row before deleting the user (FK); the recorded snapshot itself is unchanged and verifies green.

## Verification

PATCH/GET round-trip proven against a real local Postgres: county persists, partial PATCH keeps existing values, empty PATCH → 400, `total_deeds` counts real rows.

## Gates

- Backend: 48 passed
- Six-flow behavioral baseline: all flows match ✔
- Frontend: tsc 98 errors (baseline held), jest 56 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_