### PR TITLE
X2: the legitimacy batch — settings redirect, named vesting, DTT breakdown, honest sharing, findable rows, provable downloads

### DIFF
--- a/backend/routers/deeds_crud.py
+++ b/backend/routers/deeds_crud.py
@@ -235,7 +235,7 @@ def list_deeds_endpoint(user_id: int = Depends(get_current_user_id)):
         with db.conn.cursor() as cur:
             cur.execute("""
                 SELECT id, deed_type, property_address, grantor_name, grantee_name,
-                       county, status, pdf_url, created_at, updated_at
+                       county, status, pdf_url, created_at, updated_at, apn
                 FROM deeds
                 WHERE user_id = %s AND COALESCE(status, '') <> 'deleted'
                 ORDER BY created_at DESC
@@ -263,6 +263,9 @@ def list_deeds_endpoint(user_id: int = Depends(get_current_user_id)):
                     # the offset explicitly or the browser assumes local.
                     "created_at": _iso_utc(deed[8]),
                     "updated_at": _iso_utc(deed[9]),
+                    # X2.6/X2.7: the parcel id — dupe-parcel awareness in the
+                    # builder and searchable rows in Past Deeds.
+                    "apn": deed[10],
                 })
 
             return {"deeds": formatted_deeds}

--- a/backend/routers/sharing.py
+++ b/backend/routers/sharing.py
@@ -13,7 +13,9 @@ router = APIRouter()
 
 class ShareDeedCreate(BaseModel):
     deed_id: int
-    recipient_name: str
+    # X2.4: email is the recipient's identity; the name is a courtesy for
+    # the email greeting only. Blank falls back to the address itself.
+    recipient_name: Optional[str] = None
     recipient_email: str
     recipient_role: str
     message: Optional[str] = None
@@ -38,6 +40,9 @@ def share_deed_for_approval(share_data: ShareDeedCreate, user_id: int = Depends(
     from datetime import timezone
     # Use configurable expiration (default 7 days = 168 hours)
     expires_in = share_data.expires_in_hours or 168
+    # X2.4: optional name — greet by email address when blank.
+    if not (share_data.recipient_name or "").strip():
+        share_data.recipient_name = share_data.recipient_email
     expires_at = datetime.now(timezone.utc) + timedelta(hours=expires_in)
     approval_token = str(uuid.uuid4())
 

--- a/backend/tests/test_sharing_routes.py
+++ b/backend/tests/test_sharing_routes.py
@@ -35,3 +35,16 @@ def test_removed_routers_are_gone():
     assert ("POST", "/deeds/{deed_id}/share") not in routes
     assert ("POST", "/deeds/shares/resend") not in routes
     assert ("GET", "/deed-shares/{share_id}/feedback") not in routes
+
+
+def test_share_model_recipient_name_optional_email_is_identity():
+    """X2.4: email is the recipient's identity; the name is a courtesy for
+    the greeting. A blank or absent name must validate — and the create
+    path falls back to the address itself."""
+    from routers.sharing import ShareDeedCreate
+    share = ShareDeedCreate(
+        deed_id=1, recipient_email="reviewer@test.dev", recipient_role="Other")
+    assert share.recipient_name is None
+    share2 = ShareDeedCreate(
+        deed_id=1, recipient_name="  ", recipient_email="r@test.dev", recipient_role="Other")
+    assert (share2.recipient_name or "").strip() == ""

--- a/frontend/src/__tests__/flowSmalls.test.ts
+++ b/frontend/src/__tests__/flowSmalls.test.ts
@@ -48,7 +48,8 @@ describe('U3 — deed types display as names, not slugs', () => {
   it('Past Deeds rows carry grantee and doc id', () => {
     const pastDeeds = stripComments(readSource('app', 'past-deeds', 'page.tsx'));
     expect(pastDeeds).toContain('deed.grantee_name');
-    expect(pastDeeds).toContain('Doc #{deed.id}');
+    // X2.7 promoted the doc id from an under-address line to its own column.
+    expect(pastDeeds).toContain('>#{deed.id}</td>');
   });
 });
 

--- a/frontend/src/__tests__/legitimacyBatch.test.ts
+++ b/frontend/src/__tests__/legitimacyBatch.test.ts
@@ -1,0 +1,166 @@
+/**
+ * X2 — the legitimacy batch, pinned.
+ *
+ * 1. /settings lands on the real account page, never a 404.
+ * 2. Every non-trust AI vesting suggestion matches a NAMED option — the
+ *    recommended path must not look like the risky (Custom) path.
+ * 3. DTT shows its breakdown; cities without their own transfer tax get
+ *    NO fabricated city portion (the $2.20-for-any-city bug).
+ * 4/5. Share modal: email is the identity (name optional); expiry copy
+ *    states what actually happens.
+ * 6. Duplicate-parcel awareness is passive — a notice, never a block.
+ * 7. Past Deeds is searchable/filterable with a Doc ID column; dashboard
+ *    drafts read as needs-action.
+ * 8. Success-page downloads serve the server-stored bytes, and the
+ *    stored PDF's fingerprint is displayed.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+import { computeDttBreakdown } from '../lib/dttCalc';
+import { getVestingSuggestion } from '../lib/ai-helpers';
+import { VESTING_OPTIONS } from '../components/builder/sections/VestingSection';
+import type { DTTData } from '../types/builder';
+
+function readSource(...segments: string[]): string {
+  return fs.readFileSync(path.join(__dirname, '..', ...segments), 'utf8');
+}
+
+describe('X2.1 — /settings is never a dead end', () => {
+  it('redirects to the real account page', () => {
+    const src = readSource('app', 'settings', 'page.tsx');
+    expect(src).toContain("redirect('/account-settings')");
+  });
+});
+
+describe('X2.2 — accepted vesting suggestions land on named options', () => {
+  const named = VESTING_OPTIONS.map((o) => o.value.toLowerCase());
+
+  const CASES: Array<[string, string, number, string]> = [
+    ['single grantee', 'ROBERT ROE', 1, 'grant-deed'],
+    ['married couple', 'JOHN SMITH AND JANE SMITH', 2, 'grant-deed'],
+    ['two individuals', 'ANN ONE AND BOB TWO', 2, 'grant-deed'],
+    ['interspousal single', 'JANE SMITH', 1, 'interspousal-transfer'],
+    ['three grantees', 'A ONE AND B TWO AND C THREE', 3, 'grant-deed'],
+  ];
+
+  for (const [label, grantee, count, deedType] of CASES) {
+    it(`${label}: the suggested value is a NAMED option`, () => {
+      const suggestion = getVestingSuggestion(grantee, count, deedType);
+      expect(suggestion).not.toBeNull();
+      expect(named).toContain(suggestion!.value.toLowerCase());
+    });
+  }
+
+  it('trust vesting stays genuinely custom (names the trust)', () => {
+    const suggestion = getVestingSuggestion('JOHN SMITH, TRUSTEE OF THE SMITH FAMILY TRUST', 1, 'grant-deed');
+    expect(suggestion).not.toBeNull();
+    expect(named).not.toContain(suggestion!.value.toLowerCase());
+  });
+
+  it('option matching in the section is case-insensitive', () => {
+    const src = readSource('components', 'builder', 'sections', 'VestingSection.tsx');
+    expect(src).toContain('matchesOption');
+    expect(src).toMatch(/toLowerCase\(\)/);
+  });
+});
+
+describe('X2.3 — DTT breakdown, no fabricated city tax', () => {
+  const base: DTTData = {
+    isExempt: false, exemptReason: '', transferValue: '500,000',
+    calculatedAmount: '', basis: 'full_value', areaType: 'city', cityName: '',
+  };
+
+  it('a city with NO municipal transfer tax gets county-only (the $2.20 phantom is dead)', () => {
+    const b = computeDttBreakdown({ ...base, cityName: 'Glendale' });
+    expect(b).not.toBeNull();
+    expect(b!.city).toBeNull();
+    expect(b!.county).toBe('550.00');
+    expect(b!.total).toBe('550.00');
+  });
+
+  it('a city with its own transfer tax shows both portions', () => {
+    const b = computeDttBreakdown({ ...base, cityName: 'Los Angeles' });
+    expect(b!.county).toBe('550.00');
+    expect(b!.city).toBe('2250.00');
+    expect(b!.total).toBe('2800.00');
+  });
+
+  it('unincorporated is county-only', () => {
+    const b = computeDttBreakdown({ ...base, areaType: 'unincorporated', cityName: '' });
+    expect(b!.city).toBeNull();
+    expect(b!.total).toBe('550.00');
+  });
+
+  it('exempt and empty declare nothing', () => {
+    expect(computeDttBreakdown({ ...base, isExempt: true })).toBeNull();
+    expect(computeDttBreakdown({ ...base, transferValue: '' })).toBeNull();
+    expect(computeDttBreakdown(null)).toBeNull();
+  });
+
+  it('the section renders the breakdown, not one opaque total', () => {
+    const src = readSource('components', 'builder', 'sections', 'TransferTaxSection.tsx');
+    expect(src).toContain('computeDttBreakdown');
+    expect(src).toContain('dttBreakdown.county');
+    expect(src).toContain('dttBreakdown.city');
+  });
+});
+
+describe('X2.4/5 — share modal honesty', () => {
+  it('recipient name is optional; email is the identity', () => {
+    const src = readSource('app', 'past-deeds', 'page.tsx');
+    expect(src).toContain('Recipient Name <span className="text-slate-400 font-normal">(optional)</span>');
+    // The name input carries no `required`; the email input still does.
+    const nameBlock = src.substring(src.indexOf('Recipient Name'), src.indexOf('Recipient Email'));
+    expect(nameBlock).not.toContain('required');
+  });
+
+  it('expiry copy states what actually happens at expiry', () => {
+    const src = readSource('app', 'past-deeds', 'page.tsx');
+    expect(src).toContain('When the link expires it stops working');
+    expect(src).toContain('the deed itself is unaffected');
+  });
+});
+
+describe('X2.6 — duplicate-parcel awareness is passive', () => {
+  it('the builder checks the APN and notifies without blocking', () => {
+    const src = readSource('features', 'builder', 'DeedBuilder.tsx');
+    expect(src).toContain('already has a completed deed');
+    expect(src).toContain('Continuing creates a separate document');
+    // A notice, never a gate: the dupe check must not touch gateBlocked.
+    const gate = src.substring(src.indexOf('const gateBlocked'), src.indexOf('const stampConfirmed'));
+    expect(gate).not.toContain('apn');
+  });
+});
+
+describe('X2.7 — findable rows', () => {
+  it('Past Deeds has search, status filter, and a Doc ID column', () => {
+    const src = readSource('app', 'past-deeds', 'page.tsx');
+    expect(src).toContain('Search address, grantee, APN, or Doc ID');
+    expect(src).toContain('statusFilter');
+    expect(src).toContain('>Doc ID</th>');
+    expect(src).toContain('visibleDeeds.map');
+  });
+
+  it('dashboard drafts read as needs-action with a labeled Continue', () => {
+    const src = readSource('app', 'dashboard', 'page.tsx');
+    expect(src).toContain('needsAction');
+    expect(src).toContain('border-amber-400');
+    expect(src).toMatch(/Continue\s*<ArrowRight/);
+    // Last-touched time, not created time.
+    expect(src).toContain('formatDate(deed.updated_at || deed.created_at)');
+  });
+});
+
+describe('X2.8 — downloads are demonstrably server-truth', () => {
+  it('the success page fetches bytes from the authenticated download endpoint', () => {
+    const src = readSource('app', 'deed-builder', '[type]', 'success', 'success-content.tsx');
+    expect(src).toMatch(/\/deeds\/\$\{deedId\}\/download/);
+  });
+
+  it('the stored PDF fingerprint is surfaced', () => {
+    const src = readSource('app', 'deed-builder', '[type]', 'success', 'success-content.tsx');
+    expect(src).toContain('pdf_sha256');
+    expect(src).toContain('Stored PDF fingerprint');
+  });
+});

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -402,8 +402,14 @@ function DeedRow({ deed }: { deed: any }) {
     return d.toLocaleDateString()
   }
 
+  const needsAction = deed.status === 'draft' || deed.status === 'in_progress'
+
   return (
-    <div className="p-4 hover:bg-gray-50 transition-colors flex items-center justify-between gap-4">
+    // X2.7: drafts read as "needs action" at a glance — amber edge + a
+    // labeled Continue button, not an unexplained arrow.
+    <div className={`p-4 hover:bg-gray-50 transition-colors flex items-center justify-between gap-4 ${
+      needsAction ? 'border-l-4 border-amber-400' : ''
+    }`}>
       <div className="flex items-center gap-4 min-w-0 flex-1">
         <div className="w-10 h-10 rounded-lg bg-gray-100 flex items-center justify-center flex-shrink-0">
           <FileText className="w-5 h-5 text-gray-500" />
@@ -413,7 +419,7 @@ function DeedRow({ deed }: { deed: any }) {
             {formatDeedType(deed.deed_type)} {deed.property_address ? `- ${deed.property_address}` : ''}
           </p>
           <p className="text-sm text-gray-500 truncate">
-            {deed.county || 'California'} • {deed.grantor_name || 'Draft'} → {deed.grantee_name || '...'}
+            Doc #{deed.id} • {deed.grantor_name || 'Draft'} → {deed.grantee_name || '...'}
           </p>
         </div>
       </div>
@@ -424,7 +430,7 @@ function DeedRow({ deed }: { deed: any }) {
           {deed.status || 'Draft'}
         </span>
         <span className="text-sm text-gray-400 hidden sm:block">
-          {formatDate(deed.created_at)}
+          {formatDate(deed.updated_at || deed.created_at)}
         </span>
         
         {/* Actions */}
@@ -447,13 +453,14 @@ function DeedRow({ deed }: { deed: any }) {
               <Share2 className="w-4 h-4" />
             </button>
           )}
-          {(deed.status === 'draft' || deed.status === 'in_progress') && (
+          {needsAction && (
             <button
               onClick={() => router.push(`/deed-builder/${deed.deed_type || 'grant-deed'}?resume=${deed.id}`)}
-              className="p-2 hover:bg-emerald-50 rounded-lg transition-colors text-emerald-600"
+              className="flex items-center gap-1 px-3 py-1.5 bg-amber-100 hover:bg-amber-200 text-amber-800 rounded-lg transition-colors text-sm font-medium"
               title="Continue this draft"
             >
-              <ArrowRight className="w-4 h-4" />
+              Continue
+              <ArrowRight className="w-3.5 h-3.5" />
             </button>
           )}
         </div>

--- a/frontend/src/app/deed-builder/[type]/success/success-content.tsx
+++ b/frontend/src/app/deed-builder/[type]/success/success-content.tsx
@@ -38,6 +38,15 @@ export function SuccessContent() {
   const [loading, setLoading] = useState(true);
   const [copiedId, setCopiedId] = useState(false);
 
+  // X2.8: the stored PDF's sha256, stamped into metadata at store time —
+  // downloads serve exactly these fingerprinted bytes.
+  const pdfSha = (() => {
+    const meta = (deed as { metadata?: unknown } | null)?.metadata;
+    const parsed = typeof meta === 'string' ? (() => { try { return JSON.parse(meta); } catch { return {}; } })() : meta || {};
+    const sha = (parsed as { pdf_sha256?: unknown }).pdf_sha256;
+    return typeof sha === 'string' ? sha : '';
+  })();
+
   // Fetch deed details
   useEffect(() => {
     const fetchDeed = async () => {
@@ -244,12 +253,19 @@ export function SuccessContent() {
               </div>
             </div>
 
-            {/* Document ID */}
+            {/* Document ID + stored-PDF fingerprint (X2.8: downloads fetch
+                the server-stored bytes; the fingerprint makes "stored
+                immutably" demonstrable, not just asserted). */}
             {deedId && (
               <div className="flex items-center justify-between bg-slate-50 rounded-xl p-4 mb-8">
-                <div>
+                <div className="min-w-0">
                   <p className="text-xs text-slate-500 uppercase tracking-wider font-semibold mb-1">Document ID</p>
                   <p className="text-sm font-mono text-slate-700">{deedId}</p>
+                  {pdfSha && (
+                    <p className="text-xs text-slate-400 font-mono mt-1 truncate" title={`SHA-256 ${pdfSha}`}>
+                      Stored PDF fingerprint: {pdfSha.slice(0, 16)}…
+                    </p>
+                  )}
                 </div>
                 <button
                   onClick={handleCopyId}

--- a/frontend/src/app/past-deeds/page.tsx
+++ b/frontend/src/app/past-deeds/page.tsx
@@ -4,7 +4,7 @@ import type React from "react"
 import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import Sidebar from "@/components/Sidebar"
-import { FileText, Download, Share2, Trash2, AlertCircle, CheckCircle, Clock, X, Plus, Loader2 } from "lucide-react"
+import { FileText, Download, Share2, Trash2, AlertCircle, CheckCircle, Clock, X, Plus, Loader2, Search } from "lucide-react"
 import { toast } from "sonner"
 import { SessionExpiredError, apiFetch } from "@/lib/apiClient"
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog"
@@ -15,6 +15,7 @@ interface Deed {
   property_address: string
   deed_type: string
   grantee_name?: string
+  apn?: string
   status: "completed" | "draft" | "in_progress"
   created_at: string
   updated_at: string
@@ -51,6 +52,9 @@ export default function PastDeedsPageV0() {
     deedId: null,
   })
   const [downloadingId, setDownloadingId] = useState<number | null>(null)
+  // X2.7: find a deed without scrolling — text search + status filter.
+  const [searchQuery, setSearchQuery] = useState("")
+  const [statusFilter, setStatusFilter] = useState<"all" | "completed" | "draft">("all")
 
   useEffect(() => {
     fetchDeeds()
@@ -223,6 +227,21 @@ export default function PastDeedsPageV0() {
     }) + " " + d.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" })
   }
 
+  // X2.7: filter over address, grantee, doc id, APN, and type label.
+  const visibleDeeds = deeds.filter((deed) => {
+    if (statusFilter === "completed" && deed.status !== "completed") return false
+    if (statusFilter === "draft" && deed.status === "completed") return false
+    const q = searchQuery.trim().toLowerCase()
+    if (!q) return true
+    return [
+      deed.property_address,
+      deed.grantee_name,
+      deed.apn,
+      String(deed.id),
+      deedTypeLabel(deed.deed_type),
+    ].some((field) => (field || "").toLowerCase().includes(q))
+  })
+
   return (
     <div className="flex min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-50">
       <Sidebar />
@@ -238,11 +257,35 @@ export default function PastDeedsPageV0() {
 
             {/* Subheader Bar */}
             <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 bg-white rounded-xl p-4 shadow-sm border border-slate-200">
-              <div className="flex items-center gap-2">
-                <FileText className="w-5 h-5 text-[#7C4DFF]" />
-                <span className="text-lg font-semibold text-slate-700">
-                  Showing {deeds.length} {deeds.length === 1 ? "deed" : "deeds"}
-                </span>
+              <div className="flex flex-col sm:flex-row items-start sm:items-center gap-3 flex-1">
+                <div className="flex items-center gap-2 flex-shrink-0">
+                  <FileText className="w-5 h-5 text-[#7C4DFF]" />
+                  <span className="text-lg font-semibold text-slate-700">
+                    {visibleDeeds.length === deeds.length
+                      ? `Showing ${deeds.length} ${deeds.length === 1 ? "deed" : "deeds"}`
+                      : `Showing ${visibleDeeds.length} of ${deeds.length} deeds`}
+                  </span>
+                </div>
+                <div className="relative flex-1 max-w-sm">
+                  <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+                  <input
+                    type="text"
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    placeholder="Search address, grantee, APN, or Doc ID"
+                    className="w-full pl-9 pr-3 py-2 text-sm border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF]"
+                  />
+                </div>
+                <select
+                  value={statusFilter}
+                  onChange={(e) => setStatusFilter(e.target.value as "all" | "completed" | "draft")}
+                  className="px-3 py-2 text-sm border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF]"
+                  aria-label="Filter by status"
+                >
+                  <option value="all">All statuses</option>
+                  <option value="completed">Completed</option>
+                  <option value="draft">Drafts</option>
+                </select>
               </div>
               <button
                 onClick={() => router.push("/deed-builder")}
@@ -310,6 +353,7 @@ export default function PastDeedsPageV0() {
                 <table className="w-full">
                   <thead>
                     <tr className="bg-slate-50 border-b border-slate-200">
+                      <th className="text-left py-4 px-6 text-sm font-semibold text-slate-700">Doc ID</th>
                       <th className="text-left py-4 px-6 text-sm font-semibold text-slate-700">Property</th>
                       <th className="text-left py-4 px-6 text-sm font-semibold text-slate-700">Deed Type</th>
                       <th className="text-left py-4 px-6 text-sm font-semibold text-slate-700">Status</th>
@@ -319,20 +363,21 @@ export default function PastDeedsPageV0() {
                     </tr>
                   </thead>
                   <tbody>
-                    {deeds.map((deed, index) => (
+                    {visibleDeeds.map((deed, index) => (
                       <tr
                         key={deed.id}
                         className={`border-b border-slate-100 hover:bg-slate-50 transition-colors ${
                           index % 2 === 0 ? "bg-white" : "bg-slate-50/50"
                         }`}
                       >
+                        <td className="py-4 px-6 font-mono text-sm text-slate-600">#{deed.id}</td>
                         <td className="py-4 px-6">
                           {/* U3: a row identifies its deed — address alone
                               can't when one property has several. */}
                           <p className="font-medium text-slate-800">{deed.property_address}</p>
-                          <p className="text-sm text-slate-500">
-                            {deed.grantee_name ? `To ${deed.grantee_name} · ` : ""}Doc #{deed.id}
-                          </p>
+                          {deed.grantee_name && (
+                            <p className="text-sm text-slate-500">To {deed.grantee_name}</p>
+                          )}
                         </td>
                         <td className="py-4 px-6 text-slate-600">{deedTypeLabel(deed.deed_type)}</td>
                         <td className="py-4 px-6">{getStatusBadge(deed.status)}</td>
@@ -418,11 +463,10 @@ export default function PastDeedsPageV0() {
             <form onSubmit={handleShareSubmit} className="space-y-4 overflow-y-auto flex-1 min-h-0 pr-1">
               <div>
                 <label className="block text-sm font-medium text-slate-700 mb-2">
-                  Recipient Name <span className="text-red-500">*</span>
+                  Recipient Name <span className="text-slate-400 font-normal">(optional)</span>
                 </label>
                 <input
                   type="text"
-                  required
                   value={shareForm.recipient_name}
                   onChange={(e) => setShareForm({ ...shareForm, recipient_name: e.target.value })}
                   className="w-full px-4 py-3 border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF] transition-colors"
@@ -483,7 +527,12 @@ export default function PastDeedsPageV0() {
                   <option value="336">14 days</option>
                   <option value="720">30 days</option>
                 </select>
-                <p className="text-xs text-slate-500 mt-1">The recipient must approve or request changes before this date.</p>
+                {/* X2.5: say what expiry actually does. */}
+                <p className="text-xs text-slate-500 mt-1">
+                  When the link expires it stops working and the share is marked
+                  expired — the deed itself is unaffected, and you can share it
+                  again anytime.
+                </p>
               </div>
 
               {/* Footer Buttons */}

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -1,0 +1,8 @@
+// X2.1 — /settings 404'd while nav labels say "Settings" (the real page
+// lives at /account-settings). A typed or bookmarked /settings now lands
+// on the real page instead of a dead end.
+import { redirect } from 'next/navigation';
+
+export default function SettingsRedirect() {
+  redirect('/account-settings');
+}

--- a/frontend/src/components/builder/sections/TransferTaxSection.tsx
+++ b/frontend/src/components/builder/sections/TransferTaxSection.tsx
@@ -5,6 +5,7 @@ import { Calculator, Scale, ShieldCheck, X } from "lucide-react"
 import { useAIAssist } from "@/contexts/AIAssistContext"
 import { AISuggestion } from "../AISuggestion"
 import { detectDttSuggestion } from "@/lib/dttSuggestions"
+import { computeDttBreakdown } from "@/lib/dttCalc"
 import type { DTTData, LegalChoiceRecord } from "@/types/builder"
 
 interface TransferTaxSectionProps {
@@ -24,24 +25,6 @@ interface TransferTaxSectionProps {
   suggestionDismissed?: boolean
   onDismissSuggestion: () => void
 }
-
-// Cities with their own DTT rates
-const CITIES_WITH_OWN_DTT = [
-  "los angeles",
-  "san francisco",
-  "oakland",
-  "berkeley",
-  "san jose",
-  "sacramento",
-  "riverside",
-  "pomona",
-  "culver city",
-  "santa monica",
-  "redondo beach",
-  "inglewood",
-  "long beach",
-  "pasadena",
-]
 
 // DTT exemption codes
 const EXEMPTION_REASONS = [
@@ -128,34 +111,18 @@ export function TransferTaxSection({
     )
   }
 
-  // Calculate DTT when values change
-  const calculatedAmount = useMemo(() => {
-    if (!value || value.isExempt || !value.transferValue) return ""
+  // Calculate DTT when values change. X2.3: the breakdown (county + city
+  // portions) is computed here so the result can SHOW it — one opaque
+  // total hid what was being declared. DISCOVERY fixed alongside: the old
+  // math added a generic $2.20/$1,000 "city tax" for ANY city, including
+  // cities with no municipal transfer tax at all — a fabricated number on
+  // a legal declaration. City portion now applies only to cities on the
+  // own-DTT list (named rates for LA/SF/Oakland; the $2.20 approximation
+  // for the other listed cities — owner/legal to verify current
+  // schedules; all city rates here are approximations of tiered rates).
+  const dttBreakdown = useMemo(() => computeDttBreakdown(value), [value])
 
-    const amount = parseFloat(value.transferValue.replace(/[^0-9.]/g, ""))
-    if (isNaN(amount) || amount <= 0) return ""
-
-    // County rate: $1.10 per $1,000
-    const countyTax = (amount / 1000) * 1.1
-
-    // City rate varies
-    let cityTax = 0
-    if (value.areaType === "city") {
-      const cityLower = (value.cityName || "").toLowerCase()
-
-      if (cityLower.includes("los angeles")) {
-        cityTax = (amount / 1000) * 4.5
-      } else if (cityLower.includes("san francisco")) {
-        cityTax = (amount / 1000) * 7.5
-      } else if (cityLower.includes("oakland")) {
-        cityTax = (amount / 1000) * 15.0
-      } else {
-        cityTax = (amount / 1000) * 2.2
-      }
-    }
-
-    return (countyTax + cityTax).toFixed(2)
-  }, [value])
+  const calculatedAmount = dttBreakdown?.total ?? ""
 
   // Derived recalculation — not an officer action, no decision stamp.
   useEffect(() => {
@@ -355,13 +322,21 @@ export function TransferTaxSection({
             </div>
           )}
 
-          {/* Calculated Result */}
-          {calculatedAmount && (
-            <div className="flex items-center gap-2 p-3 bg-emerald-50 border border-emerald-200 rounded-lg">
-              <Calculator className="w-5 h-5 text-emerald-500" />
-              <span className="font-medium text-emerald-700">
-                Documentary Transfer Tax: ${calculatedAmount}
-              </span>
+          {/* Calculated Result — X2.3: the breakdown, not one opaque total */}
+          {dttBreakdown && (
+            <div className="p-3 bg-emerald-50 border border-emerald-200 rounded-lg space-y-1">
+              <div className="flex items-center gap-2">
+                <Calculator className="w-5 h-5 text-emerald-500" />
+                <span className="font-medium text-emerald-700">
+                  Documentary Transfer Tax: ${dttBreakdown.total}
+                </span>
+              </div>
+              <div className="text-sm text-emerald-700 pl-7">
+                County ($1.10 / $1,000): ${dttBreakdown.county}
+                {dttBreakdown.city && (
+                  <> · City of {value.cityName}: ${dttBreakdown.city}</>
+                )}
+              </div>
             </div>
           )}
         </div>

--- a/frontend/src/components/builder/sections/VestingSection.tsx
+++ b/frontend/src/components/builder/sections/VestingSection.tsx
@@ -20,13 +20,19 @@ interface VestingSectionProps {
   decision?: LegalChoiceRecord
 }
 
-const VESTING_OPTIONS = [
+export const VESTING_OPTIONS = [
+  // X2.2: "a single person" and the gender-neutral sole-and-separate are
+  // the values the AI proposes — they must exist as NAMED options or the
+  // accepted suggestion lights the Custom radio (the recommended path
+  // must not look like the risky path).
+  { value: "a single person", label: "A Single Person", min: 1, max: 1 },
   { value: "a single man", label: "A Single Man", min: 1, max: 1 },
   { value: "a single woman", label: "A Single Woman", min: 1, max: 1 },
   { value: "an unmarried man", label: "An Unmarried Man", min: 1, max: 1 },
   { value: "an unmarried woman", label: "An Unmarried Woman", min: 1, max: 1 },
   { value: "a married man as his sole and separate property", label: "Married Man - Sole & Separate", min: 1, max: 1 },
   { value: "a married woman as her sole and separate property", label: "Married Woman - Sole & Separate", min: 1, max: 1 },
+  { value: "a married person as their sole and separate property", label: "Married - Sole & Separate", min: 1, max: 1 },
   { value: "husband and wife as joint tenants", label: "Husband & Wife - Joint Tenants", min: 2, max: 2 },
   { value: "husband and wife as community property", label: "Husband & Wife - Community Property", min: 2, max: 2 },
   { value: "husband and wife as community property with right of survivorship", label: "Community Property w/ Survivorship", min: 2, max: 2 },
@@ -98,8 +104,11 @@ export function VestingSection({ value, onChange, granteeCount, deedType, grante
     }
   }
 
-  // Check if current value matches a standard option
-  const isStandardOption = filteredOptions.some((opt) => opt.value === value)
+  // Check if current value matches a standard option (case-insensitive —
+  // an accepted suggestion must select its named option, X2.2).
+  const matchesOption = (optValue: string) =>
+    !!value && optValue.trim().toLowerCase() === value.trim().toLowerCase()
+  const isStandardOption = filteredOptions.some((opt) => matchesOption(opt.value))
   const isCustom = value && !isStandardOption
 
   // Handle custom input
@@ -190,7 +199,7 @@ export function VestingSection({ value, onChange, granteeCount, deedType, grante
               key={option.value}
               className={`
                 flex items-center gap-3 p-3 border rounded-lg cursor-pointer transition-all
-                ${value === option.value
+                ${matchesOption(option.value)
                   ? "border-brand-500 bg-brand-50"
                   : "border-gray-200 hover:border-gray-300"
                 }
@@ -200,7 +209,7 @@ export function VestingSection({ value, onChange, granteeCount, deedType, grante
                 type="radio"
                 name="vesting"
                 value={option.value}
-                checked={value === option.value}
+                checked={matchesOption(option.value)}
                 onChange={(e) => {
                   manual(e.target.value)
                   setShowCustom(false)

--- a/frontend/src/features/builder/DeedBuilder.tsx
+++ b/frontend/src/features/builder/DeedBuilder.tsx
@@ -115,6 +115,39 @@ function DeedBuilderInner({ deedType, initialProperty, resumeDeedId }: DeedBuild
     };
   }, [state, isResuming, isGenerating, persistDraft]);
 
+  // X2.6 — duplicate-parcel awareness: a PASSIVE notice (never a block)
+  // when the loaded APN already has a completed deed. Legitimate reasons
+  // to proceed exist (corrections, new transfers) — the officer just
+  // shouldn't discover the earlier document after recording.
+  const dupeCheckedApnRef = useRef<string | null>(null);
+  useEffect(() => {
+    const apn = state.property?.apn?.trim();
+    if (!apn || dupeCheckedApnRef.current === apn) return;
+    dupeCheckedApnRef.current = apn;
+    (async () => {
+      try {
+        const res = await apiFetch('/deeds', {}, { label: 'Checking parcel history', silent: true });
+        if (!res.ok) return;
+        const data = await res.json();
+        const existing = (data.deeds || []).find(
+          (d: { id: number; apn?: string; status?: string; updated_at?: string; created_at?: string }) =>
+            d.apn === apn && d.status === 'completed' && d.id !== draftIdRef.current
+        );
+        if (existing) {
+          const when = existing.updated_at || existing.created_at;
+          toast.info(
+            `Heads up: this parcel (APN ${apn}) already has a completed deed — Doc #${existing.id}` +
+              (when ? `, ${new Date(when).toLocaleDateString()}` : '') +
+              `. Continuing creates a separate document.`,
+            { duration: 10000 }
+          );
+        }
+      } catch {
+        // Passive awareness only — a failed check never interrupts the flow.
+      }
+    })();
+  }, [state.property?.apn]);
+
   // Exit prompt ONLY when there are changes autosave hasn't landed yet —
   // a clean builder or a fully saved draft leaves without friction.
   useEffect(() => {

--- a/frontend/src/lib/dttCalc.ts
+++ b/frontend/src/lib/dttCalc.ts
@@ -1,0 +1,70 @@
+/**
+ * X2.3 — documentary transfer tax breakdown (county + city portions).
+ *
+ * One opaque total hid what was being declared. And the old inline math
+ * fabricated a generic $2.20/$1,000 "city tax" for ANY city — including
+ * cities with no municipal transfer tax at all — a wrong number headed
+ * for a legal declaration. City portion now applies only to cities on
+ * the own-DTT list.
+ *
+ * RATE PROVENANCE (owner/legal to verify against current schedules):
+ * county $1.10/$1,000 (R&T §11911). City rates are APPROXIMATIONS of
+ * tiered schedules: LA $4.50, SF $7.50, Oakland $15.00, other listed
+ * cities $2.20 per $1,000.
+ */
+import type { DTTData } from '@/types/builder';
+
+// Cities with their own documentary transfer tax.
+export const CITIES_WITH_OWN_DTT = [
+  'los angeles',
+  'san francisco',
+  'oakland',
+  'berkeley',
+  'san jose',
+  'sacramento',
+  'riverside',
+  'pomona',
+  'culver city',
+  'santa monica',
+  'redondo beach',
+  'inglewood',
+  'long beach',
+  'pasadena',
+];
+
+export interface DttBreakdown {
+  county: string;
+  /** null when the city levies no transfer tax of its own. */
+  city: string | null;
+  total: string;
+}
+
+export function computeDttBreakdown(value: DTTData | null): DttBreakdown | null {
+  if (!value || value.isExempt || !value.transferValue) return null;
+
+  const amount = parseFloat(value.transferValue.replace(/[^0-9.]/g, ''));
+  if (isNaN(amount) || amount <= 0) return null;
+
+  const countyTax = (amount / 1000) * 1.1;
+
+  let cityTax = 0;
+  const cityLower = (value.cityName || '').toLowerCase();
+  const hasOwnDtt = CITIES_WITH_OWN_DTT.some((c) => cityLower.includes(c));
+  if (value.areaType === 'city' && hasOwnDtt) {
+    if (cityLower.includes('los angeles')) {
+      cityTax = (amount / 1000) * 4.5;
+    } else if (cityLower.includes('san francisco')) {
+      cityTax = (amount / 1000) * 7.5;
+    } else if (cityLower.includes('oakland')) {
+      cityTax = (amount / 1000) * 15.0;
+    } else {
+      cityTax = (amount / 1000) * 2.2;
+    }
+  }
+
+  return {
+    county: countyTax.toFixed(2),
+    city: cityTax > 0 ? cityTax.toFixed(2) : null,
+    total: (countyTax + cityTax).toFixed(2),
+  };
+}


### PR DESCRIPTION
## X2 — the eight legitimacy findings that survived the dedupe

1. **`/settings` never 404s** — new redirect page → `/account-settings`. (Current source never linked `/settings`; the audited sidebar link was the pre-#63 deploy. The redirect kills typed/bookmarked URLs regardless.)

2. **Vesting suggestions land on named options.** Root cause: the AI proposes `"a single person"` and `"a married person as their sole and separate property"` — neither existed in the options list, so accepting the *recommended* value lit the *Custom* radio. Both standard CA phrasings are now named options, and matching is case-insensitive. Trust vesting stays custom (it names the trust — genuinely custom text). Pinned: every non-trust suggestion value must match a named option.

3. **DTT breakdown — plus a discovery, fixed and flagged.** The result now shows county + city portions instead of one opaque total. While implementing it: the old math added a generic **$2.20/$1,000 "city tax" for ANY city**, including cities with no municipal transfer tax — and since #56 defaults the area to "city" whenever the property has one, ordinary cities were getting **phantom tax on a legal declaration**. City portion now applies only to own-DTT-list cities. Calc extracted to `lib/dttCalc.ts` with rate provenance documented.
   **⚠️ Owner/legal review requested:** all city rates (LA 4.50, SF 7.50, Oakland 15.00, other listed cities 2.20) are approximations of tiered schedules — verify against current county/city schedules before relying on the displayed amounts.

4. **Recipient name optional** on the share modal (email is the identity; the backend greets by address when blank — model change is schema-only, no route surface change).
5. **Expiry copy states what happens**: link stops working, share marked expired, deed unaffected, share again anytime.

6. **Duplicate-parcel awareness, passive**: loading a property whose APN already has a completed deed raises a toast (Doc #, date, "continuing creates a separate document") — never a block; a pin asserts the gate logic is untouched. The deeds list endpoint now returns `apn` to power the check (also feeds search).

7. **Findable rows**: Past Deeds gains a search box (address / grantee / APN / Doc ID / type), a status filter, and a dedicated **Doc ID column** — the ID the success page hands out is finally findable. Dashboard activity rows show Doc # and **last-touched** time; drafts read as needs-action (amber edge + labeled Continue).

8. **Provable downloads**: the success page already fetched the server-stored bytes (dedupe verdict: the audit's blob suspicion was wrong) — now pinned, and the stored PDF's **SHA-256 fingerprint** displays under the Document ID, making "stored immutably" demonstrable rather than asserted.

### Gates
Jest **208** (188 + 20 new) · tsc **98** · backend **90** (+1 sharing pin) · six-flow ✔ · OpenAPI route snapshot untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_