### PR TITLE
Ticket R: builder resume — a draft opens as the deed you were building

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -320,6 +320,56 @@ def create_deed(user_id, deed_data):
             conn.close()
         return None
 
+def update_deed_draft(user_id, deed_id, deed_data):
+    """Ticket R: regenerating a resumed draft updates its row, never inserts
+    a second one. Only drafts are mutable — immutability applies to stored
+    PDFs, which flip status to 'completed'; this helper refuses those rows
+    (and deleted ones) by matching status in the WHERE clause. Metadata is
+    rebuilt exactly like create_deed so the stored PDF renders identically."""
+    conn = get_db_connection()
+    if not conn:
+        return None
+    try:
+        cursor = conn.cursor()
+        extras = {
+            key: deed_data.get(key)
+            for key in ('dtt', 'title_order_no', 'escrow_no', 'return_to', 'source', 'provenance')
+            if deed_data.get(key)
+        }
+        cursor.execute("""
+            UPDATE deeds
+            SET deed_type = %s, property_address = %s, apn = %s, county = %s,
+                legal_description = %s, grantor_name = %s, grantee_name = %s,
+                vesting = %s, requested_by = %s, metadata = %s::jsonb,
+                updated_at = CURRENT_TIMESTAMP
+            WHERE id = %s AND user_id = %s
+              AND COALESCE(status, 'draft') NOT IN ('completed', 'deleted')
+            RETURNING *
+        """, (
+            deed_data.get('deed_type'),
+            deed_data.get('property_address') or 'Unknown',
+            deed_data.get('apn'),
+            deed_data.get('county'),
+            deed_data.get('legal_description'),
+            deed_data.get('grantor_name'),
+            deed_data.get('grantee_name'),
+            deed_data.get('vesting'),
+            deed_data.get('requested_by'),
+            json.dumps(extras),
+            deed_id,
+            user_id,
+        ))
+        deed = cursor.fetchone()
+        conn.commit()
+        cursor.close()
+        conn.close()
+        return dict(deed) if deed else None
+    except Exception as e:
+        print(f"[Ticket R] Error updating draft {deed_id}: {type(e).__name__}: {e}")
+        if conn:
+            conn.close()
+        return None
+
 def get_user_deeds(user_id):
     conn = get_db_connection()
     if not conn:

--- a/backend/routers/deeds_crud.py
+++ b/backend/routers/deeds_crud.py
@@ -40,6 +40,10 @@ class DeedCreate(BaseModel):
     return_to: Optional[Union[str, Dict[str, Optional[str]]]] = Field(
         default=None, description="Mail-to for the recorded deed (name or address block)")
     provenance: Optional[Dict] = Field(default=None, description="Per-field source + confirmation timestamps (Ticket B)")
+    # Ticket R: present when regenerating a RESUMED DRAFT — updates that
+    # row instead of inserting a new one. Drafts only; completed deeds are
+    # immutable (their PDF is stored) and deleted stays deleted.
+    deed_id: Optional[int] = Field(default=None, description="Existing draft to update (builder resume)")
 
     class Config:
         extra = "ignore"  # Ignore extra fields from frontend
@@ -85,7 +89,20 @@ def create_deed_endpoint(deed: DeedCreate, user_id: int = Depends(get_current_us
     print(f"[Backend /deeds] legal_description: {deed_data.get('legal_description')[:100]}...")
     print(f"[Backend /deeds] source: {deed_data.get('source', 'unknown')}")
 
-    new_deed = create_deed(user_id, deed_data)
+    # Ticket R: a resumed draft regenerates INTO ITS OWN ROW.
+    resume_deed_id = deed_data.pop('deed_id', None)
+    if resume_deed_id:
+        from database import update_deed_draft
+        new_deed = update_deed_draft(user_id, resume_deed_id, deed_data)
+        if not new_deed:
+            # Wrong owner, already completed (PDF immutability), deleted,
+            # or missing — refuse rather than silently forking a new row.
+            raise HTTPException(
+                status_code=409,
+                detail="This deed can no longer be updated (not found, not yours, or already completed)",
+            )
+    else:
+        new_deed = create_deed(user_id, deed_data)
 
     if not new_deed:
         print(f"[Backend /deeds] ❌ create_deed returned None!")

--- a/frontend/src/__tests__/deedResume.test.ts
+++ b/frontend/src/__tests__/deedResume.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Ticket R — resume must restore the officer's recorded decisions, never
+ * fabricate them. These tests pin the doctrine clause: confirmed fields
+ * resume confirmed WITH their recorded source and timestamp; fields
+ * without recorded provenance resume as candidates (the gate re-asks);
+ * legal choices only resurrect from a recorded, timestamped decision.
+ */
+import { describe, expect, it } from '@jest/globals';
+import { hydrateStateFromDeedRow } from '../lib/deedResume';
+
+const FULL_ROW = {
+  id: 83,
+  deed_type: 'grant-deed',
+  property_address: '1358 5TH ST, Santa Monica, CA 90401',
+  apn: '4290-012-034',
+  county: 'Los Angeles',
+  legal_description: 'LOT 7, BLOCK B, TRACT 1234',
+  grantor_name: 'JOHN A. DOE',
+  grantee_name: 'ROBERT C. ROE',
+  vesting: 'a single man',
+  requested_by: 'Pacific Coast Escrow',
+  status: 'draft',
+  metadata: {
+    title_order_no: 'TO-1',
+    escrow_no: 'ESC-2',
+    return_to: { name: 'ROBERT C. ROE', address1: '1358 5TH ST', city: 'Santa Monica', state: 'CA', zip: '90401' },
+    dtt: {
+      transfer_value: '500000', is_exempt: false, exemption_reason: '',
+      basis: 'full_value', area_type: 'city', city_name: 'Santa Monica',
+      calculated_amount: '550.00',
+    },
+    provenance: {
+      apn: { source: 'sitex', confirmed_at: '2026-07-28T20:00:00Z' },
+      legalDescription: { source: 'sitex', confirmed_at: '2026-07-28T20:01:00Z' },
+      grantor: { source: 'sitex', confirmed_at: '2026-07-28T20:02:00Z' },
+      dtt: { source: 'ai_suggested', confirmed_at: '2026-07-28T20:03:00Z', code_section: 'R&T 11911', basis: 'Gift' },
+      vesting: { source: 'user', confirmed_at: '2026-07-28T20:04:00Z' },
+      preflight_overrides: { 'legal-short': { overridden_at: '2026-07-28T20:05:00Z' } },
+    },
+  },
+};
+
+describe('resume restores recorded decisions', () => {
+  const { state, gaps } = hydrateStateFromDeedRow(FULL_ROW);
+
+  it('rebuilds the core fields', () => {
+    expect(state.deedType).toBe('grant-deed');
+    expect(state.property?.address).toBe('1358 5TH ST');
+    expect(state.property?.city).toBe('Santa Monica');
+    expect(state.property?.zip).toBe('90401');
+    expect(state.property?.county).toBe('Los Angeles');
+    expect(state.grantor).toBe('JOHN A. DOE');
+    expect(state.grantee).toBe('ROBERT C. ROE');
+    expect(state.titleOrderNo).toBe('TO-1');
+    expect(state.returnTo).toBe('grantee');
+  });
+
+  it('confirmed fields resume confirmed with their recorded source + timestamp', () => {
+    expect(state.property?.provenance?.apn).toEqual({
+      value: '4290-012-034', source: 'sitex', status: 'confirmed',
+      confirmedAt: '2026-07-28T20:00:00Z',
+    });
+    expect(state.grantorProvenance?.status).toBe('confirmed');
+    expect(state.grantorProvenance?.confirmedAt).toBe('2026-07-28T20:02:00Z');
+  });
+
+  it('legal choices resurrect as their recorded LegalChoiceRecord', () => {
+    expect(state.dttDecision).toEqual({
+      source: 'ai_suggested', status: 'confirmed',
+      confirmedAt: '2026-07-28T20:03:00Z', codeSection: 'R&T 11911', basis: 'Gift',
+    });
+    expect(state.vestingDecision?.confirmedAt).toBe('2026-07-28T20:04:00Z');
+  });
+
+  it('restores the DTT data and preflight overrides', () => {
+    expect(state.dtt?.cityName).toBe('Santa Monica');
+    expect(state.dtt?.areaType).toBe('city');
+    expect(state.dtt?.transferValue).toBe('500000');
+    expect(state.preflightOverrides).toEqual({ 'legal-short': '2026-07-28T20:05:00Z' });
+  });
+
+  it('reports unrecoverable fields as explicit gaps', () => {
+    expect(gaps.some((g) => g.includes('Current-owner'))).toBe(true);
+  });
+});
+
+describe('legacy drafts fail toward re-asking, never auto-confirmed', () => {
+  const legacy = { ...FULL_ROW, metadata: { dtt: FULL_ROW.metadata.dtt } };
+  const { state, gaps } = hydrateStateFromDeedRow(legacy);
+
+  it('sourced fields resume as candidates', () => {
+    expect(state.property?.provenance?.apn?.status).toBe('candidate');
+    expect(state.property?.provenance?.legalDescription?.status).toBe('candidate');
+    expect(state.grantorProvenance?.status).toBe('candidate');
+  });
+
+  it('no legal-choice records are fabricated', () => {
+    expect(state.dttDecision).toBeUndefined();
+    expect(state.vestingDecision).toBeUndefined();
+  });
+
+  it('the missing provenance is reported, not silent', () => {
+    expect(gaps.some((g) => g.includes('legacy draft'))).toBe(true);
+  });
+});
+
+describe('a provenance entry without a timestamp is not a confirmation', () => {
+  const row = {
+    ...FULL_ROW,
+    metadata: {
+      provenance: {
+        apn: { source: 'sitex', confirmed_at: null },
+        dtt: { source: 'ai_suggested', confirmed_at: null },
+      },
+    },
+  };
+  const { state } = hydrateStateFromDeedRow(row);
+
+  it('field resumes as candidate; legal choice does not resurrect', () => {
+    expect(state.property?.provenance?.apn?.status).toBe('candidate');
+    expect(state.dttDecision).toBeUndefined();
+  });
+});

--- a/frontend/src/app/api/deeds/generate/route.ts
+++ b/frontend/src/app/api/deeds/generate/route.ts
@@ -12,6 +12,9 @@ export async function POST(req: NextRequest) {
     const payload = await req.json();
 
     const deedCreate = {
+      // Ticket R: present when regenerating a resumed draft — the backend
+      // updates that row instead of inserting a new one.
+      ...(payload.deed_id ? { deed_id: payload.deed_id } : {}),
       deed_type: payload.doc_type,
       property_address: payload.property_address || null,
       apn: payload.apn || null,

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -192,21 +192,20 @@ export default function Dashboard() {
             <AIGreeting userName={userName} />
           </div>
 
-          {/* Draft deed card (H2: honest capability — the builder has no
-              state-restore yet, so the card leads to the draft's real home
-              in Past Deeds instead of a dead-end type-selection push) */}
+          {/* Draft deed card (Ticket R: resume is real — the card opens the
+              builder hydrated from the saved row, decisions intact) */}
           {inProgressDeed && (
             <AICard
-              message={`You have a draft deed that isn't finished.`}
+              message={`You have a deed in progress. Continue where you left off?`}
               action={{
-                label: `View draft: ${inProgressDeed.property_address || inProgressDeed.deed_type || 'Draft'}`,
-                onClick: () => router.push(`/past-deeds?highlight=${inProgressDeed.id}`)
+                label: `Continue: ${inProgressDeed.property_address || inProgressDeed.deed_type || 'Draft'}`,
+                onClick: () => router.push(`/deed-builder/${inProgressDeed.deed_type || 'grant-deed'}?resume=${inProgressDeed.id}`)
               }}
               secondaryAction={{
                 label: "Start a new deed",
                 onClick: () => router.push('/deed-builder')
               }}
-              details="Drafts live in Past Deeds — open one there to review it or continue with a fresh build."
+              details="Your saved draft reopens with everything you entered — confirmations and tax decisions included."
               className="mb-8"
             />
           )}
@@ -459,10 +458,10 @@ function DeedRow({ deed }: { deed: any }) {
             </button>
           )}
           {(deed.status === 'draft' || deed.status === 'in_progress') && (
-            <button 
-              onClick={() => router.push('/deed-builder')}
+            <button
+              onClick={() => router.push(`/deed-builder/${deed.deed_type || 'grant-deed'}?resume=${deed.id}`)}
               className="p-2 hover:bg-emerald-50 rounded-lg transition-colors text-emerald-600"
-              title="Continue"
+              title="Continue this draft"
             >
               <ArrowRight className="w-4 h-4" />
             </button>

--- a/frontend/src/app/deed-builder/[type]/page.tsx
+++ b/frontend/src/app/deed-builder/[type]/page.tsx
@@ -7,15 +7,18 @@ import { SidebarProvider } from '@/contexts/SidebarContext';
 
 interface PageProps {
   params: Promise<{ type: string }>;
+  searchParams: Promise<{ resume?: string }>;
 }
 
-export default function DeedBuilderPage({ params }: PageProps) {
+export default function DeedBuilderPage({ params, searchParams }: PageProps) {
   const { type } = use(params);
-  
+  // Ticket R: ?resume={deed_id} re-opens a saved draft as the deed being built.
+  const { resume } = use(searchParams);
+
   return (
     <SidebarProvider>
       <PartnersProvider>
-        <DeedBuilder deedType={type} />
+        <DeedBuilder deedType={type} resumeDeedId={resume} />
       </PartnersProvider>
     </SidebarProvider>
   );

--- a/frontend/src/app/past-deeds/page.tsx
+++ b/frontend/src/app/past-deeds/page.tsx
@@ -84,7 +84,8 @@ export default function PastDeedsPageV0() {
   }
 
   const handleContinue = (deed: Deed) => {
-    router.push(`/deed-builder/${deed.deed_type.toLowerCase().replace(" ", "-")}`)
+    // Ticket R: drafts resume into a hydrated builder, not a blank one.
+    router.push(`/deed-builder/${deed.deed_type.toLowerCase().replace(" ", "-")}?resume=${deed.id}`)
   }
 
   const handleDownload = async (deed: Deed) => {

--- a/frontend/src/features/builder/DeedBuilder.tsx
+++ b/frontend/src/features/builder/DeedBuilder.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { toast } from 'sonner';
 import { AIAssistProvider } from '@/contexts/AIAssistContext';
@@ -25,6 +25,8 @@ import { ValidationPanel } from '@/components/builder/ValidationPanel';
 interface DeedBuilderProps {
   deedType: string;
   initialProperty?: PropertyData;
+  /** Ticket R: id of a saved draft to hydrate into the builder. */
+  resumeDeedId?: string;
 }
 
 const DEED_LABELS: Record<string, string> = {
@@ -35,9 +37,11 @@ const DEED_LABELS: Record<string, string> = {
   'tax-deed': 'Tax Deed',
 };
 
-function DeedBuilderInner({ deedType, initialProperty }: DeedBuilderProps) {
+function DeedBuilderInner({ deedType, initialProperty, resumeDeedId }: DeedBuilderProps) {
   const router = useRouter();
   useBuilderMode();
+
+  const [isResuming, setIsResuming] = useState(!!resumeDeedId);
 
   const [state, setState] = useState<DeedBuilderState>({
     deedType,
@@ -57,6 +61,47 @@ function DeedBuilderInner({ deedType, initialProperty }: DeedBuilderProps) {
 
   const [expandedSection, setExpandedSection] = useState('property');
   const [isGenerating, setIsGenerating] = useState(false);
+
+  // Ticket R: hydrate a resumed draft. The mapper restores the officer's
+  // RECORDED provenance and legal-choice decisions — fields without a
+  // recorded confirmation come back as candidates the gate re-asks.
+  useEffect(() => {
+    if (!resumeDeedId) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const token = localStorage.getItem('access_token') || localStorage.getItem('token');
+        const res = await fetch(`/api/deeds/${resumeDeedId}`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          throw new Error(err.detail || `Could not load draft (${res.status})`);
+        }
+        const row = await res.json();
+        if ((row.status || 'draft') !== 'draft') {
+          throw new Error('This deed is already completed — open it from Past Deeds instead.');
+        }
+        const { hydrateStateFromDeedRow } = await import('@/lib/deedResume');
+        const { state: restored, gaps } = hydrateStateFromDeedRow(row);
+        if (cancelled) return;
+        setState(restored);
+        if (gaps.length > 0) {
+          toast.info(`Draft restored. Not recoverable: ${gaps.join(' · ')}`, { duration: 9000 });
+        } else {
+          toast.success('Draft restored — pick up where you left off.');
+        }
+      } catch (err) {
+        if (!cancelled) {
+          toast.error(err instanceof Error ? err.message : 'Could not resume this draft.');
+        }
+      } finally {
+        if (!cancelled) setIsResuming(false);
+      }
+    })();
+    return () => { cancelled = true; };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [resumeDeedId]);
 
   const handleChange = useCallback((updates: Partial<DeedBuilderState>) => {
     setState(prev => ({ ...prev, ...updates }));
@@ -159,6 +204,8 @@ function DeedBuilderInner({ deedType, initialProperty }: DeedBuilderProps) {
     try {
       // Build the payload to match backend expectations
       const payload = {
+        // Ticket R: a resumed draft regenerates into its own row.
+        ...(resumeDeedId ? { deed_id: Number(resumeDeedId) } : {}),
         doc_type: genState.deedType,
         county: genState.property?.county || '',
         apn: genState.property?.apn || '',
@@ -243,6 +290,15 @@ function DeedBuilderInner({ deedType, initialProperty }: DeedBuilderProps) {
       setIsGenerating(false);
     }
   };
+
+  if (isResuming) {
+    return (
+      <div className="h-screen flex flex-col items-center justify-center bg-gray-100 gap-4">
+        <div className="animate-spin rounded-full h-10 w-10 border-4 border-brand-500 border-t-transparent" />
+        <p className="text-gray-600">Restoring your draft&hellip;</p>
+      </div>
+    );
+  }
 
   return (
     <div className="h-screen flex flex-col bg-gray-100">

--- a/frontend/src/lib/deedResume.ts
+++ b/frontend/src/lib/deedResume.ts
@@ -1,0 +1,167 @@
+/**
+ * Ticket R — builder resume: map a saved deed row (+ its metadata) back
+ * into a hydrated DeedBuilderState.
+ *
+ * DOCTRINE-CRITICAL: resume must restore the officer's recorded decisions,
+ * never fabricate them. A field confirmed-from-county-records resumes as
+ * confirmed with that source and timestamp (from metadata.provenance); an
+ * accepted DTT/vesting proposal resumes as its recorded LegalChoiceRecord.
+ * Where a legacy draft lacks provenance for a field, the field resumes as
+ * a CANDIDATE requiring re-confirmation — fail toward re-asking, never
+ * toward auto-confirmed. Resume must not launder unconfirmed data.
+ */
+import type {
+  DTTData,
+  DeedBuilderState,
+  FieldSource,
+  LegalChoiceRecord,
+  PropertyProvenance,
+  Sourced,
+} from '@/types/builder';
+
+interface ProvenanceEntry {
+  source?: string;
+  confirmed_at?: string | null;
+  code_section?: string;
+  basis?: string;
+}
+
+export interface ResumeResult {
+  state: DeedBuilderState;
+  /** Fields the row/metadata cannot reconstruct — reported, never silent. */
+  gaps: string[];
+}
+
+const KNOWN_SOURCES: FieldSource[] = ['sitex', 'google', 'user', 'titlepoint', 'ai_suggested'];
+
+function asSource(raw: string | undefined): FieldSource {
+  return KNOWN_SOURCES.includes(raw as FieldSource) ? (raw as FieldSource) : 'sitex';
+}
+
+/**
+ * Restore one field's Sourced wrapper from a recorded provenance entry.
+ * No entry, or an entry without a confirmation timestamp → candidate
+ * (re-confirmation required at the gate).
+ */
+function restoreSourced(value: string, entry?: ProvenanceEntry): Sourced<string> {
+  if (entry && entry.confirmed_at) {
+    return {
+      value,
+      source: asSource(entry.source),
+      status: 'confirmed',
+      confirmedAt: entry.confirmed_at,
+    };
+  }
+  return { value, source: asSource(entry?.source), status: 'candidate' };
+}
+
+function restoreLegalChoice(entry?: ProvenanceEntry): LegalChoiceRecord | undefined {
+  // A legal choice is only ever recorded as confirmed; an entry without a
+  // timestamp is not a decision and must NOT resurrect as one.
+  if (!entry || !entry.confirmed_at) return undefined;
+  return {
+    source: asSource(entry.source),
+    status: 'confirmed',
+    confirmedAt: entry.confirmed_at,
+    ...(entry.code_section ? { codeSection: entry.code_section } : {}),
+    ...(entry.basis ? { basis: entry.basis } : {}),
+  };
+}
+
+/** Best-effort split of "street, city, ST zip" (the shape the builder saves). */
+function parseAddress(full: string): { address: string; city: string; state: string; zip: string } {
+  const parts = full.split(',').map((p) => p.trim());
+  if (parts.length >= 3) {
+    const tail = parts[parts.length - 1].match(/^([A-Z]{2})\s+([\d-]+)$/);
+    if (tail) {
+      return {
+        address: parts.slice(0, parts.length - 2).join(', '),
+        city: parts[parts.length - 2],
+        state: tail[1],
+        zip: tail[2],
+      };
+    }
+  }
+  return { address: full, city: '', state: 'CA', zip: '' };
+}
+
+export function hydrateStateFromDeedRow(row: Record<string, any>): ResumeResult {
+  const gaps: string[] = [];
+  const meta: Record<string, any> =
+    typeof row.metadata === 'string' ? JSON.parse(row.metadata || '{}') : row.metadata || {};
+  const prov: Record<string, ProvenanceEntry> = meta.provenance || {};
+
+  if (!meta.provenance) {
+    gaps.push('No recorded provenance (legacy draft) — sourced fields resume as candidates requiring re-confirmation');
+  }
+
+  // ── Property ───────────────────────────────────────────────────
+  const parsed = parseAddress(row.property_address || '');
+  if (!parsed.city) {
+    gaps.push('Property city/state/zip are not stored separately — could not parse them from the address');
+  }
+  const propertyProvenance: PropertyProvenance = {};
+  if (row.apn) propertyProvenance.apn = restoreSourced(row.apn, prov.apn);
+  if (row.legal_description) {
+    propertyProvenance.legalDescription = restoreSourced(row.legal_description, prov.legalDescription);
+  }
+  // property.owner (current owner per county records) is never persisted as
+  // its own column; its bare value is unrecoverable. The grantor field
+  // carries the officer's grantor decision regardless.
+  gaps.push('Current-owner (county records) value is not persisted — owner prefill not restored');
+
+  // ── DTT (metadata stores the raw generate-payload shape) ───────
+  let dtt: DTTData | null = null;
+  if (meta.dtt) {
+    dtt = {
+      isExempt: !!meta.dtt.is_exempt,
+      exemptReason: meta.dtt.exemption_reason || '',
+      transferValue: String(meta.dtt.transfer_value ?? ''),
+      calculatedAmount: String(meta.dtt.calculated_amount ?? ''),
+      basis: meta.dtt.basis === 'less_liens' ? 'less_liens' : 'full_value',
+      areaType: meta.dtt.area_type === 'city' ? 'city' : 'unincorporated',
+      cityName: meta.dtt.city_name || '',
+    };
+  }
+
+  // ── Mail-to: dict means the grantee-at-property block ──────────
+  const returnTo =
+    meta.return_to && typeof meta.return_to === 'object' ? 'grantee' : '';
+
+  const state: DeedBuilderState = {
+    deedType: row.deed_type || 'grant-deed',
+    property: {
+      address: parsed.address,
+      city: parsed.city,
+      county: row.county || '',
+      state: parsed.state,
+      zip: parsed.zip,
+      apn: row.apn || '',
+      legalDescription: row.legal_description || '',
+      provenance: propertyProvenance,
+    },
+    grantor: row.grantor_name || '',
+    grantorProvenance: row.grantor_name
+      ? restoreSourced(row.grantor_name, prov.grantor)
+      : undefined,
+    grantee: row.grantee_name || '',
+    vesting: row.vesting || '',
+    dtt,
+    dttDecision: restoreLegalChoice(prov.dtt),
+    vestingDecision: restoreLegalChoice(prov.vesting),
+    preflightOverrides:
+      prov.preflight_overrides && typeof prov.preflight_overrides === 'object'
+        ? Object.fromEntries(
+            Object.entries(prov.preflight_overrides as Record<string, any>).map(
+              ([id, v]) => [id, (v as any)?.overridden_at ?? String(v)]
+            )
+          )
+        : undefined,
+    requestedBy: row.requested_by || '',
+    returnTo,
+    titleOrderNo: meta.title_order_no || '',
+    escrowNo: meta.escrow_no || '',
+  };
+
+  return { state, gaps };
+}


### PR DESCRIPTION
## What

Promoted from the ledger by owner ruling: with the PDFShift outage manufacturing stuck drafts, resume is now **the recovery path for real failures**. An officer whose PDF store fails retries from a saved deed instead of retyping everything.

### Route + hydrate
Drafts open `/deed-builder/{type}?resume={id}` from all three entry points — the dashboard continue-card, the dashboard row's Continue arrow, and Past Deeds' Continue. The builder fetches the owner-checked row (`GET /deeds/{id}` via the existing proxy) and `lib/deedResume.ts` maps row + metadata back into `DeedBuilderState`: property fields, APN, county, legal description, grantor/grantee/vesting, the full DTT block, order/escrow numbers, mail-to, and preflight overrides. Non-drafts refuse resume (completed deeds point to Past Deeds).

### Provenance survives resume — the doctrine clause, pinned by 9 tests
- A field confirmed-from-county-records resumes **confirmed, with its recorded source and timestamp** from `metadata.provenance` — not re-stamped as fresh input.
- An accepted DTT/vesting proposal resurrects as its recorded `LegalChoiceRecord` (code section and basis intact) — the officer's past decision is preserved, not re-asked, not re-applied as new.
- Legacy drafts without provenance, or entries without a confirmation timestamp, resume as **candidates the gate re-asks** — fail toward re-asking, never toward auto-confirmed. A provenance entry without a timestamp is not a confirmation and cannot resurrect a legal choice.

### Regenerate updates, never duplicates
The payload carries `deed_id`; the backend routes it to `update_deed_draft` — owner-checked, **drafts only**. Completed deeds get `409` (their PDF is stored and immutable — the immutability rule is untouched, it applies to stored PDFs, which drafts by definition lack); deleted stays deleted. Metadata is rebuilt identically to the create path so the stored PDF renders the same.

**Proven end-to-end against real local Postgres** — the ticket's exact verification scenario: simulated PDFShift failure → stuck draft with `pdf_error` surfaced → resume-regenerate returns the **same id**, row count unchanged, status flips to completed, edits land → post-completion update attempt refused with 409.

## Gap list (per ticket: reported, never silent — also shown in the restore toast)
- Property **city/state/zip** aren't stored as separate columns — parsed best-effort from the saved address string.
- The **current-owner** (county records) bare value is never persisted — owner prefill isn't restored; the grantor decision carries regardless.

## Save-progress (scope item 5)
**Not nearly free** — the generate endpoint always renders and stores; a save-only mode changes its semantics and response shape. Flagged per ticket; resume ships alone. If wanted later, it's a small dedicated endpoint reusing `update_deed_draft`.

## Gates
- Backend: 65 passed; six-flow baseline all match ✔
- Frontend: tsc 98 (baseline held), jest 119 passed (9 new doctrine tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_