### PR TITLE
PS2: WeasyPrint is the production render engine; PDFShift demoted to config-flagged fallback

### DIFF
--- a/backend/pdf_engine.py
+++ b/backend/pdf_engine.py
@@ -3,6 +3,15 @@ PDF Generation Engine
 Supports triple rendering: WeasyPrint (default), PDFShift (cloud), and Chromium (local)
 
 Phase 1.1: Added PDFShift integration for production-grade PDF generation
+
+PS2 (2026-07-29, owner decision): WeasyPrint IS the production engine.
+'auto' now always selects WeasyPrint — the Render box renders natively
+(shell precheck: `import weasyprint` → ok), and WeasyPrint is the engine
+every test in the harness has exercised all along, so this closes the
+test-vs-production render asymmetry from the PDFShift 401/400 incidents.
+PDFShift remains ONLY as an explicit config-flagged fallback for one
+deploy cycle (set PDF_ENGINE=pdfshift on Render to flip back); a
+follow-up ticket removes it, its allowlist code, and its env var.
 """
 import os
 import logging
@@ -93,20 +102,25 @@ def render_pdf_with_pdfshift_sync(
 
 
 def render_pdf(
-    html: str, 
-    base_url: Optional[str] = None, 
-    page_setup: Optional[Dict[str, str]] = None, 
-    engine: str = "auto",
+    html: str,
+    base_url: Optional[str] = None,
+    page_setup: Optional[Dict[str, str]] = None,
+    engine: Optional[str] = None,
     pdfshift_options: Optional[Dict[str, Any]] = None
 ) -> bytes:
     """
     Main PDF rendering function with triple engine support
-    
+
     Args:
         html: HTML content to render
         base_url: Base URL for resolving relative paths (fonts, images)
         page_setup: Page margins (for Chromium engine)
-        engine: 'auto' (default), 'pdfshift', 'weasyprint', or 'chromium'/'playwright'
+        engine: None (default: PDF_ENGINE env var, else 'auto'), 'auto',
+            'pdfshift', 'weasyprint', or 'chromium'/'playwright'.
+            PS2 note: the old default was the string "auto", which is
+            truthy — `engine or os.getenv("PDF_ENGINE")` therefore NEVER
+            read the env var from the stored-PDF pipeline. The fallback
+            flag has to actually work, so the default is now None.
         pdfshift_options: Additional options for PDFShift API
     
     Returns:
@@ -117,21 +131,17 @@ def render_pdf(
         RuntimeError: If engine dependencies missing
     
     Engine Selection (when 'auto'):
-        1. PDFShift - if PDFSHIFT_API_KEY is set (best quality)
-        2. WeasyPrint - fallback (fast, local)
+        WeasyPrint, always (PS2). The presence of a PDFShift key no longer
+        changes the engine — flipping back requires the explicit
+        PDF_ENGINE=pdfshift fallback flag.
     """
     # Get engine from parameter or environment variable
     requested_engine = (engine or os.getenv("PDF_ENGINE") or "auto").lower()
-    
-    # Auto-select engine based on available services
+
+    # PS2: 'auto' means WeasyPrint — the engine the test harness exercises.
     if requested_engine == "auto":
-        from services.pdfshift_service import pdfshift_service
-        if pdfshift_service.is_configured():
-            selected_engine = "pdfshift"
-            logger.info("PDF Engine: Auto-selected PDFShift (API key configured)")
-        else:
-            selected_engine = "weasyprint"
-            logger.info("PDF Engine: Auto-selected WeasyPrint (PDFShift not configured)")
+        selected_engine = "weasyprint"
+        logger.info("PDF Engine: WeasyPrint (production engine; PDF_ENGINE=pdfshift is the fallback flag)")
     else:
         selected_engine = requested_engine
     
@@ -169,10 +179,10 @@ def render_pdf(
 
 
 async def render_pdf_async(
-    html: str, 
-    base_url: Optional[str] = None, 
-    page_setup: Optional[Dict[str, str]] = None, 
-    engine: str = "auto",
+    html: str,
+    base_url: Optional[str] = None,
+    page_setup: Optional[Dict[str, str]] = None,
+    engine: Optional[str] = None,
     pdfshift_options: Optional[Dict[str, Any]] = None
 ) -> bytes:
     """
@@ -181,11 +191,10 @@ async def render_pdf_async(
     Preferred for PDFShift as it uses async HTTP client
     """
     requested_engine = (engine or os.getenv("PDF_ENGINE") or "auto").lower()
-    
-    # Auto-select engine
+
+    # PS2: 'auto' means WeasyPrint (same rule as the sync path).
     if requested_engine == "auto":
-        from services.pdfshift_service import pdfshift_service
-        selected_engine = "pdfshift" if pdfshift_service.is_configured() else "weasyprint"
+        selected_engine = "weasyprint"
     else:
         selected_engine = requested_engine
     

--- a/backend/scripts/ps2_parity_check.py
+++ b/backend/scripts/ps2_parity_check.py
@@ -1,0 +1,146 @@
+"""PS2 production-parity check — run ON THE RENDER BOX (owner, Tier 3 shell).
+
+Renders the same fixture deed through BOTH engines — WeasyPrint (the new
+production engine) and PDFShift (the outgoing one) — and diffs the
+pdfplumber geometry: recorder-zone caption position, title position,
+APN/boundary line, statutory strings, mail-to block, page count. This
+proves WeasyPrint's output honors the chassis measurements on the real
+production box, not just in CI.
+
+Usage (Render shell, PDFSHIFT_API_KEY still set):
+    cd backend && python scripts/ps2_parity_check.py
+
+Exit 0 = parity within tolerance; exit 1 = differences to review.
+No database access, no writes — render + measure only.
+"""
+import io
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pdfplumber  # noqa: E402
+
+from services.deed_pdf import render_deed_html  # noqa: E402
+from pdf_engine import render_pdf  # noqa: E402
+
+# Positional tolerance between engines, in PDF points. Different renderers
+# rasterize fonts slightly differently; the chassis cares about layout
+# geometry (half-inch scale), not sub-point font metrics.
+TOLERANCE_PT = 9.0
+
+FIXTURE_ROW = {
+    "id": 0,
+    "deed_type": "grant-deed",
+    "grantor_name": "PARITY CHECK GRANTOR",
+    "grantee_name": "PARITY CHECK GRANTEE",
+    "legal_description": "LOT 7, BLOCK B, TRACT 12345, IN THE CITY OF SANTA MONICA",
+    "county": "Los Angeles",
+    "apn": "4290-012-034",
+    "vesting": "a single man",
+    "requested_by": "Parity Escrow",
+    "metadata": {
+        "return_to": {"name": "PARITY CHECK GRANTEE", "address1": "1358 5TH ST",
+                      "city": "Santa Monica", "state": "CA", "zip": "90401"},
+        "title_order_no": "TO-PARITY", "escrow_no": "ESC-PARITY",
+        "dtt": {"calculated_amount": "550.00", "basis": "full_value",
+                "area_type": "city", "city_name": "Santa Monica", "is_exempt": False},
+    },
+}
+
+STATUTORY_STRINGS = [
+    "SPACE ABOVE THIS LINE IS FOR RECORDER",   # §27361.6 caption
+    "THE UNDERSIGNED GRANTOR(S) DECLARE(S)",   # R&T §11932 lead-in
+    "DOCUMENTARY TRANSFER TAX IS",
+    "MAIL TAX STATEMENTS AS DIRECTED ABOVE",
+    "WHEN RECORDED MAIL TO",
+]
+
+LANDMARKS = {
+    "recorder_caption": "RECORDER",     # word within the caption line
+    "title": "GRANT",                    # the GRANT DEED title
+    "apn_boundary": "APN:",
+    "dtt_lead": "UNDERSIGNED",
+}
+
+
+def measure(pdf_bytes):
+    out = {"page_count": None, "strings": {}, "landmarks": {}}
+    with pdfplumber.open(io.BytesIO(pdf_bytes)) as doc:
+        out["page_count"] = len(doc.pages)
+        page = doc.pages[0]
+        text = page.extract_text().upper()
+        for s in STATUTORY_STRINGS:
+            out["strings"][s] = s in text
+        words = page.extract_words()
+        for name, needle in LANDMARKS.items():
+            hits = [w for w in words if needle in w["text"].upper()]
+            out["landmarks"][name] = (round(hits[0]["x0"], 1), round(hits[0]["top"], 1)) if hits else None
+        lines = page.extract_text().splitlines()
+        try:
+            i = next(k for k, l in enumerate(lines) if "WHEN RECORDED MAIL TO" in l.upper())
+            out["mailto_block"] = [l.strip() for l in lines[i + 1 : i + 4]]
+        except StopIteration:
+            out["mailto_block"] = []
+    return out
+
+
+def main():
+    html = render_deed_html(FIXTURE_ROW)
+
+    print("Rendering with WeasyPrint (new production engine)…")
+    weasy = measure(render_pdf(html, engine="weasyprint"))
+
+    if not os.getenv("PDFSHIFT_API_KEY"):
+        print("PDFSHIFT_API_KEY not set — cannot render the comparison side.")
+        print("Run this on the production box while the key is still configured.")
+        return 1
+
+    print("Rendering with PDFShift (outgoing engine)…")
+    shift = measure(render_pdf(html, engine="pdfshift"))
+
+    failures = []
+
+    if weasy["page_count"] != shift["page_count"]:
+        failures.append(f"page count: weasy={weasy['page_count']} pdfshift={shift['page_count']}")
+
+    for s in STATUTORY_STRINGS:
+        w, p = weasy["strings"][s], shift["strings"][s]
+        status = "OK" if w and p else "MISSING"
+        print(f"  [{status}] statutory: {s!r} (weasy={w}, pdfshift={p})")
+        if not w:
+            failures.append(f"statutory string missing under WeasyPrint: {s!r}")
+
+    for name in LANDMARKS:
+        w, p = weasy["landmarks"][name], shift["landmarks"][name]
+        if not w:
+            failures.append(f"landmark {name} not found under WeasyPrint")
+            continue
+        if not p:
+            print(f"  [WARN] landmark {name}: absent under PDFShift (weasy at {w})")
+            continue
+        dx, dy = abs(w[0] - p[0]), abs(w[1] - p[1])
+        ok = dx <= TOLERANCE_PT and dy <= TOLERANCE_PT
+        print(f"  [{'OK' if ok else 'DRIFT'}] {name}: weasy={w} pdfshift={p} Δ=({dx:.1f}, {dy:.1f})pt")
+        if not ok:
+            failures.append(f"landmark {name} drift ({dx:.1f}, {dy:.1f})pt exceeds {TOLERANCE_PT}pt")
+
+    if weasy["mailto_block"] != shift["mailto_block"]:
+        print(f"  [WARN] mail-to lines differ: weasy={weasy['mailto_block']} pdfshift={shift['mailto_block']}")
+    else:
+        print(f"  [OK] mail-to block identical: {weasy['mailto_block']}")
+    if len(weasy["mailto_block"]) < 3:
+        failures.append(f"mail-to block incomplete under WeasyPrint: {weasy['mailto_block']}")
+
+    print()
+    if failures:
+        print("PARITY CHECK FAILED:")
+        for f in failures:
+            print(f"  - {f}")
+        return 1
+    print("PARITY CHECK PASSED — WeasyPrint honors the chassis on this box.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tests/test_engine_selection.py
+++ b/backend/tests/test_engine_selection.py
@@ -1,0 +1,94 @@
+"""PS2 — WeasyPrint is the production render engine (owner decision,
+2026-07-29; Render shell precheck `import weasyprint` → ok).
+
+The old 'auto' rule silently selected PDFShift whenever PDFSHIFT_API_KEY
+was set — which is how production ran an engine no test ever exercised
+(the 401 and 400 incidents lived in exactly that gap). Pinned here:
+
+- 'auto' selects WeasyPrint even when a PDFShift key IS configured.
+- PDF_ENGINE=pdfshift remains the explicit, config-flagged fallback for
+  one deploy cycle; a follow-up removes PDFShift entirely.
+- The auto path never consults the PDFShift service again.
+"""
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+import pdf_engine
+
+
+def _fail_pdfshift(*a, **k):
+    raise AssertionError("PDFShift was invoked on the auto path")
+
+
+def test_auto_selects_weasyprint_even_with_pdfshift_key(monkeypatch):
+    monkeypatch.setenv("PDFSHIFT_API_KEY", "sk_test_key_present")
+    monkeypatch.delenv("PDF_ENGINE", raising=False)
+    with patch.object(pdf_engine, "render_pdf_with_weasyprint", return_value=b"%PDF-weasy") as weasy, \
+            patch.object(pdf_engine, "render_pdf_with_pdfshift_sync", side_effect=_fail_pdfshift):
+        out = pdf_engine.render_pdf("<html></html>")
+    assert out == b"%PDF-weasy"
+    assert weasy.called
+
+
+def test_async_auto_selects_weasyprint_even_with_pdfshift_key(monkeypatch):
+    monkeypatch.setenv("PDFSHIFT_API_KEY", "sk_test_key_present")
+    monkeypatch.delenv("PDF_ENGINE", raising=False)
+    with patch.object(pdf_engine, "render_pdf_with_weasyprint", return_value=b"%PDF-weasy"), \
+            patch.object(pdf_engine, "render_pdf_with_pdfshift", side_effect=_fail_pdfshift):
+        out = asyncio.run(pdf_engine.render_pdf_async("<html></html>"))
+    assert out == b"%PDF-weasy"
+
+
+def test_pdf_engine_env_var_is_the_explicit_fallback_flag(monkeypatch):
+    """Flipping back to PDFShift is a deliberate config action, kept for
+    one deploy cycle — not an automatic consequence of a key existing."""
+    monkeypatch.setenv("PDF_ENGINE", "pdfshift")
+    with patch.object(pdf_engine, "render_pdf_with_pdfshift_sync", return_value=b"%PDF-shift") as shift:
+        out = pdf_engine.render_pdf("<html></html>")
+    assert out == b"%PDF-shift"
+    assert shift.called
+
+
+def test_async_env_var_fallback_also_works(monkeypatch):
+    monkeypatch.setenv("PDF_ENGINE", "pdfshift")
+    with patch.object(pdf_engine, "render_pdf_with_pdfshift", return_value=b"%PDF-shift"):
+        out = asyncio.run(pdf_engine.render_pdf_async("<html></html>"))
+    assert out == b"%PDF-shift"
+
+
+def test_the_default_call_reads_the_env_flag_at_all(monkeypatch):
+    """Latent bug found while pinning PS2: the old signature defaulted
+    engine to the STRING "auto", which is truthy — so
+    `engine or os.getenv("PDF_ENGINE")` never read the env var from the
+    stored-PDF pipeline (render_pdf(html) with no engine arg). The
+    fallback flag must actually flip the engine, so the default is None."""
+    import inspect
+    sig = inspect.signature(pdf_engine.render_pdf)
+    assert sig.parameters["engine"].default is None
+    sig_async = inspect.signature(pdf_engine.render_pdf_async)
+    assert sig_async.parameters["engine"].default is None
+
+
+def test_explicit_engine_param_still_routes_to_pdfshift(monkeypatch):
+    monkeypatch.delenv("PDF_ENGINE", raising=False)
+    with patch.object(pdf_engine, "render_pdf_with_pdfshift_sync", return_value=b"%PDF-shift"):
+        out = pdf_engine.render_pdf("<html></html>", engine="pdfshift")
+    assert out == b"%PDF-shift"
+
+
+def test_unknown_engine_still_rejected(monkeypatch):
+    monkeypatch.delenv("PDF_ENGINE", raising=False)
+    with pytest.raises(ValueError):
+        pdf_engine.render_pdf("<html></html>", engine="lasergun")
+
+
+def test_auto_path_never_consults_the_pdfshift_service():
+    """Source pin: the silent key-presence auto-selection must not
+    reappear — that pattern is what hid an unexercised engine in the
+    flagship flow."""
+    import inspect
+    src = inspect.getsource(pdf_engine)
+    assert "Auto-selected PDFShift" not in src
+    assert 'selected_engine = "pdfshift" if' not in src


### PR DESCRIPTION
## PS2 — Render-engine consolidation (owner decision, shell precheck passed)

### The flip
`auto` now always selects **WeasyPrint** — the engine every test in the harness has exercised all along. **This closes the test-vs-production engine asymmetry**: the PDFShift 401 (auth shape) and 400 (Playwright stowaways) incidents both lived in the one path no test exercised, precisely because a configured API key silently flipped production onto an unexercised engine. After this merges, production runs the exact render path the harness verifies.

PDFShift is **not deleted**: setting `PDF_ENGINE=pdfshift` on Render flips back for one deploy cycle. The follow-up ticket then removes PDFShift, its allowlist code, its env var, and closes the account.

### Latent bug found while pinning
The fallback flag was **dead** in the stored-PDF pipeline: `render_pdf` defaulted `engine` to the *string* `"auto"` (truthy), so `engine or os.getenv("PDF_ENGINE")` never consulted the env var on default calls. Default is now `None` — precedence: explicit param → `PDF_ENGINE` env → auto(=WeasyPrint). Pinned by signature test. (Without this fix, the one-cycle fallback would have been an illusion.)

### Production-parity verification (owner, Tier 3 — Render shell, key still set)
```
cd backend && python scripts/ps2_parity_check.py
```
Renders the same fixture deed through **both** engines and diffs the pdfplumber geometry: recorder caption / title / APN boundary / DTT lead-in positions (9 pt tolerance), the five statutory strings, the mail-to block line-by-line, and page count. Exit 0 = WeasyPrint honors the chassis **on the real box**, not just in CI. (pdfplumber ships in requirements since #66, deliberately for this.) Recommended sequence: merge → deploy → run parity script → if green, ticket the PDFShift removal.

### Pins — `test_engine_selection.py` (8 tests)
- `auto` → WeasyPrint even with a PDFShift key configured (sync + async; the PDFShift side *asserts not-called*)
- `PDF_ENGINE=pdfshift` routes to PDFShift (sync + async) — the fallback flag, now actually functional
- Explicit `engine=` param honored; unknown engines still rejected
- Source pin: the silent key-presence auto-selection can never return
- Signature pin: `engine` defaults to `None` in both entry points

### Gates
- Backend: **89 passed** (81 + 8 new) · six-flow baseline ✔ vs real Postgres
- Backend-only change set — no schema, no routes, no snapshot churn

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_