### PR TITLE
F6: V0 visual re-implementation — signup/login pair, onboarding, sidebar

### DIFF
--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,12 +1,18 @@
 "use client"
 
+// F6: visual re-implementation from the V0 reference (temp-v0, reference
+// only). Logic contracts preserved: auth check, ?registered banner + email
+// prefill, ?redirect param, admin-role redirect, per-status error copy,
+// AuthManager.setAuth storage. The demo-credentials card stays gated to
+// development builds (the reference showed it unconditionally — that and
+// its dropped admin redirect were bugs in the reference, not the design).
 import type React from "react"
 
 import { useState, useEffect, Suspense } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import Link from "next/link"
 import { AuthManager } from "../../utils/auth"
-import { Eye, EyeOff, AlertCircle, CheckCircle2, Zap, Copy, Check } from "lucide-react"
+import { Eye, EyeOff, AlertCircle, CheckCircle2, Zap, Copy, Check, ShieldCheck } from "lucide-react"
 
 function LoginContent() {
   const [formData, setFormData] = useState({ email: "", password: "" })
@@ -15,6 +21,7 @@ function LoginContent() {
   const [successMessage, setSuccessMessage] = useState("")
   const [showPassword, setShowPassword] = useState(false)
   const [copiedField, setCopiedField] = useState<string | null>(null)
+  const [showDemo, setShowDemo] = useState(false)
   const router = useRouter()
   const searchParams = useSearchParams()
 
@@ -68,7 +75,7 @@ function LoginContent() {
           AuthManager.setAuth(token, data.user)
         }
         setSuccessMessage("Login successful! Redirecting...")
-        
+
         // Check if user is admin and redirect accordingly
         let redirectTo = searchParams.get("redirect") || "/dashboard"
         if (token) {
@@ -118,7 +125,7 @@ function LoginContent() {
       passEl.dispatchEvent(new Event("change", { bubbles: true }))
     }
 
-    setSuccessMessage("Credentials filled! Click 'Sign In' above.")
+    setSuccessMessage("Credentials filled! Click 'Sign in' above.")
     setError("")
   }
 
@@ -129,192 +136,219 @@ function LoginContent() {
   }
 
   return (
-    <div className="min-h-screen bg-[#F9F9F9] flex items-center justify-center px-4 py-12">
-      <div className="w-full max-w-md space-y-8 animate-in fade-in duration-500">
-        {/* Header */}
-        <div className="text-center space-y-2">
-          <Link href="/" className="inline-block">
-            <h1 className="text-4xl font-bold text-[#1F2B37] tracking-tight">DeedPro</h1>
+    <div className="min-h-screen bg-gray-50 flex flex-col">
+      {/* Top brand bar */}
+      <header className="px-4 sm:px-6 lg:px-8 py-5">
+        <div className="max-w-6xl mx-auto flex items-center justify-between">
+          <Link href="/" className="flex items-center gap-2.5">
+            <span className="w-8 h-8 rounded-lg bg-brand-500 flex items-center justify-center">
+              <ShieldCheck className="w-5 h-5 text-white" />
+            </span>
+            <span className="text-xl font-bold tracking-tight text-gray-900">DeedPro</span>
           </Link>
-          <h2 className="text-2xl font-bold text-[#1F2B37]">Welcome Back</h2>
-          <p className="text-[#6B7280]">Sign in to your account to continue</p>
+          <Link
+            href="/register"
+            className="text-sm font-medium text-gray-500 hover:text-gray-900 transition-colors"
+          >
+            Don&apos;t have an account? <span className="text-brand-500">Sign up</span>
+          </Link>
         </div>
+      </header>
 
-        {/* Main Login Card */}
-        <div className="bg-white rounded-2xl shadow-lg border border-[#E5E7EB] p-8 space-y-6">
-          {/* Success Message */}
-          {successMessage && (
-            <div className="flex items-start gap-3 p-4 bg-[#10B981]/10 border border-[#10B981]/20 rounded-lg animate-in slide-in-from-top duration-300">
-              <CheckCircle2 className="w-5 h-5 text-[#10B981] flex-shrink-0 mt-0.5" />
-              <p className="text-sm text-[#10B981] font-medium">{successMessage}</p>
-            </div>
-          )}
+      {/* Centered form column */}
+      <main className="flex-1 flex items-center justify-center px-4 py-8">
+        <div className="w-full max-w-md space-y-6 animate-in fade-in duration-500">
+          {/* Heading */}
+          <div className="space-y-1.5">
+            <h1 className="text-2xl font-bold tracking-tight text-gray-900">Welcome back</h1>
+            <p className="text-[15px] text-gray-500 leading-relaxed">
+              Sign in to continue creating recorder-ready deeds.
+            </p>
+          </div>
 
-          {/* Error Message */}
-          {error && (
-            <div className="flex items-start gap-3 p-4 bg-[#EF4444]/10 border border-[#EF4444]/20 rounded-lg animate-in slide-in-from-top duration-300">
-              <AlertCircle className="w-5 h-5 text-[#EF4444] flex-shrink-0 mt-0.5" />
-              <p className="text-sm text-[#EF4444] font-medium">{error}</p>
-            </div>
-          )}
+          {/* Main Login Card */}
+          <div className="bg-white rounded-2xl shadow-sm border border-gray-200 p-7 space-y-5">
+            {/* Success Message */}
+            {successMessage && (
+              <div className="flex items-start gap-3 p-3.5 bg-success-50 border border-success-500/20 rounded-lg animate-in slide-in-from-top duration-300">
+                <CheckCircle2 className="w-5 h-5 text-success-500 flex-shrink-0 mt-0.5" />
+                <p className="text-sm text-success-600 font-medium">{successMessage}</p>
+              </div>
+            )}
 
-          {/* Login Form */}
-          <form onSubmit={handleSubmit} className="space-y-5">
-            {/* Email Field */}
-            <div className="space-y-2">
-              <label htmlFor="email" className="block text-sm font-semibold text-[#1F2B37]">
-                Email Address
-              </label>
-              <input
-                id="email"
-                type="email"
-                value={formData.email}
-                onChange={(e) => setFormData({ ...formData, email: e.target.value })}
-                className="w-full px-4 py-3 bg-white border border-[#E5E7EB] rounded-lg text-[#1F2B37] placeholder:text-[#9CA3AF] focus:outline-none focus:ring-2 focus:ring-[#7C4DFF] focus:border-transparent transition-all"
-                placeholder="you@example.com"
-                required
-                disabled={loading}
-                autoFocus
-              />
-            </div>
+            {/* Error Message */}
+            {error && (
+              <div className="flex items-start gap-3 p-3.5 bg-error-50 border border-error-500/20 rounded-lg animate-in slide-in-from-top duration-300">
+                <AlertCircle className="w-5 h-5 text-error-500 flex-shrink-0 mt-0.5" />
+                <p className="text-sm text-error-600 font-medium">{error}</p>
+              </div>
+            )}
 
-            {/* Password Field */}
-            <div className="space-y-2">
-              <label htmlFor="password" className="block text-sm font-semibold text-[#1F2B37]">
-                Password
-              </label>
-              <div className="relative">
+            {/* Login Form */}
+            <form onSubmit={handleSubmit} className="space-y-4">
+              {/* Email Field */}
+              <div className="space-y-1.5">
+                <label htmlFor="email" className="block text-sm font-semibold text-gray-900">
+                  Email address
+                </label>
                 <input
-                  id="password"
-                  type={showPassword ? "text" : "password"}
-                  value={formData.password}
-                  onChange={(e) => setFormData({ ...formData, password: e.target.value })}
-                  className="w-full px-4 py-3 pr-12 bg-white border border-[#E5E7EB] rounded-lg text-[#1F2B37] placeholder:text-[#9CA3AF] focus:outline-none focus:ring-2 focus:ring-[#7C4DFF] focus:border-transparent transition-all"
-                  placeholder="Enter your password"
+                  id="email"
+                  type="email"
+                  value={formData.email}
+                  onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+                  className="w-full px-4 py-3 bg-white border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent transition-all"
+                  placeholder="you@company.com"
                   required
                   disabled={loading}
+                  autoFocus
                 />
-                <button
-                  type="button"
-                  onClick={() => setShowPassword(!showPassword)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-[#6B7280] hover:text-[#1F2B37] transition-colors"
-                  aria-label={showPassword ? "Hide password" : "Show password"}
-                >
-                  {showPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
-                </button>
               </div>
-            </div>
 
-            {/* Submit Button */}
-            <button
-              type="submit"
-              disabled={loading}
-              className="w-full bg-[#7C4DFF] hover:bg-[#6B3FE6] text-white font-semibold py-4 rounded-lg transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed shadow-lg shadow-[#7C4DFF]/20 hover:shadow-xl hover:shadow-[#7C4DFF]/30"
-            >
-              {loading ? (
-                <span className="flex items-center justify-center gap-2">
-                  <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24">
-                    <circle
-                      className="opacity-25"
-                      cx="12"
-                      cy="12"
-                      r="10"
-                      stroke="currentColor"
-                      strokeWidth="4"
-                      fill="none"
-                    />
-                    <path
-                      className="opacity-75"
-                      fill="currentColor"
-                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                    />
-                  </svg>
-                  Signing in...
+              {/* Password Field */}
+              <div className="space-y-1.5">
+                <div className="flex items-center justify-between">
+                  <label htmlFor="password" className="block text-sm font-semibold text-gray-900">
+                    Password
+                  </label>
+                  <Link
+                    href="/forgot-password"
+                    className="text-xs font-medium text-brand-500 hover:text-brand-600 transition-colors"
+                  >
+                    Forgot password?
+                  </Link>
+                </div>
+                <div className="relative">
+                  <input
+                    id="password"
+                    type={showPassword ? "text" : "password"}
+                    value={formData.password}
+                    onChange={(e) => setFormData({ ...formData, password: e.target.value })}
+                    className="w-full px-4 py-3 pr-12 bg-white border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent transition-all"
+                    placeholder="Enter your password"
+                    required
+                    disabled={loading}
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword(!showPassword)}
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-900 transition-colors"
+                    aria-label={showPassword ? "Hide password" : "Show password"}
+                  >
+                    {showPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
+                  </button>
+                </div>
+              </div>
+
+              {/* Submit Button */}
+              <button
+                type="submit"
+                disabled={loading}
+                className="w-full bg-brand-500 hover:bg-brand-600 text-white font-semibold py-3.5 rounded-lg transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2"
+              >
+                {loading ? (
+                  <span className="flex items-center justify-center gap-2">
+                    <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24">
+                      <circle
+                        className="opacity-25"
+                        cx="12"
+                        cy="12"
+                        r="10"
+                        stroke="currentColor"
+                        strokeWidth="4"
+                        fill="none"
+                      />
+                      <path
+                        className="opacity-75"
+                        fill="currentColor"
+                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                      />
+                    </svg>
+                    Signing in...
+                  </span>
+                ) : (
+                  "Sign in"
+                )}
+              </button>
+            </form>
+          </div>
+
+          {/* Demo Credentials — dev only, collapsible */}
+          {process.env.NODE_ENV === 'development' && (
+            <div className="bg-white rounded-2xl border border-gray-200 overflow-hidden">
+              <button
+                type="button"
+                onClick={() => setShowDemo((v) => !v)}
+                className="w-full flex items-center justify-between gap-2 px-5 py-3.5 text-left"
+                aria-expanded={showDemo}
+              >
+                <span className="flex items-center gap-2">
+                  <span className="w-7 h-7 bg-brand-50 rounded-md flex items-center justify-center">
+                    <Zap className="w-4 h-4 text-brand-500" />
+                  </span>
+                  <span className="text-sm font-semibold text-gray-900">Demo credentials</span>
+                  <span className="text-xs text-warning-600 bg-warning-50 px-2 py-0.5 rounded-full">Dev only</span>
                 </span>
-              ) : (
-                "Sign In"
+                <span className="text-xs font-medium text-brand-500">{showDemo ? "Hide" : "Show"}</span>
+              </button>
+
+              {showDemo && (
+                <div className="px-5 pb-5 space-y-3 border-t border-gray-100 pt-4">
+                  <div className="space-y-1">
+                    <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide">Email</p>
+                    <div className="flex items-center justify-between gap-2 p-2.5 bg-gray-50 rounded-lg border border-gray-200">
+                      <code className="text-sm text-gray-900 font-mono">gerardoh@gmail.com</code>
+                      <button
+                        onClick={() => copyToClipboard("gerardoh@gmail.com", "email")}
+                        className="text-gray-500 hover:text-brand-500 transition-colors"
+                        aria-label="Copy email"
+                      >
+                        {copiedField === "email" ? (
+                          <Check className="w-4 h-4 text-success-500" />
+                        ) : (
+                          <Copy className="w-4 h-4" />
+                        )}
+                      </button>
+                    </div>
+                  </div>
+
+                  <div className="space-y-1">
+                    <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide">Password</p>
+                    <div className="flex items-center justify-between gap-2 p-2.5 bg-gray-50 rounded-lg border border-gray-200">
+                      <code className="text-sm text-gray-900 font-mono">Test123!</code>
+                      <button
+                        onClick={() => copyToClipboard("Test123!", "password")}
+                        className="text-gray-500 hover:text-brand-500 transition-colors"
+                        aria-label="Copy password"
+                      >
+                        {copiedField === "password" ? (
+                          <Check className="w-4 h-4 text-success-500" />
+                        ) : (
+                          <Copy className="w-4 h-4" />
+                        )}
+                      </button>
+                    </div>
+                  </div>
+
+                  <button
+                    type="button"
+                    onClick={handleDemoFill}
+                    className="w-full bg-gray-900 hover:bg-gray-700 text-white font-semibold py-2.5 rounded-lg transition-all duration-200 flex items-center justify-center gap-2 text-sm"
+                  >
+                    <Zap className="w-4 h-4" />
+                    Fill login form
+                  </button>
+                </div>
               )}
-            </button>
-          </form>
-
-          {/* Links */}
-          <div className="flex items-center justify-between text-sm">
-            <Link href="/forgot-password" className="text-[#7C4DFF] hover:text-[#6B3FE6] font-medium transition-colors">
-              Forgot password?
-            </Link>
-            <Link href="/register" className="text-[#6B7280] hover:text-[#1F2B37] font-medium transition-colors">
-              Don't have an account? <span className="text-[#7C4DFF]">Sign up</span>
-            </Link>
-          </div>
-        </div>
-
-        {/* Demo Credentials Card - Only show in development */}
-        {process.env.NODE_ENV === 'development' && (
-          <div className="bg-white rounded-2xl shadow-lg border border-[#E5E7EB] p-6 space-y-4">
-            <div className="flex items-center gap-2">
-              <div className="w-8 h-8 bg-[#7C4DFF]/10 rounded-lg flex items-center justify-center">
-                <Zap className="w-4 h-4 text-[#7C4DFF]" />
-              </div>
-              <h3 className="font-bold text-[#1F2B37]">Demo Credentials</h3>
-              <span className="ml-auto text-xs text-amber-600 bg-amber-100 px-2 py-0.5 rounded-full">Dev only</span>
             </div>
+          )}
 
-            <div className="space-y-3">
-              <div className="space-y-1">
-                <p className="text-xs font-semibold text-[#6B7280] uppercase tracking-wide">Email</p>
-                <div className="flex items-center justify-between gap-2 p-3 bg-[#F9F9F9] rounded-lg border border-[#E5E7EB]">
-                  <code className="text-sm text-[#1F2B37] font-mono">gerardoh@gmail.com</code>
-                  <button
-                    onClick={() => copyToClipboard("gerardoh@gmail.com", "email")}
-                    className="text-[#6B7280] hover:text-[#7C4DFF] transition-colors"
-                    aria-label="Copy email"
-                  >
-                    {copiedField === "email" ? (
-                      <Check className="w-4 h-4 text-[#10B981]" />
-                    ) : (
-                      <Copy className="w-4 h-4" />
-                    )}
-                  </button>
-                </div>
-              </div>
-
-              <div className="space-y-1">
-                <p className="text-xs font-semibold text-[#6B7280] uppercase tracking-wide">Password</p>
-                <div className="flex items-center justify-between gap-2 p-3 bg-[#F9F9F9] rounded-lg border border-[#E5E7EB]">
-                  <code className="text-sm text-[#1F2B37] font-mono">Test123!</code>
-                  <button
-                    onClick={() => copyToClipboard("Test123!", "password")}
-                    className="text-[#6B7280] hover:text-[#7C4DFF] transition-colors"
-                    aria-label="Copy password"
-                  >
-                    {copiedField === "password" ? (
-                      <Check className="w-4 h-4 text-[#10B981]" />
-                    ) : (
-                      <Copy className="w-4 h-4" />
-                    )}
-                  </button>
-                </div>
-              </div>
-            </div>
-
-            <button
-              type="button"
-              onClick={handleDemoFill}
-              className="w-full bg-[#1F2B37] hover:bg-[#374151] text-white font-semibold py-3 rounded-lg transition-all duration-200 flex items-center justify-center gap-2"
-            >
-              <Zap className="w-4 h-4" />
-              Fill Login Form
-            </button>
-          </div>
-        )}
-
-        {/* Back to Home */}
-        <div className="text-center">
-          <Link href="/" className="text-sm text-[#6B7280] hover:text-[#1F2B37] font-medium transition-colors">
-            ← Back to Home
-          </Link>
+          {/* Trust footer */}
+          <p className="flex items-center justify-center gap-1.5 text-xs text-gray-400">
+            <ShieldCheck className="w-3.5 h-3.5" />
+            Trusted by escrow &amp; title professionals
+          </p>
         </div>
-      </div>
+      </main>
     </div>
   )
 }
@@ -323,8 +357,8 @@ export default function LoginPage() {
   return (
     <Suspense
       fallback={
-        <div className="min-h-screen bg-[#F9F9F9] flex items-center justify-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-4 border-[#7C4DFF] border-t-transparent" />
+        <div className="min-h-screen bg-gray-50 flex items-center justify-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-4 border-brand-500 border-t-transparent" />
         </div>
       }
     >

--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -1,8 +1,17 @@
 "use client"
 
+// F6: visual re-implementation from the V0 reference (temp-v0, reference
+// only). F3 logic contracts preserved: county persists via
+// PATCH /users/profile (the reference POSTed to a nonexistent
+// /users/onboarding and swallowed failures — bugs in the reference),
+// save errors keep the user on the page, skip records completion
+// server-side, and the builder route is /deed-builder.
+import type React from "react"
+
 import { useState } from "react"
 import { useRouter } from "next/navigation"
-import { Sparkles, MapPin, ArrowRight } from "lucide-react"
+import Link from "next/link"
+import { ShieldCheck, MapPin, ArrowRight, Sparkles } from "lucide-react"
 
 // California counties for the dropdown
 const CA_COUNTIES = [
@@ -16,12 +25,6 @@ const CA_COUNTIES = [
   "Ventura", "Yolo", "Yuba"
 ]
 
-/**
- * Single-question onboarding (F3). Name and role are collected at signup —
- * the only thing worth asking here is the default county, and it persists
- * server-side via PATCH /users/profile so the completion gate is server
- * truth, never a localStorage-only flag (bugs #9/#10).
- */
 export default function OnboardingPage() {
   const router = useRouter()
   const [county, setCounty] = useState("Los Angeles")
@@ -62,6 +65,11 @@ export default function OnboardingPage() {
     }
   }
 
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    await handleComplete("/deed-builder")
+  }
+
   const handleSkip = async () => {
     // Skip still records completion server-side so the dashboard gate stops
     // re-prompting; if the save fails, this device passes via localStorage
@@ -77,92 +85,125 @@ export default function OnboardingPage() {
 
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col">
-      {/* Header */}
-      <header className="bg-white border-b border-gray-200 px-6 py-4">
-        <div className="max-w-xl mx-auto flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <div className="w-8 h-8 bg-violet-600 rounded-lg flex items-center justify-center">
-              <span className="text-white font-bold text-sm">DP</span>
-            </div>
-            <span className="font-bold text-gray-900">DeedPro</span>
-          </div>
+      {/* Top brand bar */}
+      <header className="px-4 sm:px-6 lg:px-8 py-5">
+        <div className="max-w-6xl mx-auto flex items-center justify-between">
+          <Link href="/" className="flex items-center gap-2.5">
+            <span className="w-8 h-8 rounded-lg bg-brand-500 flex items-center justify-center">
+              <ShieldCheck className="w-5 h-5 text-white" />
+            </span>
+            <span className="text-xl font-bold tracking-tight text-gray-900">DeedPro</span>
+          </Link>
           <button
+            type="button"
             onClick={handleSkip}
-            className="text-sm text-gray-500 hover:text-gray-700"
+            className="text-sm font-medium text-gray-500 hover:text-gray-900 transition-colors"
           >
             Skip for now
           </button>
         </div>
       </header>
 
-      {/* Main Content */}
-      <main className="flex-1 flex items-center justify-center p-6">
-        <div className="w-full max-w-xl">
-          <div className="bg-emerald-50 border border-emerald-200 rounded-2xl p-6 mb-8">
-            <div className="flex items-start gap-4">
-              <div className="w-10 h-10 rounded-full bg-emerald-100 flex items-center justify-center flex-shrink-0">
-                <Sparkles className="w-5 h-5 text-emerald-600" />
-              </div>
-              <div>
-                <h1 className="text-xl font-bold text-emerald-800 mb-1">Welcome to DeedPro!</h1>
-                <p className="text-emerald-700">
-                  One quick question and you&apos;re in: which county do you work in most often?
-                  We&apos;ll use it as your default.
-                </p>
-              </div>
-            </div>
+      {/* Centered single-step */}
+      <main className="flex-1 flex items-center justify-center px-4 py-8">
+        <div className="w-full max-w-md space-y-6 animate-in fade-in duration-500">
+          {/* Welcome */}
+          <div className="space-y-2">
+            <span className="inline-flex items-center gap-1.5 text-xs font-semibold text-brand-500 bg-brand-50 px-3 py-1 rounded-full">
+              <Sparkles className="w-3.5 h-3.5" />
+              Welcome to DeedPro
+            </span>
+            <h1 className="text-2xl font-bold tracking-tight text-gray-900">
+              One quick thing before your first deed
+            </h1>
+            <p className="text-[15px] text-gray-500 leading-relaxed">
+              Pick the county you record in most often. We&apos;ll use it as your default — you can
+              always change it later.
+            </p>
           </div>
 
-          <div className="bg-white rounded-2xl border border-gray-200 p-8">
-            <label className="block text-lg font-semibold text-gray-900 mb-2">
-              <MapPin className="w-5 h-5 inline mr-2 text-gray-400" />
-              Default County
-            </label>
-            <select
-              value={county}
-              onChange={(e) => setCounty(e.target.value)}
-              className="w-full px-4 py-4 text-lg border border-gray-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent"
-              autoFocus
-            >
-              {CA_COUNTIES.map((c) => (
-                <option key={c} value={c}>{c}</option>
-              ))}
-            </select>
-
-            {county === "Los Angeles" && (
-              <div className="mt-4 p-4 bg-amber-50 border border-amber-200 rounded-xl">
-                <p className="text-sm text-amber-800">
-                  <strong>💡 Tip:</strong> Los Angeles has both county ($1.10/1000) and city
-                  transfer taxes. We&apos;ll help you calculate the right amount for each property.
-                </p>
-              </div>
-            )}
-
+          {/* Card */}
+          <form onSubmit={handleSubmit} className="bg-white rounded-2xl shadow-sm border border-gray-200 p-7 space-y-5">
             {error && (
-              <div className="mt-4 p-4 bg-red-50 border border-red-200 rounded-xl">
-                <p className="text-sm text-red-800">{error}</p>
+              <div className="p-3.5 bg-error-50 border border-error-500/20 rounded-lg text-error-600 text-sm font-medium">
+                {error}
               </div>
             )}
-          </div>
 
-          <div className="space-y-3 mt-8">
+            <div className="space-y-1.5">
+              <label htmlFor="default_county" className="block text-sm font-semibold text-gray-900">
+                Default county
+              </label>
+              <div className="relative">
+                <MapPin className="absolute left-3.5 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400 pointer-events-none" />
+                <select
+                  id="default_county"
+                  name="default_county"
+                  value={county}
+                  onChange={(e) => setCounty(e.target.value)}
+                  autoFocus
+                  className="w-full pl-11 pr-4 py-3 bg-white border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent transition-all appearance-none"
+                >
+                  {CA_COUNTIES.map((c) => (
+                    <option key={c} value={c}>
+                      {c} County
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <p className="text-xs text-gray-400">California counties shown. More states coming soon.</p>
+            </div>
+
+            {/* Primary CTA */}
             <button
-              onClick={() => handleComplete("/deed-builder")}
+              type="submit"
               disabled={loading}
-              className="w-full bg-emerald-600 hover:bg-emerald-700 text-white font-semibold py-4 rounded-xl transition-all flex items-center justify-center gap-2 shadow-lg shadow-emerald-500/20 disabled:opacity-60"
+              className="w-full bg-brand-500 hover:bg-brand-600 text-white font-semibold py-3.5 rounded-lg transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 flex items-center justify-center gap-2"
             >
-              <Sparkles className="w-5 h-5" />
-              {loading ? "Saving..." : "Take me to my first deed"}
-              <ArrowRight className="w-4 h-4" />
+              {loading ? (
+                <span className="flex items-center justify-center gap-2">
+                  <svg className="animate-spin h-5 w-5" viewBox="0 0 24 24">
+                    <circle
+                      className="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      strokeWidth="4"
+                      fill="none"
+                    />
+                    <path
+                      className="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+                    />
+                  </svg>
+                  Setting up...
+                </span>
+              ) : (
+                <>
+                  Take me to my first deed
+                  <ArrowRight className="w-4 h-4" />
+                </>
+              )}
             </button>
+
+            {/* Secondary: save the county but land on the dashboard */}
             <button
+              type="button"
               onClick={() => handleComplete("/dashboard")}
               disabled={loading}
-              className="w-full text-gray-600 hover:text-gray-800 font-medium py-3 transition-colors disabled:opacity-60"
+              className="w-full text-sm font-medium text-gray-500 hover:text-gray-900 transition-colors disabled:opacity-60"
             >
-              Take me to my dashboard
+              Save and take me to my dashboard
             </button>
-          </div>
+          </form>
+
+          {/* Trust footer */}
+          <p className="flex items-center justify-center gap-1.5 text-xs text-gray-400">
+            <ShieldCheck className="w-3.5 h-3.5" />
+            Your preferences stay private to your workspace
+          </p>
         </div>
       </main>
     </div>

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -1,11 +1,15 @@
 "use client"
 
+// F6: visual re-implementation from the V0 reference (temp-v0, reference
+// only). Logic contracts preserved: every field, validation rule, and the
+// F2 auto-login success handler (the reference still had the old
+// redirect-to-login flow — a bug in the reference, not a design choice).
 import type React from "react"
 
 import { useState } from "react"
 import { useRouter } from "next/navigation"
 import Link from "next/link"
-import { Eye, EyeOff, CheckCircle2, Zap, Shield } from "lucide-react"
+import { Eye, EyeOff, ShieldCheck } from "lucide-react"
 import { AuthManager } from "@/utils/auth"
 
 const states = [
@@ -229,45 +233,58 @@ export default function RegisterPage() {
     if (/\d/.test(password)) strength++
     if (/[^a-zA-Z0-9]/.test(password)) strength++
 
-    if (strength <= 2) return { strength, label: "Weak", color: "bg-red-500" }
-    if (strength <= 3) return { strength, label: "Fair", color: "bg-yellow-500" }
+    if (strength <= 2) return { strength, label: "Weak", color: "bg-error-500" }
+    if (strength <= 3) return { strength, label: "Fair", color: "bg-warning-500" }
     if (strength <= 4) return { strength, label: "Good", color: "bg-blue-500" }
-    return { strength, label: "Strong", color: "bg-green-500" }
+    return { strength, label: "Strong", color: "bg-success-500" }
   }
 
   const passwordStrength = getPasswordStrength()
 
+  const inputBase =
+    "w-full px-4 py-3 bg-white border rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent transition-all"
+
   return (
-    <div className="min-h-screen bg-[#F9F9F9] flex flex-col">
-      {/* Header */}
-      <header className="bg-white border-b border-gray-200">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
-          <Link href="/" className="text-2xl font-bold text-[#1F2B37]">
-            DeedPro
+    <div className="min-h-screen bg-gray-50 flex flex-col">
+      {/* Top brand bar */}
+      <header className="px-4 sm:px-6 lg:px-8 py-5">
+        <div className="max-w-6xl mx-auto flex items-center justify-between">
+          <Link href="/" className="flex items-center gap-2.5">
+            <span className="w-8 h-8 rounded-lg bg-brand-500 flex items-center justify-center">
+              <ShieldCheck className="w-5 h-5 text-white" />
+            </span>
+            <span className="text-xl font-bold tracking-tight text-gray-900">DeedPro</span>
+          </Link>
+          <Link href="/login" className="text-sm font-medium text-gray-500 hover:text-gray-900 transition-colors">
+            Already have an account? <span className="text-brand-500">Sign in</span>
           </Link>
         </div>
       </header>
 
-      {/* Main Content */}
-      <main className="flex-1 py-12 px-4 sm:px-6 lg:px-8">
-        <div className="max-w-4xl mx-auto">
-          {/* Header Section */}
-          <div className="text-center mb-8">
-            <h1 className="text-4xl font-bold text-[#1F2B37] mb-3">Join DeedPro Today</h1>
-            <p className="text-lg text-gray-600">Start creating professional deeds in seconds</p>
+      {/* Centered form column */}
+      <main className="flex-1 flex items-center justify-center px-4 py-8">
+        <div className="w-full max-w-xl space-y-6 animate-in fade-in duration-500">
+          {/* Heading */}
+          <div className="space-y-1.5">
+            <h1 className="text-2xl font-bold tracking-tight text-gray-900">Create your account</h1>
+            <p className="text-[15px] text-gray-500 leading-relaxed">
+              Set up your workspace to start generating recorder-ready deeds.
+            </p>
           </div>
 
           {/* Registration Form Card */}
-          <div className="bg-white rounded-2xl shadow-sm border border-gray-200 p-8 mb-12">
+          <div className="bg-white rounded-2xl shadow-sm border border-gray-200 p-7">
             {error && (
-              <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-lg text-red-700 text-sm">{error}</div>
+              <div className="mb-6 p-3.5 bg-error-50 border border-error-500/20 rounded-lg text-error-600 text-sm font-medium">
+                {error}
+              </div>
             )}
 
-            <form onSubmit={handleSubmit} className="space-y-6">
+            <form onSubmit={handleSubmit} className="space-y-5">
               {/* Email */}
-              <div>
-                <label htmlFor="email" className="block text-sm font-semibold text-[#1F2B37] mb-2">
-                  Email Address <span className="text-red-500">*</span>
+              <div className="space-y-1.5">
+                <label htmlFor="email" className="block text-sm font-semibold text-gray-900">
+                  Email address <span className="text-error-500">*</span>
                 </label>
                 <input
                   type="email"
@@ -275,19 +292,17 @@ export default function RegisterPage() {
                   name="email"
                   value={formData.email}
                   onChange={handleChange}
-                  className={`w-full px-4 py-3 border ${
-                    validationErrors.email ? "border-red-500" : "border-gray-300"
-                  } rounded-lg focus:outline-none focus:ring-2 focus:ring-[#7C4DFF] focus:border-transparent transition-all`}
+                  className={`${inputBase} ${validationErrors.email ? "border-error-500" : "border-gray-200"}`}
                   placeholder="you@company.com"
                 />
-                {validationErrors.email && <p className="mt-1 text-sm text-red-500">{validationErrors.email}</p>}
+                {validationErrors.email && <p className="mt-1 text-sm text-error-500">{validationErrors.email}</p>}
               </div>
 
               {/* Password & Confirm Password */}
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <div>
-                  <label htmlFor="password" className="block text-sm font-semibold text-[#1F2B37] mb-2">
-                    Password <span className="text-red-500">*</span>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+                <div className="space-y-1.5">
+                  <label htmlFor="password" className="block text-sm font-semibold text-gray-900">
+                    Password <span className="text-error-500">*</span>
                   </label>
                   <div className="relative">
                     <input
@@ -296,15 +311,16 @@ export default function RegisterPage() {
                       name="password"
                       value={formData.password}
                       onChange={handleChange}
-                      className={`w-full px-4 py-3 border ${
-                        validationErrors.password ? "border-red-500" : "border-gray-300"
-                      } rounded-lg focus:outline-none focus:ring-2 focus:ring-[#7C4DFF] focus:border-transparent transition-all pr-12`}
+                      className={`${inputBase} pr-12 ${
+                        validationErrors.password ? "border-error-500" : "border-gray-200"
+                      }`}
                       placeholder="••••••••"
                     />
                     <button
                       type="button"
                       onClick={() => setShowPassword(!showPassword)}
-                      className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 transition-colors"
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-900 transition-colors"
+                      aria-label={showPassword ? "Hide password" : "Show password"}
                     >
                       {showPassword ? <EyeOff size={20} /> : <Eye size={20} />}
                     </button>
@@ -318,18 +334,18 @@ export default function RegisterPage() {
                             style={{ width: `${(passwordStrength.strength / 5) * 100}%` }}
                           />
                         </div>
-                        <span className="text-xs font-medium text-gray-600">{passwordStrength.label}</span>
+                        <span className="text-xs font-medium text-gray-500">{passwordStrength.label}</span>
                       </div>
                     </div>
                   )}
                   {validationErrors.password && (
-                    <p className="mt-1 text-sm text-red-500">{validationErrors.password}</p>
+                    <p className="mt-1 text-sm text-error-500">{validationErrors.password}</p>
                   )}
                 </div>
 
-                <div>
-                  <label htmlFor="confirmPassword" className="block text-sm font-semibold text-[#1F2B37] mb-2">
-                    Confirm Password <span className="text-red-500">*</span>
+                <div className="space-y-1.5">
+                  <label htmlFor="confirmPassword" className="block text-sm font-semibold text-gray-900">
+                    Confirm password <span className="text-error-500">*</span>
                   </label>
                   <div className="relative">
                     <input
@@ -338,29 +354,30 @@ export default function RegisterPage() {
                       name="confirmPassword"
                       value={formData.confirmPassword}
                       onChange={handleChange}
-                      className={`w-full px-4 py-3 border ${
-                        validationErrors.confirmPassword ? "border-red-500" : "border-gray-300"
-                      } rounded-lg focus:outline-none focus:ring-2 focus:ring-[#7C4DFF] focus:border-transparent transition-all pr-12`}
+                      className={`${inputBase} pr-12 ${
+                        validationErrors.confirmPassword ? "border-error-500" : "border-gray-200"
+                      }`}
                       placeholder="••••••••"
                     />
                     <button
                       type="button"
                       onClick={() => setShowConfirmPassword(!showConfirmPassword)}
-                      className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 transition-colors"
+                      className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-900 transition-colors"
+                      aria-label={showConfirmPassword ? "Hide password" : "Show password"}
                     >
                       {showConfirmPassword ? <EyeOff size={20} /> : <Eye size={20} />}
                     </button>
                   </div>
                   {validationErrors.confirmPassword && (
-                    <p className="mt-1 text-sm text-red-500">{validationErrors.confirmPassword}</p>
+                    <p className="mt-1 text-sm text-error-500">{validationErrors.confirmPassword}</p>
                   )}
                 </div>
               </div>
 
               {/* Full Name */}
-              <div>
-                <label htmlFor="fullName" className="block text-sm font-semibold text-[#1F2B37] mb-2">
-                  Full Name <span className="text-red-500">*</span>
+              <div className="space-y-1.5">
+                <label htmlFor="fullName" className="block text-sm font-semibold text-gray-900">
+                  Full name <span className="text-error-500">*</span>
                 </label>
                 <input
                   type="text"
@@ -368,28 +385,26 @@ export default function RegisterPage() {
                   name="fullName"
                   value={formData.fullName}
                   onChange={handleChange}
-                  className={`w-full px-4 py-3 border ${
-                    validationErrors.fullName ? "border-red-500" : "border-gray-300"
-                  } rounded-lg focus:outline-none focus:ring-2 focus:ring-[#7C4DFF] focus:border-transparent transition-all`}
+                  className={`${inputBase} ${validationErrors.fullName ? "border-error-500" : "border-gray-200"}`}
                   placeholder="John Smith"
                 />
-                {validationErrors.fullName && <p className="mt-1 text-sm text-red-500">{validationErrors.fullName}</p>}
+                {validationErrors.fullName && <p className="mt-1 text-sm text-error-500">{validationErrors.fullName}</p>}
               </div>
 
               {/* Role & State */}
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <div>
-                  <label htmlFor="role" className="block text-sm font-semibold text-[#1F2B37] mb-2">
-                    Professional Role <span className="text-red-500">*</span>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+                <div className="space-y-1.5">
+                  <label htmlFor="role" className="block text-sm font-semibold text-gray-900">
+                    Professional role <span className="text-error-500">*</span>
                   </label>
                   <select
                     id="role"
                     name="role"
                     value={formData.role}
                     onChange={handleChange}
-                    className={`w-full px-4 py-3 border ${
-                      validationErrors.role ? "border-red-500" : "border-gray-300"
-                    } rounded-lg focus:outline-none focus:ring-2 focus:ring-[#7C4DFF] focus:border-transparent transition-all bg-white`}
+                    className={`${inputBase} bg-white ${
+                      validationErrors.role ? "border-error-500" : "border-gray-200"
+                    }`}
                   >
                     <option value="">Select your role</option>
                     {roles.map((role) => (
@@ -398,21 +413,21 @@ export default function RegisterPage() {
                       </option>
                     ))}
                   </select>
-                  {validationErrors.role && <p className="mt-1 text-sm text-red-500">{validationErrors.role}</p>}
+                  {validationErrors.role && <p className="mt-1 text-sm text-error-500">{validationErrors.role}</p>}
                 </div>
 
-                <div>
-                  <label htmlFor="state" className="block text-sm font-semibold text-[#1F2B37] mb-2">
-                    State <span className="text-red-500">*</span>
+                <div className="space-y-1.5">
+                  <label htmlFor="state" className="block text-sm font-semibold text-gray-900">
+                    State <span className="text-error-500">*</span>
                   </label>
                   <select
                     id="state"
                     name="state"
                     value={formData.state}
                     onChange={handleChange}
-                    className={`w-full px-4 py-3 border ${
-                      validationErrors.state ? "border-red-500" : "border-gray-300"
-                    } rounded-lg focus:outline-none focus:ring-2 focus:ring-[#7C4DFF] focus:border-transparent transition-all bg-white`}
+                    className={`${inputBase} bg-white ${
+                      validationErrors.state ? "border-error-500" : "border-gray-200"
+                    }`}
                   >
                     <option value="">Select your state</option>
                     {states.map((state) => (
@@ -421,15 +436,15 @@ export default function RegisterPage() {
                       </option>
                     ))}
                   </select>
-                  {validationErrors.state && <p className="mt-1 text-sm text-red-500">{validationErrors.state}</p>}
+                  {validationErrors.state && <p className="mt-1 text-sm text-error-500">{validationErrors.state}</p>}
                 </div>
               </div>
 
               {/* Company Name & Company Type */}
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <div>
-                  <label htmlFor="companyName" className="block text-sm font-semibold text-[#1F2B37] mb-2">
-                    Company Name <span className="text-gray-400 text-xs">(Optional)</span>
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+                <div className="space-y-1.5">
+                  <label htmlFor="companyName" className="block text-sm font-semibold text-gray-900">
+                    Company name <span className="text-gray-400 text-xs font-normal">(Optional)</span>
                   </label>
                   <input
                     type="text"
@@ -437,21 +452,21 @@ export default function RegisterPage() {
                     name="companyName"
                     value={formData.companyName}
                     onChange={handleChange}
-                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#7C4DFF] focus:border-transparent transition-all"
+                    className={`${inputBase} border-gray-200`}
                     placeholder="Your Company LLC"
                   />
                 </div>
 
-                <div>
-                  <label htmlFor="companyType" className="block text-sm font-semibold text-[#1F2B37] mb-2">
-                    Company Type <span className="text-gray-400 text-xs">(Optional)</span>
+                <div className="space-y-1.5">
+                  <label htmlFor="companyType" className="block text-sm font-semibold text-gray-900">
+                    Company type <span className="text-gray-400 text-xs font-normal">(Optional)</span>
                   </label>
                   <select
                     id="companyType"
                     name="companyType"
                     value={formData.companyType}
                     onChange={handleChange}
-                    className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#7C4DFF] focus:border-transparent transition-all bg-white"
+                    className={`${inputBase} bg-white border-gray-200`}
                   >
                     <option value="">Select company type</option>
                     {companyTypes.map((type) => (
@@ -464,9 +479,9 @@ export default function RegisterPage() {
               </div>
 
               {/* Phone */}
-              <div>
-                <label htmlFor="phone" className="block text-sm font-semibold text-[#1F2B37] mb-2">
-                  Phone Number <span className="text-gray-400 text-xs">(Optional)</span>
+              <div className="space-y-1.5">
+                <label htmlFor="phone" className="block text-sm font-semibold text-gray-900">
+                  Phone number <span className="text-gray-400 text-xs font-normal">(Optional)</span>
                 </label>
                 <input
                   type="tel"
@@ -474,13 +489,13 @@ export default function RegisterPage() {
                   name="phone"
                   value={formData.phone}
                   onChange={handleChange}
-                  className="w-full px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#7C4DFF] focus:border-transparent transition-all"
+                  className={`${inputBase} border-gray-200`}
                   placeholder="(555) 123-4567"
                 />
               </div>
 
               {/* Checkboxes */}
-              <div className="space-y-3 pt-2">
+              <div className="space-y-3 pt-1">
                 <div className="flex items-start">
                   <input
                     type="checkbox"
@@ -488,22 +503,22 @@ export default function RegisterPage() {
                     name="agreeTerms"
                     checked={formData.agreeTerms}
                     onChange={handleChange}
-                    className="mt-1 h-4 w-4 text-[#7C4DFF] border-gray-300 rounded focus:ring-[#7C4DFF] focus:ring-2"
+                    className="mt-1 h-4 w-4 text-brand-500 border-gray-200 rounded focus:ring-brand-500 focus:ring-2"
                   />
                   <label htmlFor="agreeTerms" className="ml-3 text-sm text-gray-700">
                     I agree to the{" "}
-                    <Link href="/terms" className="text-[#7C4DFF] hover:underline font-medium">
+                    <Link href="/terms" className="text-brand-500 hover:underline font-medium">
                       Terms of Service
                     </Link>{" "}
                     and{" "}
-                    <Link href="/privacy" className="text-[#7C4DFF] hover:underline font-medium">
+                    <Link href="/privacy" className="text-brand-500 hover:underline font-medium">
                       Privacy Policy
                     </Link>
-                    <span className="text-red-500 ml-1">*</span>
+                    <span className="text-error-500 ml-1">*</span>
                   </label>
                 </div>
                 {validationErrors.agreeTerms && (
-                  <p className="ml-7 text-sm text-red-500">{validationErrors.agreeTerms}</p>
+                  <p className="ml-7 text-sm text-error-500">{validationErrors.agreeTerms}</p>
                 )}
 
                 <div className="flex items-start">
@@ -513,7 +528,7 @@ export default function RegisterPage() {
                     name="subscribe"
                     checked={formData.subscribe}
                     onChange={handleChange}
-                    className="mt-1 h-4 w-4 text-[#7C4DFF] border-gray-300 rounded focus:ring-[#7C4DFF] focus:ring-2"
+                    className="mt-1 h-4 w-4 text-brand-500 border-gray-200 rounded focus:ring-brand-500 focus:ring-2"
                   />
                   <label htmlFor="subscribe" className="ml-3 text-sm text-gray-700">
                     Send me product updates and tips via email
@@ -525,56 +540,28 @@ export default function RegisterPage() {
               <button
                 type="submit"
                 disabled={loading}
-                className="w-full bg-[#7C4DFF] text-white font-semibold py-4 rounded-lg hover:bg-[#6A3FE8] transition-all disabled:opacity-50 disabled:cursor-not-allowed shadow-lg shadow-[#7C4DFF]/20"
+                className="w-full bg-brand-500 text-white font-semibold py-3.5 rounded-lg hover:bg-brand-600 transition-all disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2"
               >
-                {loading ? "Creating Account..." : "Create My Account"}
+                {loading ? "Creating account..." : "Create my account"}
               </button>
 
               {/* Sign In Link */}
-              <p className="text-center text-sm text-gray-600">
+              <p className="text-center text-sm text-gray-500">
                 Already have an account?{" "}
-                <Link href="/login" className="text-[#7C4DFF] hover:underline font-semibold">
+                <Link href="/login" className="text-brand-500 hover:underline font-semibold">
                   Sign in
                 </Link>
               </p>
             </form>
           </div>
 
-          {/* Feature Cards */}
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <div className="bg-white rounded-xl p-6 border border-gray-200 text-center">
-              <div className="w-12 h-12 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
-                <CheckCircle2 className="text-green-600" size={24} />
-              </div>
-              <h3 className="font-bold text-[#1F2B37] mb-2">Free to Start</h3>
-              <p className="text-sm text-gray-600">No credit card required. Start creating deeds immediately.</p>
-            </div>
-
-            <div className="bg-white rounded-xl p-6 border border-gray-200 text-center">
-              <div className="w-12 h-12 bg-purple-100 rounded-full flex items-center justify-center mx-auto mb-4">
-                <Zap className="text-[#7C4DFF]" size={24} />
-              </div>
-              <h3 className="font-bold text-[#1F2B37] mb-2">AI-Powered</h3>
-              <p className="text-sm text-gray-600">Generate professional deeds in seconds with AI assistance.</p>
-            </div>
-
-            <div className="bg-white rounded-xl p-6 border border-gray-200 text-center">
-              <div className="w-12 h-12 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4">
-                <Shield className="text-blue-600" size={24} />
-              </div>
-              <h3 className="font-bold text-[#1F2B37] mb-2">Secure & Compliant</h3>
-              <p className="text-sm text-gray-600">Bank-level security with state-specific compliance built in.</p>
-            </div>
-          </div>
+          {/* Trust footer */}
+          <p className="flex items-center justify-center gap-1.5 text-xs text-gray-400">
+            <ShieldCheck className="w-3.5 h-3.5" />
+            Bank-level security &middot; State-specific compliance built in
+          </p>
         </div>
       </main>
-
-      {/* Footer */}
-      <footer className="bg-white border-t border-gray-200 py-6">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center text-sm text-gray-600">
-          © 2025 DeedPro. All rights reserved.
-        </div>
-      </footer>
     </div>
   )
 }

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,133 +1,190 @@
 'use client';
 
+// F6: visual re-implementation from the V0 reference (temp-v0, reference
+// only — not merged). Logic contracts preserved: nav items and hrefs,
+// AuthManager.isAdmin() gating, AuthManager.logout(), collapse/expand.
+// Fixed by design: the active accent now renders (the old `border-l-3`
+// class doesn't exist in Tailwind), active matching is exact-plus-subroute
+// instead of bare startsWith, and mobile gets an off-canvas drawer.
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import React, { useState, useEffect } from 'react';
 import { AuthManager } from '../utils/auth';
-import { Home, FileText, FolderOpen, Users, UserPlus, Settings, Shield, LogOut, ChevronLeft, ChevronRight } from 'lucide-react';
+import {
+  LayoutDashboard,
+  FilePlus2,
+  Files,
+  Share2,
+  Users,
+  Settings,
+  ShieldCheck,
+  LogOut,
+  Menu,
+  X,
+  ChevronLeft,
+  ChevronRight,
+} from 'lucide-react';
+
+const NAV_ITEMS = [
+  { href: '/dashboard', icon: LayoutDashboard, label: 'Dashboard' },
+  { href: '/deed-builder', icon: FilePlus2, label: 'Create Deed' },
+  { href: '/past-deeds', icon: Files, label: 'Past Deeds' },
+  { href: '/shared-deeds', icon: Share2, label: 'Shared Deeds' },
+  { href: '/partners', icon: Users, label: 'Partners' },
+  { href: '/account-settings', icon: Settings, label: 'Settings' },
+];
+
+const ADMIN_ITEM = { href: '/admin', icon: ShieldCheck, label: 'Admin' };
 
 export default function Sidebar() {
   const pathname = usePathname();
   const [isCollapsed, setIsCollapsed] = useState(false);
+  const [isMobileOpen, setIsMobileOpen] = useState(false);
   const [isAdmin, setIsAdmin] = useState(false);
 
-  // Check admin status on mount
+  // Check admin status on mount (localStorage isn't available during SSR)
   useEffect(() => {
     setIsAdmin(AuthManager.isAdmin());
   }, []);
-
-  const toggleSidebar = () => {
-    setIsCollapsed(!isCollapsed);
-  };
 
   const handleLogout = () => {
     AuthManager.logout();
     window.location.href = '/login';
   };
 
-  // Base nav items (shown to all users)
-  const navItems = [
-    { href: '/dashboard', icon: Home, label: 'Dashboard' },
-    { href: '/deed-builder', icon: FileText, label: 'Create Deed' },
-    { href: '/past-deeds', icon: FolderOpen, label: 'Past Deeds' },
-    { href: '/shared-deeds', icon: Users, label: 'Shared Deeds' },
-    { href: '/partners', icon: UserPlus, label: 'Partners' },
-    { href: '/account-settings', icon: Settings, label: 'Settings' },
-    // Admin link - only added if user is admin (see below)
-  ];
+  // Active = exact match or a sub-route of the item (so /deed-builder/grant-deed
+  // keeps Create Deed lit without the old prefix over-matching).
+  const isActive = (href: string) =>
+    pathname === href || !!pathname?.startsWith(`${href}/`);
 
-  // Add admin link only for admin users
-  if (isAdmin) {
-    navItems.push({ href: '/admin', icon: Shield, label: 'Admin' });
-  }
+  const items = isAdmin ? [...NAV_ITEMS, ADMIN_ITEM] : NAV_ITEMS;
 
-  const isActive = (href: string) => {
-    if (href === '/dashboard') {
-      return pathname === '/dashboard';
-    }
-    return pathname?.startsWith(href);
-  };
+  const navList = (collapsed: boolean) => (
+    <ul className="flex-1 px-3 py-4 space-y-1 overflow-y-auto" aria-label="Primary">
+      {items.map((item) => {
+        const Icon = item.icon;
+        const active = isActive(item.href);
+        return (
+          <li key={item.href}>
+            <Link
+              href={item.href}
+              onClick={() => setIsMobileOpen(false)}
+              aria-current={active ? 'page' : undefined}
+              title={collapsed ? item.label : undefined}
+              className={`relative flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors ${
+                collapsed ? 'justify-center' : ''
+              } ${
+                active
+                  ? 'bg-brand-50 text-brand-600'
+                  : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
+              }`}
+            >
+              <span
+                className={`absolute left-0 top-1/2 -translate-y-1/2 h-6 w-1 rounded-r-full bg-brand-500 transition-opacity ${
+                  active ? 'opacity-100' : 'opacity-0'
+                }`}
+                aria-hidden="true"
+              />
+              <Icon className="w-5 h-5 flex-shrink-0" />
+              {!collapsed && <span className="truncate">{item.label}</span>}
+            </Link>
+          </li>
+        );
+      })}
+    </ul>
+  );
 
-  return (
-    <nav 
-      className={`bg-white border-r border-gray-200 h-screen sticky top-0 flex flex-col transition-all duration-300 ${
-        isCollapsed ? 'w-16' : 'w-64'
+  const brand = (collapsed: boolean) => (
+    <div
+      className={`flex items-center gap-2.5 px-5 py-5 border-b border-gray-100 ${
+        collapsed ? 'justify-center px-0' : ''
       }`}
     >
-      {/* Header */}
-      <div className="p-4 border-b border-gray-200 flex items-center justify-between">
-        {!isCollapsed && (
-          <div className="flex items-center gap-3">
-            <div className="w-10 h-10 bg-[#7C4DFF] rounded-lg flex items-center justify-center text-white font-bold text-lg">
-              DP
-            </div>
-            <div>
-              <h2 className="text-lg font-bold text-[#1F2B37]">DeedPro</h2>
-            </div>
-          </div>
-        )}
-        {isCollapsed && (
-          <div className="w-10 h-10 bg-[#7C4DFF] rounded-lg flex items-center justify-center text-white font-bold text-lg mx-auto">
-            DP
-          </div>
-        )}
-      </div>
+      <span className="w-9 h-9 rounded-lg bg-brand-500 flex items-center justify-center flex-shrink-0">
+        <ShieldCheck className="w-5 h-5 text-white" />
+      </span>
+      {!collapsed && (
+        <span className="text-xl font-bold tracking-tight text-gray-900">DeedPro</span>
+      )}
+    </div>
+  );
 
-      {/* Toggle Button */}
+  const logoutButton = (collapsed: boolean) => (
+    <div className="px-3 py-4 border-t border-gray-100">
       <button
-        onClick={toggleSidebar}
-        className="absolute -right-3 top-20 bg-white border border-gray-200 rounded-full p-1 hover:bg-gray-50 transition-colors z-10 shadow-sm"
-        title={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+        onClick={handleLogout}
+        title={collapsed ? 'Logout' : undefined}
+        className={`flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-error-600 hover:bg-error-50 transition-colors w-full ${
+          collapsed ? 'justify-center' : ''
+        }`}
       >
-        {isCollapsed ? (
-          <ChevronRight className="w-4 h-4 text-gray-600" />
-        ) : (
-          <ChevronLeft className="w-4 h-4 text-gray-600" />
-        )}
+        <LogOut className="w-5 h-5 flex-shrink-0" />
+        {!collapsed && <span>Logout</span>}
+      </button>
+    </div>
+  );
+
+  return (
+    <>
+      {/* Mobile: floating menu button (pages lay Sidebar + main in a flex
+          row, so a fixed trigger avoids reflowing every page on mobile) */}
+      <button
+        onClick={() => setIsMobileOpen(true)}
+        className="md:hidden fixed top-4 right-4 z-40 p-2.5 rounded-full bg-white border border-gray-200 shadow-md text-gray-600 hover:text-brand-500 transition-colors"
+        aria-label="Open navigation menu"
+      >
+        <Menu className="w-5 h-5" />
       </button>
 
-      {/* Navigation Links */}
-      <ul className="flex-1 p-2 space-y-1 overflow-y-auto">
-        {navItems.map((item) => {
-          const Icon = item.icon;
-          const active = isActive(item.href);
-          return (
-            <li key={item.href}>
-              <Link
-                href={item.href}
-                className={`
-                  flex items-center gap-3 px-3 py-3.5 rounded-lg font-medium 
-                  transition-all duration-200 ease-out
-                  ${active 
-                    ? 'bg-[#7C4DFF]/15 text-[#7C4DFF] border-l-3 border-[#7C4DFF] shadow-sm' 
-                    : 'text-gray-700 hover:bg-[#7C4DFF]/10 hover:text-[#7C4DFF] hover:translate-x-1'
-                  }
-                `}
-                title={isCollapsed ? item.label : ''}
-              >
-                <Icon className={`w-5 h-5 flex-shrink-0 transition-transform ${active ? 'text-[#7C4DFF] scale-110' : ''}`} />
-                {!isCollapsed && (
-                  <span className="text-base">{item.label}</span>
-                )}
-              </Link>
-            </li>
-          );
-        })}
+      {/* Mobile off-canvas overlay */}
+      {isMobileOpen && (
+        <div
+          className="md:hidden fixed inset-0 bg-black/40 z-40"
+          onClick={() => setIsMobileOpen(false)}
+          aria-hidden="true"
+        />
+      )}
 
-        {/* Logout Button */}
-        <li className="pt-4 mt-4 border-t border-gray-200">
+      {/* Mobile off-canvas drawer */}
+      <aside
+        className={`md:hidden fixed top-0 left-0 h-full w-72 bg-white z-50 flex flex-col shadow-xl transform transition-transform duration-300 ease-in-out ${
+          isMobileOpen ? 'translate-x-0' : '-translate-x-full'
+        }`}
+        aria-hidden={!isMobileOpen}
+      >
+        <div className="flex items-center justify-between border-b border-gray-100 pr-3">
+          {brand(false)}
           <button
-            onClick={handleLogout}
-            className="flex items-center gap-3 px-3 py-3.5 rounded-lg text-gray-700 hover:bg-red-50 hover:text-red-600 transition-colors group w-full"
-            title={isCollapsed ? 'Logout' : ''}
+            onClick={() => setIsMobileOpen(false)}
+            className="p-2 rounded-lg text-gray-600 hover:bg-gray-100 transition-colors"
+            aria-label="Close navigation menu"
           >
-            <LogOut className="w-5 h-5 flex-shrink-0" />
-            {!isCollapsed && (
-              <span className="font-medium text-base">Logout</span>
-            )}
+            <X className="w-5 h-5" />
           </button>
-        </li>
-      </ul>
-    </nav>
+        </div>
+        {navList(false)}
+        {logoutButton(false)}
+      </aside>
+
+      {/* Desktop sidebar (collapsible icon rail) */}
+      <nav
+        className={`hidden md:flex md:flex-col bg-white border-r border-gray-200 h-screen sticky top-0 transition-all duration-300 ${
+          isCollapsed ? 'w-20' : 'w-64'
+        }`}
+      >
+        <div className="relative">
+          {brand(isCollapsed)}
+          <button
+            onClick={() => setIsCollapsed((v) => !v)}
+            className="absolute -right-3 top-6 w-6 h-6 rounded-full bg-white border border-gray-200 shadow-sm flex items-center justify-center text-gray-500 hover:text-brand-500 hover:border-brand-500 transition-colors z-10"
+            aria-label={isCollapsed ? 'Expand sidebar' : 'Collapse sidebar'}
+          >
+            {isCollapsed ? <ChevronRight className="w-4 h-4" /> : <ChevronLeft className="w-4 h-4" />}
+          </button>
+        </div>
+        {navList(isCollapsed)}
+        {logoutButton(isCollapsed)}
+      </nav>
+    </>
   );
 }


### PR DESCRIPTION
## What

Re-implements the three approved F6 surfaces from the V0 reference drop (`v0/design-drop` — reference only, never merged). Per the F6 rules, the visuals come from the reference; the logic comes from our tree; every place the reference deviated from the "Keep intact, exactly" contracts was treated as a bug in the reference and discarded. The reference's raw hex is replaced with our brand Tailwind tokens (`brand-*`, `success/warning/error-*`, standard grays).

### Sidebar (used by 10 pages)
- **The active state finally renders.** The old `border-l-3` class doesn't exist in Tailwind, so the accent bar never drew. Active items now get a real accent bar + `brand-50` fill.
- Active matching is exact-or-subroute (`/deed-builder/grant-deed` keeps Create Deed lit) instead of bare `startsWith`.
- **Mobile:** off-canvas drawer with a floating fixed trigger. Pages lay `<Sidebar /><main>` in a flex row, so a fixed trigger adds mobile nav without reflowing all 10 pages — previously the rail squeezed content on phones.
- Contracts kept: nav items and hrefs (including `/deed-builder`, not the reference's `/create-deed`), `AuthManager.isAdmin()` gating, `AuthManager.logout()`, collapse/expand rail.

### Login + Register (matched pair)
Top brand bar, calm single-column card, trust footer. Kept exactly: registered-banner + email prefill, `?redirect` param, **admin-role redirect** (the reference dropped it), per-status error copy, `AuthManager.setAuth`; register keeps every field, validation rule, and the **F2 auto-login handler** (the reference still had the old redirect-to-login flow). The demo-credentials card stays **dev-only** — the reference rendered it unconditionally, which would have put a real email/password in the production UI.

### Onboarding
V0's single-step design over the F3 contract: county persists via `PATCH /users/profile` (the reference POSTed to a nonexistent `/users/onboarding` and swallowed failures), save errors keep the user on the page, skip records completion server-side, and both destinations survive — "Take me to my first deed" (`/deed-builder`) and "Save and take me to my dashboard".

## Reference-bug ledger (V0 deviations discarded)
1. Login: demo credentials hardcoded and shown unconditionally.
2. Login: admin-role redirect dropped.
3. Register: pre-F2 redirect-to-login success flow.
4. Onboarding: `POST /users/onboarding` (nonexistent), failures swallowed, `/create-deed` route.
5. Sidebar: `/create-deed` href, nonstandard admin check (`user.is_admin`), raw hex everywhere.

## Gates
- tsc 98 errors (baseline held), jest 56 passed, production build clean
- Frontend-only — backend suite and six-flow baseline unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_