### PR TITLE
Profile hygiene: deed-face fields normalized at the write choke points

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -490,12 +490,27 @@ def get_user_profile(user_id):
             conn.close()
         return None
 
+def clean_profile_text(value):
+    """Trim + collapse internal whitespace on a profile text field.
+
+    Profile strings print on deed faces (requested-by, company lines) —
+    '  Pacific COast TItle ' was stored verbatim and rode onto documents.
+    Whitespace is machine noise and gets fixed here; CASE is the owner's
+    text and is never touched (auto-'fixing' McDonald or LLC would corrupt
+    real names). Blank collapses to None.
+    """
+    if value is None:
+        return None
+    cleaned = " ".join(str(value).split())
+    return cleaned or None
+
+
 def update_user_profile(user_id, profile_data):
     """Update or create user profile for AI defaults"""
     conn = get_db_connection()
     if not conn:
         return False
-    
+
     try:
         cursor = conn.cursor()
         cursor.execute("""
@@ -515,11 +530,13 @@ def update_user_profile(user_id, profile_data):
                 updated_at = CURRENT_TIMESTAMP
         """, (
             user_id,
-            profile_data.get('company_name'),
-            profile_data.get('business_address'),
-            profile_data.get('license_number'),
+            # Deed-face fields are normalized at the write choke point —
+            # whatever endpoint or script feeds this, the row is clean.
+            clean_profile_text(profile_data.get('company_name')),
+            clean_profile_text(profile_data.get('business_address')),
+            clean_profile_text(profile_data.get('license_number')),
             profile_data.get('role', 'escrow_officer'),
-            profile_data.get('default_county'),
+            clean_profile_text(profile_data.get('default_county')),
             profile_data.get('preferred_deed_type', 'grant_deed'),
             profile_data.get('auto_populate_company_info', True)
         ))

--- a/backend/routers/users_auth.py
+++ b/backend/routers/users_auth.py
@@ -18,7 +18,7 @@ from auth import (
     get_password_hash, verify_password, create_access_token,
     get_current_user_id, AuthUtils
 )
-from database import get_user_profile, update_user_profile, get_recent_properties
+from database import clean_profile_text, get_user_profile, update_user_profile, get_recent_properties
 
 router = APIRouter()
 
@@ -71,6 +71,11 @@ async def register_user(user: UserRegister = Body(...)):
         if not AuthUtils.validate_state_code(user.state):
             raise HTTPException(status_code=400, detail="Invalid state code")
 
+        # Profile-hygiene: a name that is all whitespace is no name — the
+        # value prints on deed faces and emails.
+        if not clean_profile_text(user.full_name):
+            raise HTTPException(status_code=400, detail="Full name is required")
+
         # Hash password
         hashed_password = get_password_hash(user.password)
 
@@ -86,8 +91,12 @@ async def register_user(user: UserRegister = Body(...)):
                 VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 RETURNING id
             """, (
-                user.email.lower(), hashed_password, user.full_name, user.role,
-                user.company_name, user.company_type, user.phone, user.state.upper(),
+                # Profile-hygiene: name/company/phone print on deed faces
+                # and emails — normalize whitespace at the write, never case.
+                user.email.lower(), hashed_password,
+                clean_profile_text(user.full_name), user.role,
+                clean_profile_text(user.company_name), user.company_type,
+                clean_profile_text(user.phone), user.state.upper(),
                 user.subscribe, 'free'
             ))
             result = cur.fetchone()

--- a/backend/tests/test_profile_hygiene.py
+++ b/backend/tests/test_profile_hygiene.py
@@ -1,0 +1,62 @@
+"""Profile-field hygiene at save time (the #65 follow-up ticket).
+
+Profile strings print on deed faces — the audited "Pacific COast TItle "
+was stored verbatim (trailing space and all) and rode onto documents.
+Normalization lives at the WRITE choke points (update_user_profile and
+the registration INSERT), so every endpoint or script that feeds them
+stores clean rows. Whitespace is machine noise and is fixed; CASE is the
+owner's text and is never touched — auto-"fixing" McDonald or LLC would
+corrupt real names.
+"""
+from unittest.mock import MagicMock, patch
+
+from database import clean_profile_text, update_user_profile
+
+
+def test_clean_profile_text_trims_and_collapses():
+    assert clean_profile_text("  Pacific COast TItle ") == "Pacific COast TItle"
+    assert clean_profile_text("Two   Words\t Here") == "Two Words Here"
+    assert clean_profile_text("already clean") == "already clean"
+
+
+def test_clean_profile_text_never_touches_case():
+    assert clean_profile_text("McDonald Escrow LLC") == "McDonald Escrow LLC"
+    assert clean_profile_text("PACIFIC COAST") == "PACIFIC COAST"
+
+
+def test_clean_profile_text_blank_collapses_to_none():
+    assert clean_profile_text("   ") is None
+    assert clean_profile_text("") is None
+    assert clean_profile_text(None) is None
+
+
+def test_update_user_profile_normalizes_deed_face_fields():
+    conn = MagicMock()
+    cursor = MagicMock()
+    conn.cursor.return_value = cursor
+
+    with patch("database.get_db_connection", return_value=conn):
+        ok = update_user_profile(7, {
+            "company_name": "  Pacific COast TItle ",
+            "business_address": " 123  Main   St ",
+            "license_number": "  LIC-99  ",
+            "default_county": " Los   Angeles ",
+        })
+
+    assert ok is True
+    params = cursor.execute.call_args[0][1]
+    assert params[1] == "Pacific COast TItle"   # trimmed, case untouched
+    assert params[2] == "123 Main St"
+    assert params[3] == "LIC-99"
+    assert params[5] == "Los Angeles"
+
+
+def test_registration_normalizes_and_rejects_blank_names():
+    """The register INSERT runs through clean_profile_text, and an
+    all-whitespace full name is a 400, not a NULL row."""
+    import inspect
+    import routers.users_auth as mod
+    src = inspect.getsource(mod)
+    assert "clean_profile_text(user.full_name)" in src
+    assert "clean_profile_text(user.company_name)" in src
+    assert 'detail="Full name is required"' in src


### PR DESCRIPTION
## The #65 follow-up ticket — trim/validate profile fields used on deed faces at save time

`"Pacific COast TItle "` (trailing space included) was stored verbatim and printed on deed faces. Normalization now lives at the **write choke points**, so every endpoint or script feeding them stores clean rows:

- **`database.clean_profile_text`** — trim + collapse internal whitespace; blank → `None`. **Case is never touched**: the typos are the owner's text to fix (the live row is already corrected owner-side); auto-"fixing" would corrupt McDonald, LLC, and friends.
- **`update_user_profile`**: `company_name`, `business_address`, `license_number`, `default_county` all normalized.
- **Registration INSERT**: `full_name`, `company_name`, `phone` normalized — and an all-whitespace full name is now a **400** ("Full name is required"), not a NULL row.

### 🔍 Discovery — flagged, not fixed (Settings is deferred to the auditor's step-5 rerun)
`account-settings`' `handleSave` **saves nothing** — it toasts "Profile saved!" with no request behind it. Fabricated success, invariant #4's exact shape. Queued as the first item for the Settings content audit rather than fixed out of scope here.

### Pins — `test_profile_hygiene.py` (5)
trim/collapse behavior · case never touched · blank→None · `update_user_profile` end-to-end param capture · registration source pins (normalization + blank-name rejection)

### Gates
Backend **88 passed** (83 + 5 new) · six-flow ✔ vs real Postgres · backend-only diff, no route/schema changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_