### PR TITLE
U3: flow smalls — row identity, one-click lookup, clean labels, confirm-advance, honest chrome

### DIFF
--- a/frontend/src/__tests__/flowSmalls.test.ts
+++ b/frontend/src/__tests__/flowSmalls.test.ts
@@ -1,0 +1,131 @@
+/**
+ * U3 — per-deed tax (batch of smalls), pinned.
+ *
+ * Rows identify deeds (label + grantee + doc id + time); property lookup is
+ * deterministic (suggestion click always fetches); autocomplete labels say
+ * "City, CA" without the county mash; explicit confirms advance the
+ * accordion; grantee input uppercases; downloads acknowledge themselves;
+ * the builder names its way home; no chat-style promise without a chat.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+import { deedTypeLabel, DEED_LABELS } from '../lib/deedTypes';
+import { formatSuggestionSecondary } from '../lib/addressLabels';
+
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+}
+
+function readSource(...segments: string[]): string {
+  return fs.readFileSync(path.join(__dirname, '..', ...segments), 'utf8');
+}
+
+describe('U3 — deed types display as names, not slugs', () => {
+  it('maps every known slug', () => {
+    expect(deedTypeLabel('grant-deed')).toBe('Grant Deed');
+    expect(deedTypeLabel('quitclaim-deed')).toBe('Quitclaim Deed');
+    expect(deedTypeLabel('interspousal-transfer')).toBe('Interspousal Transfer Deed');
+    expect(deedTypeLabel('warranty-deed')).toBe('Warranty Deed');
+    expect(deedTypeLabel('tax-deed')).toBe('Tax Deed');
+  });
+
+  it('unknown slugs title-case instead of leaking raw', () => {
+    expect(deedTypeLabel('trust-transfer-deed')).toBe('Trust Transfer Deed');
+    expect(deedTypeLabel(undefined)).toBe('Deed');
+  });
+
+  it('the builder header and Past Deeds read from the SAME map', () => {
+    const builder = stripComments(readSource('features', 'builder', 'DeedBuilder.tsx'));
+    const pastDeeds = stripComments(readSource('app', 'past-deeds', 'page.tsx'));
+    expect(builder).toContain("from '@/lib/deedTypes'");
+    expect(pastDeeds).toContain('deedTypeLabel(deed.deed_type)');
+    // The old raw-slug cell is gone.
+    expect(pastDeeds).not.toContain('>{deed.deed_type}<');
+    expect(Object.keys(DEED_LABELS).length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('Past Deeds rows carry grantee and doc id', () => {
+    const pastDeeds = stripComments(readSource('app', 'past-deeds', 'page.tsx'));
+    expect(pastDeeds).toContain('deed.grantee_name');
+    expect(pastDeeds).toContain('Doc #{deed.id}');
+  });
+});
+
+describe('U3 — autocomplete secondary labels: "City, CA", no county mash', () => {
+  it('drops county and country segments', () => {
+    expect(formatSuggestionSecondary('Santa Monica, Los Angeles County, CA, USA')).toBe(
+      'Santa Monica, CA'
+    );
+    expect(formatSuggestionSecondary('Los Angeles, CA, USA')).toBe('Los Angeles, CA');
+  });
+
+  it('handles empty input', () => {
+    expect(formatSuggestionSecondary(undefined)).toBe('');
+    expect(formatSuggestionSecondary('')).toBe('');
+  });
+
+  it('the dropdown renders through the formatter', () => {
+    const src = stripComments(
+      readSource('components', 'builder', 'sections', 'PropertySection.tsx')
+    );
+    expect(src).toContain('formatSuggestionSecondary(prediction.structured_formatting.secondary_text)');
+  });
+});
+
+describe('U3 — deterministic lookup: suggestion click always fetches', () => {
+  it('handleSelectAddress ends by fetching with the parsed address it just built', () => {
+    const src = stripComments(
+      readSource('components', 'builder', 'sections', 'PropertySection.tsx')
+    );
+    expect(src).toContain('fetchPropertyData(parsed)');
+  });
+});
+
+describe('U3 — explicit confirm advances the accordion', () => {
+  it('GrantorSection advances on confirm and edit-save, never on keystrokes', () => {
+    const src = stripComments(
+      readSource('components', 'builder', 'sections', 'GrantorSection.tsx')
+    );
+    expect((src.match(/onComplete\?\.\(\)/g) || []).length).toBe(2);
+    // The plain typing input path must NOT advance.
+    expect(src).toMatch(/onChange=\{\(e\) => handleEdit\(e\.target\.value\)\}/);
+  });
+
+  it('InputPanel wires grantor completion to the grantee section', () => {
+    const src = stripComments(readSource('components', 'builder', 'InputPanel.tsx'));
+    expect(src).toContain("onComplete={() => onSectionChange('grantee')}");
+  });
+});
+
+describe('U3 — grantee input auto-uppercases (already true; pinned so it stays)', () => {
+  it('the input maps its value through toUpperCase', () => {
+    const src = stripComments(
+      readSource('components', 'builder', 'sections', 'GranteeSection.tsx')
+    );
+    expect(src).toContain('onChange(e.target.value.toUpperCase())');
+  });
+});
+
+describe('U3 — downloads acknowledge themselves', () => {
+  it('Past Deeds tracks the in-flight download and toasts the outcome', () => {
+    const src = stripComments(readSource('app', 'past-deeds', 'page.tsx'));
+    expect(src).toContain('setDownloadingId(deed.id)');
+    expect(src).toContain('PDF downloaded');
+    // Failure surfaces the endpoint's real reason, not a shrug.
+    expect(src).toContain('err.detail');
+  });
+});
+
+describe('U3 — the builder names its way home; no dead affordances', () => {
+  it('the header link says Dashboard and the handler-less Help button is gone', () => {
+    const src = stripComments(readSource('components', 'builder', 'BuilderHeader.tsx'));
+    expect(src).toContain('Dashboard');
+    expect(src).not.toContain('HelpCircle');
+  });
+
+  it('the dashboard greeting makes no chat promise', () => {
+    const src = stripComments(readSource('components', 'ui', 'AIGreeting.tsx'));
+    expect(src).not.toContain('How can I help');
+  });
+});

--- a/frontend/src/app/past-deeds/page.tsx
+++ b/frontend/src/app/past-deeds/page.tsx
@@ -7,11 +7,13 @@ import Sidebar from "@/components/Sidebar"
 import { FileText, Download, Share2, Trash2, AlertCircle, CheckCircle, Clock, X, Plus, Loader2 } from "lucide-react"
 import { toast } from "sonner"
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog"
+import { deedTypeLabel } from "@/lib/deedTypes"
 
 interface Deed {
   id: number
   property_address: string
   deed_type: string
+  grantee_name?: string
   status: "completed" | "draft" | "in_progress"
   created_at: string
   updated_at: string
@@ -47,6 +49,7 @@ export default function PastDeedsPageV0() {
     isOpen: false,
     deedId: null,
   })
+  const [downloadingId, setDownloadingId] = useState<number | null>(null)
 
   useEffect(() => {
     fetchDeeds()
@@ -91,25 +94,36 @@ export default function PastDeedsPageV0() {
   const handleDownload = async (deed: Deed) => {
     // The stored PDF is served by the authenticated download endpoint; fetch
     // it as a blob since window.open can't carry the Authorization header.
+    // U3: the click acknowledges itself — spinner on the row's button while
+    // fetching, toast on the outcome either way.
+    setDownloadingId(deed.id)
     try {
       const api = process.env.NEXT_PUBLIC_API_URL || "https://deedpro-main-api.onrender.com"
       const token = localStorage.getItem("access_token") || localStorage.getItem("token")
       const response = await fetch(`${api}/deeds/${deed.id}/download`, {
         headers: { Authorization: `Bearer ${token}` },
       })
-      if (!response.ok) throw new Error("Download failed")
+      if (!response.ok) {
+        // The endpoint's 500 carries the real reason (exception class +
+        // message) — surface it, don't shrug.
+        const err = await response.json().catch(() => ({}))
+        throw new Error(err.detail || `Download failed (${response.status})`)
+      }
       const blob = await response.blob()
       const url = window.URL.createObjectURL(blob)
       const a = document.createElement("a")
       a.href = url
-      a.download = `${deed.deed_type || "Deed"}_${deed.id}.pdf`
+      a.download = `${deedTypeLabel(deed.deed_type).replace(/ /g, "_")}_${deed.id}.pdf`
       document.body.appendChild(a)
       a.click()
       window.URL.revokeObjectURL(url)
       document.body.removeChild(a)
+      toast.success(`Deed #${deed.id} PDF downloaded`)
     } catch (err) {
       console.error("Download error:", err)
-      toast.error("PDF not available for this deed")
+      toast.error(err instanceof Error ? err.message : "PDF not available for this deed")
+    } finally {
+      setDownloadingId(null)
     }
   }
 
@@ -217,12 +231,15 @@ export default function PastDeedsPageV0() {
     )
   }
 
+  // U3: rows identify deeds — with several drafts on one address, the date
+  // alone can't; show the time too (U1.4's full ISO timestamps make it real).
   const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString("en-US", {
+    const d = new Date(dateString)
+    return d.toLocaleDateString("en-US", {
       month: "2-digit",
       day: "2-digit",
       year: "numeric",
-    })
+    }) + " " + d.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" })
   }
 
   return (
@@ -328,8 +345,15 @@ export default function PastDeedsPageV0() {
                           index % 2 === 0 ? "bg-white" : "bg-slate-50/50"
                         }`}
                       >
-                        <td className="py-4 px-6 font-medium text-slate-800">{deed.property_address}</td>
-                        <td className="py-4 px-6 text-slate-600">{deed.deed_type}</td>
+                        <td className="py-4 px-6">
+                          {/* U3: a row identifies its deed — address alone
+                              can't when one property has several. */}
+                          <p className="font-medium text-slate-800">{deed.property_address}</p>
+                          <p className="text-sm text-slate-500">
+                            {deed.grantee_name ? `To ${deed.grantee_name} · ` : ""}Doc #{deed.id}
+                          </p>
+                        </td>
+                        <td className="py-4 px-6 text-slate-600">{deedTypeLabel(deed.deed_type)}</td>
                         <td className="py-4 px-6">{getStatusBadge(deed.status)}</td>
                         <td className="py-4 px-6 text-sm text-slate-600">{formatDate(deed.created_at)}</td>
                         <td className="py-4 px-6 text-sm text-slate-600">{formatDate(deed.updated_at)}</td>
@@ -348,10 +372,15 @@ export default function PastDeedsPageV0() {
                               <>
                                 <button
                                   onClick={() => handleDownload(deed)}
-                                  className="p-2 bg-[#7C4DFF] hover:bg-[#6a3de8] text-white rounded-lg transition-colors"
+                                  disabled={downloadingId === deed.id}
+                                  className="p-2 bg-[#7C4DFF] hover:bg-[#6a3de8] text-white rounded-lg transition-colors disabled:opacity-60"
                                   title="Download PDF"
                                 >
-                                  <Download className="w-4 h-4" />
+                                  {downloadingId === deed.id ? (
+                                    <Loader2 className="w-4 h-4 animate-spin" />
+                                  ) : (
+                                    <Download className="w-4 h-4" />
+                                  )}
                                 </button>
                                 <button
                                   onClick={() => handleShareClick(deed.id)}

--- a/frontend/src/components/builder/BuilderHeader.tsx
+++ b/frontend/src/components/builder/BuilderHeader.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ArrowLeft, FileText, HelpCircle } from 'lucide-react';
+import { ArrowLeft, FileText } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { AIToggle } from './AIToggle';
 
@@ -18,12 +18,14 @@ export function BuilderHeader({ deedType }: BuilderHeaderProps) {
   return (
     <header className="h-14 bg-white border-b border-gray-200 flex items-center justify-between px-6 flex-shrink-0">
       <div className="flex items-center gap-4">
+        {/* U3: the way home says where it goes — "Exit" didn't read as a
+            nav affordance inside the chrome-less builder. */}
         <button
           onClick={handleExit}
           className="flex items-center gap-2 text-gray-500 hover:text-gray-900 transition-colors"
         >
           <ArrowLeft className="w-5 h-5" />
-          <span className="text-sm font-medium">Exit</span>
+          <span className="text-sm font-medium">Dashboard</span>
         </button>
         
         <div className="h-6 w-px bg-gray-200" />
@@ -36,10 +38,8 @@ export function BuilderHeader({ deedType }: BuilderHeaderProps) {
 
       <div className="flex items-center gap-4">
         <AIToggle />
-        <button className="flex items-center gap-2 text-gray-500 hover:text-gray-900 transition-colors">
-          <HelpCircle className="w-5 h-5" />
-          <span className="text-sm font-medium">Help</span>
-        </button>
+        {/* The dead "Help" button (no handler) is removed — same fake-
+            affordance class as the chat banner this ticket kills. */}
       </div>
     </header>
   );

--- a/frontend/src/components/builder/InputPanel.tsx
+++ b/frontend/src/components/builder/InputPanel.tsx
@@ -105,6 +105,7 @@ export function InputPanel({
             onChange={(grantor, grantorProvenance) => onChange({ grantor, grantorProvenance })}
             suggestedName={state.property?.owner}
             provenance={state.grantorProvenance}
+            onComplete={() => onSectionChange('grantee')}
           />
         </InputSection>
 

--- a/frontend/src/components/builder/sections/GrantorSection.tsx
+++ b/frontend/src/components/builder/sections/GrantorSection.tsx
@@ -12,9 +12,11 @@ interface GrantorSectionProps {
   onChange: (grantor: string, provenance: Sourced<string>) => void;
   suggestedName?: string;
   provenance?: Sourced<string>;
+  /** U3: explicit confirm/edit-save advances the accordion (typing never does). */
+  onComplete?: () => void;
 }
 
-export function GrantorSection({ value, onChange, suggestedName, provenance }: GrantorSectionProps) {
+export function GrantorSection({ value, onChange, suggestedName, provenance, onComplete }: GrantorSectionProps) {
   const { enabled: aiEnabled } = useAIAssist();
   const [guidanceDismissed, setGuidanceDismissed] = useState(false);
 
@@ -33,6 +35,7 @@ export function GrantorSection({ value, onChange, suggestedName, provenance }: G
       status: 'confirmed',
       confirmedAt: new Date().toISOString(),
     });
+    onComplete?.();
   };
 
   const handleEdit = (newValue: string) => {
@@ -67,7 +70,12 @@ export function GrantorSection({ value, onChange, suggestedName, provenance }: G
           label="Grantor Name (Current Owner)"
           field={provenance ?? { value, source: 'sitex', status: 'candidate' }}
           onConfirm={handleConfirm}
-          onEdit={handleEdit}
+          onEdit={(v) => {
+            // An edit-save is an explicit officer action, like Confirm —
+            // it advances. Keystrokes in the plain input below never do.
+            handleEdit(v);
+            onComplete?.();
+          }}
         />
       ) : (
         <div>

--- a/frontend/src/components/builder/sections/PropertySection.tsx
+++ b/frontend/src/components/builder/sections/PropertySection.tsx
@@ -7,6 +7,7 @@ import { useAIAssist } from "@/contexts/AIAssistContext"
 import { AISuggestion } from "../AISuggestion"
 import { ConfirmableField } from "../ConfirmableField"
 import { propertyCandidatesRemaining } from "@/lib/provenance"
+import { formatSuggestionSecondary } from "@/lib/addressLabels"
 
 interface PropertySectionProps {
   value: PropertyData | null
@@ -338,15 +339,20 @@ export function PropertySection({ value, onChange, onComplete }: PropertySection
     setPropertyMatches(null)
     setPropertyMatchCount(0)
     setError(null)
+    // U3: ONE behavior — selecting a suggestion always fetches the county
+    // records. The extra "now click Search" step was the nondeterminism the
+    // audit flagged (state hasn't landed yet, so pass parsed directly).
+    fetchPropertyData(parsed)
   }
 
   // Fetch property data from SiteX
-  const fetchPropertyData = async () => {
-    if (!selectedParsedAddress) {
+  const fetchPropertyData = async (parsedArg?: ParsedAddress) => {
+    const parsedAddress = parsedArg ?? selectedParsedAddress
+    if (!parsedAddress) {
       setError("Please select an address from the dropdown first")
       return
     }
-    
+
     setIsLoadingProperty(true)
     setError(null)
     setPropertyMatches(null)
@@ -363,10 +369,10 @@ export function PropertySection({ value, onChange, onComplete }: PropertySection
       // state: str = "CA"
       // zip: Optional[str] (alias for zip_code)
       const payload = {
-        address: selectedParsedAddress.street,  // Backend expects "address" as street
-        city: selectedParsedAddress.city || undefined,
-        state: selectedParsedAddress.state || 'CA',
-        zip_code: selectedParsedAddress.zip || undefined,
+        address: parsedAddress.street,  // Backend expects "address" as street
+        city: parsedAddress.city || undefined,
+        state: parsedAddress.state || 'CA',
+        zip_code: parsedAddress.zip || undefined,
       }
       
       console.log("Property search payload:", {
@@ -752,7 +758,7 @@ export function PropertySection({ value, onChange, onComplete }: PropertySection
                     {prediction.structured_formatting.main_text}
                   </p>
                   <p className="text-sm text-gray-500">
-                    {prediction.structured_formatting.secondary_text}
+                    {formatSuggestionSecondary(prediction.structured_formatting.secondary_text)}
                   </p>
                 </div>
               </button>

--- a/frontend/src/components/ui/AIGreeting.tsx
+++ b/frontend/src/components/ui/AIGreeting.tsx
@@ -43,7 +43,9 @@ export function AIGreeting({ userName, className = "" }: AIGreetingProps) {
         <h1 className="text-2xl font-bold text-gray-900">
           {greeting}, {displayName}!
         </h1>
-        <p className="text-gray-500 text-sm">How can I help you today?</p>
+        {/* U3: no chat-style promise with no chat behind it — the line under
+            the greeting states what the page actually is. */}
+        <p className="text-gray-500 text-sm">Here&apos;s where your deeds stand.</p>
       </div>
     </div>
   )

--- a/frontend/src/features/builder/DeedBuilder.tsx
+++ b/frontend/src/features/builder/DeedBuilder.tsx
@@ -10,6 +10,7 @@ import { PreviewPanel } from '@/components/builder/PreviewPanel';
 import { useBuilderMode } from '@/hooks/useBuilderMode';
 import { DeedBuilderState, PropertyData, Sourced } from '@/types/builder';
 import { buildDeedPayload, hasMeaningfulData } from '@/lib/deedPayload';
+import { DEED_LABELS } from '@/lib/deedTypes';
 import {
   MaterialFieldKey,
   collectCandidateFields,
@@ -27,14 +28,6 @@ interface DeedBuilderProps {
   /** Ticket R: id of a saved draft to hydrate into the builder. */
   resumeDeedId?: string;
 }
-
-const DEED_LABELS: Record<string, string> = {
-  'grant-deed': 'Grant Deed',
-  'quitclaim-deed': 'Quitclaim Deed',
-  'interspousal-transfer': 'Interspousal Transfer Deed',
-  'warranty-deed': 'Warranty Deed',
-  'tax-deed': 'Tax Deed',
-};
 
 function DeedBuilderInner({ deedType, initialProperty, resumeDeedId }: DeedBuilderProps) {
   const router = useRouter();

--- a/frontend/src/lib/addressLabels.ts
+++ b/frontend/src/lib/addressLabels.ts
@@ -1,0 +1,13 @@
+/**
+ * U3 — autocomplete secondary labels read "City, CA", not the Google mash
+ * ("Santa Monica, Los Angeles County, CA, USA"). County and country are
+ * noise in a CA-only product; the officer is picking a street address.
+ */
+export function formatSuggestionSecondary(secondary: string | undefined): string {
+  if (!secondary) return '';
+  return secondary
+    .split(',')
+    .map((part) => part.trim())
+    .filter((part) => part && part !== 'USA' && !/County$/i.test(part))
+    .join(', ');
+}

--- a/frontend/src/lib/deedTypes.ts
+++ b/frontend/src/lib/deedTypes.ts
@@ -1,0 +1,23 @@
+/**
+ * U3 — one place for deed-type naming. The builder header already showed
+ * "Grant Deed" while Past Deeds rows showed the raw slug ("grant-deed");
+ * both now read from here.
+ */
+export const DEED_LABELS: Record<string, string> = {
+  'grant-deed': 'Grant Deed',
+  'quitclaim-deed': 'Quitclaim Deed',
+  'interspousal-transfer': 'Interspousal Transfer Deed',
+  'warranty-deed': 'Warranty Deed',
+  'tax-deed': 'Tax Deed',
+};
+
+/** Slug → display label; unknown slugs title-case rather than leak raw. */
+export function deedTypeLabel(slug: string | undefined | null): string {
+  if (!slug) return 'Deed';
+  const known = DEED_LABELS[slug];
+  if (known) return known;
+  return slug
+    .split('-')
+    .map((w) => (w ? w[0].toUpperCase() + w.slice(1) : w))
+    .join(' ');
+}


### PR DESCRIPTION
## UX audit U3 — per-deed tax (batch of smalls)

### Rows identify deeds
- Deed type displays as **"Grant Deed"**, not the slug — via new shared `lib/deedTypes` (the builder header now reads the *same* map, so naming can't fork). Unknown slugs title-case instead of leaking raw.
- Past Deeds rows add **grantee + Doc #id** under the address, and the Created/Updated columns now show the **time** — several drafts on one address were otherwise indistinguishable (U1.4's full ISO timestamps make this real).

### Deterministic property lookup
Selecting an autocomplete suggestion now **always fetches county records** — the extra "now click Search" step was the nondeterminism. `fetchPropertyData` takes the parsed address directly (state hasn't landed at click time); the Search button remains as the retry affordance.

### Autocomplete labels
Secondary text renders through `formatSuggestionSecondary` — **"Santa Monica, CA"**, dropping the "Los Angeles County, …, USA" mash.

### Accordion auto-advance on confirm
`GrantorSection` advances to Grantee on **Confirm or edit-save** — explicit officer actions only; keystrokes in the plain input never advance. (Property already holds-then-advances since U2.) Combined with U2, this removes the audit's ~5 navigation clicks.

### Grantee auto-uppercase
Already true in the current code — the audit ran on an older build. Pinned by test so it stays true.

### Downloads acknowledge themselves
Per-row spinner while fetching, success toast on completion, and failures surface the endpoint's **real detail** (exception class + message from the download 500) instead of a generic "PDF not available".

### Honest chrome
- The builder's way home now says **"Dashboard"** — "Exit" didn't read as navigation inside the chrome-less builder.
- The handler-less **Help** button is removed (same fake-affordance class as the chat banner).
- The dashboard greeting drops **"How can I help you today?"** — no chat is wired there — for "Here's where your deeds stand."

### Flagged, not touched (per ticket)
Share/revoke + Settings (follow-up audit pending); junk seed data (owner-side); "Pacific COast TItle" profile string — owner data fix, plus the proposed separate small ticket: **trim/validate profile fields used on deed faces at save time**.

### Gates
- Jest: **165** (151 + 14 new in `flowSmalls.test.ts`) · tsc frozen at **98**
- Frontend-only change set — no routes, no schema, no snapshot churn

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_