### PR TITLE
Demo credentials visible pre-launch — env-controlled, still never in source

### DIFF
--- a/frontend/src/__tests__/demoCredsGate.test.ts
+++ b/frontend/src/__tests__/demoCredsGate.test.ts
@@ -1,13 +1,12 @@
 /**
- * X0 (security hotfix) — demo credentials can never render outside local
- * dev, and never exist in source at all.
+ * Demo credentials — never in source; visibility is env-controlled.
  *
- * History this pins against: the demo card shipped always-visible with
- * committed credential constants (#48/#55, a deliberate convenience
- * decision) and the round-2 security audit found the real credentials in
- * the production login bundle. Reversed: values come only from untracked
- * env (.env.local), and the card renders only when the build-time-inlined
- * NODE_ENV is 'development' — production builds eliminate the branch.
+ * History: committed constants shipped always-visible (#48/#55); the
+ * round-2 audit found them in the production bundle; X0 removed them
+ * from source and dev-gated the card. Owner decision 2026-07-29: the
+ * card SHOWS pre-launch — so the gate is now env-presence (set the
+ * NEXT_PUBLIC_DEMO_* vars on Vercel to show it, delete them at launch
+ * to remove it). What can never change: no credential value in git.
  */
 import { describe, expect, it } from '@jest/globals';
 import * as fs from 'fs';
@@ -27,8 +26,8 @@ describe('X0 — demo credentials gate', () => {
     expect(LOGIN).toContain('process.env.NEXT_PUBLIC_DEMO_PASSWORD');
   });
 
-  it('the card is gated on development NODE_ENV, checked at build time', () => {
-    expect(LOGIN).toMatch(/process\.env\.NODE_ENV === ["']development["']/);
+  it('the card renders only when both env values exist', () => {
+    expect(LOGIN).toContain('const SHOW_DEMO_CARD = !!DEMO_EMAIL && !!DEMO_PASSWORD');
     expect(LOGIN).toContain('{SHOW_DEMO_CARD && (');
   });
 

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -14,17 +14,15 @@ import Link from "next/link"
 import { AuthManager } from "../../utils/auth"
 import { Eye, EyeOff, AlertCircle, CheckCircle2, Zap, Copy, Check, ShieldCheck, FileCheck2, Landmark, ScrollText } from "lucide-react"
 
-// X0 (security hotfix): demo credentials NEVER ship in source or in a
-// production bundle. The always-visible card was a deliberate convenience
-// decision (#48/#55) reversed by the round-2 security audit. The card now
-// renders ONLY in local dev, with values from untracked env
-// (.env.local: NEXT_PUBLIC_DEMO_EMAIL / NEXT_PUBLIC_DEMO_PASSWORD) —
-// NODE_ENV is inlined at build time, so production builds eliminate the
-// entire branch, and Vercel doesn't define the vars regardless.
+// Demo credentials: values live ONLY in env (never in git — X0's rule
+// stands). Pre-launch, the owner sets NEXT_PUBLIC_DEMO_EMAIL/PASSWORD on
+// Vercel and the card shows on the production login page (owner decision,
+// 2026-07-29: visible until launch); deleting the vars + redeploying
+// removes it with no code change. NEXT_PUBLIC_* values are inlined at
+// build time, so a redeploy is needed for changes to take effect.
 const DEMO_EMAIL = process.env.NEXT_PUBLIC_DEMO_EMAIL || ""
 const DEMO_PASSWORD = process.env.NEXT_PUBLIC_DEMO_PASSWORD || ""
-const SHOW_DEMO_CARD =
-  process.env.NODE_ENV === "development" && !!DEMO_EMAIL && !!DEMO_PASSWORD
+const SHOW_DEMO_CARD = !!DEMO_EMAIL && !!DEMO_PASSWORD
 
 function LoginContent() {
   const [formData, setFormData] = useState({ email: "", password: "" })
@@ -277,8 +275,8 @@ function LoginContent() {
               </button>
             </form>
 
-            {/* Demo credentials — LOCAL DEV ONLY (X0). The prod build
-                dead-code-eliminates this branch via the inlined NODE_ENV. */}
+            {/* Demo credentials — rendered only when the env vars are set
+                (pre-launch convenience; values never live in source). */}
             {SHOW_DEMO_CARD && (
             <div className="border border-gray-200 rounded-xl overflow-hidden">
               <button


### PR DESCRIPTION
## Owner decision: demo credentials on the login page until launch

Implements the request without reversing X0's core rule — **the values still exist only in env, never in git**:

- The card's gate changes from dev-only to **env-presence**: `SHOW_DEMO_CARD = !!DEMO_EMAIL && !!DEMO_PASSWORD`.
- **To show it (owner, one time):** on Vercel, set `NEXT_PUBLIC_DEMO_EMAIL` and `NEXT_PUBLIC_DEMO_PASSWORD` → redeploy. The card appears on the production login page with the copy buttons and Fill-form flow exactly as before.
- **At launch:** delete the two vars → redeploy. The card vanishes with no code change. (`NEXT_PUBLIC_*` values inline at build time, so each change needs a redeploy.)
- X0's structural pins stand unchanged: no credential literal anywhere in frontend source, frontend-wide scan enforced. The gate pin now asserts the env-presence contract.

### ⚠️ One caveat for the owner
Whatever password you set in the env var becomes **deliberately public** on the login page. Use the demo account's rotated password — and make sure that password isn't shared with the `realty.reports@gmail.com` Google account itself or anything else. Public-by-design is fine for a demo tenant; shared credentials are not.

### Gates
Jest **226** · tsc **98** · frontend-only, two files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_