### PR TITLE
PDFShift 400 fix: strip Playwright stowaway params + surface error bodies

### DIFF
--- a/backend/pdf_engine.py
+++ b/backend/pdf_engine.py
@@ -155,10 +155,10 @@ def render_pdf(
     
     elif selected_engine == "pdfshift":
         logger.debug("Rendering PDF with PDFShift")
-        # Convert page_setup to PDFShift margin format if needed
+        # Margins are owned by the templates' @page CSS — do NOT inject the
+        # page_setup dict as a PDFShift "margin" option (object form 400s;
+        # a margin override would also fight the measured chassis geometry).
         options = pdfshift_options or {}
-        if page_setup and "margin" not in options:
-            options["margin"] = page_setup
         return render_pdf_with_pdfshift_sync(html, options)
     
     else:
@@ -199,8 +199,6 @@ async def render_pdf_async(
     
     if selected_engine == "pdfshift":
         options = pdfshift_options or {}
-        if page_setup and "margin" not in options:
-            options["margin"] = page_setup
         return await render_pdf_with_pdfshift(html, options)
     
     elif selected_engine == "weasyprint":

--- a/backend/services/pdfshift_service.py
+++ b/backend/services/pdfshift_service.py
@@ -58,19 +58,15 @@ class PDFShiftService:
         if not self.is_configured():
             raise RuntimeError("PDFSHIFT_API_KEY environment variable not set")
         
-        # Default options optimized for legal documents
+        # ONLY documented PDFShift v3 parameters. The old defaults copied
+        # Playwright page.pdf() options (printBackground, preferCSSPageSize,
+        # displayHeaderFooter) and a margin object — PDFShift validates
+        # strictly and 400'd every real render (2026-07-28, the lock behind
+        # the auth lock). Page size and margins are owned by the templates'
+        # @page CSS, which Chrome print honors.
         default_options = {
             "source": html,
-            "format": "Letter",  # US Letter 8.5" x 11"
-            "margin": {
-                "top": "0.5in",
-                "right": "0.625in", 
-                "bottom": "0.625in",
-                "left": "0.75in"  # Extra left margin for binding
-            },
-            "printBackground": True,
-            "preferCSSPageSize": True,  # Honor @page CSS rules
-            "displayHeaderFooter": False,
+            "format": "Letter",
             "landscape": False,
         }
         
@@ -147,17 +143,11 @@ class PDFShiftService:
         if not self.is_configured():
             raise RuntimeError("PDFSHIFT_API_KEY environment variable not set")
         
+        # Documented PDFShift v3 parameters only (see async path note).
         default_options = {
             "source": html,
             "format": "Letter",
-            "margin": {
-                "top": "0.5in",
-                "right": "0.625in", 
-                "bottom": "0.625in",
-                "left": "0.75in"
-            },
-            "printBackground": True,
-            "preferCSSPageSize": True,
+            "landscape": False,
         }
         
         if options:
@@ -175,7 +165,12 @@ class PDFShiftService:
                 auth=("api", self.api_key),
                 json=default_options
             )
-            response.raise_for_status()
+            if response.status_code >= 400:
+                # PDFShift's error body names the offending parameter —
+                # never discard it (the 400 diagnosis lived in this body).
+                raise RuntimeError(
+                    f"PDFShift {response.status_code}: {response.text[:300]}"
+                )
             return response.content
 
 

--- a/backend/tests/test_pdfshift_auth.py
+++ b/backend/tests/test_pdfshift_auth.py
@@ -47,8 +47,8 @@ def test_sync_path_sends_api_as_username_and_key_as_password(monkeypatch):
         def post(self, url, **kwargs):
             captured.update(kwargs, url=url)
             resp = MagicMock()
+            resp.status_code = 200
             resp.content = b"%PDF-fake"
-            resp.raise_for_status = MagicMock()
             return resp
 
     with patch("services.pdfshift_service.httpx.Client", FakeClient):
@@ -81,6 +81,89 @@ def test_async_path_sends_api_as_username_and_key_as_password(monkeypatch):
 
     assert out == b"%PDF-fake"
     assert captured["auth"] == ("api", "sk_test_pinned_key")
+
+
+ALLOWED_PDFSHIFT_PARAMS = {"source", "format", "landscape"}
+PLAYWRIGHT_STOWAWAYS = {"printBackground", "preferCSSPageSize", "displayHeaderFooter", "margin"}
+
+
+def test_sync_payload_contains_only_documented_pdfshift_params(monkeypatch):
+    """The 400 incident: the payload carried Playwright page.pdf() options
+    (printBackground, preferCSSPageSize, displayHeaderFooter) and a margin
+    object — PDFShift validates strictly and rejected every real render.
+    The proven-working shell call sent a minimal body; this pins it."""
+    svc = _make_service(monkeypatch)
+    captured = {}
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            pass
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+        def post(self, url, **kwargs):
+            captured.update(kwargs)
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.content = b"%PDF-fake"
+            return resp
+
+    with patch("services.pdfshift_service.httpx.Client", FakeClient):
+        svc.render_pdf_sync("<html></html>")
+
+    sent = set(captured["json"].keys())
+    assert sent <= ALLOWED_PDFSHIFT_PARAMS, f"undocumented params sent: {sent - ALLOWED_PDFSHIFT_PARAMS}"
+    assert not (sent & PLAYWRIGHT_STOWAWAYS)
+
+
+def test_async_payload_contains_only_documented_pdfshift_params(monkeypatch):
+    svc = _make_service(monkeypatch)
+    captured = {}
+
+    class FakeAsyncClient:
+        def __init__(self, **kwargs):
+            pass
+        async def __aenter__(self):
+            return self
+        async def __aexit__(self, *a):
+            return False
+        async def post(self, url, **kwargs):
+            captured.update(kwargs)
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.content = b"%PDF-fake"
+            return resp
+
+    with patch("services.pdfshift_service.httpx.AsyncClient", FakeAsyncClient):
+        asyncio.run(svc.render_pdf("<html></html>"))
+
+    sent = set(captured["json"].keys())
+    assert sent <= ALLOWED_PDFSHIFT_PARAMS, f"undocumented params sent: {sent - ALLOWED_PDFSHIFT_PARAMS}"
+    assert not (sent & PLAYWRIGHT_STOWAWAYS)
+
+
+def test_sync_error_surfaces_the_response_body(monkeypatch):
+    """PDFShift's 400 body names the offending field — the sync path used
+    to raise_for_status and throw the diagnosis away."""
+    svc = _make_service(monkeypatch)
+
+    class FakeClient:
+        def __init__(self, **kwargs):
+            pass
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+        def post(self, url, **kwargs):
+            resp = MagicMock()
+            resp.status_code = 400
+            resp.text = '{"error": "some_param is not a valid parameter"}'
+            return resp
+
+    with patch("services.pdfshift_service.httpx.Client", FakeClient):
+        with pytest.raises(RuntimeError, match="some_param is not a valid parameter"):
+            svc.render_pdf_sync("<html></html>")
 
 
 def test_key_is_never_the_username():


### PR DESCRIPTION
## The lock behind the auth lock

With the 401 dead (#57 confirmed live), PDFShift began 400ing the real render — while the shell's minimal `{'source': html}` call converts fine. Per the ticket's step 2, the offending parameters were **identifiable from code review alone**, so this PR ships the fix and the body-surfacing together.

**Root cause:** the payload carried **Playwright `page.pdf()` options** — `printBackground`, `preferCSSPageSize`, `displayHeaderFooter` — plus a `margin` object. Those are Chrome-DevTools/Playwright parameters, not PDFShift API fields; someone copied them across when the integration was written, and PDFShift's strict validation rejects unknown parameters with 400. They sat harmlessly for months because the auth bug 401'd first — three locks on one door, each invisible behind the previous.

## Changes

1. **Documented params only, both paths:** `source`, `format`, `landscape`. Page size and margins are owned by the templates' `@page` CSS (which Chrome print honors) — `pdf_engine` no longer injects the `page_setup` dict as a `margin` option either, which would have both risked the object-form 400 *and* fought the measured chassis geometry.
2. **Never discard the diagnosis again:** the sync path's `raise_for_status` threw away the JSON body that names the offending field — exactly why this 400 needed a second round-trip through Jerry. Errors now raise `PDFShift {status}: {body}`, which flows through the existing `pdf_error` surfacing into the toast.
3. **Pinning tests (3 new):** payload allowlist enforced in both sync and async paths with the Playwright stowaways asserted absent by name; 4xx body-surfacing pinned; auth-shape pins intact.

## Follow-up queued (next PR, per owner)

The two resume persistence gaps: store property city/state/zip at save (the property search already has them) and persist the county-owner value into metadata so owner-prefill survives resume.

## Gates

- Backend: 68 passed; six-flow baseline all match ✔
- Backend-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_