### PR TITLE
U2: one confirmation model, mortal toasts, correction-path copy, honest placeholders

### DIFF
--- a/frontend/src/__tests__/confirmationModel.test.ts
+++ b/frontend/src/__tests__/confirmationModel.test.ts
@@ -1,0 +1,156 @@
+/**
+ * U2 — one confirmation model + on-page truth, pinned.
+ *
+ * 1. Inline confirmation as county data lands is THE model: the Property
+ *    accordion holds until every present county-record field is confirmed
+ *    (advancing past unconfirmed cards is what made APN/Legal "surprise
+ *    gates at the finish line"), and the gate modal never re-asks a field
+ *    confirmed inline.
+ * 2. No immortal toasts: every toast dismissable, none survives a route
+ *    change, and "Draft restored" can only fire from the resume path.
+ * 3. Immutability copy carries the correction path (accurate today: a
+ *    corrected deed is a new row, both retained).
+ * 4. No placeholder that reads as an entered value.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+import { collectCandidateFields, propertyCandidatesRemaining } from '../lib/provenance';
+import type { DeedBuilderState, PropertyData } from '../types/builder';
+
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+}
+
+function readSource(...segments: string[]): string {
+  return fs.readFileSync(path.join(__dirname, '..', ...segments), 'utf8');
+}
+
+function propertyFixture(overrides: Partial<PropertyData> = {}): PropertyData {
+  return {
+    address: '1358 5TH ST',
+    city: 'Santa Monica',
+    county: 'Los Angeles',
+    state: 'CA',
+    zip: '90401',
+    apn: '4290-012-034',
+    legalDescription: 'LOT 7, BLOCK B',
+    owner: 'JANE Q. OWNER',
+    provenance: {
+      apn: { value: '4290-012-034', source: 'sitex', status: 'candidate' },
+      legalDescription: { value: 'LOT 7, BLOCK B', source: 'sitex', status: 'candidate' },
+      owner: { value: 'JANE Q. OWNER', source: 'sitex', status: 'candidate' },
+    },
+    ...overrides,
+  };
+}
+
+describe('U2.1 — the accordion holds until present county fields are confirmed', () => {
+  it('fresh county data leaves all present fields as remaining candidates', () => {
+    expect(propertyCandidatesRemaining(propertyFixture()).sort()).toEqual(
+      ['apn', 'legalDescription', 'owner'].sort()
+    );
+  });
+
+  it('confirming fields empties the list one by one — the last one advances', () => {
+    const p = propertyFixture();
+    p.provenance!.apn = { ...p.provenance!.apn!, status: 'confirmed', confirmedAt: 't' };
+    p.provenance!.owner = { ...p.provenance!.owner!, status: 'confirmed', confirmedAt: 't' };
+    expect(propertyCandidatesRemaining(p)).toEqual(['legalDescription']);
+    p.provenance!.legalDescription = {
+      ...p.provenance!.legalDescription!, status: 'confirmed', confirmedAt: 't',
+    };
+    expect(propertyCandidatesRemaining(p)).toEqual([]);
+  });
+
+  it('EMPTY fields have nothing to confirm and never hold the accordion (U0 rule)', () => {
+    const p = propertyFixture({ owner: '', apn: '' });
+    expect(propertyCandidatesRemaining(p)).toEqual(['legalDescription']);
+  });
+
+  it('a field without a provenance stamp is still a candidate (legacy data fails toward re-asking)', () => {
+    const p = propertyFixture({ provenance: {} });
+    expect(propertyCandidatesRemaining(p).length).toBe(3);
+  });
+
+  it('PropertySection guards every auto-advance with the remaining-candidates check', () => {
+    const src = stripComments(
+      readSource('components', 'builder', 'sections', 'PropertySection.tsx')
+    );
+    // Both fetch-success paths and the confirm/edit path advance only
+    // through the guard — no unconditional onComplete() after data lands.
+    const guarded = (src.match(/propertyCandidatesRemaining\((?:propertyData|next)\)\.length === 0\) onComplete\(\)/g) || []).length;
+    expect(guarded).toBe(3);
+    expect(src).not.toMatch(/onChange\(propertyData\)\s*\n\s*onComplete\(\)/);
+  });
+});
+
+describe('U2.1 — the gate modal never re-asks a field confirmed inline', () => {
+  it('a confirmed field is absent from the modal list; unconfirmed siblings remain', () => {
+    const state: DeedBuilderState = {
+      deedType: 'grant-deed',
+      property: propertyFixture(),
+      grantor: '',
+      grantee: '',
+      vesting: '',
+      dtt: null,
+      requestedBy: '',
+      returnTo: '',
+      titleOrderNo: '',
+      escrowNo: '',
+    };
+    state.property!.provenance!.apn = {
+      value: '4290-012-034', source: 'sitex', status: 'confirmed', confirmedAt: 't',
+    };
+    const keys = collectCandidateFields(state).map((c) => c.key);
+    expect(keys).not.toContain('apn');
+    expect(keys).toContain('legalDescription');
+    expect(keys).toContain('owner');
+  });
+});
+
+describe('U2.2 — no immortal toasts', () => {
+  it('the Toaster renders close buttons and the route-dismiss sentinel is mounted', () => {
+    const layout = stripComments(readSource('app', 'layout.tsx'));
+    expect(layout).toContain('closeButton');
+    expect(layout).toContain('<ToastRouteDismiss />');
+  });
+
+  it('ToastRouteDismiss dismisses on pathname change only — never on mount', () => {
+    const src = stripComments(readSource('components', 'ToastRouteDismiss.tsx'));
+    expect(src).toContain('toast.dismiss()');
+    expect(src).toContain('previous.current !== pathname');
+  });
+
+  it('"Draft restored" fires only inside the resume-gated effect', () => {
+    const src = readSource('features', 'builder', 'DeedBuilder.tsx');
+    const gate = src.indexOf('if (!resumeDeedId) return;');
+    const restored = src.indexOf('Draft restored');
+    const effectEnd = src.indexOf('}, [resumeDeedId]);');
+    expect(gate).toBeGreaterThan(-1);
+    expect(restored).toBeGreaterThan(gate);
+    expect(restored).toBeLessThan(effectEnd);
+    // And nowhere else.
+    expect(src.indexOf('Draft restored', effectEnd)).toBe(-1);
+  });
+});
+
+describe('U2.3 — immutability copy carries the correction path', () => {
+  it('the gate modal explains how to fix a generated deed', () => {
+    const src = readSource('features', 'builder', 'DeedBuilder.tsx');
+    expect(src).toContain('stored immutably');
+    expect(src).toContain('Generate a corrected deed');
+    expect(src).toContain('the record keeps both');
+  });
+});
+
+describe('U2.4 — no placeholder that reads as an entered value', () => {
+  it('Transfer Value hints with words, not a plausible dollar amount', () => {
+    const src = stripComments(
+      readSource('components', 'builder', 'sections', 'TransferTaxSection.tsx')
+    );
+    expect(src).not.toMatch(/placeholder="[\d,.]+"/);
+    // And the city input no longer previews the REAL city as a placeholder.
+    expect(src).not.toContain('placeholder={city');
+  });
+});

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -5,6 +5,7 @@ import "./globals.css";
 // Phase 24-A: vibrancy-boost.css DELETED - V0 design system taking over
 // V0 provides all styling via route group layouts (see (v0-landing)/layout.tsx)
 import { Toaster } from 'sonner'; // UI Polish: Toast notifications
+import { ToastRouteDismiss } from '@/components/ToastRouteDismiss';
 
 const inter = Inter({ 
   subsets: ["latin"],
@@ -46,8 +47,12 @@ export default function RootLayout({
             strategy="beforeInteractive"
           />
         )}
-        <Toaster 
+        {/* U2.2: every toast is dismissable (closeButton) and none survives
+            a route change (ToastRouteDismiss) — the immortal-toast fix. */}
+        <ToastRouteDismiss />
+        <Toaster
           position="top-right"
+          closeButton
           toastOptions={{
             style: {
               background: 'white',

--- a/frontend/src/components/ToastRouteDismiss.tsx
+++ b/frontend/src/components/ToastRouteDismiss.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+/**
+ * U2.2 — toasts die on navigation. A toast narrates the page that raised
+ * it; surviving a route change is how "Draft restored" haunted sessions
+ * that never resumed anything. Dismisses everything whenever the pathname
+ * changes (first render mounts with the pathname — no dismissal fires).
+ */
+import { useEffect, useRef } from 'react';
+import { usePathname } from 'next/navigation';
+import { toast } from 'sonner';
+
+export function ToastRouteDismiss() {
+  const pathname = usePathname();
+  const previous = useRef(pathname);
+
+  useEffect(() => {
+    if (previous.current !== pathname) {
+      previous.current = pathname;
+      toast.dismiss();
+    }
+  }, [pathname]);
+
+  return null;
+}

--- a/frontend/src/components/builder/sections/PropertySection.tsx
+++ b/frontend/src/components/builder/sections/PropertySection.tsx
@@ -6,6 +6,7 @@ import type { PropertyData, PropertyProvenance, Sourced } from "@/types/builder"
 import { useAIAssist } from "@/contexts/AIAssistContext"
 import { AISuggestion } from "../AISuggestion"
 import { ConfirmableField } from "../ConfirmableField"
+import { propertyCandidatesRemaining } from "@/lib/provenance"
 
 interface PropertySectionProps {
   value: PropertyData | null
@@ -398,11 +399,15 @@ export function PropertySection({ value, onChange, onComplete }: PropertySection
       const result = await response.json()
 
       if (result.status === 'success' && result.data) {
-        // Single property found
+        // Single property found. U2.1: do NOT auto-advance past unconfirmed
+        // county-record fields — advancing here is what made APN/Legal
+        // "surprise gates at the finish line" (the officer never saw the
+        // inline cards before the gate modal re-asked). The accordion
+        // advances when the last present field is confirmed below.
         const propertyData = mapSiteXResponse(result.data, searchQuery)
         onChange(propertyData)
-        onComplete()
-        
+        if (propertyCandidatesRemaining(propertyData).length === 0) onComplete()
+
       } else if (result.status === 'multi_match' && result.matches?.length > 0) {
         setPropertyMatches(result.matches)
         setPropertyMatchCount(result.match_count || result.matches.length)
@@ -448,9 +453,11 @@ export function PropertySection({ value, onChange, onComplete }: PropertySection
       const result = await response.json()
 
       if (result.status === 'success' && result.data) {
+        // U2.1: same rule as the single-match path — the accordion holds
+        // until the county-record fields are confirmed inline.
         const propertyData = mapSiteXResponse(result.data, match.address || selectedBuildingAddress)
         onChange(propertyData)
-        onComplete()
+        if (propertyCandidatesRemaining(propertyData).length === 0) onComplete()
       } else {
         setError('Failed to fetch property details. Please try again.')
       }
@@ -528,12 +535,20 @@ export function PropertySection({ value, onChange, onComplete }: PropertySection
     setError(null)
   }
 
+  // U2.1: after a confirm/edit lands, advance the accordion once the LAST
+  // present county-record field is confirmed — inline confirmation as the
+  // data lands is the one model; the gate modal only mops up leftovers.
+  const changeAndMaybeAdvance = (next: PropertyData) => {
+    onChange(next)
+    if (propertyCandidatesRemaining(next).length === 0) onComplete()
+  }
+
   // Confirm a single SiteX-sourced field: flip to confirmed, stamp the time.
   const confirmField = (key: keyof PropertyProvenance) => {
     if (!value) return
     const existing = value.provenance?.[key]
     if (!existing) return
-    onChange({
+    changeAndMaybeAdvance({
       ...value,
       provenance: {
         ...value.provenance,
@@ -547,7 +562,7 @@ export function PropertySection({ value, onChange, onComplete }: PropertySection
   // field (read by the generation payload) in sync.
   const editField = (key: keyof PropertyProvenance, newValue: string) => {
     if (!value) return
-    onChange({
+    changeAndMaybeAdvance({
       ...value,
       [key]: newValue,
       provenance: {

--- a/frontend/src/components/builder/sections/TransferTaxSection.tsx
+++ b/frontend/src/components/builder/sections/TransferTaxSection.tsx
@@ -284,7 +284,9 @@ export function TransferTaxSection({
                   const formatted = raw ? parseInt(raw).toLocaleString() : ""
                   manual({ ...value, transferValue: formatted })
                 }}
-                placeholder="500,000"
+                // U2.4: a realistic dollar amount as placeholder reads as an
+                // entered value — the hint must be words, not a number.
+                placeholder="Enter amount"
                 className="w-full pl-8 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
               />
             </div>
@@ -345,7 +347,9 @@ export function TransferTaxSection({
                 type="text"
                 value={value.cityName || ""}
                 onChange={(e) => manual({ ...value, cityName: e.target.value })}
-                placeholder={city || "City name"}
+                // U2.4 same defect class: the real city as a placeholder
+                // looked like a filled-in value while printing nothing.
+                placeholder="City name"
                 className="w-full px-3 py-2 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
               />
             </div>

--- a/frontend/src/features/builder/DeedBuilder.tsx
+++ b/frontend/src/features/builder/DeedBuilder.tsx
@@ -381,8 +381,9 @@ function DeedBuilderInner({ deedType, initialProperty, resumeDeedId }: DeedBuild
             <div className="w-full max-w-xl bg-white rounded-xl shadow-2xl p-6 max-h-[85vh] overflow-y-auto">
               <h2 className="text-lg font-semibold text-gray-900 mb-1">Ready to generate?</h2>
               <p className="text-sm text-gray-500 mb-4">
-                The generated document is final and stored immutably. Resolve the
-                items below first.
+                The generated document is final and stored immutably. Need
+                changes? Generate a corrected deed — the record keeps both.
+                Resolve the items below first.
               </p>
 
               <ValidationPanel

--- a/frontend/src/lib/provenance.ts
+++ b/frontend/src/lib/provenance.ts
@@ -67,6 +67,24 @@ function materialFieldProvenance(
     : propertyFieldProvenance(state, key);
 }
 
+/**
+ * U2.1 — one confirmation model: the Property section holds the accordion
+ * until every PRESENT county-record field is confirmed (empty fields have
+ * nothing to confirm, U0). Advancing earlier is what turned APN/Legal into
+ * "surprise gates at the finish line" — the officer never saw the inline
+ * cards before the modal re-asked.
+ */
+export function propertyCandidatesRemaining(
+  property: DeedBuilderState['property'],
+): Array<keyof PropertyProvenance> {
+  if (!property) return [];
+  return PROPERTY_KEYS.filter((key) => {
+    const bare = ((property[key] ?? '') as string).trim();
+    if (!bare) return false;
+    return (property.provenance?.[key]?.status ?? 'candidate') !== 'confirmed';
+  });
+}
+
 /** Every material field still awaiting confirmation. Empty array = gate open. */
 export function collectCandidateFields(state: DeedBuilderState): CandidateField[] {
   const keys: MaterialFieldKey[] = [...PROPERTY_KEYS, 'grantor'];


### PR DESCRIPTION
## UX audit U2 — One confirmation model + on-page truth

### U2.1 — Inline confirmation as county data lands is THE model
Root cause of the "surprise gates at the finish line": `PropertySection` called `onComplete()` the moment the county fetch returned, auto-advancing the accordion **past** the unconfirmed APN/Legal/Owner cards — so the officer first met them in the generate modal. The inline affordances were never missing; they were being skipped.

- The accordion now **holds** until the last present county-record field is confirmed or edited inline, then advances (both single-match and multi-match fetch paths, plus confirm/edit — all three guarded by the new pure helper `propertyCandidatesRemaining`).
- Empty fields have nothing to confirm and never hold the accordion (U0 rule); unstamped legacy data stays a candidate (fails toward re-asking).
- The gate modal already listed only still-unconfirmed items (`collectCandidateFields`); an explicit pin now proves it **never re-asks a field confirmed inline**. The counter has derived from the gate's math since U0.

### U2.2 — Mortal toasts
- `Toaster` gains `closeButton` — every toast dismissable.
- New `ToastRouteDismiss` (mounted in the root layout) dismisses all toasts on pathname change, mount-safe. The "Draft restored" sighting in a non-resume session was a 9-second toast outliving client-side navigation; a source pin proves the toast only exists inside the resume-gated effect.

### U2.3 — Immutability copy carries the correction path
Gate modal: "The generated document is final and stored immutably. **Need changes? Generate a corrected deed — the record keeps both.** Resolve the items below first." (Accurate today: a corrected deed is a new row; both are retained.)

### U2.4 — No placeholder that reads as a value
- Transfer Value `placeholder="500,000"` → `"Enter amount"` (words, not a plausible number).
- Same defect class on the DTT city input: `placeholder={city || …}` previewed the *real* city while printing nothing → static `"City name"`.

### Gates
- Jest: **151** (140 + 11 new in `confirmationModel.test.ts`) · tsc frozen at **98**
- Frontend-only change set — no routes, no schema, no snapshot churn

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_