### PR TITLE
PDFShift auth fix: key goes in the password slot, not the username

### DIFF
--- a/backend/services/pdfshift_service.py
+++ b/backend/services/pdfshift_service.py
@@ -90,7 +90,7 @@ class PDFShiftService:
             async with httpx.AsyncClient(timeout=request_timeout) as client:
                 response = await client.post(
                     self.base_url,
-                    auth=(self.api_key, ""),  # Basic auth with API key
+                    auth=("api", self.api_key),  # PDFShift basic auth: username 'api', key as PASSWORD
                     json=default_options,
                     headers={
                         "Content-Type": "application/json",
@@ -172,7 +172,7 @@ class PDFShiftService:
         with httpx.Client(timeout=request_timeout) as client:
             response = client.post(
                 self.base_url,
-                auth=(self.api_key, ""),
+                auth=("api", self.api_key),
                 json=default_options
             )
             response.raise_for_status()

--- a/backend/tests/test_pdfshift_auth.py
+++ b/backend/tests/test_pdfshift_auth.py
@@ -1,0 +1,92 @@
+"""PDFShift auth-shape pin (production 401 incident, 2026-07-28).
+
+Production rendered every deed through PDFShift (auto-selected whenever
+PDFSHIFT_API_KEY is set) while tests rendered through WeasyPrint (no key
+in CI) — so the auth bug lived in the one path no test exercised. The
+code sent the key as the basic-auth USERNAME with an empty password
+(`auth=(key, "")`); PDFShift authenticates username 'api' with the key
+as PASSWORD (`auth=('api', key)`) — proven by a direct call from the
+production shell: same key, correct shape, 200.
+
+These tests capture the auth tuple actually handed to httpx in BOTH the
+sync and async paths, so the shape can never silently regress, and pin
+the env var name the service reads.
+"""
+import asyncio
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from services.pdfshift_service import PDFShiftService
+
+
+def _make_service(monkeypatch):
+    monkeypatch.setenv("PDFSHIFT_API_KEY", "sk_test_pinned_key")
+    return PDFShiftService()
+
+
+def test_reads_the_env_var_the_shell_proof_used(monkeypatch):
+    monkeypatch.delenv("PDFSHIFT_API_KEY", raising=False)
+    assert PDFShiftService().is_configured() is False
+    svc = _make_service(monkeypatch)
+    assert svc.is_configured() is True
+    assert svc.api_key == "sk_test_pinned_key"
+
+
+def test_sync_path_sends_api_as_username_and_key_as_password(monkeypatch):
+    svc = _make_service(monkeypatch)
+    captured = {}
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            pass
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+        def post(self, url, **kwargs):
+            captured.update(kwargs, url=url)
+            resp = MagicMock()
+            resp.content = b"%PDF-fake"
+            resp.raise_for_status = MagicMock()
+            return resp
+
+    with patch("services.pdfshift_service.httpx.Client", FakeClient):
+        out = svc.render_pdf_sync("<html></html>")
+
+    assert out == b"%PDF-fake"
+    assert captured["auth"] == ("api", "sk_test_pinned_key")
+
+
+def test_async_path_sends_api_as_username_and_key_as_password(monkeypatch):
+    svc = _make_service(monkeypatch)
+    captured = {}
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs):
+            pass
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, *a):
+            return False
+        async def post(self, url, **kwargs):
+            captured.update(kwargs, url=url)
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.content = b"%PDF-fake"
+            return resp
+
+    with patch("services.pdfshift_service.httpx.AsyncClient", FakeAsyncClient):
+        out = asyncio.run(svc.render_pdf("<html></html>"))
+
+    assert out == b"%PDF-fake"
+    assert captured["auth"] == ("api", "sk_test_pinned_key")
+
+
+def test_key_is_never_the_username():
+    """Source-level backstop: the broken shape must not reappear anywhere."""
+    import inspect
+    import services.pdfshift_service as mod
+    src = inspect.getsource(mod)
+    assert 'auth=(self.api_key' not in src
+    assert src.count('auth=("api", self.api_key)') == 2


### PR DESCRIPTION
## The bug — exactly the first classic suspect

The owner's production-shell proof cornered it: same key, same box, `auth=('api', key)` → 200. Our code sent `auth=(self.api_key, "")` — **the key as the basic-auth username with an empty password** — at both call sites (async and sync). PDFShift authenticates username `api` with the key as *password*; we've been sending `KEY:` instead of `api:KEY`, so every production render 401'd. Fixed to the proven form at both sites.

With this deployed, the chain finally closes: schema converged (H1) → PDFShift authenticates (this PR) → PDF stores → status flips to completed → stuck deeds self-heal on next download.

## Why no test ever caught it (the asymmetry, on the record)

`pdf_engine`'s `auto` mode selects **PDFShift whenever `PDFSHIFT_API_KEY` is set** — so production always rendered through PDFShift. Tests and CI have no key — so every test ever written rendered through **WeasyPrint**. The auth bug lived in the one path no test exercised. Same species as the schema-divergence lesson: *the harness must exercise what production runs.*

**Pinned now (4 tests):** behavioral capture of the auth tuple actually handed to httpx in both sync and async paths (`("api", key)` or fail), the env-var name (`PDFSHIFT_API_KEY`, the one the shell proof used), and a source-level backstop that the key-as-username shape cannot reappear.

## Deliberate or vestigial? — answer to the standing question

**Both engines are deliberate, neither is vestigial.** PDFShift was adopted (Phase 1.1) as the production engine for Chrome-quality rendering; WeasyPrint is the auto-fallback and the local/CI engine. But the asymmetry runs deeper than auth: **G2/G3's geometry verification measured WeasyPrint output** — production ships pages rendered by an engine the measurement harness has never measured. Chrome and WeasyPrint can disagree on fonts, margins, and page breaks.

**Proposed follow-on (PS2)** — consolidate to one measured path, owner's call between:
- **(a) Standardize production on WeasyPrint** *(recommended)*: test-what-you-ship becomes literal — every gate already measures WeasyPrint output; drops a vendor, a credential, and a per-deed API dependency. Precheck needed first: one paste in the Render shell — `python -c "import weasyprint; print('ok')"` — to confirm Render's Python env carries the system libs (if it errors, this option needs a Docker build and gets costlier).
- **(b) Keep PDFShift primary**: then a one-time PDFShift-rendered sample gets the same pdfplumber measurement treatment as the owner's reference sample (manual, not per-CI — putting the key in CI buys flakiness), and the auth pin carries the rest.

Either way the render-layer asymmetry gets closed the same way the schema one did: one authority, tests exercising it.

## Gates

- Backend: 65 passed (4 new); six-flow baseline all match ✔
- Backend-only — no frontend, template, or route changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_