### PR TITLE
U0: gate integrity — display desync, gate intact; one-truth counter

### DIFF
--- a/frontend/src/__tests__/gateTruth.test.ts
+++ b/frontend/src/__tests__/gateTruth.test.ts
@@ -1,0 +1,96 @@
+/**
+ * U0 (UX audit) — the gate integrity question, answered and pinned.
+ *
+ * Verdict: the GATE was intact — a non-empty unconfirmed material field is
+ * always a candidate and always blocks generation; an empty field has
+ * nothing to confirm and never reaches the PDF. The DISPLAY lied: the
+ * header counter derived "complete" from mere field presence, and the
+ * property card rendered a confirm affordance for an empty owner. These
+ * tests pin both truths and the one-source derivation that replaces them.
+ */
+import { describe, expect, it } from '@jest/globals';
+import { collectCandidateFields } from '../lib/provenance';
+import { deriveSectionTruth } from '../lib/deedValidation';
+import type { DeedBuilderState } from '../types/builder';
+
+function baseState(overrides: Partial<DeedBuilderState> = {}): DeedBuilderState {
+  return {
+    deedType: 'grant-deed',
+    property: {
+      address: '1358 5TH ST',
+      city: 'Santa Monica',
+      county: 'Los Angeles',
+      state: 'CA',
+      zip: '90401',
+      apn: '4290-012-034',
+      legalDescription: 'LOT 7, BLOCK B',
+      provenance: {
+        apn: { value: '4290-012-034', source: 'sitex', status: 'confirmed', confirmedAt: 't' },
+        legalDescription: { value: 'LOT 7, BLOCK B', source: 'sitex', status: 'confirmed', confirmedAt: 't' },
+      },
+    },
+    grantor: 'JOHN A. DOE',
+    grantorProvenance: { value: 'JOHN A. DOE', source: 'user', status: 'confirmed', confirmedAt: 't' },
+    grantee: 'ROBERT C. ROE',
+    vesting: 'a single man',
+    dtt: {
+      isExempt: false, exemptReason: '', transferValue: '500000',
+      calculatedAmount: '550.00', basis: 'full_value', areaType: 'city', cityName: 'Santa Monica',
+    },
+    dttDecision: { source: 'user', status: 'confirmed', confirmedAt: 't' },
+    requestedBy: 'Pacific Coast Escrow',
+    returnTo: 'grantee',
+    ...overrides,
+  };
+}
+
+describe('the gate itself (doctrine pin)', () => {
+  it('a NON-EMPTY unconfirmed material field is always a candidate — generation blocks', () => {
+    const s = baseState();
+    s.property!.owner = 'SOMEBODY UNCONFIRMED';
+    // no provenance stamp for owner → candidate
+    const candidates = collectCandidateFields(s);
+    expect(candidates.some((c) => c.key === 'owner')).toBe(true);
+  });
+
+  it('an EMPTY field has nothing to confirm — it is never a candidate', () => {
+    const s = baseState(); // owner absent entirely
+    expect(collectCandidateFields(s).some((c) => c.key === 'owner')).toBe(false);
+  });
+});
+
+describe('one truth: the counter derives from gate math', () => {
+  it('a section holding an unconfirmed candidate is NOT complete', () => {
+    const s = baseState();
+    s.property!.owner = 'SOMEBODY UNCONFIRMED';
+    const truth = deriveSectionTruth(s);
+    expect(truth.statuses.property).toBe('warning');
+    expect(truth.completedCount).toBeLessThan(truth.totalSections);
+    expect(truth.pendingConfirmations).toBeGreaterThan(0);
+    // Candidates don't disable the button — the gate modal confirms them.
+    expect(truth.readyForGate).toBe(true);
+  });
+
+  it('an empty owner neither blocks nor warns — no phantom "unconfirmed"', () => {
+    const truth = deriveSectionTruth(baseState());
+    expect(truth.statuses.property).toBe('complete');
+    expect(truth.completedCount).toBe(truth.totalSections);
+    expect(truth.pendingConfirmations).toBe(0);
+  });
+
+  it('a failing substantive check marks its section and blocks the button', () => {
+    const s = baseState({ vesting: '' });
+    const truth = deriveSectionTruth(s);
+    expect(truth.statuses.vesting).toBe('empty');
+    expect(truth.readyForGate).toBe(false);
+  });
+
+  it('"N of N complete" is impossible while the gate would still block', () => {
+    const s = baseState();
+    s.property!.provenance!.apn!.status = 'candidate';
+    const truth = deriveSectionTruth(s);
+    const gateWouldBlock = collectCandidateFields(s).length > 0;
+    expect(gateWouldBlock).toBe(true);
+    expect(truth.completedCount).toBeLessThan(truth.totalSections);
+  });
+});

--- a/frontend/src/components/builder/InputPanel.tsx
+++ b/frontend/src/components/builder/InputPanel.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from 'react';
 import { Sparkles } from 'lucide-react';
 import { InputSection, SectionStatus } from './InputSection';
+import { deriveSectionTruth } from '@/lib/deedValidation';
 import { PropertySection } from './sections/PropertySection';
 import { GrantorSection } from './sections/GrantorSection';
 import { GranteeSection } from './sections/GranteeSection';
@@ -29,43 +30,17 @@ export function InputPanel({
   onSectionChange,
 }: InputPanelProps) {
   
-  const statuses = useMemo(() => {
-    const getStatus = (section: string): SectionStatus => {
-      switch (section) {
-        case 'property':
-          return state.property?.address ? 'complete' : 'empty';
-        case 'grantor':
-          return state.grantor?.trim() ? 'complete' : 'empty';
-        case 'grantee':
-          if (!state.grantee?.trim()) return 'empty';
-          if (state.grantee.trim().toUpperCase() === state.grantor?.trim().toUpperCase()) return 'warning';
-          return 'complete';
-        case 'vesting':
-          return state.vesting ? 'complete' : 'empty';
-        case 'transferTax':
-          if (state.dtt?.isExempt && state.dtt?.exemptReason) return 'complete';
-          if (state.dtt?.transferValue) return 'complete';
-          return 'empty';
-        case 'recording':
-          return state.requestedBy?.trim() ? 'complete' : 'empty';
-        default:
-          return 'empty';
-      }
-    };
-
-    return {
-      property: getStatus('property'),
-      grantor: getStatus('grantor'),
-      grantee: getStatus('grantee'),
-      vesting: getStatus('vesting'),
-      transferTax: getStatus('transferTax'),
-      recording: getStatus('recording'),
-    };
-  }, [state]);
-
-  const completedCount = Object.values(statuses).filter(s => s === 'complete').length;
-  const totalSections = 6;
-  const isReady = completedCount === totalSections;
+  // U0: ONE TRUTH — section status derives from the generation gate's own
+  // math (deriveSectionTruth), so the counter can never claim "complete"
+  // for a section the gate would still stop. The Generate button enables
+  // once sections are filled and substantive checks pass; unconfirmed
+  // candidates don't disable it — the gate modal is their confirm-all
+  // affordance, and the hint below the button says they're coming.
+  const truth = useMemo(() => deriveSectionTruth(state), [state]);
+  const statuses = truth.statuses as Record<string, SectionStatus>;
+  const completedCount = truth.completedCount;
+  const totalSections = truth.totalSections;
+  const isReady = truth.readyForGate;
 
   const toggleSection = (section: string) => {
     onSectionChange(expandedSection === section ? '' : section);
@@ -246,6 +221,12 @@ export function InputPanel({
         {!isReady && (
           <p className="text-center text-sm text-gray-500 mt-2">
             Complete all sections to generate
+          </p>
+        )}
+        {isReady && truth.pendingConfirmations > 0 && (
+          <p className="text-center text-sm text-amber-600 mt-2">
+            {truth.pendingConfirmations} county-record field{truth.pendingConfirmations === 1 ? '' : 's'} await
+            confirmation — you&apos;ll confirm before the PDF generates.
           </p>
         )}
       </div>

--- a/frontend/src/components/builder/sections/PropertySection.tsx
+++ b/frontend/src/components/builder/sections/PropertySection.tsx
@@ -575,9 +575,14 @@ export function PropertySection({ value, onChange, onComplete }: PropertySection
   // RENDER: Property loaded successfully
   // ─────────────────────────────────────────────────────────────────
   if (value?.address) {
-    const allConfirmed = (['apn', 'legalDescription', 'owner'] as const).every(
-      (k) => provenanceFor(k).status === 'confirmed'
-    )
+    // U0: an EMPTY field has nothing to confirm — the generation gate
+    // ignores it (nothing unconfirmed can reach the PDF), so the UI must
+    // not render a confirm affordance or an "unconfirmed" warning for it.
+    // The audit's "No value / unconfirmed" card was exactly that mismatch.
+    const hasValue = (k: 'apn' | 'legalDescription' | 'owner') =>
+      !!((k === 'apn' ? value?.apn : k === 'legalDescription' ? value?.legalDescription : value?.owner) || '').trim()
+    const presentKeys = (['apn', 'legalDescription', 'owner'] as const).filter(hasValue)
+    const allConfirmed = presentKeys.every((k) => provenanceFor(k).status === 'confirmed')
 
     return (
       <div className="space-y-4">
@@ -596,25 +601,36 @@ export function PropertySection({ value, onChange, onComplete }: PropertySection
         </div>
 
         <div className="space-y-3">
-          <ConfirmableField
-            label="APN"
-            field={provenanceFor('apn')}
-            onConfirm={() => confirmField('apn')}
-            onEdit={(v) => editField('apn', v)}
-          />
-          <ConfirmableField
-            label="Current Owner"
-            field={provenanceFor('owner')}
-            onConfirm={() => confirmField('owner')}
-            onEdit={(v) => editField('owner', v)}
-          />
-          <ConfirmableField
-            label="Legal Description"
-            field={provenanceFor('legalDescription')}
-            multiline
-            onConfirm={() => confirmField('legalDescription')}
-            onEdit={(v) => editField('legalDescription', v)}
-          />
+          {hasValue('apn') && (
+            <ConfirmableField
+              label="APN"
+              field={provenanceFor('apn')}
+              onConfirm={() => confirmField('apn')}
+              onEdit={(v) => editField('apn', v)}
+            />
+          )}
+          {hasValue('owner') ? (
+            <ConfirmableField
+              label="Current Owner"
+              field={provenanceFor('owner')}
+              onConfirm={() => confirmField('owner')}
+              onEdit={(v) => editField('owner', v)}
+            />
+          ) : (
+            <p className="text-sm text-gray-500 p-3 border border-gray-200 rounded-lg">
+              Current owner: not returned by county records. The grantor you
+              enter is what prints on the deed.
+            </p>
+          )}
+          {hasValue('legalDescription') && (
+            <ConfirmableField
+              label="Legal Description"
+              field={provenanceFor('legalDescription')}
+              multiline
+              onConfirm={() => confirmField('legalDescription')}
+              onEdit={(v) => editField('legalDescription', v)}
+            />
+          )}
         </div>
 
         {!allConfirmed && (

--- a/frontend/src/lib/deedValidation.ts
+++ b/frontend/src/lib/deedValidation.ts
@@ -118,3 +118,77 @@ export function unresolvedPreflight(
   const overrides = state.preflightOverrides ?? {};
   return evaluateRecorderPreflight(state).filter((c) => !c.ok && !overrides[c.id]);
 }
+
+// ─────────────────────────────────────────────────────────────────
+// U0 (UX audit): ONE TRUTH for section completeness. The header counter
+// used to derive "complete" from mere field presence while the generation
+// gate derived from confirmation state — so a resumed draft could show
+// "6 of 6 sections complete" beside an unconfirmed-field warning. Section
+// status now derives from the gate's own primitives: a section holding
+// unconfirmed candidate DATA fields or failing substantive checks is not
+// complete. (Empty optional fields — e.g. an owner never returned by
+// county records — have nothing to confirm and do not tarnish a section:
+// the gate ignores them and nothing unconfirmed can reach the PDF.)
+// ─────────────────────────────────────────────────────────────────
+import { collectCandidateFields } from '@/lib/provenance';
+
+export type SectionStatus = 'complete' | 'warning' | 'empty' | 'error';
+
+const CANDIDATE_SECTION: Record<string, string> = {
+  apn: 'property',
+  legalDescription: 'property',
+  owner: 'property',
+  grantor: 'grantor',
+};
+
+export interface SectionTruth {
+  statuses: Record<string, SectionStatus>;
+  completedCount: number;
+  totalSections: number;
+  /** Sections filled + substantive checks pass — candidates alone don't
+   * block the button; the gate modal is their confirm-all affordance. */
+  readyForGate: boolean;
+  /** Unconfirmed data fields the gate will ask about. */
+  pendingConfirmations: number;
+}
+
+export function deriveSectionTruth(state: DeedBuilderState): SectionTruth {
+  const candidates = collectCandidateFields(state);
+  const candidateSections = new Set(candidates.map((c) => CANDIDATE_SECTION[c.key]));
+  const failingSections = new Set(
+    evaluateSubstantive(state).filter((c) => !c.ok).map((c) => c.sectionId)
+  );
+
+  const status = (section: string, filled: boolean, extraWarning = false): SectionStatus => {
+    if (!filled) return 'empty';
+    if (candidateSections.has(section) || failingSections.has(section) || extraWarning) {
+      return 'warning';
+    }
+    return 'complete';
+  };
+
+  const granteeEchoesGrantor =
+    !!state.grantee?.trim() &&
+    state.grantee.trim().toUpperCase() === state.grantor?.trim().toUpperCase();
+
+  const statuses: Record<string, SectionStatus> = {
+    property: status('property', !!state.property?.address),
+    grantor: status('grantor', !!state.grantor?.trim()),
+    grantee: status('grantee', !!state.grantee?.trim(), granteeEchoesGrantor),
+    vesting: status('vesting', !!state.vesting?.trim()),
+    transferTax: status(
+      'transferTax',
+      !!(state.dtt?.isExempt && state.dtt?.exemptReason) || !!state.dtt?.transferValue
+    ),
+    recording: status('recording', !!state.requestedBy?.trim()),
+  };
+
+  const values = Object.values(statuses);
+  return {
+    statuses,
+    completedCount: values.filter((s) => s === 'complete').length,
+    totalSections: values.length,
+    readyForGate: !values.includes('empty') && failingSections.size === 0,
+    pendingConfirmations: candidates.length,
+  };
+}


### PR DESCRIPTION
## The investigation's answer: display-state desync — the gate was intact

**Can generation proceed with an empty/unconfirmed material field?** Two cases, two answers:

- **Non-empty unconfirmed** → always a candidate (`collectCandidateFields` wraps every unstamped value), always blocks — Generate opens the confirm modal, never generates. No resume path bypasses this: resume restores provenance or leaves fields as candidates (Ticket R's fail-toward-re-asking), and candidates block.
- **Empty** → nothing to confirm, and nothing enters the PDF (the owner field never prints; the grantor, which does print, is separately required + confirmed). The audit's resumed legacy draft had an **empty** owner — never persisted pre-#61 — so the gate correctly ignored it. **No doctrine violation.**

**What lied was the display, twice:**
1. The header counter derived "complete" from mere field presence (`property: address ? 'complete' : 'empty'`) — blind to confirmation state, hence "6 of 6" beside warnings.
2. `PropertySection` rendered an amber "From county records — confirm" card with **"No value"** for the empty owner — a confirm affordance for nothing. That's the exact warning banner in the audit's screenshot.

## The fix: one truth

`deriveSectionTruth()` in `deedValidation` derives section status from the gate's own primitives — a section holding unconfirmed candidates or failing substantive checks is **not complete**. The counter consumes it. The Generate button enables on filled-plus-substantive-passing; candidates alone don't disable it (the gate modal is their designed confirm-all affordance) and an amber hint under the button announces them: *"N county-record fields await confirmation — you'll confirm before the PDF generates."* Empty fields render a neutral explanatory note, never a confirm card.

**Pinned by 6 tests**, headlined by: *"N of N complete" is impossible while the gate would still block* — the counter and the gate can never disagree again.

This also lands U2.1's "progress counter derives from the gate's math" clause early — U2's remaining work builds on this helper.

## Gates

- tsc 98 (baseline held), jest 127 (6 new)
- Frontend-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_