### PR TITLE
H1+H2: fix the silent PDF store (production hotfix) + honest draft card

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -59,7 +59,74 @@ def create_tables():
                 updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )
         """)
-        
+
+        # ──────────────────────────────────────────────────────────────
+        # H1: ONE SCHEMA AUTHORITY. Every column/table the code needs is
+        # converged here, idempotently, at startup — production and the
+        # six-flow test DB derive from this same function. The columns
+        # below existed in production via historical migrations but not in
+        # the CREATEs above; the six-flow harness used to carry its own
+        # copy of these ALTERs, which is exactly how completed_at ended up
+        # existing in tests but not production (the silent-PDF-store
+        # incident, 2026-07-28). ensure_schema no longer amends schema.
+        # Any deliberate test-only divergence requires a cited comment.
+        # ──────────────────────────────────────────────────────────────
+        for stmt in [
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS password_hash TEXT",
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS full_name VARCHAR(255)",
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS role VARCHAR(50) DEFAULT 'user'",
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS plan VARCHAR(50) DEFAULT 'free'",
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS is_active BOOLEAN DEFAULT TRUE",
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS last_login TIMESTAMP",
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS stripe_customer_id VARCHAR(255)",
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS phone VARCHAR(50)",
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS company_name VARCHAR(255)",
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS company_type VARCHAR(100)",
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS state VARCHAR(10)",
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS subscription_status VARCHAR(50)",
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS verified BOOLEAN DEFAULT FALSE",
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS subscribe BOOLEAN DEFAULT FALSE",
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS agree_terms BOOLEAN DEFAULT TRUE",
+            "ALTER TABLE deeds ADD COLUMN IF NOT EXISTS grantor_name VARCHAR(255)",
+            "ALTER TABLE deeds ADD COLUMN IF NOT EXISTS grantee_name VARCHAR(255)",
+            "ALTER TABLE deeds ADD COLUMN IF NOT EXISTS pdf_url VARCHAR(500)",
+            "ALTER TABLE deeds ADD COLUMN IF NOT EXISTS metadata JSONB DEFAULT '{}'",
+            "ALTER TABLE deeds ADD COLUMN IF NOT EXISTS requested_by VARCHAR(255)",
+            # The column whose absence broke every production PDF store:
+            # store_deed_pdf stamps completed-on-store (PR #41); the ALTER
+            # only ever ran in the test harness. Now it runs here.
+            "ALTER TABLE deeds ADD COLUMN IF NOT EXISTS completed_at TIMESTAMP",
+            """CREATE TABLE IF NOT EXISTS deed_pdfs (
+                deed_id INTEGER PRIMARY KEY REFERENCES deeds(id) ON DELETE CASCADE,
+                pdf_data BYTEA NOT NULL,
+                sha256 VARCHAR(64) NOT NULL,
+                generated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )""",
+            """CREATE TABLE IF NOT EXISTS deed_shares (
+                id SERIAL PRIMARY KEY,
+                deed_id INT NOT NULL,
+                owner_user_id INT NOT NULL,
+                recipient_email TEXT NOT NULL,
+                token UUID DEFAULT gen_random_uuid(),
+                status VARCHAR(16) DEFAULT 'sent',
+                expires_at TIMESTAMPTZ,
+                created_at TIMESTAMPTZ DEFAULT now(),
+                updated_at TIMESTAMPTZ DEFAULT now(),
+                feedback TEXT, feedback_at TIMESTAMPTZ, feedback_by VARCHAR(255),
+                viewed_at TIMESTAMPTZ, view_count INT DEFAULT 0,
+                last_reminder_sent_at TIMESTAMPTZ, reminder_count INT DEFAULT 0
+            )""",
+            """CREATE TABLE IF NOT EXISTS plan_limits (
+                plan_name VARCHAR(50) PRIMARY KEY,
+                max_deeds_per_month INT,
+                api_calls_per_month INT,
+                ai_assistance BOOLEAN,
+                integrations_enabled BOOLEAN,
+                priority_support BOOLEAN
+            )""",
+        ]:
+            cursor.execute(stmt)
+
         # Create payment_methods table
         cursor.execute("""
             CREATE TABLE IF NOT EXISTS payment_methods (

--- a/backend/routers/deeds_crud.py
+++ b/backend/routers/deeds_crud.py
@@ -103,6 +103,15 @@ def create_deed_endpoint(deed: DeedCreate, user_id: int = Depends(get_current_us
             db.conn.rollback()
         except Exception:
             pass
+        # H1 (invariant #4, the flagship flow): a deed saved without its
+        # PDF must SAY so — print-only failure let production celebrate
+        # every generation while storing nothing (completed_at incident).
+        # The deed stays a draft; /download retries the render on request.
+        new_deed["pdf_error"] = (
+            "The deed was saved, but its PDF could not be generated and "
+            "stored. It remains a draft; opening or downloading it will "
+            "retry."
+        )
 
     # Phase 7: Send deed completion notification
     try:

--- a/backend/scripts/six_flow_baseline.py
+++ b/backend/scripts/six_flow_baseline.py
@@ -33,51 +33,21 @@ BASELINE_PASSWORD = "Baseline!Passw0rd"
 
 
 def ensure_schema(db_url):
-    """Bring a fresh database up to the columns the live flows need."""
+    """Prepare the test database for a deterministic run.
+
+    H1 class-killer (silent-PDF-store incident, 2026-07-28): this harness
+    carries NO schema statements of its own. Schema comes solely from
+    database.create_tables() — the same code path production runs at
+    startup — so a column can never again exist in tests but not in
+    production. Any deliberate test-only divergence must be added here
+    with a comment citing why. What remains below is data cleanup only.
+    """
     import psycopg2
     conn = psycopg2.connect(db_url)
     conn.autocommit = True
     cur = conn.cursor()
     from database import create_tables
     create_tables()
-    for stmt in [
-        "ALTER TABLE users ADD COLUMN IF NOT EXISTS password_hash TEXT",
-        "ALTER TABLE users ADD COLUMN IF NOT EXISTS full_name VARCHAR(255)",
-        "ALTER TABLE users ADD COLUMN IF NOT EXISTS role VARCHAR(50) DEFAULT 'user'",
-        "ALTER TABLE users ADD COLUMN IF NOT EXISTS plan VARCHAR(50) DEFAULT 'free'",
-        "ALTER TABLE users ADD COLUMN IF NOT EXISTS is_active BOOLEAN DEFAULT TRUE",
-        "ALTER TABLE users ADD COLUMN IF NOT EXISTS last_login TIMESTAMP",
-        "ALTER TABLE users ADD COLUMN IF NOT EXISTS stripe_customer_id VARCHAR(255)",
-        "ALTER TABLE users ADD COLUMN IF NOT EXISTS phone VARCHAR(50)",
-        "ALTER TABLE users ADD COLUMN IF NOT EXISTS company_name VARCHAR(255)",
-        "ALTER TABLE users ADD COLUMN IF NOT EXISTS company_type VARCHAR(100)",
-        "ALTER TABLE users ADD COLUMN IF NOT EXISTS state VARCHAR(10)",
-        "ALTER TABLE users ADD COLUMN IF NOT EXISTS subscription_status VARCHAR(50)",
-        "ALTER TABLE users ADD COLUMN IF NOT EXISTS verified BOOLEAN DEFAULT FALSE",
-        "ALTER TABLE users ADD COLUMN IF NOT EXISTS subscribe BOOLEAN DEFAULT FALSE",
-        "ALTER TABLE users ADD COLUMN IF NOT EXISTS agree_terms BOOLEAN DEFAULT TRUE",
-        "ALTER TABLE deeds ADD COLUMN IF NOT EXISTS grantor_name VARCHAR(255)",
-        "ALTER TABLE deeds ADD COLUMN IF NOT EXISTS grantee_name VARCHAR(255)",
-        "ALTER TABLE deeds ADD COLUMN IF NOT EXISTS pdf_url VARCHAR(500)",
-        "ALTER TABLE deeds ADD COLUMN IF NOT EXISTS metadata JSONB DEFAULT '{}'",
-        "ALTER TABLE deeds ADD COLUMN IF NOT EXISTS requested_by VARCHAR(255)",
-        "ALTER TABLE deeds ADD COLUMN IF NOT EXISTS completed_at TIMESTAMP",
-        """CREATE TABLE IF NOT EXISTS deed_shares (
-            id SERIAL PRIMARY KEY,
-            deed_id INT NOT NULL,
-            owner_user_id INT NOT NULL,
-            recipient_email TEXT NOT NULL,
-            token UUID DEFAULT gen_random_uuid(),
-            status VARCHAR(16) DEFAULT 'sent',
-            expires_at TIMESTAMPTZ,
-            created_at TIMESTAMPTZ DEFAULT now(),
-            updated_at TIMESTAMPTZ DEFAULT now(),
-            feedback TEXT, feedback_at TIMESTAMPTZ, feedback_by VARCHAR(255),
-            viewed_at TIMESTAMPTZ, view_count INT DEFAULT 0,
-            last_reminder_sent_at TIMESTAMPTZ, reminder_count INT DEFAULT 0
-        )""",
-    ]:
-        cur.execute(stmt)
     # deterministic reruns
     cur.execute("DELETE FROM deed_shares")
     cur.execute("DELETE FROM deed_pdfs") if _table_exists(cur, "deed_pdfs") else None

--- a/docs/DOCTRINE_CONFORMANCE.md
+++ b/docs/DOCTRINE_CONFORMANCE.md
@@ -123,11 +123,32 @@ with the fabricated success hiding the failure. Both fixed: standard
 resolver chain; failures return 502 `success: false` (the caller already
 handles thrown errors and degrades gracefully).
 
+**Findings (H1, the silent-PDF-store incident — 2026-07-28).** Production's
+`deeds` table never received the `completed_at` column that the stored-PDF
+pipeline stamps: the ALTER had been applied to the six-flow **test**
+harness's own schema list instead of the production schema path, so the
+baseline verified a schema production didn't have. Every production PDF
+store failed; the failure was print-only and non-blocking (the bug #8
+rollback made it resilient — and therefore silent), so the UI celebrated
+every generation while storing nothing. Three fixes: (1) `create_tables`
+is now the **single schema authority** — all columns/tables the code
+needs converge there idempotently at startup, and the test harness derives
+from that same function with no schema statements of its own (any
+deliberate test-only divergence requires a cited comment); (2) stuck
+deeds self-heal on next download; (3) a save whose PDF store fails now
+carries `pdf_error` in the response, the builder warns instead of
+celebrating, and the post-generation page shows an honest "PDF Not Ready"
+state. **Lesson recorded:** resilience without surfacing is camouflage —
+every non-blocking catch must emit a caller-visible signal.
+
 **Enforced by.**
 - `frontend/src/__tests__/proxyErrorHonesty.test.ts` — source-scans every
   proxy route: no empty-array response bodies; no `success: true` in any
   catch block; every catch that returns JSON carries an explicit 4xx/5xx.
 - `frontend/src/__tests__/integration/fault-injection.test.ts`
+- One schema authority: `scripts/six_flow_baseline.py::ensure_schema`
+  contains no ALTER/CREATE statements — schema comes only from
+  `database.create_tables`, the path production runs at startup.
 
 ---
 
@@ -212,3 +233,4 @@ issuance and authenticated flows against live Postgres.
 |---|---|
 | 2026-07-28 | Initial sweep: partner-API chassis fix, AI-chat proxy honesty fix, proxy source-scan test, partner-render tests. Draft pending owner decisions on §7. |
 | 2026-07-28 | Owner rulings executed: /api/generate-deed excised (snapshot re-recorded), /api/ai/chat logged-in-only + guard test + no-key 503, recitals ruling recorded. Report finalized. |
+| 2026-07-28 | H1 silent-PDF-store incident recorded under invariant #4: one-schema-authority rule (create_tables converges production + tests), store-failure surfaced in response/UI, resilience-without-surfacing lesson. Feature candidate ledgered: true builder resume (persist/restore keyed to deed id), pending usage evidence. |

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -192,19 +192,21 @@ export default function Dashboard() {
             <AIGreeting userName={userName} />
           </div>
 
-          {/* Continue where you left off (AI Card) */}
+          {/* Draft deed card (H2: honest capability — the builder has no
+              state-restore yet, so the card leads to the draft's real home
+              in Past Deeds instead of a dead-end type-selection push) */}
           {inProgressDeed && (
             <AICard
-              message={`You have a deed in progress. Want to continue where you left off?`}
+              message={`You have a draft deed that isn't finished.`}
               action={{
-                label: `Continue: ${inProgressDeed.property_address || inProgressDeed.deed_type || 'Draft'}`,
-                onClick: () => router.push('/deed-builder')
+                label: `View draft: ${inProgressDeed.property_address || inProgressDeed.deed_type || 'Draft'}`,
+                onClick: () => router.push(`/past-deeds?highlight=${inProgressDeed.id}`)
               }}
               secondaryAction={{
-                label: "Start fresh",
+                label: "Start a new deed",
                 onClick: () => router.push('/deed-builder')
               }}
-              details="Your work is automatically saved. You can continue anytime without losing progress."
+              details="Drafts live in Past Deeds — open one there to review it or continue with a fresh build."
               className="mb-8"
             />
           )}

--- a/frontend/src/app/deed-builder/[type]/success/success-content.tsx
+++ b/frontend/src/app/deed-builder/[type]/success/success-content.tsx
@@ -24,6 +24,7 @@ interface DeedDetails {
   pdf_url?: string;
   created_at?: string;
   deed_type?: string;
+  status?: string;
 }
 
 export function SuccessContent() {
@@ -155,6 +156,11 @@ export function SuccessContent() {
 
   const propertyAddress = deed?.property_address || deed?.property || 'Your Property';
 
+  // H1 (invariant #4): the celebration is conditional on the deed actually
+  // completing (stored PDF flips status to 'completed'). A draft here means
+  // the PDF store failed — say so; Download/Preview retry the render.
+  const pdfPending = !!deed && deed.status !== 'completed';
+
   if (loading) {
     return (
       <div className="flex min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-50">
@@ -179,23 +185,36 @@ export function SuccessContent() {
       <main className="flex-1 p-6 md:p-10 lg:p-16 overflow-auto">
         <div className="max-w-[1200px] mx-auto">
           
-          {/* Success Header */}
+          {/* Success (or honest pending) header */}
           <div className="text-center mb-12">
-            {/* Success Animation */}
-            <div className="relative inline-block mb-8">
-              <div className="w-28 h-28 bg-gradient-to-br from-green-100 to-emerald-100 rounded-full flex items-center justify-center mx-auto shadow-lg ring-4 ring-green-50 animate-bounce-once">
-                <CheckCircle className="w-14 h-14 text-green-500" strokeWidth={2.5} />
+            {pdfPending ? (
+              <div className="relative inline-block mb-8">
+                <div className="w-28 h-28 bg-gradient-to-br from-amber-100 to-orange-100 rounded-full flex items-center justify-center mx-auto shadow-lg ring-4 ring-amber-50">
+                  <FileText className="w-14 h-14 text-amber-500" strokeWidth={2.5} />
+                </div>
               </div>
-              {/* Decorative elements */}
-              <div className="absolute -top-2 -right-2 w-5 h-5 bg-[#7C4DFF] rounded-full animate-ping opacity-75" />
-              <div className="absolute -bottom-1 -left-3 w-4 h-4 bg-amber-400 rounded-full animate-ping opacity-75" style={{ animationDelay: '150ms' }} />
-              <div className="absolute top-0 -left-4 w-3 h-3 bg-green-400 rounded-full animate-ping opacity-75" style={{ animationDelay: '300ms' }} />
-              <Sparkles className="absolute -top-4 right-4 w-6 h-6 text-amber-400 animate-pulse" />
-            </div>
+            ) : (
+              <div className="relative inline-block mb-8">
+                <div className="w-28 h-28 bg-gradient-to-br from-green-100 to-emerald-100 rounded-full flex items-center justify-center mx-auto shadow-lg ring-4 ring-green-50 animate-bounce-once">
+                  <CheckCircle className="w-14 h-14 text-green-500" strokeWidth={2.5} />
+                </div>
+                {/* Decorative elements */}
+                <div className="absolute -top-2 -right-2 w-5 h-5 bg-[#7C4DFF] rounded-full animate-ping opacity-75" />
+                <div className="absolute -bottom-1 -left-3 w-4 h-4 bg-amber-400 rounded-full animate-ping opacity-75" style={{ animationDelay: '150ms' }} />
+                <div className="absolute top-0 -left-4 w-3 h-3 bg-green-400 rounded-full animate-ping opacity-75" style={{ animationDelay: '300ms' }} />
+                <Sparkles className="absolute -top-4 right-4 w-6 h-6 text-amber-400 animate-pulse" />
+              </div>
+            )}
 
             <h1 className="text-4xl md:text-5xl font-bold text-slate-800 mb-4 tracking-tight">
-              Deed Generated Successfully!
+              {pdfPending ? 'Deed Saved — PDF Not Ready' : 'Deed Generated Successfully!'}
             </h1>
+            {pdfPending && (
+              <p className="text-base text-amber-700 bg-amber-50 border border-amber-200 rounded-xl px-4 py-3 max-w-xl mx-auto mb-4">
+                The deed was saved, but its PDF hasn&apos;t been stored yet.
+                It remains a draft — Preview or Download below will retry the render.
+              </p>
+            )}
             <p className="text-xl text-slate-600 mb-2">
               {DEED_LABELS[type] || 'Deed'} for
             </p>

--- a/frontend/src/features/builder/DeedBuilder.tsx
+++ b/frontend/src/features/builder/DeedBuilder.tsx
@@ -210,7 +210,13 @@ function DeedBuilderInner({ deedType, initialProperty }: DeedBuilderProps) {
       
       const result = await response.json();
       const generatedDeedId = result.id || result.deed_id;
-      toast.success('Deed generated successfully!');
+      // H1 (invariant #4): a save whose PDF store failed is not a success —
+      // say so instead of celebrating a half-failure.
+      if (result.pdf_error) {
+        toast.warning(result.pdf_error);
+      } else {
+        toast.success('Deed generated successfully!');
+      }
       router.push(`/deed-builder/${deedType}/success?id=${generatedDeedId}`);
     } catch (err) {
       console.error('Generation failed:', err);


### PR DESCRIPTION
## The incident

Production's `deeds` table never received `completed_at`. The ALTER that adds it only ever ran in the six-flow **test** harness's private schema list — so the baseline verified a schema production didn't have, and every production PDF store since the completed-on-store deploy failed at `store_deed_pdf`'s UPDATE. The bug #8 rollback made the failure non-blocking, and therefore **silent**: the UI celebrated every generation while storing nothing. One missing column produced all three demo-run symptoms — the stuck "deed in progress" card (the deed genuinely stayed a draft), the dead Download, and the dead Preview (both hit the self-heal path, which died on the same column).

## H1 — all three parts, plus the class-killer

1. **One schema authority.** `create_tables` now converges every column and table the code needs, idempotently, at startup: `completed_at`, the historical `users`/`deeds` columns, `deed_pdfs`, `deed_shares`, `plan_limits`. Production self-converges on the next Render deploy — no manual migration.
2. **Class-killer (per owner directive):** `ensure_schema` in the six-flow harness now carries **zero** schema statements — it invokes the real `create_tables`, the same code path production runs. A column can never again exist in tests but not in production; any deliberate test-only divergence requires a cited comment. **Proven:** a brand-new database built *only* by `create_tables` passes all six flows against the recorded snapshot.
3. **Self-heal:** existing stuck deeds recover on their next download automatically once the column exists (the retry path already did the right thing — it just kept hitting the same missing column).
4. **Invariant #4 on the flagship flow:** a save whose PDF store fails now returns `pdf_error` in the response (failure-path only — the success response shape is unchanged, so no snapshot churn), the builder toasts a warning instead of "Deed generated successfully!", and the post-generation page renders an honest amber **"Deed Saved — PDF Not Ready"** state instead of the celebration animation, with Preview/Download wired to the retry.

Lesson recorded in `DOCTRINE_CONFORMANCE.md` under invariant #4: **resilience without surfacing is camouflage** — bug #8's rollback is exactly why this failure was invisible.

## H2 — honest draft card (per owner ruling)

The dashboard's "deed in progress" card pushed to `/deed-builder` — the type-selection page — because the builder has no state-restore. The card now leads to the draft's real home (`/past-deeds?highlight=<id>`), with "Start a new deed" as the secondary. **"True builder resume"** (persist/restore keyed to deed id) is ledgered in the conformance doc as a feature candidate pending usage evidence — post-H1, genuine drafts become rare, since today's "drafts" were all failed stores.

## Gates

- Backend: 60 passed
- Six-flow baseline: all match on the existing test DB **and** on a fresh DB built solely by `create_tables` (the strongest possible rehearsal of production's next startup)
- Frontend: tsc 98 (baseline held), jest 110 passed
- No route changes; success-path response shapes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_