### PR TITLE
X1: failures are loud — apiFetch interceptor, session-expiry never silent, freeze + modal fixes

### DIFF
--- a/frontend/src/__tests__/apiClient.test.ts
+++ b/frontend/src/__tests__/apiClient.test.ts
@@ -1,0 +1,109 @@
+/**
+ * X1 — the loud-failure client, behavior-pinned.
+ *
+ * The audited P0: a session expired silently and every later action
+ * failed with zero UI response. apiFetch is the one place failures
+ * surface; these tests pin the three behaviors that make silence
+ * impossible: non-2xx toasts naming the failure, 401 always becomes the
+ * session-expired state (toast + cleared auth + redirect + thrown
+ * SessionExpiredError), and `silent` mutes generic noise but NEVER 401.
+ */
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+const toastError = jest.fn();
+jest.mock('sonner', () => ({
+  toast: {
+    error: (...args: unknown[]) => toastError(...args),
+    success: jest.fn(),
+    info: jest.fn(),
+    warning: jest.fn(),
+    dismiss: jest.fn(),
+  },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { apiFetch, SessionExpiredError, navigation } = require('../lib/apiClient');
+
+let redirectedTo = '';
+
+function mockResponse(status: number, body: unknown = {}): Response {
+  const resp = {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+    clone: () => resp,
+  };
+  return resp as unknown as Response;
+}
+
+beforeEach(() => {
+  toastError.mockClear();
+  localStorage.clear();
+  localStorage.setItem('access_token', 'tok-123');
+  redirectedTo = '';
+  // jsdom can't navigate — stub the client's navigation indirection.
+  navigation.goTo = (url: string) => { redirectedTo = url; };
+  navigation.current = () => '/past-deeds';
+});
+
+describe('X1 — apiFetch loud failures', () => {
+  it('attaches the session token and passes 2xx through quietly', async () => {
+    let seenAuth: string | null = null;
+    global.fetch = jest.fn(async (_url: any, init: any) => {
+      seenAuth = new Headers(init.headers).get('Authorization');
+      return mockResponse(200, { fine: true });
+    }) as any;
+
+    const res = await apiFetch('/deeds', {}, { label: 'Loading deeds' });
+    expect(res.ok).toBe(true);
+    expect(seenAuth).toBe('Bearer tok-123');
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it('non-2xx surfaces a toast naming the action, status, and backend detail', async () => {
+    global.fetch = jest.fn(async () => mockResponse(500, { detail: 'db exploded' })) as any;
+
+    const res = await apiFetch('/deeds', {}, { label: 'Loading deeds' });
+    expect(res.status).toBe(500);
+    expect(toastError).toHaveBeenCalledTimes(1);
+    const msg = String(toastError.mock.calls[0][0]);
+    expect(msg).toContain('Loading deeds');
+    expect(msg).toContain('500');
+    expect(msg).toContain('db exploded');
+  });
+
+  it('401 is the session-expired state: toast, cleared auth, redirect, thrown error', async () => {
+    global.fetch = jest.fn(async () => mockResponse(401, { detail: 'Could not validate credentials' })) as any;
+
+    await expect(apiFetch('/shared-deeds', { method: 'POST' })).rejects.toBeInstanceOf(
+      SessionExpiredError
+    );
+    expect(toastError).toHaveBeenCalled();
+    expect(String(toastError.mock.calls[0][0])).toContain('session has expired');
+    expect(localStorage.getItem('access_token')).toBeNull();
+    expect(redirectedTo).toContain('/login?expired=1');
+    expect(redirectedTo).toContain(encodeURIComponent('/past-deeds'));
+  });
+
+  it('silent mutes generic failures but NEVER a 401', async () => {
+    global.fetch = jest.fn(async () => mockResponse(500, { detail: 'boom' })) as any;
+    await apiFetch('/api/deeds/draft', { method: 'POST' }, { silent: true });
+    expect(toastError).not.toHaveBeenCalled();
+
+    global.fetch = jest.fn(async () => mockResponse(401)) as any;
+    await expect(
+      apiFetch('/api/deeds/draft', { method: 'POST' }, { silent: true })
+    ).rejects.toBeInstanceOf(SessionExpiredError);
+    expect(toastError).toHaveBeenCalled();
+    expect(redirectedTo).toContain('/login?expired=1');
+  });
+
+  it('network failure is loud and rethrown', async () => {
+    global.fetch = jest.fn(async () => {
+      throw new TypeError('fetch failed');
+    }) as any;
+
+    await expect(apiFetch('/deeds', {}, { label: 'Loading deeds' })).rejects.toThrow('fetch failed');
+    expect(String(toastError.mock.calls[0][0])).toContain('network error');
+  });
+});

--- a/frontend/src/__tests__/loudFailures.test.ts
+++ b/frontend/src/__tests__/loudFailures.test.ts
@@ -1,0 +1,79 @@
+/**
+ * X1 — adoption + freeze/viewport pins.
+ *
+ * The client exists (apiClient.test.ts pins its behavior); these pins
+ * make sure the audited pages actually USE it, that the login page names
+ * the expired session, that the full-viewport backdrop blur behind
+ * modals (the Past Deeds renderer freeze) stays gone, and that the share
+ * modal keeps its submit reachable at normal window heights.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+
+function readSource(...segments: string[]): string {
+  return fs.readFileSync(path.join(__dirname, '..', ...segments), 'utf8');
+}
+
+const AUDITED_PAGES: Array<[string, string[]]> = [
+  ['past-deeds', ['app', 'past-deeds', 'page.tsx']],
+  ['shared-deeds', ['app', 'shared-deeds', 'page.tsx']],
+  ['dashboard', ['app', 'dashboard', 'page.tsx']],
+];
+
+describe('X1 — the audited pages route API calls through apiFetch', () => {
+  for (const [name, segments] of AUDITED_PAGES) {
+    it(`${name} uses apiFetch for backend calls`, () => {
+      const src = readSource(...segments);
+      expect(src).toContain("from \"@/lib/apiClient\"");
+      // No bare fetch(`${api}/...`) to the backend remains. (The dashboard
+      // auth-check profile fetch predates X1 and redirects on failure
+      // itself; backend DATA calls are the audited surface.)
+      expect(src).not.toMatch(/fetch\(`\$\{api\}/);
+    });
+  }
+
+  it('the builder autosave/generate/resume go through apiFetch (401 never silent)', () => {
+    const src = readSource('features', 'builder', 'DeedBuilder.tsx');
+    expect(src).toContain("from '@/lib/apiClient'");
+    expect((src.match(/apiFetch\(/g) || []).length).toBeGreaterThanOrEqual(3);
+    expect(src).not.toMatch(/await fetch\('\/api\/deeds/);
+  });
+
+  it('shared-deeds Try Again refetches instead of reloading blind', () => {
+    const src = readSource('app', 'shared-deeds', 'page.tsx');
+    expect(src).toContain('onClick={() => fetchSharedDeeds()}');
+    expect(src).not.toContain('window.location.reload()');
+  });
+});
+
+describe('X1 — session expiry is named at the login page', () => {
+  it('login shows the expired-session message for ?expired=1', () => {
+    const src = readSource('app', 'login', 'page.tsx');
+    expect(src).toContain('searchParams.get("expired")');
+    expect(src).toContain('Your session expired');
+  });
+});
+
+describe('X1 — renderer freeze: no full-viewport backdrop blur behind modals', () => {
+  const BLUR_SURFACES: Array<string[]> = [
+    ['app', 'past-deeds', 'page.tsx'],
+    ['app', 'shared-deeds', 'page.tsx'],
+    ['components', 'ui', 'ConfirmDialog.tsx'],
+  ];
+  for (const segments of BLUR_SURFACES) {
+    it(`${segments.join('/')} dims without blurring`, () => {
+      const src = readSource(...segments);
+      expect(src).not.toContain('backdrop-blur');
+      expect(src).toContain('bg-black/50');
+    });
+  }
+});
+
+describe('X1 — share modal is viewport-safe', () => {
+  it('the modal is a flex column whose form body scrolls, keeping the footer reachable', () => {
+    const src = readSource('app', 'past-deeds', 'page.tsx');
+    expect(src).toMatch(/max-h-\[85vh\] flex flex-col/);
+    expect(src).toMatch(/onSubmit=\{handleShareSubmit\} className="[^"]*overflow-y-auto flex-1/);
+  });
+});

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -9,6 +9,7 @@ import { AICard } from "@/components/ui/AICard"
 import { AIEmptyState } from "@/components/ui/AIEmptyState"
 import { AuthManager } from "@/utils/auth"
 import { pickInProgressDeed } from "@/lib/latestDraft"
+import { SessionExpiredError, apiFetch } from "@/lib/apiClient"
 import { 
   FileText, Clock, CheckCircle, Send, 
   TrendingUp, Activity, Download, Share2, 
@@ -89,13 +90,10 @@ export default function Dashboard() {
   useEffect(() => {
     if (!isAuthenticated) return
 
-    const api = process.env.NEXT_PUBLIC_API_URL || "https://deedpro-main-api.onrender.com"
-    const token = localStorage.getItem("access_token")
     ;(async () => {
       try {
-        const res = await fetch(`${api}/deeds/summary`, {
-          headers: token ? { Authorization: `Bearer ${token}` } : {},
-        })
+        // X1: loud failures — apiFetch toasts non-2xx and handles 401.
+        const res = await apiFetch(`/deeds/summary`, {}, { label: "Loading dashboard summary" })
 
         if (res.ok) {
           const data = await res.json()
@@ -107,9 +105,7 @@ export default function Dashboard() {
           })
         } else {
           // Fallback: calculate from deeds list
-          const list = await fetch(`${api}/deeds`, {
-            headers: token ? { Authorization: `Bearer ${token}` } : {},
-          })
+          const list = await apiFetch(`/deeds`, {}, { label: "Loading deeds", silent: true })
           if (list.ok) {
             const data = await list.json()
             const deeds = Array.isArray(data.deeds) ? data.deeds : []
@@ -125,6 +121,7 @@ export default function Dashboard() {
           }
         }
       } catch (e) {
+        if (e instanceof SessionExpiredError) return
         console.error("Failed to load dashboard summary:", e)
       }
     })()
@@ -135,16 +132,7 @@ export default function Dashboard() {
       const token = localStorage.getItem("access_token")
       if (!token) return
 
-      const response = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL || "https://deedpro-main-api.onrender.com"}/deeds`,
-        {
-          method: "GET",
-          headers: {
-            Authorization: `Bearer ${token}`,
-            "Content-Type": "application/json",
-          },
-        }
-      )
+      const response = await apiFetch(`/deeds`, {}, { label: "Loading your deeds" })
 
       if (response.ok) {
         const data = await response.json()
@@ -157,6 +145,7 @@ export default function Dashboard() {
         setDeedsError(data.detail || `Couldn't load your deeds (${response.status})`)
       }
     } catch (error) {
+      if (error instanceof SessionExpiredError) return
       console.error("Error fetching recent deeds:", error)
       setDeedsError("Couldn't load your deeds. Check your connection and try again.")
     }
@@ -341,11 +330,8 @@ function DeedRow({ deed }: { deed: any }) {
   // reach it; fetch the stored PDF as a blob like Past Deeds does.
   const handleDownload = async () => {
     try {
-      const api = process.env.NEXT_PUBLIC_API_URL || "https://deedpro-main-api.onrender.com"
-      const token = localStorage.getItem("access_token")
-      const response = await fetch(`${api}/deeds/${deed.id}/download`, {
-        headers: { Authorization: `Bearer ${token}` },
-      })
+      // X1: loud failures — apiFetch toasts non-2xx and handles 401.
+      const response = await apiFetch(`/deeds/${deed.id}/download`, {}, { label: `Downloading deed #${deed.id}` })
       if (!response.ok) throw new Error("Download failed")
       const blob = await response.blob()
       const url = window.URL.createObjectURL(blob)
@@ -357,6 +343,7 @@ function DeedRow({ deed }: { deed: any }) {
       window.URL.revokeObjectURL(url)
       document.body.removeChild(a)
     } catch (err) {
+      if (err instanceof SessionExpiredError) return
       console.error("Download error:", err)
     }
   }

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -44,6 +44,12 @@ function LoginContent() {
       return
     }
 
+    // X1: arrived here because a session expired mid-action — say so
+    // instead of presenting a blank login as if nothing happened.
+    if (searchParams.get("expired") === "1") {
+      setError("Your session expired. Sign in again to pick up where you left off.")
+    }
+
     // Check for registration success message
     if (searchParams.get("registered") === "true") {
       const email = searchParams.get("email")

--- a/frontend/src/app/past-deeds/page.tsx
+++ b/frontend/src/app/past-deeds/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation"
 import Sidebar from "@/components/Sidebar"
 import { FileText, Download, Share2, Trash2, AlertCircle, CheckCircle, Clock, X, Plus, Loader2 } from "lucide-react"
 import { toast } from "sonner"
+import { SessionExpiredError, apiFetch } from "@/lib/apiClient"
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog"
 import { deedTypeLabel } from "@/lib/deedTypes"
 
@@ -57,28 +58,24 @@ export default function PastDeedsPageV0() {
 
   const fetchDeeds = async () => {
     try {
-      const api = process.env.NEXT_PUBLIC_API_URL || "https://deedpro-main-api.onrender.com"
       const token = localStorage.getItem("access_token")
-
       if (!token) {
         router.push("/login?redirect=/past-deeds")
         return
       }
 
-      const response = await fetch(`${api}/deeds`, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
-      })
+      // X1: apiFetch surfaces every failure (401 = session-expired redirect).
+      const response = await apiFetch(`/deeds`, {}, { label: "Loading deeds" })
 
       if (!response.ok) {
-        throw new Error("Failed to fetch deeds")
+        const data = await response.json().catch(() => ({}))
+        throw new Error(data.detail || `Failed to fetch deeds (${response.status})`)
       }
 
       const data = await response.json()
       setDeeds(Array.isArray(data) ? data : data.deeds || [])
     } catch (err) {
+      if (err instanceof SessionExpiredError) return
       console.error("Error fetching deeds:", err)
       setError(err instanceof Error ? err.message : "Failed to load deeds")
     } finally {
@@ -98,11 +95,7 @@ export default function PastDeedsPageV0() {
     // fetching, toast on the outcome either way.
     setDownloadingId(deed.id)
     try {
-      const api = process.env.NEXT_PUBLIC_API_URL || "https://deedpro-main-api.onrender.com"
-      const token = localStorage.getItem("access_token") || localStorage.getItem("token")
-      const response = await fetch(`${api}/deeds/${deed.id}/download`, {
-        headers: { Authorization: `Bearer ${token}` },
-      })
+      const response = await apiFetch(`/deeds/${deed.id}/download`, {}, { label: `Downloading deed #${deed.id}` })
       if (!response.ok) {
         // The endpoint's 500 carries the real reason (exception class +
         // message) — surface it, don't shrug.
@@ -139,23 +132,19 @@ export default function PastDeedsPageV0() {
     setShareError(null)
 
     try {
-      const api = process.env.NEXT_PUBLIC_API_URL || "https://deedpro-main-api.onrender.com"
-      const token = localStorage.getItem("access_token")
-
-      const response = await fetch(`${api}/shared-deeds`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
+      const response = await apiFetch(
+        `/shared-deeds`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ deed_id: selectedDeedId, ...shareForm }),
         },
-        body: JSON.stringify({
-          deed_id: selectedDeedId,
-          ...shareForm,
-        }),
-      })
+        { label: "Sharing deed" }
+      )
 
       if (!response.ok) {
-        throw new Error("Failed to share deed")
+        const data = await response.json().catch(() => ({}))
+        throw new Error(data.detail || `Failed to share deed (${response.status})`)
       }
 
       // Success - close modal and reset form
@@ -183,15 +172,7 @@ export default function PastDeedsPageV0() {
     if (!deleteConfirm.deedId) return
 
     try {
-      const api = process.env.NEXT_PUBLIC_API_URL || "https://deedpro-main-api.onrender.com"
-      const token = localStorage.getItem("access_token")
-
-      const response = await fetch(`${api}/deeds/${deleteConfirm.deedId}`, {
-        method: "DELETE",
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      })
+      const response = await apiFetch(`/deeds/${deleteConfirm.deedId}`, { method: "DELETE" }, { label: "Deleting deed" })
 
       if (!response.ok) {
         throw new Error("Failed to delete deed")
@@ -412,8 +393,8 @@ export default function PastDeedsPageV0() {
 
       {/* Share Modal */}
       {shareModalOpen && (
-        <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-50">
-          <div className="bg-white rounded-2xl shadow-2xl max-w-[550px] w-full p-8 max-h-[90vh] overflow-y-auto">
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
+          <div className="bg-white rounded-2xl shadow-2xl max-w-[550px] w-full p-6 max-h-[85vh] flex flex-col">
             {/* Header */}
             <div className="flex items-center justify-between mb-6">
               <h2 className="text-2xl font-bold text-slate-800">Share Deed</h2>
@@ -434,7 +415,7 @@ export default function PastDeedsPageV0() {
             )}
 
             {/* Form */}
-            <form onSubmit={handleShareSubmit} className="space-y-4">
+            <form onSubmit={handleShareSubmit} className="space-y-4 overflow-y-auto flex-1 min-h-0 pr-1">
               <div>
                 <label className="block text-sm font-medium text-slate-700 mb-2">
                   Recipient Name <span className="text-red-500">*</span>

--- a/frontend/src/app/shared-deeds/page.tsx
+++ b/frontend/src/app/shared-deeds/page.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation"
 import Sidebar from "@/components/Sidebar"
 import { Send, Eye, Clock, CheckCircle, XCircle, AlertCircle, RotateCw, X, Plus, FileText, MessageSquare } from "lucide-react"
 import { toast } from "sonner"
+import { SessionExpiredError, apiFetch } from "@/lib/apiClient"
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog"
 
 interface SharedDeed {
@@ -65,29 +66,27 @@ export default function SharedDeedsPageV0() {
   }, [])
 
   const fetchSharedDeeds = async () => {
+    setLoading(true)
+    setError(null)
     try {
-      const api = process.env.NEXT_PUBLIC_API_URL || "https://deedpro-main-api.onrender.com"
       const token = localStorage.getItem("access_token")
-
       if (!token) {
         router.push("/login?redirect=/shared-deeds")
         return
       }
 
-      const response = await fetch(`${api}/shared-deeds`, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
-      })
+      // X1: apiFetch surfaces every failure (401 = session-expired redirect).
+      const response = await apiFetch(`/shared-deeds`, {}, { label: "Loading shared deeds" })
 
       if (!response.ok) {
-        throw new Error("Failed to fetch shared deeds")
+        const data = await response.json().catch(() => ({}))
+        throw new Error(data.detail || `Failed to fetch shared deeds (${response.status})`)
       }
 
       const data = await response.json()
       setSharedDeeds(Array.isArray(data) ? data : data.shared_deeds || [])
     } catch (err) {
+      if (err instanceof SessionExpiredError) return
       console.error("Error fetching shared deeds:", err)
       setError(err instanceof Error ? err.message : "Failed to load shared deeds")
     } finally {
@@ -97,16 +96,9 @@ export default function SharedDeedsPageV0() {
 
   const handleViewFeedback = async (shareId: number) => {
     try {
-      const api = process.env.NEXT_PUBLIC_API_URL || "https://deedpro-main-api.onrender.com"
-      const token = localStorage.getItem("access_token")
-
       let feedbackText = ""
       
-      const response = await fetch(`${api}/shared-deeds/${shareId}/feedback`, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      })
+      const response = await apiFetch(`/shared-deeds/${shareId}/feedback`, {}, { label: "Loading feedback" })
 
       if (response.ok) {
         const data = await response.json()
@@ -141,15 +133,7 @@ export default function SharedDeedsPageV0() {
 
   const handleRemind = async (shareId: number) => {
     try {
-      const api = process.env.NEXT_PUBLIC_API_URL || "https://deedpro-main-api.onrender.com"
-      const token = localStorage.getItem("access_token")
-
-      const response = await fetch(`${api}/shared-deeds/${shareId}/resend`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      })
+      const response = await apiFetch(`/shared-deeds/${shareId}/resend`, { method: "POST" }, { label: "Sending reminder" })
 
       if (!response.ok) {
         throw new Error("Failed to send reminder")
@@ -170,15 +154,7 @@ export default function SharedDeedsPageV0() {
     if (!revokeConfirm.shareId) return
 
     try {
-      const api = process.env.NEXT_PUBLIC_API_URL || "https://deedpro-main-api.onrender.com"
-      const token = localStorage.getItem("access_token")
-
-      const response = await fetch(`${api}/shared-deeds/${revokeConfirm.shareId}/revoke`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      })
+      const response = await apiFetch(`/shared-deeds/${revokeConfirm.shareId}/revoke`, { method: "POST" }, { label: "Revoking access" })
 
       if (!response.ok) {
         throw new Error("Failed to revoke access")
@@ -313,7 +289,7 @@ export default function SharedDeedsPageV0() {
                 <p className="text-slate-600">{error}</p>
               </div>
               <button
-                onClick={() => window.location.reload()}
+                onClick={() => fetchSharedDeeds()}
                 className="px-6 py-3 bg-[#7C4DFF] hover:bg-[#6a3de8] text-white font-semibold rounded-xl shadow-md transition-all"
               >
                 Try Again
@@ -452,7 +428,7 @@ export default function SharedDeedsPageV0() {
 
       {/* Feedback Modal */}
       {feedbackModal.open && (
-        <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-50">
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
           <div className="bg-white rounded-2xl shadow-2xl max-w-[600px] w-full p-8">
             <div className="flex items-center justify-between mb-6">
               <div className="flex items-center gap-3">
@@ -525,7 +501,7 @@ export default function SharedDeedsPageV0() {
 
       {/* Share New Deed Modal (Placeholder) */}
       {shareModalOpen && (
-        <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center p-4 z-50">
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
           <div className="bg-white rounded-2xl shadow-2xl max-w-[600px] w-full p-8">
             <div className="flex items-center justify-between mb-6">
               <h2 className="text-2xl font-bold text-slate-800">Share Deed for Review</h2>

--- a/frontend/src/components/ui/ConfirmDialog.tsx
+++ b/frontend/src/components/ui/ConfirmDialog.tsx
@@ -48,7 +48,7 @@ export function ConfirmDialog({
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       {/* Backdrop */}
       <div 
-        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        className="absolute inset-0 bg-black/50"
         onClick={onClose}
       />
       

--- a/frontend/src/features/builder/DeedBuilder.tsx
+++ b/frontend/src/features/builder/DeedBuilder.tsx
@@ -11,6 +11,7 @@ import { useBuilderMode } from '@/hooks/useBuilderMode';
 import { DeedBuilderState, PropertyData, Sourced } from '@/types/builder';
 import { buildDeedPayload, hasMeaningfulData } from '@/lib/deedPayload';
 import { DEED_LABELS } from '@/lib/deedTypes';
+import { SessionExpiredError, apiFetch } from '@/lib/apiClient';
 import {
   MaterialFieldKey,
   collectCandidateFields,
@@ -69,18 +70,17 @@ function DeedBuilderInner({ deedType, initialProperty, resumeDeedId }: DeedBuild
   const persistDraft = useCallback((s: DeedBuilderState, serialized: string): Promise<void> => {
     const run = (async () => {
       try {
-        const token = localStorage.getItem('access_token') || localStorage.getItem('token');
-        const res = await fetch('/api/deeds/draft', {
+        // X1: silent for ordinary failures (background save; the exit prompt
+        // is the surface) — but a 401 is NEVER silent: the audited disaster
+        // was typing into a dead session with no warning at all.
+        const res = await apiFetch('/api/deeds/draft', {
           method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            Authorization: `Bearer ${token}`,
-          },
+          headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             ...(draftIdRef.current ? { deed_id: draftIdRef.current } : {}),
             ...buildDeedPayload(s),
           }),
-        });
+        }, { label: 'Autosave', silent: true });
         if (res.ok) {
           const row = await res.json();
           if (row.id) draftIdRef.current = row.id;
@@ -91,7 +91,9 @@ function DeedBuilderInner({ deedType, initialProperty, resumeDeedId }: DeedBuild
           console.warn(`[autosave] draft save failed (${res.status})`);
         }
       } catch (err) {
-        console.warn('[autosave] draft save failed:', err);
+        if (!(err instanceof SessionExpiredError)) {
+          console.warn('[autosave] draft save failed:', err);
+        }
       } finally {
         inflightSaveRef.current = null;
       }
@@ -136,10 +138,8 @@ function DeedBuilderInner({ deedType, initialProperty, resumeDeedId }: DeedBuild
     let cancelled = false;
     (async () => {
       try {
-        const token = localStorage.getItem('access_token') || localStorage.getItem('token');
-        const res = await fetch(`/api/deeds/${resumeDeedId}`, {
-          headers: { Authorization: `Bearer ${token}` },
-        });
+        // X1: apiFetch attaches auth and makes failures loud (401 = expired).
+        const res = await apiFetch(`/api/deeds/${resumeDeedId}`, {}, { label: 'Loading draft', silent: true });
         if (!res.ok) {
           const err = await res.json().catch(() => ({}));
           throw new Error(err.detail || `Could not load draft (${res.status})`);
@@ -161,6 +161,7 @@ function DeedBuilderInner({ deedType, initialProperty, resumeDeedId }: DeedBuild
           toast.success('Draft restored — pick up where you left off.');
         }
       } catch (err) {
+        if (err instanceof SessionExpiredError) return;
         if (!cancelled) {
           toast.error(err instanceof Error ? err.message : 'Could not resume this draft.');
         }
@@ -284,18 +285,14 @@ function DeedBuilderInner({ deedType, initialProperty, resumeDeedId }: DeedBuild
         ...serialized,
       };
 
-      const response = await fetch('/api/deeds/generate', {
+      // X1: apiFetch attaches the session token (G1's fossil-key fallback
+      // included) and handles 401 as session-expired. silent — this catch
+      // block already surfaces failures with the backend's detail.
+      const response = await apiFetch('/api/deeds/generate', {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          // G1: AuthManager stores the session under 'access_token'; the bare
-          // 'token' key is a pre-AuthManager fossil nothing writes anymore.
-          // This was the only call site reading it without the fallback —
-          // every fresh session generated with "Bearer null" (demo blocker).
-          'Authorization': `Bearer ${localStorage.getItem('access_token') || localStorage.getItem('token')}`,
-        },
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload),
-      });
+      }, { label: 'Generating deed', silent: true });
 
       if (!response.ok) {
         const error = await response.json().catch(() => ({ detail: 'Generation failed' }));
@@ -321,6 +318,7 @@ function DeedBuilderInner({ deedType, initialProperty, resumeDeedId }: DeedBuild
       lastSavedRef.current = JSON.stringify(serialized);
       router.push(`/deed-builder/${deedType}/success?id=${generatedDeedId}`);
     } catch (err) {
+      if (err instanceof SessionExpiredError) return;
       console.error('Generation failed:', err);
       toast.error(err instanceof Error ? err.message : 'Generation failed. Please try again.');
     } finally {

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -1,0 +1,113 @@
+/**
+ * X1 — failures are loud, everywhere this client is used.
+ *
+ * The round-2 audit's P0: a session expired with zero warning and every
+ * subsequent action failed in silence (share POST → 401, nothing on
+ * screen). Every page did its own fetch with its own (often absent)
+ * error handling. This wrapper is the one place failures surface:
+ *
+ *   - non-2xx  → a toast NAMING the failure (label + status + the
+ *                backend's detail string when present), response still
+ *                returned so callers keep their own error UI;
+ *   - 401      → never silent: session-expired toast, auth cleared,
+ *                redirect to /login?expired=1&redirect=<here>, and a
+ *                SessionExpiredError thrown so callers stop;
+ *   - network  → a toast saying the server was unreachable, rethrown.
+ *
+ * `silent: true` (autosave-style background calls) suppresses the
+ * generic toasts — but a 401 is NEVER silent, that's the whole bug.
+ */
+import { toast } from 'sonner';
+
+export class SessionExpiredError extends Error {
+  constructor() {
+    super('Session expired');
+    this.name = 'SessionExpiredError';
+  }
+}
+
+export function apiBase(): string {
+  return process.env.NEXT_PUBLIC_API_URL || 'https://deedpro-main-api.onrender.com';
+}
+
+interface ApiFetchOptions {
+  /** Human name for the action, used in failure toasts. Defaults to the path. */
+  label?: string;
+  /** Suppress generic failure toasts (background autosave). 401 is never silent. */
+  silent?: boolean;
+  /** Skip the Authorization header (public endpoints). */
+  noAuth?: boolean;
+}
+
+/** Navigation indirection — jsdom can't navigate, so tests stub this. */
+export const navigation = {
+  goTo(url: string): void {
+    window.location.href = url;
+  },
+  current(): string {
+    return window.location.pathname + window.location.search;
+  },
+};
+
+function handleSessionExpired(): void {
+  toast.error('Your session has expired — please sign in again to continue.', {
+    id: 'session-expired', // one toast, however many calls fail behind it
+    duration: 10000,
+  });
+  try {
+    localStorage.removeItem('access_token');
+    localStorage.removeItem('token'); // pre-AuthManager fossil key (G1)
+    localStorage.removeItem('user_data');
+  } catch {
+    /* storage unavailable — redirect is still the surface */
+  }
+  navigation.goTo(`/login?expired=1&redirect=${encodeURIComponent(navigation.current())}`);
+}
+
+/**
+ * Fetch with loud failures. `path` is either an absolute URL or a
+ * backend path starting with '/' (prefixed with the API base). Relative
+ * same-origin paths ('/api/...') pass through untouched.
+ */
+export async function apiFetch(
+  path: string,
+  init: RequestInit = {},
+  opts: ApiFetchOptions = {}
+): Promise<Response> {
+  const url = path.startsWith('http') || path.startsWith('/api/')
+    ? path
+    : `${apiBase()}${path}`;
+  const label = opts.label || `${(init.method || 'GET').toUpperCase()} ${path}`;
+
+  const headers = new Headers(init.headers || {});
+  if (!opts.noAuth && !headers.has('Authorization')) {
+    const token = localStorage.getItem('access_token') || localStorage.getItem('token');
+    if (token) headers.set('Authorization', `Bearer ${token}`);
+  }
+
+  let response: Response;
+  try {
+    response = await fetch(url, { ...init, headers });
+  } catch (err) {
+    if (!opts.silent) {
+      toast.error(`${label}: network error — could not reach the server.`);
+    }
+    throw err;
+  }
+
+  if (response.status === 401) {
+    handleSessionExpired();
+    throw new SessionExpiredError();
+  }
+
+  if (!response.ok && !opts.silent) {
+    const detail = await response
+      .clone()
+      .json()
+      .then((b) => (typeof b?.detail === 'string' ? b.detail : ''))
+      .catch(() => '');
+    toast.error(`${label} failed (${response.status})${detail ? `: ${detail.slice(0, 200)}` : ''}`);
+  }
+
+  return response;
+}


### PR DESCRIPTION
## X1 — the auditor's P0 (explains their findings #1–#3)

### (a) + (b) Global loud-failure client
New `lib/apiClient.ts` — the one place failures surface:
- **non-2xx** → toast naming the action, status, and the backend's `detail`; the response is still returned so pages keep their own error UI
- **401 → never silent**: session-expired toast (deduped by id — one toast however many calls fail behind it), auth keys cleared (including G1's fossil `token` key), redirect to `/login?expired=1&redirect=<here>`, and a thrown `SessionExpiredError` so callers stop. The login page names the expiry ("Your session expired. Sign in again to pick up where you left off.") instead of presenting a blank form.
- **network failure** → loud and rethrown
- **`silent: true`** (background autosave) mutes generic toasts but **never** a 401 — typing into a dead session was the audited disaster

Adopted at every audited surface: past-deeds (list/download/share/delete), shared-deeds (list/feedback/resend/revoke — **"Try Again" now actually refetches** instead of `window.location.reload()`), dashboard (summary/list/row-download — the row download previously swallowed errors into `console.error`), and the builder (resume/generate/**autosave** — an autosave 401 now surfaces immediately).

### (c) Sharing-stack retest — verdict
Fresh account → fresh token → real Postgres: **share POST 200 · list 200 · revoke 200 · unauthenticated POST properly rejected.**
**The sharing stack was never broken — it was auth-starved.** Every sharing failure the auditor logged is explained by the dead session; nothing further to fix in the stack itself.

### Past Deeds renderer freeze — root cause + fix
The share modal (and both shared-deeds modals, and `ConfirmDialog`) drew **`backdrop-blur-sm` over a full-viewport fixed overlay** — forcing re-rasterization of the entire table behind it on every frame, which matches "hard-froze the renderer repeatedly with the share modal open." Dimming (`bg-black/50`) stays; blur removed everywhere, pinned.

### Share modal viewport-safety
Now a flex column capped at `85vh`: header fixed, form body scrolls, footer buttons always reachable — no more submit below the fold.

### Pins
- `apiClient.test.ts` (5): token attachment, non-2xx toast content, the full 401 state (toast + cleared auth + redirect + throw), silent-mutes-generic-but-never-401, loud network failure
- `loudFailures.test.ts` (9): apiFetch adoption per audited page + builder, honest Try Again, expired-login copy, no backdrop-blur on any modal surface, viewport-safe modal structure

### Gates
Jest **188** (173 + 15 new) · tsc **98** · backend **89** · six-flow ✔

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_