### PR TITLE
Deed fixes: mail-to address, DTT city fill, PDF-failure diagnostics

### DIFF
--- a/backend/routers/deeds_crud.py
+++ b/backend/routers/deeds_crud.py
@@ -1,6 +1,6 @@
 """Deed CRUD endpoints (T8 split — moved verbatim from main.py)."""
 from time import time
-from typing import Dict, Optional
+from typing import Dict, Optional, Union
 
 from fastapi import APIRouter, Depends, HTTPException, Response
 from psycopg2.extras import RealDictCursor
@@ -33,7 +33,11 @@ class DeedCreate(BaseModel):
     dtt: Optional[Dict] = Field(default=None, description="Documentary transfer tax details from the builder")
     title_order_no: Optional[str] = Field(default=None)
     escrow_no: Optional[str] = Field(default=None)
-    return_to: Optional[str] = Field(default=None, description="Mail-to name for the recorded deed")
+    # Bare string (name only, legacy) or a full mail-to block
+    # ({name, company?, address1, address2?, city, state, zip}) — the
+    # template and build_context_from_row handle both shapes.
+    return_to: Optional[Union[str, Dict[str, Optional[str]]]] = Field(
+        default=None, description="Mail-to for the recorded deed (name or address block)")
     provenance: Optional[Dict] = Field(default=None, description="Per-field source + confirmation timestamps (Ticket B)")
 
     class Config:
@@ -112,6 +116,10 @@ def create_deed_endpoint(deed: DeedCreate, user_id: int = Depends(get_current_us
             "stored. It remains a draft; opening or downloading it will "
             "retry."
         )
+        # Diagnostic surfacing: the owner of the deed may see WHY (class +
+        # trimmed message) — a generic error hid the completed_at incident
+        # for weeks. Render logs carry the full trace.
+        new_deed["pdf_error_detail"] = f"{type(pdf_error).__name__}: {str(pdf_error)[:200]}"
 
     # Phase 7: Send deed completion notification
     try:
@@ -396,4 +404,9 @@ def download_deed_endpoint(deed_id: int, user_id: int = Depends(get_current_user
     except Exception as e:
         print(f"Error downloading deed {deed_id}: {e}")
         db.conn.rollback()
-        raise HTTPException(status_code=500, detail="Failed to generate deed PDF")
+        # Diagnostic surfacing: this is the self-heal retry path — an
+        # authenticated owner needs the real reason, not a shrug.
+        raise HTTPException(
+            status_code=500,
+            detail=f"Failed to generate deed PDF — {type(e).__name__}: {str(e)[:200]}",
+        )

--- a/backend/tests/test_deed_pdf.py
+++ b/backend/tests/test_deed_pdf.py
@@ -60,6 +60,19 @@ def test_context_reads_metadata_extras_including_json_string():
         assert ctx["dtt"]["city_name"] == "Los Angeles"
 
 
+def test_return_to_dict_passes_through_with_address():
+    """Mail-to may arrive as a full address block (builder sends the
+    grantee at the property address); the context must pass it through so
+    the deed prints WHERE to mail, not just a name."""
+    meta = {"return_to": {"name": "JANE ROE", "address1": "1358 5TH ST",
+                          "city": "Santa Monica", "state": "CA", "zip": "90401"}}
+    ctx = build_context_from_row(minimal_row(metadata=meta))
+    assert ctx["return_to"]["address1"] == "1358 5TH ST"
+    html = _normalized(__import__("services.deed_pdf", fromlist=["render_deed_html"]).render_deed_html(minimal_row(metadata=meta)))
+    assert "1358 5TH ST" in html
+    assert "Santa Monica, CA 90401" in html
+
+
 def test_exempt_dtt_maps_to_zero_amount():
     dtt = _map_dtt({"is_exempt": True, "exemption_reason": "R&T 11911", "area_type": "unincorporated"})
     assert dtt["amount"] == "0.00"

--- a/frontend/src/app/deed-builder/[type]/success/success-content.tsx
+++ b/frontend/src/app/deed-builder/[type]/success/success-content.tsx
@@ -78,7 +78,15 @@ export function SuccessContent() {
     const response = await fetch(`${api}/deeds/${deedId}/download`, {
       headers: { 'Authorization': `Bearer ${token}` },
     });
-    if (!response.ok) return null;
+    if (!response.ok) {
+      // Diagnostic surfacing: the retry path reports WHY it failed — a
+      // generic "not available" hid the completed_at incident for weeks.
+      const data = await response.json().catch(() => ({}));
+      if (data.detail) {
+        toast.error(String(data.detail), { duration: 12000 });
+      }
+      return null;
+    }
     const blob = await response.blob();
     return window.URL.createObjectURL(blob);
   };

--- a/frontend/src/components/builder/PreviewPanel.tsx
+++ b/frontend/src/components/builder/PreviewPanel.tsx
@@ -45,7 +45,14 @@ function Checkline({ marked }: { marked: boolean }) {
 export function PreviewPanel({ state, activeSection }: PreviewPanelProps) {
   const preview = useMemo(() => ({
     requestedBy: state.requestedBy || '[Recording Requested By]',
-    returnTo: state.returnTo || state.requestedBy || '[Return To]',
+    // Mirror the generate payload: 'grantee' resolves to the grantee name,
+    // mailed at the property address (never render the literal 'grantee').
+    returnTo: state.returnTo === 'grantee'
+      ? state.grantee || '[GRANTEE NAME]'
+      : state.returnTo || state.requestedBy || '[Return To]',
+    returnToAddress: state.returnTo === 'grantee' && state.property
+      ? `${state.property.address}, ${state.property.city}, ${state.property.state} ${state.property.zip}`
+      : '',
     apn: state.property?.apn || '',
     titleOrderNo: state.titleOrderNo || '',
     escrowNo: state.escrowNo || '',
@@ -100,6 +107,9 @@ export function PreviewPanel({ state, activeSection }: PreviewPanelProps) {
                 </div>
                 <div className="min-h-[0.3in] mb-2">
                   <span className={`text-[10px] ${placeholder(preview.returnTo)}`}>{preview.returnTo}</span>
+                  {preview.returnToAddress && (
+                    <><br /><span className="text-[10px]">{preview.returnToAddress}</span></>
+                  )}
                 </div>
 
                 <div className="text-[10px]">Order No.: {preview.titleOrderNo || '____________'}</div>

--- a/frontend/src/components/builder/sections/TransferTaxSection.tsx
+++ b/frontend/src/components/builder/sections/TransferTaxSection.tsx
@@ -80,15 +80,20 @@ export function TransferTaxSection({
   // or enters values manually (the pre-TT auto-apply behavior is removed).
   useEffect(() => {
     if (!value) {
-      const isInCity = city && CITIES_WITH_OWN_DTT.some((c) => city.toLowerCase().includes(c))
+      // The property's city is DATA (from county records) — default the
+      // declaration's area to it whenever one exists. The old init only
+      // set "city" for cities with their OWN transfer tax, so ordinary
+      // incorporated properties initialized as "unincorporated" with a
+      // blank City-of line on the deed. The own-DTT list matters for the
+      // RATE calculation below, not for whether a city exists.
       onChange({
         isExempt: false,
         exemptReason: "",
         transferValue: "",
         calculatedAmount: "",
         basis: "full_value",
-        areaType: isInCity ? "city" : "unincorporated",
-        cityName: isInCity ? city : "",
+        areaType: city ? "city" : "unincorporated",
+        cityName: city || "",
       })
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -313,12 +318,10 @@ export function TransferTaxSection({
               <input
                 type="radio"
                 checked={value.areaType === "city"}
-                onChange={() => manual({ ...value, areaType: "city" })}
+                onChange={() => manual({ ...value, areaType: "city", cityName: value.cityName || city || "" })}
                 className="w-4 h-4 text-brand-500"
               />
-              <span className="text-sm text-gray-700">
-                City{value.cityName ? ` of ${value.cityName}` : ""}
-              </span>
+              <span className="text-sm text-gray-700">City</span>
             </label>
             <label className="flex items-center gap-2 cursor-pointer">
               <input
@@ -330,6 +333,23 @@ export function TransferTaxSection({
               <span className="text-sm text-gray-700">Unincorporated</span>
             </label>
           </div>
+
+          {/* City name — fills the deed's "City of ____" line */}
+          {value.areaType === "city" && (
+            <div className="space-y-1">
+              <label htmlFor="dtt-city" className="block text-sm font-medium text-gray-700">
+                City of
+              </label>
+              <input
+                id="dtt-city"
+                type="text"
+                value={value.cityName || ""}
+                onChange={(e) => manual({ ...value, cityName: e.target.value })}
+                placeholder={city || "City name"}
+                className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+              />
+            </div>
+          )}
 
           {/* Calculated Result */}
           {calculatedAmount && (

--- a/frontend/src/features/builder/DeedBuilder.tsx
+++ b/frontend/src/features/builder/DeedBuilder.tsx
@@ -168,7 +168,20 @@ function DeedBuilderInner({ deedType, initialProperty }: DeedBuilderProps) {
         grantees_text: genState.grantee,
         vesting: genState.vesting,
         requested_by: genState.requestedBy,
-        return_to: genState.returnTo === 'grantee' ? genState.grantee : genState.requestedBy,
+        // Mail-to: when the deed returns to the grantee, it mails to the
+        // grantee AT THE PROPERTY (the standard default) — send the full
+        // address block so the recorded deed shows where to mail it.
+        // Requester-return stays name-only (partner mailing addresses live
+        // in the partner record; not yet collected in the builder).
+        return_to: genState.returnTo === 'grantee'
+          ? {
+              name: genState.grantee,
+              address1: genState.property?.address || '',
+              city: genState.property?.city || '',
+              state: genState.property?.state || '',
+              zip: genState.property?.zip || '',
+            }
+          : genState.requestedBy,
         title_order_no: genState.titleOrderNo || '',
         escrow_no: genState.escrowNo || '',
         dtt: {
@@ -213,7 +226,12 @@ function DeedBuilderInner({ deedType, initialProperty }: DeedBuilderProps) {
       // H1 (invariant #4): a save whose PDF store failed is not a success —
       // say so instead of celebrating a half-failure.
       if (result.pdf_error) {
-        toast.warning(result.pdf_error);
+        toast.warning(
+          result.pdf_error_detail
+            ? `${result.pdf_error} (${result.pdf_error_detail})`
+            : result.pdf_error,
+          { duration: 12000 }
+        );
       } else {
         toast.success('Deed generated successfully!');
       }


### PR DESCRIPTION
## Three demo-note findings

### 1. "Return to should show address" — it never could

The builder sent `return_to` as a bare name (or the literal string `'grantee'`), so the recorded deed printed a mail-to with nowhere to mail it. Now: **grantee-return sends the full block — the grantee at the property address** (the standard escrow default), through `DeedCreate` widened to `str | dict` (the template and context mapper already handled both shapes). The live preview mirrors it (it was rendering the literal word `grantee`). Requester-return stays name-only for now — partner mailing addresses live in the partner records and wiring them through is a small future enhancement.

**Proven on a real stored PDF** via local Postgres: "ROBERT C. ROE / 1358 5TH ST / Santa Monica, CA 90401" renders in the mail-to block; new test pins the dict pass-through.

### 2. "City of ___ is blank — how do we fill the city?" — there was no way

Two defects: the initializer conflated *"has its own city transfer tax"* with *"is in a city"* (only LA/SF/Oakland-class cities defaulted to City; every ordinary incorporated property initialized as **Unincorporated** with a blank City-of line), and the City radio never set a name — with **no city input anywhere** in the section. Now: area defaults to the property's actual city (data from county records; the own-DTT list affects only the *rate*), the City radio prefills the name, and a **"City of" text input** appears when City is selected. Every edit records as the officer's manual instruction — doctrine unchanged. Verified: "City of Santa Monica" renders on the stored PDF.

### 3. PDF store still failing in production — the next failure names itself

H1's honesty worked exactly as designed (you saw the amber page and the honest toast) but the *generic* message can't tell us **why** production still fails post-H1. This PR makes the next attempt self-diagnosing:
- the generate response carries `pdf_error_detail` (exception class + trimmed message), shown in the builder toast;
- the download/self-heal path's 500 names the real error, surfaced by the success page.

**Jerry:** after this deploys, generate one deed (or hit Download on a stuck one) and read the toast — it will name the actual production error, which tells us in one line whether `create_tables` converged the schema at startup or something else (WeasyPrint, PDFShift config) is failing. Render's logs under `[T2] PDF generation failed` have the full trace if you want it.

## Gates

- Backend: 61 passed; six-flow baseline all match ✔
- Frontend: tsc 98 (baseline held), jest 110 passed
- End-to-end PDF verification against real local Postgres

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_