### PR TITLE
Login refresh: modern split-screen, new demo credentials, honest forgot-password

### DIFF
--- a/backend/routers/auth_extra.py
+++ b/backend/routers/auth_extra.py
@@ -12,12 +12,12 @@ try:
     # Project-local utilities
     from database import get_db_connection
     from auth import create_access_token, get_password_hash, AuthUtils, ALGORITHM, SECRET_KEY
-    from utils.email import send_email  # Phase 7.5: Relative import first
+    from utils.email import send_email, email_configured  # Phase 7.5: Relative import first
 except Exception as e:
     # Fallback names if modules are under different paths; adjust as needed in your repo
     from backend.database import get_db_connection  # type: ignore
     from backend.auth import create_access_token, get_password_hash, AuthUtils, ALGORITHM, SECRET_KEY  # type: ignore
-    from backend.utils.email import send_email  # Phase 7.5: Absolute fallback
+    from backend.utils.email import send_email, email_configured  # Phase 7.5: Absolute fallback
 
 router = APIRouter()
 
@@ -49,6 +49,14 @@ class VerifyEmailRequest(BaseModel):
 @router.post("/users/forgot-password")
 def forgot_password(payload: ForgotPasswordRequest):
     """Send password reset email. Always return success to avoid user enumeration."""
+    # Invariant #4: with no email provider configured, "we sent a reset
+    # link" is a fabricated success. Fail uniformly BEFORE the user lookup
+    # so the honest error carries no enumeration signal either.
+    if not email_configured():
+        raise HTTPException(
+            status_code=503,
+            detail="Password reset is not available yet — email service is not configured.",
+        )
     email = payload.email.lower()
     try:
         conn = get_db_connection()
@@ -65,12 +73,19 @@ def forgot_password(payload: ForgotPasswordRequest):
             expires_delta=timedelta(hours=RESET_TOKEN_TTL_HOURS)
         )
         reset_url = f"{FRONTEND_URL}/reset-password?token={reset_token}"
-        send_email(
+        sent = send_email(
             to=email,
             subject="Reset your DeedPro password",
             body=f"<p>Hi {full_name},</p><p>Click <a href='{reset_url}'>here</a> to reset your password. This link expires in {RESET_TOKEN_TTL_HOURS} hour(s).</p>"
         )
+        if not sent:
+            # Provider configured but the send failed: log loudly, keep the
+            # generic message (a distinct error here would leak that the
+            # account exists).
+            print(f"[forgot-password] send_email failed for an existing account")
         return {"message": "If the email exists, we sent a reset link."}
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail="Failed to process request")
 

--- a/backend/utils/email.py
+++ b/backend/utils/email.py
@@ -1,13 +1,24 @@
 import os
 from typing import Optional
 
+def email_configured() -> bool:
+    """True when an email provider is actually wired up."""
+    return bool(os.getenv('SENDGRID_API_KEY'))
+
+
 def send_email(to: str, subject: str, body: str) -> bool:
-    """Send email via SendGrid if configured; otherwise log to console for dev/test."""
+    """Send email via SendGrid if configured; otherwise log and report failure.
+
+    Invariant #4 (doctrine sweep): returning True while only printing to the
+    console is a fabricated success — it let /users/forgot-password tell
+    users "reset link sent" with no email infrastructure configured at all.
+    Callers that treat email as optional already handle False.
+    """
     api_key = os.getenv('SENDGRID_API_KEY')
     from_email = os.getenv('SENDGRID_FROM_EMAIL') or os.getenv('FROM_EMAIL', 'noreply@deedpro.com')
     if not api_key:
-        print(f"[email:dev] To={to}\nSubject={subject}\nBody={body[:200]}...")
-        return True
+        print(f"[email:unconfigured] Would send To={to} Subject={subject} — SENDGRID_API_KEY not set")
+        return False
     try:
         from sendgrid import SendGridAPIClient
         from sendgrid.helpers.mail import Mail

--- a/frontend/src/app/forgot-password/page.tsx
+++ b/frontend/src/app/forgot-password/page.tsx
@@ -36,6 +36,10 @@ export default function ForgotPasswordPage() {
 
       if (response.ok) {
         setMessage("Password reset link sent to your email!")
+      } else if (response.status === 503) {
+        // Honest unconfigured state (invariant #4) — don't claim a send.
+        const data = await response.json().catch(() => ({}))
+        setError(data.detail || "Password reset isn't available yet. Please contact support.")
       } else if (response.status === 404) {
         setError("Email address not found")
       } else {

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -1,18 +1,21 @@
 "use client"
 
-// F6: visual re-implementation from the V0 reference (temp-v0, reference
-// only). Logic contracts preserved: auth check, ?registered banner + email
-// prefill, ?redirect param, admin-role redirect, per-status error copy,
-// AuthManager.setAuth storage. The demo-credentials card stays gated to
-// development builds (the reference showed it unconditionally — that and
-// its dropped admin redirect were bugs in the reference, not the design).
+// Login refresh (owner request 2026-07-29): modern split-screen — form
+// column left, brand panel right (hidden on mobile). Logic contracts
+// unchanged from F6: auth check, ?registered banner + email prefill,
+// ?redirect param, admin-role redirect, per-status error copy,
+// AuthManager.setAuth storage, always-visible demo-credentials card
+// (owner decision 2026-07-27; credentials updated 2026-07-29).
 import type React from "react"
 
 import { useState, useEffect, Suspense } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import Link from "next/link"
 import { AuthManager } from "../../utils/auth"
-import { Eye, EyeOff, AlertCircle, CheckCircle2, Zap, Copy, Check, ShieldCheck } from "lucide-react"
+import { Eye, EyeOff, AlertCircle, CheckCircle2, Zap, Copy, Check, ShieldCheck, FileCheck2, Landmark, ScrollText } from "lucide-react"
+
+const DEMO_EMAIL = "realty.reports@gmail.com"
+const DEMO_PASSWORD = "Alpha637#"
 
 function LoginContent() {
   const [formData, setFormData] = useState({ email: "", password: "" })
@@ -109,19 +112,17 @@ function LoginContent() {
   }
 
   const handleDemoFill = () => {
-    const email = "gerardoh@gmail.com"
-    const password = "Test123!"
-    setFormData({ email, password })
+    setFormData({ email: DEMO_EMAIL, password: DEMO_PASSWORD })
 
     const emailEl = document.getElementById("email") as HTMLInputElement
     const passEl = document.getElementById("password") as HTMLInputElement
 
     if (emailEl) {
-      emailEl.value = email
+      emailEl.value = DEMO_EMAIL
       emailEl.dispatchEvent(new Event("change", { bubbles: true }))
     }
     if (passEl) {
-      passEl.value = password
+      passEl.value = DEMO_PASSWORD
       passEl.dispatchEvent(new Event("change", { bubbles: true }))
     }
 
@@ -136,41 +137,31 @@ function LoginContent() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 flex flex-col">
-      {/* Top brand bar */}
-      <header className="px-4 sm:px-6 lg:px-8 py-5">
-        <div className="max-w-6xl mx-auto flex items-center justify-between">
-          <Link href="/" className="flex items-center gap-2.5">
-            <span className="w-8 h-8 rounded-lg bg-brand-500 flex items-center justify-center">
-              <ShieldCheck className="w-5 h-5 text-white" />
-            </span>
-            <span className="text-xl font-bold tracking-tight text-gray-900">DeedPro</span>
-          </Link>
-          <Link
-            href="/register"
-            className="text-sm font-medium text-gray-500 hover:text-gray-900 transition-colors"
-          >
-            Don&apos;t have an account? <span className="text-brand-500">Sign up</span>
-          </Link>
-        </div>
-      </header>
+    <div className="min-h-screen grid lg:grid-cols-2 bg-white">
 
-      {/* Centered form column */}
-      <main className="flex-1 flex items-center justify-center px-4 py-8">
-        <div className="w-full max-w-md space-y-6 animate-in fade-in duration-500">
-          {/* Heading */}
-          <div className="space-y-1.5">
-            <h1 className="text-2xl font-bold tracking-tight text-gray-900">Welcome back</h1>
-            <p className="text-[15px] text-gray-500 leading-relaxed">
-              Sign in to continue creating recorder-ready deeds.
-            </p>
-          </div>
+      {/* ── Form column ─────────────────────────────────────────── */}
+      <div className="flex flex-col px-6 sm:px-12 py-8">
+        {/* Brand row */}
+        <Link href="/" className="flex items-center gap-2.5 self-start">
+          <span className="w-9 h-9 rounded-xl bg-brand-500 flex items-center justify-center shadow-brand">
+            <ShieldCheck className="w-5 h-5 text-white" />
+          </span>
+          <span className="text-xl font-bold tracking-tight text-gray-900">DeedPro</span>
+        </Link>
 
-          {/* Main Login Card */}
-          <div className="bg-white rounded-2xl shadow-sm border border-gray-200 p-7 space-y-5">
+        <div className="flex-1 flex items-center justify-center py-10">
+          <div className="w-full max-w-sm space-y-7 animate-in fade-in slide-in-from-bottom-2 duration-500">
+            {/* Heading */}
+            <div className="space-y-2">
+              <h1 className="text-3xl font-bold tracking-tight text-gray-900">Welcome back</h1>
+              <p className="text-[15px] text-gray-500 leading-relaxed">
+                Sign in to continue creating recorder-ready deeds.
+              </p>
+            </div>
+
             {/* Success Message */}
             {successMessage && (
-              <div className="flex items-start gap-3 p-3.5 bg-success-50 border border-success-500/20 rounded-lg animate-in slide-in-from-top duration-300">
+              <div className="flex items-start gap-3 p-3.5 bg-success-50 border border-success-500/20 rounded-xl animate-in slide-in-from-top duration-300">
                 <CheckCircle2 className="w-5 h-5 text-success-500 flex-shrink-0 mt-0.5" />
                 <p className="text-sm text-success-600 font-medium">{successMessage}</p>
               </div>
@@ -178,14 +169,14 @@ function LoginContent() {
 
             {/* Error Message */}
             {error && (
-              <div className="flex items-start gap-3 p-3.5 bg-error-50 border border-error-500/20 rounded-lg animate-in slide-in-from-top duration-300">
+              <div className="flex items-start gap-3 p-3.5 bg-error-50 border border-error-500/20 rounded-xl animate-in slide-in-from-top duration-300">
                 <AlertCircle className="w-5 h-5 text-error-500 flex-shrink-0 mt-0.5" />
                 <p className="text-sm text-error-600 font-medium">{error}</p>
               </div>
             )}
 
             {/* Login Form */}
-            <form onSubmit={handleSubmit} className="space-y-4">
+            <form onSubmit={handleSubmit} className="space-y-5">
               {/* Email Field */}
               <div className="space-y-1.5">
                 <label htmlFor="email" className="block text-sm font-semibold text-gray-900">
@@ -196,7 +187,7 @@ function LoginContent() {
                   type="email"
                   value={formData.email}
                   onChange={(e) => setFormData({ ...formData, email: e.target.value })}
-                  className="w-full px-4 py-3 bg-white border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent transition-all"
+                  className="w-full px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl text-gray-900 placeholder:text-gray-400 focus:outline-none focus:bg-white focus:ring-2 focus:ring-brand-500 focus:border-transparent transition-all"
                   placeholder="you@company.com"
                   required
                   disabled={loading}
@@ -223,7 +214,7 @@ function LoginContent() {
                     type={showPassword ? "text" : "password"}
                     value={formData.password}
                     onChange={(e) => setFormData({ ...formData, password: e.target.value })}
-                    className="w-full px-4 py-3 pr-12 bg-white border border-gray-200 rounded-lg text-gray-900 placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent transition-all"
+                    className="w-full px-4 py-3 pr-12 bg-gray-50 border border-gray-200 rounded-xl text-gray-900 placeholder:text-gray-400 focus:outline-none focus:bg-white focus:ring-2 focus:ring-brand-500 focus:border-transparent transition-all"
                     placeholder="Enter your password"
                     required
                     disabled={loading}
@@ -231,7 +222,7 @@ function LoginContent() {
                   <button
                     type="button"
                     onClick={() => setShowPassword(!showPassword)}
-                    className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-900 transition-colors"
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-700 transition-colors"
                     aria-label={showPassword ? "Hide password" : "Show password"}
                   >
                     {showPassword ? <EyeOff className="w-5 h-5" /> : <Eye className="w-5 h-5" />}
@@ -243,7 +234,7 @@ function LoginContent() {
               <button
                 type="submit"
                 disabled={loading}
-                className="w-full bg-brand-500 hover:bg-brand-600 text-white font-semibold py-3.5 rounded-lg transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2"
+                className="w-full bg-brand-500 hover:bg-brand-600 text-white font-semibold py-3.5 rounded-xl shadow-brand hover:shadow-brand-lg transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2"
               >
                 {loading ? (
                   <span className="flex items-center justify-center gap-2">
@@ -270,84 +261,130 @@ function LoginContent() {
                 )}
               </button>
             </form>
-          </div>
 
-          {/* Demo Credentials — always shown, collapsible (owner decision
-              2026-07-27: the V0 design renders these unconditionally so
-              logging in for demos is one click) */}
-          <div className="bg-white rounded-2xl border border-gray-200 overflow-hidden">
-            <button
-              type="button"
-              onClick={() => setShowDemo((v) => !v)}
-              className="w-full flex items-center justify-between gap-2 px-5 py-3.5 text-left"
-              aria-expanded={showDemo}
-            >
-              <span className="flex items-center gap-2">
-                <span className="w-7 h-7 bg-brand-50 rounded-md flex items-center justify-center">
-                  <Zap className="w-4 h-4 text-brand-500" />
+            {/* Demo Credentials — always shown, collapsible */}
+            <div className="border border-gray-200 rounded-xl overflow-hidden">
+              <button
+                type="button"
+                onClick={() => setShowDemo((v) => !v)}
+                className="w-full flex items-center justify-between gap-2 px-4 py-3 text-left hover:bg-gray-50 transition-colors"
+                aria-expanded={showDemo}
+              >
+                <span className="flex items-center gap-2">
+                  <span className="w-7 h-7 bg-brand-50 rounded-lg flex items-center justify-center">
+                    <Zap className="w-4 h-4 text-brand-500" />
+                  </span>
+                  <span className="text-sm font-semibold text-gray-900">Demo credentials</span>
                 </span>
-                <span className="text-sm font-semibold text-gray-900">Demo credentials</span>
-              </span>
-              <span className="text-xs font-medium text-brand-500">{showDemo ? "Hide" : "Show"}</span>
-            </button>
+                <span className="text-xs font-medium text-brand-500">{showDemo ? "Hide" : "Show"}</span>
+              </button>
 
-            {showDemo && (
-              <div className="px-5 pb-5 space-y-3 border-t border-gray-100 pt-4">
-                <div className="space-y-1">
-                  <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide">Email</p>
-                  <div className="flex items-center justify-between gap-2 p-2.5 bg-gray-50 rounded-lg border border-gray-200">
-                    <code className="text-sm text-gray-900 font-mono">gerardoh@gmail.com</code>
-                    <button
-                      onClick={() => copyToClipboard("gerardoh@gmail.com", "email")}
-                      className="text-gray-500 hover:text-brand-500 transition-colors"
-                      aria-label="Copy email"
-                    >
-                      {copiedField === "email" ? (
-                        <Check className="w-4 h-4 text-success-500" />
-                      ) : (
-                        <Copy className="w-4 h-4" />
-                      )}
-                    </button>
+              {showDemo && (
+                <div className="px-4 pb-4 space-y-3 border-t border-gray-100 pt-3">
+                  <div className="space-y-1">
+                    <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide">Email</p>
+                    <div className="flex items-center justify-between gap-2 p-2.5 bg-gray-50 rounded-lg border border-gray-200">
+                      <code className="text-sm text-gray-900 font-mono">{DEMO_EMAIL}</code>
+                      <button
+                        onClick={() => copyToClipboard(DEMO_EMAIL, "email")}
+                        className="text-gray-400 hover:text-brand-500 transition-colors"
+                        aria-label="Copy email"
+                      >
+                        {copiedField === "email" ? (
+                          <Check className="w-4 h-4 text-success-500" />
+                        ) : (
+                          <Copy className="w-4 h-4" />
+                        )}
+                      </button>
+                    </div>
                   </div>
-                </div>
 
-                <div className="space-y-1">
-                  <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide">Password</p>
-                  <div className="flex items-center justify-between gap-2 p-2.5 bg-gray-50 rounded-lg border border-gray-200">
-                    <code className="text-sm text-gray-900 font-mono">Test123!</code>
-                    <button
-                      onClick={() => copyToClipboard("Test123!", "password")}
-                      className="text-gray-500 hover:text-brand-500 transition-colors"
-                      aria-label="Copy password"
-                    >
-                      {copiedField === "password" ? (
-                        <Check className="w-4 h-4 text-success-500" />
-                      ) : (
-                        <Copy className="w-4 h-4" />
-                      )}
-                    </button>
+                  <div className="space-y-1">
+                    <p className="text-xs font-semibold text-gray-500 uppercase tracking-wide">Password</p>
+                    <div className="flex items-center justify-between gap-2 p-2.5 bg-gray-50 rounded-lg border border-gray-200">
+                      <code className="text-sm text-gray-900 font-mono">{DEMO_PASSWORD}</code>
+                      <button
+                        onClick={() => copyToClipboard(DEMO_PASSWORD, "password")}
+                        className="text-gray-400 hover:text-brand-500 transition-colors"
+                        aria-label="Copy password"
+                      >
+                        {copiedField === "password" ? (
+                          <Check className="w-4 h-4 text-success-500" />
+                        ) : (
+                          <Copy className="w-4 h-4" />
+                        )}
+                      </button>
+                    </div>
                   </div>
-                </div>
 
-                <button
-                  type="button"
-                  onClick={handleDemoFill}
-                  className="w-full bg-gray-900 hover:bg-gray-700 text-white font-semibold py-2.5 rounded-lg transition-all duration-200 flex items-center justify-center gap-2 text-sm"
-                >
-                  <Zap className="w-4 h-4" />
-                  Fill login form
-                </button>
-              </div>
-            )}
+                  <button
+                    type="button"
+                    onClick={handleDemoFill}
+                    className="w-full bg-gray-900 hover:bg-gray-700 text-white font-semibold py-2.5 rounded-lg transition-all duration-200 flex items-center justify-center gap-2 text-sm"
+                  >
+                    <Zap className="w-4 h-4" />
+                    Fill login form
+                  </button>
+                </div>
+              )}
+            </div>
+
+            {/* Sign-up link */}
+            <p className="text-center text-sm text-gray-500">
+              Don&apos;t have an account?{" "}
+              <Link href="/register" className="text-brand-500 hover:text-brand-600 font-semibold transition-colors">
+                Sign up free
+              </Link>
+            </p>
           </div>
-
-          {/* Trust footer */}
-          <p className="flex items-center justify-center gap-1.5 text-xs text-gray-400">
-            <ShieldCheck className="w-3.5 h-3.5" />
-            Trusted by escrow &amp; title professionals
-          </p>
         </div>
-      </main>
+
+        {/* Trust footer */}
+        <p className="flex items-center justify-center gap-1.5 text-xs text-gray-400">
+          <ShieldCheck className="w-3.5 h-3.5" />
+          Trusted by escrow &amp; title professionals
+        </p>
+      </div>
+
+      {/* ── Brand panel (desktop only) ───────────────────────────── */}
+      <div className="hidden lg:flex flex-col justify-between bg-gradient-to-br from-brand-700 via-brand-500 to-brand-400 p-14 text-white relative overflow-hidden">
+        {/* Decorative document silhouettes */}
+        <div className="absolute -right-24 -top-24 w-96 h-96 rounded-[3rem] bg-white/10 rotate-12" aria-hidden="true" />
+        <div className="absolute -right-10 top-40 w-72 h-96 rounded-[2rem] bg-white/10 -rotate-6" aria-hidden="true" />
+        <div className="absolute right-24 -bottom-32 w-80 h-80 rounded-full bg-white/10" aria-hidden="true" />
+
+        <div className="relative z-10" />
+
+        <div className="relative z-10 max-w-md space-y-8">
+          <h2 className="text-4xl font-bold leading-tight tracking-tight">
+            Recorder-ready deeds in minutes.
+          </h2>
+          <ul className="space-y-4 text-[15px] text-white/90">
+            <li className="flex items-start gap-3">
+              <span className="w-8 h-8 rounded-lg bg-white/15 flex items-center justify-center flex-shrink-0">
+                <Landmark className="w-4 h-4" />
+              </span>
+              <span className="pt-1">Property data pulled straight from county records — you confirm every value.</span>
+            </li>
+            <li className="flex items-start gap-3">
+              <span className="w-8 h-8 rounded-lg bg-white/15 flex items-center justify-center flex-shrink-0">
+                <ScrollText className="w-4 h-4" />
+              </span>
+              <span className="pt-1">Statutory transfer-tax declarations and the &sect;1189 acknowledgment, built into every document.</span>
+            </li>
+            <li className="flex items-start gap-3">
+              <span className="w-8 h-8 rounded-lg bg-white/15 flex items-center justify-center flex-shrink-0">
+                <FileCheck2 className="w-4 h-4" />
+              </span>
+              <span className="pt-1">Every PDF stored immutably and fingerprinted the moment it&apos;s generated.</span>
+            </li>
+          </ul>
+        </div>
+
+        <p className="relative z-10 text-sm text-white/70">
+          Built for California escrow &amp; title workflows.
+        </p>
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Three owner requests in one PR

### 1. Forgot-password "didn't work" — root cause: it fabricated success at three layers

With no `SENDGRID_API_KEY` configured, `send_email` **printed to the server console and returned True**; the endpoint ignored the return value anyway; the page told users "Password reset link sent to your email!" No email infrastructure exists anywhere in the chain — the button worked perfectly, it just lied (invariant #4, email edition).

Now honest end to end:
- `send_email` returns `False` when unconfigured (new `email_configured()` helper). The sharing/notification callers already treat the bool as advisory — their `email_sent` flags become truthful.
- `/users/forgot-password` fails uniformly with **503 before the user lookup** when email is unconfigured — honest, and carrying zero enumeration signal. Configured-but-failed sends log loudly behind the generic anti-enumeration message.
- The page surfaces the 503 plainly instead of claiming a send.

**Owner-side to actually enable reset emails** (the ledger's "email infra decision"): set `SENDGRID_API_KEY`, `SENDGRID_FROM_EMAIL`, and `FRONTEND_URL` on Render — note reset links currently default to `localhost:3000` without `FRONTEND_URL`.

### 2. New demo credentials

Card and "Fill login form" now use `realty.reports@gmail.com` / `Alpha637#` (single constants, both spots).

### 3. Modern login redesign

Split-screen: form column left — soft-filled rounded-xl inputs, brand-shadow CTA, collapsible demo card, sign-up footer; brand panel right (desktop only) — brand gradient, "Recorder-ready deeds in minutes." with three product statements (county-records confirm flow, statutory declarations + §1189, immutable fingerprinted PDFs), decorative silhouettes. Mobile gets the clean single-column form.

All logic contracts preserved: auth check, `?registered` banner + email prefill, `?redirect` param, admin-role redirect, per-status error copy, `AuthManager.setAuth`, Suspense wrapper, always-visible demo card.

## Gates

- Backend: 60 passed; six-flow baseline all match ✔
- Frontend: tsc 98 (baseline held), jest 110 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_