### PR TITLE
G1: fix generate-path auth — Bearer null on fresh sessions (demo blocker)

### DIFF
--- a/frontend/src/features/builder/DeedBuilder.tsx
+++ b/frontend/src/features/builder/DeedBuilder.tsx
@@ -194,7 +194,11 @@ function DeedBuilderInner({ deedType, initialProperty }: DeedBuilderProps) {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${localStorage.getItem('token')}`,
+          // G1: AuthManager stores the session under 'access_token'; the bare
+          // 'token' key is a pre-AuthManager fossil nothing writes anymore.
+          // This was the only call site reading it without the fallback —
+          // every fresh session generated with "Bearer null" (demo blocker).
+          'Authorization': `Bearer ${localStorage.getItem('access_token') || localStorage.getItem('token')}`,
         },
         body: JSON.stringify(payload),
       });

--- a/frontend/src/utils/auth.ts
+++ b/frontend/src/utils/auth.ts
@@ -94,7 +94,12 @@ export class AuthManager {
       // Clear auth data
       localStorage.removeItem(this.TOKEN_KEY);
       localStorage.removeItem(this.USER_KEY);
-      
+
+      // G1: also clear the legacy pre-AuthManager 'token' key. A stale copy
+      // masked the dead read in DeedBuilder for months — logout must not
+      // leave fossil credentials behind to camouflage the next one.
+      localStorage.removeItem('token');
+
       // PATCH4a-FIX: Clear wizard state (both Modern and Classic)
       // This ensures user gets fresh property search on next login
       localStorage.removeItem('deedWizardDraft_modern');


### PR DESCRIPTION
## What

Fixes the demo blocker: "Could not validate credentials" when generating a deed.

**Root cause.** `DeedBuilder`'s generate call sent `Authorization: Bearer ${localStorage.getItem('token')}` — the pre-AuthManager legacy key that nothing writes anymore, and the **only** call site in the frontend reading it without the `access_token` fallback. Every fresh session generated with `Bearer null` → 401. A stale legacy `'token'` entry in long-lived browsers masked this for months (and `logout()` never deleted it); the demo run on a fresh account removed the camouflage.

**Both halves:**
- Generate reads `access_token` with the standard legacy fallback, matching the other 20+ call sites.
- `AuthManager.logout()` now clears the legacy `'token'` key too — killing the masking mechanism, not just this instance.

**Empirically cleared before fixing** (real Postgres, real JWT decode): register-minted token → 200 on `POST /deeds`; login-minted token → 200; claim sets identical (`sub`/`email`/`role`/`exp`); `Bearer null` reproduces the exact 401. The `/api/deeds/generate` proxy forwards the header verbatim and middleware excludes `/api/*` — F1/F2 never touched this path.

## Gates

- tsc 98 errors (baseline held), jest 56 passed
- Frontend-only — backend and six-flow unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_