### PR TITLE
X0 (security hotfix): demo credentials never render outside local dev, never exist in source

### DIFF
--- a/frontend/src/__tests__/demoCredsGate.test.ts
+++ b/frontend/src/__tests__/demoCredsGate.test.ts
@@ -1,0 +1,66 @@
+/**
+ * X0 (security hotfix) — demo credentials can never render outside local
+ * dev, and never exist in source at all.
+ *
+ * History this pins against: the demo card shipped always-visible with
+ * committed credential constants (#48/#55, a deliberate convenience
+ * decision) and the round-2 security audit found the real credentials in
+ * the production login bundle. Reversed: values come only from untracked
+ * env (.env.local), and the card renders only when the build-time-inlined
+ * NODE_ENV is 'development' — production builds eliminate the branch.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const LOGIN = fs.readFileSync(
+  path.join(__dirname, '..', 'app', 'login', 'page.tsx'),
+  'utf8'
+);
+
+describe('X0 — demo credentials gate', () => {
+  it('no credential literal exists in source — values come from env only', () => {
+    expect(LOGIN).not.toMatch(/DEMO_EMAIL\s*=\s*["'][^"']+["']/);
+    expect(LOGIN).not.toMatch(/DEMO_PASSWORD\s*=\s*["'][^"']+["']/);
+    expect(LOGIN).not.toMatch(/@gmail\.com/);
+    expect(LOGIN).toContain('process.env.NEXT_PUBLIC_DEMO_EMAIL');
+    expect(LOGIN).toContain('process.env.NEXT_PUBLIC_DEMO_PASSWORD');
+  });
+
+  it('the card is gated on development NODE_ENV, checked at build time', () => {
+    expect(LOGIN).toMatch(/process\.env\.NODE_ENV === ["']development["']/);
+    expect(LOGIN).toContain('{SHOW_DEMO_CARD && (');
+  });
+
+  it('the demo block cannot render unconditionally again', () => {
+    // The pre-X0 marker comment ("always shown") must not return, and the
+    // card markup must sit inside the gate.
+    expect(LOGIN).not.toContain('always shown');
+    const gate = LOGIN.indexOf('{SHOW_DEMO_CARD && (');
+    const card = LOGIN.indexOf('Demo credentials</span>');
+    expect(gate).toBeGreaterThan(-1);
+    expect(card).toBeGreaterThan(gate);
+  });
+
+  it('no demo-credential literal assignment exists anywhere in frontend source', () => {
+    // Structural scan (never embeds a secret in this file): any
+    // DEMO_EMAIL/DEMO_PASSWORD assigned from a string literal, anywhere,
+    // is a violation — values may only come from env.
+    const root = path.join(__dirname, '..');
+    const offenders: string[] = [];
+    const walk = (dir: string) => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const p = path.join(dir, entry.name);
+        if (entry.isDirectory()) walk(p);
+        else if (/\.(ts|tsx)$/.test(entry.name) && !p.endsWith('demoCredsGate.test.ts')) {
+          const src = fs.readFileSync(p, 'utf8');
+          if (/DEMO_(EMAIL|PASSWORD)\s*=\s*["'][^"']+["']/.test(src)) {
+            offenders.push(p);
+          }
+        }
+      }
+    };
+    walk(root);
+    expect(offenders).toEqual([]);
+  });
+});

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -14,8 +14,17 @@ import Link from "next/link"
 import { AuthManager } from "../../utils/auth"
 import { Eye, EyeOff, AlertCircle, CheckCircle2, Zap, Copy, Check, ShieldCheck, FileCheck2, Landmark, ScrollText } from "lucide-react"
 
-const DEMO_EMAIL = "realty.reports@gmail.com"
-const DEMO_PASSWORD = "Alpha637#"
+// X0 (security hotfix): demo credentials NEVER ship in source or in a
+// production bundle. The always-visible card was a deliberate convenience
+// decision (#48/#55) reversed by the round-2 security audit. The card now
+// renders ONLY in local dev, with values from untracked env
+// (.env.local: NEXT_PUBLIC_DEMO_EMAIL / NEXT_PUBLIC_DEMO_PASSWORD) —
+// NODE_ENV is inlined at build time, so production builds eliminate the
+// entire branch, and Vercel doesn't define the vars regardless.
+const DEMO_EMAIL = process.env.NEXT_PUBLIC_DEMO_EMAIL || ""
+const DEMO_PASSWORD = process.env.NEXT_PUBLIC_DEMO_PASSWORD || ""
+const SHOW_DEMO_CARD =
+  process.env.NODE_ENV === "development" && !!DEMO_EMAIL && !!DEMO_PASSWORD
 
 function LoginContent() {
   const [formData, setFormData] = useState({ email: "", password: "" })
@@ -262,7 +271,9 @@ function LoginContent() {
               </button>
             </form>
 
-            {/* Demo Credentials — always shown, collapsible */}
+            {/* Demo credentials — LOCAL DEV ONLY (X0). The prod build
+                dead-code-eliminates this branch via the inlined NODE_ENV. */}
+            {SHOW_DEMO_CARD && (
             <div className="border border-gray-200 rounded-xl overflow-hidden">
               <button
                 type="button"
@@ -328,6 +339,7 @@ function LoginContent() {
                 </div>
               )}
             </div>
+            )}
 
             {/* Sign-up link */}
             <p className="text-center text-sm text-gray-500">


### PR DESCRIPTION
## X0 — Security hotfix (rides alone)

### Finding confirmed live
Probed the production Vercel deployment directly: the real demo credentials are present in `/_next/static/chunks/app/login/page-*.js`, with the full "Demo credentials / Show" card.

### Investigation verdict: not a failed gate — no gate ever existed
F6's V0 reference had the credentials unconditional and that was flagged as a reference bug at the time — but the owner then explicitly ordered the card always-visible (#48: *"I wanted it that way specifically so it's easier to log in"*), and the #55 login redesign rebuilt it that way with committed constants. This finding is that deliberate convenience decision colliding with the round-2 security audit. The audit's instruction supersedes; reversal implemented.

### Fix
- **Credential literals removed from source entirely.** `DEMO_EMAIL`/`DEMO_PASSWORD` now read `process.env.NEXT_PUBLIC_DEMO_*` — set them in gitignored `frontend/.env.local` for local dev; they are never defined on Vercel.
- **Dev-only render gate**: the card renders only when the build-time-inlined `NODE_ENV === 'development'` — production builds dead-code-eliminate the whole branch.
- **Proven on a production build**: the built login chunk contains zero card markup ("Demo credentials", "Fill login form" both absent) and zero credential values; only the two env-var *names* survive as inlined identifiers.

### Pins — `demoCredsGate.test.ts` (4 tests)
- No literal credential assignment in the login page; env-only sourcing
- The dev gate wraps the card markup (position-checked)
- The pre-X0 "always shown" pattern cannot return
- Frontend-wide structural scan: any `DEMO_EMAIL/DEMO_PASSWORD = "literal"` anywhere fails the suite — written without embedding a secret in the test itself

### ⚠️ Tier 3 — owner action required
The exposed credentials were public in the production bundle and remain in git history: **rotate the demo account's password** (and consider the Gmail account if that password is reused anywhere). Rotation is owner-only per standing policy; not performed here. After rotation, the new values go only into `.env.local`.

### Gates
Jest **173** (169 + 4 new) · tsc frozen at **98** · production build verified clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_