### PR TITLE
F4: dashboard honesty — real statuses, real counts, visible errors

### DIFF
--- a/backend/routers/deeds_crud.py
+++ b/backend/routers/deeds_crud.py
@@ -147,7 +147,7 @@ def list_deeds_endpoint(user_id: int = Depends(get_current_user_id)):
         with db.conn.cursor() as cur:
             cur.execute("""
                 SELECT id, deed_type, property_address, grantor_name, grantee_name,
-                       created_at, updated_at
+                       county, status, pdf_url, created_at, updated_at
                 FROM deeds
                 WHERE user_id = %s AND COALESCE(status, '') <> 'deleted'
                 ORDER BY created_at DESC
@@ -155,19 +155,21 @@ def list_deeds_endpoint(user_id: int = Depends(get_current_user_id)):
 
             deeds = cur.fetchall()
 
-            # Format deeds for frontend (Phase 6-1: Fixed field names to match frontend)
+            # F4: real column values under the schema's own names — the row
+            # used to hardcode status "completed" and rename fields (bug #11).
             formatted_deeds = []
             for deed in deeds:
                 formatted_deeds.append({
                     "id": deed[0],
                     "deed_type": deed[1],
-                    "property": deed[2],  # Frontend expects 'property' not 'address'
-                    "grantor": deed[3],
-                    "grantee": deed[4],
-                    "created_at": deed[5].strftime("%Y-%m-%d") if deed[5] else None,  # Frontend expects 'created_at' not 'date'
-                    "updated_at": deed[6].strftime("%Y-%m-%d") if deed[6] else None,  # Add updated_at
-                    "status": "completed",  # Default status - you can add a status column later
-                    "recorded": False  # Default - you can add a recorded column later
+                    "property_address": deed[2],
+                    "grantor_name": deed[3],
+                    "grantee_name": deed[4],
+                    "county": deed[5],
+                    "status": deed[6] or "draft",
+                    "pdf_url": deed[7],
+                    "created_at": deed[8].strftime("%Y-%m-%d") if deed[8] else None,
+                    "updated_at": deed[9].strftime("%Y-%m-%d") if deed[9] else None,
                 })
 
             return {"deeds": formatted_deeds}
@@ -188,12 +190,14 @@ def deeds_summary(user_id: int = Depends(get_current_user_id)) -> Dict[str, int]
             raise HTTPException(status_code=500, detail="Database connection not available")
 
         with db.conn.cursor() as cur:
-            # Query for status counts
+            # F4: real status counts. Vocabulary matches the admin tab:
+            # a deed is 'completed' (stored PDF) or it's a draft — the old
+            # query counted every deed as completed and hardcoded 0 drafts.
             cur.execute("""
                 SELECT
                     COUNT(*) as total,
-                    COUNT(*) FILTER (WHERE deed_type IS NOT NULL) as completed,
-                    0 as in_progress
+                    COUNT(*) FILTER (WHERE status = 'completed') as completed,
+                    COUNT(*) FILTER (WHERE COALESCE(status, 'draft') <> 'completed') as drafts
                 FROM deeds
                 WHERE user_id = %s AND COALESCE(status, '') <> 'deleted'
             """, (user_id,))
@@ -201,7 +205,7 @@ def deeds_summary(user_id: int = Depends(get_current_user_id)) -> Dict[str, int]
             row = cur.fetchone()
             total = row[0] if row else 0
             completed = row[1] if row else 0
-            in_progress = row[2] if row else 0
+            drafts = row[2] if row else 0
 
             # Query for deeds created this month
             cur.execute("""
@@ -217,7 +221,7 @@ def deeds_summary(user_id: int = Depends(get_current_user_id)) -> Dict[str, int]
             return {
                 "total": total,
                 "completed": completed,
-                "in_progress": in_progress,
+                "drafts": drafts,
                 "month": month
             }
 

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -19,11 +19,12 @@ export default function Dashboard() {
   const [loading, setLoading] = useState(true)
   const [userName, setUserName] = useState<string>("")
   const [recentDeeds, setRecentDeeds] = useState<any[]>([])
+  const [deedsError, setDeedsError] = useState<string | null>(null)
   const [summary, setSummary] = useState<{
     total: number
     completed: number
-    in_progress: number
-    pending: number
+    drafts: number
+    month: number
   } | null>(null)
   const router = useRouter()
 
@@ -100,8 +101,8 @@ export default function Dashboard() {
           setSummary({
             total: data.total || 0,
             completed: data.completed || 0,
-            in_progress: data.in_progress || 0,
-            pending: data.pending || data.shared || 0,
+            drafts: data.drafts || 0,
+            month: data.month || 0,
           })
         } else {
           // Fallback: calculate from deeds list
@@ -111,11 +112,14 @@ export default function Dashboard() {
           if (list.ok) {
             const data = await list.json()
             const deeds = Array.isArray(data.deeds) ? data.deeds : []
+            const monthStart = new Date()
+            monthStart.setDate(1)
+            monthStart.setHours(0, 0, 0, 0)
             setSummary({
               total: deeds.length,
               completed: deeds.filter((d: any) => d.status === "completed").length,
-              in_progress: deeds.filter((d: any) => d.status === "draft" || d.status === "in_progress").length,
-              pending: deeds.filter((d: any) => d.status === "shared" || d.status === "pending").length,
+              drafts: deeds.filter((d: any) => d.status !== "completed").length,
+              month: deeds.filter((d: any) => d.created_at && new Date(d.created_at) >= monthStart).length,
             })
           }
         }
@@ -144,9 +148,16 @@ export default function Dashboard() {
       if (response.ok) {
         const data = await response.json()
         setRecentDeeds(data.deeds || [])
+        setDeedsError(null)
+      } else {
+        // F4: a failed load used to render as the "welcome, create your
+        // first deed" empty state — say what actually happened instead.
+        const data = await response.json().catch(() => ({}))
+        setDeedsError(data.detail || `Couldn't load your deeds (${response.status})`)
       }
     } catch (error) {
       console.error("Error fetching recent deeds:", error)
+      setDeedsError("Couldn't load your deeds. Check your connection and try again.")
     }
   }
 
@@ -208,15 +219,15 @@ export default function Dashboard() {
                 color="purple"
               />
               <StatCard
-                label="In Progress"
-                value={summary?.in_progress ?? 0}
+                label="Drafts"
+                value={summary?.drafts ?? 0}
                 icon={<Clock className="w-5 h-5" />}
                 color="yellow"
               />
               <StatCard
-                label="Pending Review"
-                value={summary?.pending ?? 0}
-                icon={<Send className="w-5 h-5" />}
+                label="This Month"
+                value={summary?.month ?? 0}
+                icon={<TrendingUp className="w-5 h-5" />}
                 color="blue"
               />
               <StatCard
@@ -239,8 +250,19 @@ export default function Dashboard() {
             </button>
           )}
 
-          {/* Recent Activity or Empty State */}
-          {hasDeeds ? (
+          {/* Recent Activity, load error, or Empty State */}
+          {deedsError ? (
+            <div className="bg-white rounded-2xl shadow-sm border border-red-200 p-8 text-center">
+              <p className="text-red-700 font-medium mb-1">Couldn&apos;t load your deeds</p>
+              <p className="text-sm text-gray-500 mb-4">{deedsError}</p>
+              <button
+                onClick={() => fetchRecentDeeds()}
+                className="px-5 py-2 bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-semibold rounded-lg transition-colors"
+              >
+                Retry
+              </button>
+            </div>
+          ) : hasDeeds ? (
             <div className="bg-white rounded-2xl shadow-sm border border-gray-200 overflow-hidden">
               <div className="p-4 md:p-6 border-b border-gray-100">
                 <div className="flex items-center gap-2">
@@ -310,7 +332,31 @@ function StatCard({
 // Deed Row Component
 function DeedRow({ deed }: { deed: any }) {
   const router = useRouter()
-  
+
+  // pdf_url is a backend-relative authenticated path — window.open can't
+  // reach it; fetch the stored PDF as a blob like Past Deeds does.
+  const handleDownload = async () => {
+    try {
+      const api = process.env.NEXT_PUBLIC_API_URL || "https://deedpro-main-api.onrender.com"
+      const token = localStorage.getItem("access_token")
+      const response = await fetch(`${api}/deeds/${deed.id}/download`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      if (!response.ok) throw new Error("Download failed")
+      const blob = await response.blob()
+      const url = window.URL.createObjectURL(blob)
+      const a = document.createElement("a")
+      a.href = url
+      a.download = `${deed.deed_type || "Deed"}_${deed.id}.pdf`
+      document.body.appendChild(a)
+      a.click()
+      window.URL.revokeObjectURL(url)
+      document.body.removeChild(a)
+    } catch (err) {
+      console.error("Download error:", err)
+    }
+  }
+
   const getStatusStyle = (status: string) => {
     switch (status?.toLowerCase()) {
       case 'completed':
@@ -393,8 +439,8 @@ function DeedRow({ deed }: { deed: any }) {
         {/* Actions */}
         <div className="flex items-center gap-1">
           {deed.status === 'completed' && deed.pdf_url && (
-            <button 
-              onClick={() => window.open(deed.pdf_url, '_blank')}
+            <button
+              onClick={handleDownload}
               className="p-2 hover:bg-gray-100 rounded-lg transition-colors text-gray-400 hover:text-gray-600"
               title="Download PDF"
             >
@@ -402,9 +448,10 @@ function DeedRow({ deed }: { deed: any }) {
             </button>
           )}
           {deed.status === 'completed' && (
-            <button 
+            <button
+              onClick={() => router.push('/past-deeds')}
               className="p-2 hover:bg-gray-100 rounded-lg transition-colors text-gray-400 hover:text-gray-600"
-              title="Share"
+              title="Share from Past Deeds"
             >
               <Share2 className="w-4 h-4" />
             </button>

--- a/frontend/src/app/past-deeds/page.tsx
+++ b/frontend/src/app/past-deeds/page.tsx
@@ -10,10 +10,9 @@ import { ConfirmDialog } from "@/components/ui/ConfirmDialog"
 
 interface Deed {
   id: number
-  property: string
+  property_address: string
   deed_type: string
   status: "completed" | "draft" | "in_progress"
-  progress: number
   created_at: string
   updated_at: string
   pdf_url?: string
@@ -315,7 +314,6 @@ export default function PastDeedsPageV0() {
                       <th className="text-left py-4 px-6 text-sm font-semibold text-slate-700">Property</th>
                       <th className="text-left py-4 px-6 text-sm font-semibold text-slate-700">Deed Type</th>
                       <th className="text-left py-4 px-6 text-sm font-semibold text-slate-700">Status</th>
-                      <th className="text-left py-4 px-6 text-sm font-semibold text-slate-700">Progress</th>
                       <th className="text-left py-4 px-6 text-sm font-semibold text-slate-700">Created</th>
                       <th className="text-left py-4 px-6 text-sm font-semibold text-slate-700">Updated</th>
                       <th className="text-left py-4 px-6 text-sm font-semibold text-slate-700">Actions</th>
@@ -329,22 +327,9 @@ export default function PastDeedsPageV0() {
                           index % 2 === 0 ? "bg-white" : "bg-slate-50/50"
                         }`}
                       >
-                        <td className="py-4 px-6 font-medium text-slate-800">{deed.property}</td>
+                        <td className="py-4 px-6 font-medium text-slate-800">{deed.property_address}</td>
                         <td className="py-4 px-6 text-slate-600">{deed.deed_type}</td>
                         <td className="py-4 px-6">{getStatusBadge(deed.status)}</td>
-                        <td className="py-4 px-6">
-                          <div className="flex items-center gap-3">
-                            <div className="w-20 h-2 bg-slate-200 rounded-full overflow-hidden">
-                              <div
-                                className={`h-full rounded-full transition-all ${
-                                  deed.progress === 100 ? "bg-green-500" : "bg-[#7C4DFF]"
-                                }`}
-                                style={{ width: `${deed.progress}%` }}
-                              />
-                            </div>
-                            <span className="text-sm text-slate-600 font-medium">{deed.progress}%</span>
-                          </div>
-                        </td>
                         <td className="py-4 px-6 text-sm text-slate-600">{formatDate(deed.created_at)}</td>
                         <td className="py-4 px-6 text-sm text-slate-600">{formatDate(deed.updated_at)}</td>
                         <td className="py-4 px-6">


### PR DESCRIPTION
## What

Fixes bug #11 and the stuck-placeholder dashboard.

**`GET /deeds` told a story.** Every row came back `status: "completed"` (hardcoded), with renamed fields (`property`/`grantor`/`grantee`) and a fake `recorded: false`. It now returns each deed's real status (`draft`/`completed`) under the schema's own names — `property_address`, `grantor_name`, `grantee_name`, plus `county` and `pdf_url` which the dashboard row was already trying to read.

**`GET /deeds/summary` counted fiction.** `completed` counted every deed with a non-null type; `in_progress` was a SQL literal `0`; the dashboard's "Pending Review" tile read keys (`pending`/`shared`) that were never returned. Summary now counts real statuses — `completed` and `drafts` (same vocabulary as the admin tab: a deed is completed or it's a draft) — and the already-real `month` count is finally displayed.

**Dashboard.** Tiles are now Total / Drafts / This Month / Completed. A failed deeds fetch renders an error panel with Retry instead of silently showing the "create your first deed" welcome over real data. The row's Download button fetches the stored PDF with auth (`pdf_url` is a backend-relative authenticated path; `window.open` on it could never work), and the dead Share button (no handler) now routes to Past Deeds where the share modal lives. The draft-continue AICard now actually fires, since drafts are no longer reported as completed.

**Past Deeds.** `property` → `property_address`; the Progress column is gone — the backend never returned `progress`, so it rendered `undefined%` on every row.

## Flagged, not fixed (per ticket instruction)

- `backend/routers/api_v1/router.py:374` — the public partner API (`POST /api/v1/deeds`) hardcodes `status="completed"` in its response. It does generate the PDF synchronously in that request, so it may be honest in practice, but it's a hardcode and deserves its own look.

## Gates

- Backend: 48 passed
- Six-flow behavioral baseline: all flows match ✔
- Frontend: tsc 98 errors (baseline held), jest 56 passed
- List/summary response shapes verified against a real local Postgres

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_