### PR TITLE
D2: builder polish trio — Next buttons, requesting-party address, bold APN

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -279,7 +279,8 @@ def create_deed(user_id, deed_data):
         extras = {
             key: deed_data.get(key)
             for key in ('dtt', 'title_order_no', 'escrow_no', 'return_to', 'source', 'provenance',
-                        'property_city', 'property_state', 'property_zip', 'current_owner')
+                        'property_city', 'property_state', 'property_zip', 'current_owner',
+                        'requested_by_address')
             if deed_data.get(key)
         }
 
@@ -335,7 +336,8 @@ def update_deed_draft(user_id, deed_id, deed_data):
         extras = {
             key: deed_data.get(key)
             for key in ('dtt', 'title_order_no', 'escrow_no', 'return_to', 'source', 'provenance',
-                        'property_city', 'property_state', 'property_zip', 'current_owner')
+                        'property_city', 'property_state', 'property_zip', 'current_owner',
+                        'requested_by_address')
             if deed_data.get(key)
         }
         cursor.execute("""
@@ -389,7 +391,8 @@ def save_draft_row(user_id, deed_id, deed_data):
         extras = {
             key: deed_data.get(key)
             for key in ('dtt', 'title_order_no', 'escrow_no', 'return_to', 'source', 'provenance',
-                        'property_city', 'property_state', 'property_zip', 'current_owner')
+                        'property_city', 'property_state', 'property_zip', 'current_owner',
+                        'requested_by_address')
             if deed_data.get(key)
         }
         if deed_id:

--- a/backend/routers/deeds_crud.py
+++ b/backend/routers/deeds_crud.py
@@ -39,6 +39,7 @@ class DeedCreate(BaseModel):
     grantee_name: str = Field(..., min_length=1, description="Grantee name (required, non-empty)")
     vesting: Optional[str] = Field(default=None)
     requested_by: Optional[str] = Field(default=None, description="Person/company requesting the deed (e.g., escrow officer)")
+    requested_by_address: Optional[str] = Field(default=None, description="Requesting party's mailing address (one line)")
     source: Optional[str] = Field(default=None, description="Data source tracking (e.g., 'modern-canonical', 'classic')")
     # T2: extras persisted into deeds.metadata so the stored PDF can render
     # the complete document (DTT declaration, reference numbers, mail-to).
@@ -87,6 +88,7 @@ class DraftSave(BaseModel):
     grantee_name: Optional[str] = None
     vesting: Optional[str] = None
     requested_by: Optional[str] = None
+    requested_by_address: Optional[str] = None
     source: Optional[str] = None
     dtt: Optional[Dict] = None
     title_order_no: Optional[str] = None

--- a/backend/routers/partners.py
+++ b/backend/routers/partners.py
@@ -111,12 +111,22 @@ async def get_partners_selectlist(
         organization_id = get_user_organization(user_id)
         partners = list_partners(organization_id, active_only=True)
 
-        # Simplify for dropdown
+        # Simplify for dropdown. D2: the address rides along so selecting
+        # a partner can fill the deed's "Recording Requested By" block —
+        # the data always existed on the partner row; the deed never got it.
+        def _addr(p):
+            street = " ".join(str(p.get(k) or "").strip() for k in ("address_line1", "address_line2")).strip()
+            locality = " ".join(str(p.get(k) or "").strip() for k in ("state", "postal_code")).strip()
+            city = str(p.get("city") or "").strip()
+            tail = ", ".join(x for x in (city, locality) if x)
+            return ", ".join(x for x in (street, tail) if x)
+
         return [
             {
                 'id': p['id'],
                 'name': p['company_name'],
-                'category': p.get('category', 'other')
+                'category': p.get('category', 'other'),
+                'address': _addr(p),
             }
             for p in partners
         ]

--- a/backend/services/deed_pdf.py
+++ b/backend/services/deed_pdf.py
@@ -84,6 +84,7 @@ def build_context_from_row(row):
         "apn": row.get("apn") or "",
         "vesting": row.get("vesting") or "",
         "requested_by": row.get("requested_by") or "",
+        "requested_by_address": meta.get("requested_by_address") or "",
         "title_order_no": meta.get("title_order_no") or "",
         "escrow_no": meta.get("escrow_no") or "",
         "return_to": return_to,

--- a/backend/tests/test_d2_display.py
+++ b/backend/tests/test_d2_display.py
@@ -1,0 +1,60 @@
+"""D2 — requesting-party address on the deed face + bold APN.
+
+Audit answer (D2.2): the address was captured all along — on the PARTNER
+record (address_line1/city/state/postal_code) — but the builder took only
+the partner's name, so the deed header printed "Recording Requested By"
+with no address. The path now carries it: partner selectlist assembles a
+one-line address → builder state → metadata.requested_by_address →
+template header, same treatment as D1's mail-to block.
+"""
+import io
+
+import pdfplumber
+
+from services.deed_pdf import render_deed_html, render_deed_pdf
+from tests.test_deed_pdf import ALL_DEED_TYPES, minimal_row, _normalized
+
+ADDR_META = {"requested_by_address": "456 Escrow Way, Suite 9, Los Angeles, CA 90012"}
+
+
+def test_requesting_party_address_renders_on_every_deed_type():
+    for deed_type in ALL_DEED_TYPES:
+        html = _normalized(render_deed_html(minimal_row(deed_type=deed_type, metadata=ADDR_META)))
+        assert "456 Escrow Way, Suite 9, Los Angeles, CA 90012" in html, deed_type
+
+
+def test_requesting_party_address_prints_under_the_name():
+    pdf = render_deed_pdf(minimal_row(metadata=ADDR_META))
+    with pdfplumber.open(io.BytesIO(pdf)) as doc:
+        lines = doc.pages[0].extract_text().splitlines()
+    req = next(i for i, l in enumerate(lines) if "RECORDING REQUESTED BY" in l.upper())
+    block = "\n".join(lines[req : req + 4])
+    assert "Acme Escrow" in block
+    assert "456 Escrow Way" in block
+
+
+def test_no_address_line_when_none_given():
+    html = render_deed_html(minimal_row())
+    assert "456 Escrow Way" not in html
+
+
+def test_apn_prints_bold_like_the_parties():
+    """D2.3: both APN appearances — the header boundary ref and the body
+    parcel line — carry bold, matching the D1 legal-description treatment."""
+    pdf = render_deed_pdf(minimal_row())
+    with pdfplumber.open(io.BytesIO(pdf)) as doc:
+        words = doc.pages[0].extract_words(extra_attrs=["fontname"])
+    apn_words = [w for w in words if "1234-567-890" in w["text"]]
+    assert len(apn_words) >= 2, "expected APN in header and body"
+    for w in apn_words:
+        assert "Bold" in w["fontname"], f"APN rendered {w['fontname']}"
+
+
+def test_apn_bold_in_every_chassis():
+    for deed_type in ALL_DEED_TYPES:
+        html = render_deed_html(minimal_row(deed_type=deed_type))
+        for cls in (".apn-ref", ".apn-line"):
+            assert cls in html, (deed_type, cls)
+            block = html[html.index(cls):]
+            block = block[: block.index("}")]
+            assert "font-weight: bold" in block, (deed_type, cls)

--- a/backend/tests/test_partners_routes.py
+++ b/backend/tests/test_partners_routes.py
@@ -46,7 +46,10 @@ def test_selectlist_resolves_to_selectlist_handler(client, path):
     with patch("routers.partners.list_partners", return_value=FAKE_PARTNERS):
         res = client.get(path, headers={"Authorization": "Bearer x"})
     assert res.status_code == 200
+    # D2: the selectlist carries the partner's one-line address so
+    # selecting a partner fills the deed's requesting-party block.
     assert res.json() == [
         {"id": "11111111-1111-1111-1111-111111111111",
-         "name": "Pacific Coast Title", "category": "title"},
+         "name": "Pacific Coast Title", "category": "title",
+         "address": ""},
     ]

--- a/frontend/src/__tests__/d2BuilderTrio.test.ts
+++ b/frontend/src/__tests__/d2BuilderTrio.test.ts
@@ -1,0 +1,77 @@
+/**
+ * D2 — the builder polish trio, pinned (frontend half).
+ *
+ * 1. Typed sections get "Next" buttons — forward momentum WITHOUT fake
+ *    confirmations: "Confirm" stays reserved for external-source data
+ *    (the doctrine boundary the owner drew).
+ * 2. The requesting party's address travels: partner record → builder
+ *    state → payload → preview line under the name.
+ * 3. APN is bold on the preview, both appearances.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+import { buildDeedPayload } from '../lib/deedPayload';
+import type { DeedBuilderState } from '../types/builder';
+
+function readSource(...segments: string[]): string {
+  return fs.readFileSync(path.join(__dirname, '..', ...segments), 'utf8');
+}
+
+const INPUT_PANEL = readSource('components', 'builder', 'InputPanel.tsx');
+const PREVIEW = readSource('components', 'builder', 'PreviewPanel.tsx');
+const RECORDING = readSource('components', 'builder', 'sections', 'RecordingSection.tsx');
+
+describe('D2.1 — Next buttons on typed sections, never confirm affordances', () => {
+  it('grantee → vesting → transfer tax → recording → done', () => {
+    expect(INPUT_PANEL).toContain('<SectionNext to="vesting" label="Next: Vesting" />');
+    expect(INPUT_PANEL).toContain('<SectionNext to="transferTax" label="Next: Transfer Tax" />');
+    expect(INPUT_PANEL).toContain('<SectionNext to="recording" label="Next: Recording Info" />');
+    expect(INPUT_PANEL).toContain('<SectionNext to="" label="Done — review your deed" />');
+  });
+
+  it('typed sections gained NO confirm affordances (doctrine boundary)', () => {
+    // ConfirmableField remains only where external-source data lives.
+    const grantee = readSource('components', 'builder', 'sections', 'GranteeSection.tsx');
+    expect(grantee).not.toContain('ConfirmableField');
+    expect(RECORDING).not.toContain('ConfirmableField');
+  });
+});
+
+describe('D2.2 — the requesting-party address travels the full path', () => {
+  it('selecting a partner carries the address into state', () => {
+    expect(RECORDING).toContain('requestedByAddress: partner?.address');
+  });
+
+  it('the address is editable as its own field', () => {
+    expect(RECORDING).toContain('Requesting Party Address');
+  });
+
+  it('buildDeedPayload carries requested_by_address', () => {
+    const state = {
+      deedType: 'grant-deed', property: null, grantor: '', grantee: '',
+      vesting: '', dtt: null, requestedBy: 'Acme Escrow',
+      requestedByAddress: '456 Escrow Way, Los Angeles, CA 90012',
+      returnTo: '', titleOrderNo: '', escrowNo: '',
+    } as DeedBuilderState;
+    expect(buildDeedPayload(state).requested_by_address).toBe('456 Escrow Way, Los Angeles, CA 90012');
+  });
+
+  it('the preview prints the address under the requesting party', () => {
+    expect(PREVIEW).toContain('preview.requestedByAddress');
+  });
+
+  it('the resume mapper restores it', () => {
+    const resume = readSource('lib', 'deedResume.ts');
+    expect(resume).toContain('requestedByAddress: meta.requested_by_address');
+  });
+});
+
+describe('D2.3 — APN is bold on the preview', () => {
+  it('both appearances carry font-bold', () => {
+    const boundary = PREVIEW.substring(PREVIEW.indexOf('Boundary row'), PREVIEW.indexOf('Title */'));
+    expect(boundary).toMatch(/font-bold[^`]*\$\{highlight\('property'\)\}/);
+    const parcel = PREVIEW.substring(PREVIEW.indexOf('Parcel Number'));
+    expect(PREVIEW).toMatch(/font-bold[^\n]*\n\s*Assessor/);
+  });
+});

--- a/frontend/src/app/api/deeds/draft/route.ts
+++ b/frontend/src/app/api/deeds/draft/route.ts
@@ -30,6 +30,7 @@ export async function POST(req: NextRequest) {
       grantee_name: payload.grantees_text || null,
       vesting: payload.vesting || null,
       requested_by: payload.requested_by || null,
+      requested_by_address: payload.requested_by_address || null,
       source: 'deed-builder',
       dtt: payload.dtt || null,
       title_order_no: payload.title_order_no || null,

--- a/frontend/src/app/api/deeds/generate/route.ts
+++ b/frontend/src/app/api/deeds/generate/route.ts
@@ -28,6 +28,7 @@ export async function POST(req: NextRequest) {
       grantee_name: payload.grantees_text || '',
       vesting: payload.vesting || null,
       requested_by: payload.requested_by || null,
+      requested_by_address: payload.requested_by_address || null,
       source: 'deed-builder',
       // Persisted into deeds.metadata so the stored PDF renders the full
       // document (DTT declaration, reference numbers, mail-to).

--- a/frontend/src/components/builder/InputPanel.tsx
+++ b/frontend/src/components/builder/InputPanel.tsx
@@ -46,6 +46,21 @@ export function InputPanel({
     onSectionChange(expandedSection === section ? '' : section);
   };
 
+  // D2: typed sections get a "Next" button — same forward momentum as
+  // confirm-advance, with NO fake confirmations: the officer's own typing
+  // is their act; "Confirm" stays reserved for external-source data.
+  const SectionNext = ({ to, label }: { to: string; label: string }) => (
+    <div className="pt-3 flex justify-end">
+      <button
+        type="button"
+        onClick={() => onSectionChange(to)}
+        className="px-4 py-2 bg-gray-900 hover:bg-gray-700 text-white text-sm font-medium rounded-lg transition-colors"
+      >
+        {label}
+      </button>
+    </div>
+  );
+
   return (
     <div className="h-full flex flex-col bg-gray-50">
       {/* Header */}
@@ -122,6 +137,7 @@ export function InputPanel({
             onChange={(grantee) => onChange({ grantee })}
             grantorName={state.grantor}
           />
+          <SectionNext to="vesting" label="Next: Vesting" />
         </InputSection>
 
         <InputSection
@@ -142,6 +158,7 @@ export function InputPanel({
             deedType={state.deedType}
             grantee={state.grantee}
           />
+          <SectionNext to="transferTax" label="Next: Transfer Tax" />
         </InputSection>
 
         <InputSection
@@ -171,6 +188,7 @@ export function InputPanel({
             suggestionDismissed={state.dttSuggestionDismissed}
             onDismissSuggestion={() => onChange({ dttSuggestionDismissed: true })}
           />
+          <SectionNext to="recording" label="Next: Recording Info" />
         </InputSection>
 
         <InputSection
@@ -183,11 +201,13 @@ export function InputPanel({
         >
           <RecordingSection
             requestedBy={state.requestedBy}
+            requestedByAddress={state.requestedByAddress}
             returnTo={state.returnTo}
             titleOrderNo={state.titleOrderNo}
             escrowNo={state.escrowNo}
             onChange={(updates) => onChange(updates)}
           />
+          <SectionNext to="" label="Done — review your deed" />
         </InputSection>
       </div>
 

--- a/frontend/src/components/builder/PreviewPanel.tsx
+++ b/frontend/src/components/builder/PreviewPanel.tsx
@@ -45,6 +45,7 @@ function Checkline({ marked }: { marked: boolean }) {
 export function PreviewPanel({ state, activeSection }: PreviewPanelProps) {
   const preview = useMemo(() => ({
     requestedBy: state.requestedBy || '[Recording Requested By]',
+    requestedByAddress: state.requestedByAddress || '',
     // Mirror the generate payload: 'grantee' resolves to the grantee name,
     // mailed at the property address (never render the literal 'grantee').
     returnTo: state.returnTo === 'grantee'
@@ -118,6 +119,11 @@ export function PreviewPanel({ state, activeSection }: PreviewPanelProps) {
                 <div className="text-[9px] font-bold uppercase tracking-wide">Recording Requested By:</div>
                 <div className="min-h-[0.3in] mb-2">
                   <span className={`text-[10px] ${placeholder(preview.requestedBy)} ${dataHighlight(preview.requestedBy)}`}>{preview.requestedBy}</span>
+                  {/* D2: the requesting party's address prints under their
+                      name — same treatment as the mail-to block. */}
+                  {preview.requestedByAddress && (
+                    <span className={`block text-[10px] ${dataHighlight(preview.requestedByAddress)}`}>{preview.requestedByAddress}</span>
+                  )}
                 </div>
 
                 <div className="text-[9px] font-bold uppercase tracking-wide">
@@ -148,7 +154,7 @@ export function PreviewPanel({ state, activeSection }: PreviewPanelProps) {
 
             {/* Boundary row: APN left, recorder caption right, rule under */}
             <div className="flex justify-between items-baseline border-b border-black pb-0.5 mb-3">
-              <span className={`text-[10px] ${highlight('property')}`}>
+              <span className={`text-[10px] font-bold ${highlight('property')}`}>
                 APN: <span className={`font-mono tracking-wide ${dataHighlight(preview.apn)}`}>{preview.apn || '____________'}</span>
               </span>
               <span className="text-[7.5px] font-bold uppercase">{RECORDER_CAPTION}</span>
@@ -232,7 +238,7 @@ export function PreviewPanel({ state, activeSection }: PreviewPanelProps) {
             </div>
 
             {preview.apn && (
-              <div className={`mb-4 text-[10.5pt] ${highlight('property')}`}>
+              <div className={`mb-4 text-[10.5pt] font-bold ${highlight('property')}`}>
                 Assessor&rsquo;s Parcel Number: <span className={`font-mono tracking-wider ${dataHighlight(preview.apn)}`}>{preview.apn}</span>
               </div>
             )}

--- a/frontend/src/components/builder/sections/RecordingSection.tsx
+++ b/frontend/src/components/builder/sections/RecordingSection.tsx
@@ -9,13 +9,15 @@ import { AddPartnerModal, PartnerFormData } from '@/components/modals/AddPartner
 
 interface RecordingSectionProps {
   requestedBy: string;
+  /** D2: the requesting party's mailing address (prints under their name). */
+  requestedByAddress?: string;
   returnTo: string;
   titleOrderNo?: string;
   escrowNo?: string;
-  onChange: (updates: { requestedBy?: string; returnTo?: string; titleOrderNo?: string; escrowNo?: string }) => void;
+  onChange: (updates: { requestedBy?: string; requestedByAddress?: string; returnTo?: string; titleOrderNo?: string; escrowNo?: string }) => void;
 }
 
-export function RecordingSection({ requestedBy, returnTo, titleOrderNo, escrowNo, onChange }: RecordingSectionProps) {
+export function RecordingSection({ requestedBy, requestedByAddress, returnTo, titleOrderNo, escrowNo, onChange }: RecordingSectionProps) {
   const { enabled: aiEnabled } = useAIAssist();
   const [guidanceDismissed, setGuidanceDismissed] = useState(false);
   const [showAddModal, setShowAddModal] = useState(false);
@@ -41,8 +43,10 @@ export function RecordingSection({ requestedBy, returnTo, titleOrderNo, escrowNo
       return;
     }
     
-    onChange({ requestedBy: value });
+    // D2: the partner record already carries the mailing address — selecting
+    // a partner fills both the name and the address that print on the deed.
     const partner = partners.find(p => p.label === value);
+    onChange({ requestedBy: value, requestedByAddress: partner?.address || requestedByAddress || '' });
     if (partner) {
       localStorage.setItem('lastPartnerUsed', partner.id);
     }
@@ -66,7 +70,11 @@ export function RecordingSection({ requestedBy, returnTo, titleOrderNo, escrowNo
       
       // Auto-select the new partner (use company_name as the label)
       if (newPartner?.company_name) {
-        onChange({ requestedBy: newPartner.company_name });
+        const addr = [
+          [newPartner.address_line1, newPartner.address_line2].filter(Boolean).join(' '),
+          [newPartner.city, [newPartner.state, newPartner.postal_code].filter(Boolean).join(' ')].filter(Boolean).join(', '),
+        ].filter(Boolean).join(', ');
+        onChange({ requestedBy: newPartner.company_name, requestedByAddress: addr });
         localStorage.setItem('lastPartnerUsed', newPartner.id);
       }
       
@@ -128,6 +136,21 @@ export function RecordingSection({ requestedBy, returnTo, titleOrderNo, escrowNo
             No partners yet. Select &quot;➕ Add New Partner&quot; to create one.
           </p>
         ) : null}
+      </div>
+
+      {/* D2: the requesting party's address prints under their name in the
+          deed header — filled from the partner record, editable here. */}
+      <div>
+        <label className="block text-sm font-medium text-gray-700 mb-1">
+          Requesting Party Address <span className="text-gray-400 font-normal">(optional)</span>
+        </label>
+        <input
+          type="text"
+          value={requestedByAddress || ''}
+          onChange={(e) => onChange({ requestedByAddress: e.target.value })}
+          placeholder="Street, City, ST ZIP"
+          className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+        />
       </div>
 
       {/* Add Partner Modal */}

--- a/frontend/src/features/builder/DeedBuilder.tsx
+++ b/frontend/src/features/builder/DeedBuilder.tsx
@@ -47,6 +47,7 @@ function DeedBuilderInner({ deedType, initialProperty, resumeDeedId }: DeedBuild
     vesting: '',
     dtt: null,
     requestedBy: '',
+    requestedByAddress: '',
     returnTo: '',
     titleOrderNo: '',
     escrowNo: '',

--- a/frontend/src/features/partners/PartnersContext.tsx
+++ b/frontend/src/features/partners/PartnersContext.tsx
@@ -31,6 +31,8 @@ export interface PartnerOption {
   category: string;
   company_name?: string;
   contact_name?: string;
+  /** D2: one-line mailing address, assembled server-side. */
+  address?: string;
 }
 
 export interface CreatePartnerData {
@@ -129,6 +131,7 @@ export function PartnersProvider({ children }: { children: React.ReactNode }) {
         category: item.category || 'other',
         company_name: item.company_name,
         contact_name: item.contact_name,
+        address: item.address || '',
       }));
 
       setPartners(normalized);

--- a/frontend/src/lib/deedPayload.ts
+++ b/frontend/src/lib/deedPayload.ts
@@ -29,6 +29,7 @@ export function buildDeedPayload(genState: DeedBuilderState) {
     grantees_text: genState.grantee,
     vesting: genState.vesting,
     requested_by: genState.requestedBy,
+    requested_by_address: genState.requestedByAddress || '',
     // Mail-to: when the deed returns to the grantee, it mails to the
     // grantee AT THE PROPERTY (the standard default) — send the full
     // address block so the recorded deed shows where to mail it.

--- a/frontend/src/lib/deedResume.ts
+++ b/frontend/src/lib/deedResume.ts
@@ -166,6 +166,7 @@ export function hydrateStateFromDeedRow(row: Record<string, any>): ResumeResult 
           )
         : undefined,
     requestedBy: row.requested_by || '',
+    requestedByAddress: meta.requested_by_address || '',
     returnTo,
     titleOrderNo: meta.title_order_no || '',
     escrowNo: meta.escrow_no || '',

--- a/frontend/src/types/builder.ts
+++ b/frontend/src/types/builder.ts
@@ -94,6 +94,8 @@ export interface DeedBuilderState {
    */
   preflightOverrides?: Record<string, string>;
   requestedBy: string;
+  /** D2: the requesting party's mailing address (one line, optional). */
+  requestedByAddress?: string;
   returnTo: string;
   titleOrderNo?: string;
   escrowNo?: string;

--- a/templates/grant_deed_ca/index.jinja2
+++ b/templates/grant_deed_ca/index.jinja2
@@ -92,6 +92,8 @@
         }
 
         .apn-ref {
+            /* D2: the parcel id carries the same weight as the parties. */
+            font-weight: bold;
             font-size: 10pt;
         }
 
@@ -192,7 +194,7 @@
             margin: 0.08in 0;
         }
 
-        .apn-line {
+        .apn-line { font-weight: bold;
             margin-top: 0.08in;
         }
 
@@ -310,7 +312,7 @@
         <header class="header-section">
             <div class="recording-info">
                 <div class="recording-label">Recording Requested By:</div>
-                <div class="recording-value">{{ requested_by or title_company or '' }}</div>
+                <div class="recording-value">{{ requested_by or title_company or '' }}{% if requested_by_address %}<br>{{ requested_by_address }}{% endif %}</div>
 
                 <div class="recording-label">Mail Tax Statements and<br>When Recorded Mail To:</div>
                 <div class="recording-value">

--- a/templates/interspousal_transfer_ca/index.jinja2
+++ b/templates/interspousal_transfer_ca/index.jinja2
@@ -27,7 +27,8 @@
         .recording-value { margin-bottom: 0.12in; min-height: 0.35in; }
         .ref-line { font-size: 10pt; }
         .header-boundary { display: flex; justify-content: space-between; align-items: baseline; border-bottom: 0.75pt solid #000; padding-bottom: 0.03in; margin-bottom: 0.12in; }
-        .apn-ref { font-size: 10pt; }
+        /* D2: parcel id weighted like the parties. */
+        .apn-ref { font-weight: bold; font-size: 10pt; }
         .recorder-caption { font-size: 7.5pt; font-weight: bold; text-transform: uppercase; }
 
         .deed-title { text-align: center; font-size: 14pt; font-weight: bold; letter-spacing: 2px; text-transform: uppercase; margin: 0.08in 0 0.12in 0; }
@@ -41,7 +42,7 @@
         /* D1: description weighted like the parties. */
         .legal-content { font-weight: bold; white-space: pre-wrap; margin: 0.08in 0; }
         .legal-exhibit-ref { font-weight: bold; margin: 0.08in 0; }
-        .apn-line { margin-top: 0.08in; }
+        .apn-line { font-weight: bold; margin-top: 0.08in; }
 
         .spousal-declaration { font-size: 10pt; line-height: 1.45; margin: 0.12in 0; }
 
@@ -70,7 +71,7 @@
         <header class="header-section">
             <div class="recording-info">
                 <div class="recording-label">Recording Requested By:</div>
-                <div class="recording-value">{{ requested_by or title_company or '' }}</div>
+                <div class="recording-value">{{ requested_by or title_company or '' }}{% if requested_by_address %}<br>{{ requested_by_address }}{% endif %}</div>
 
                 <div class="recording-label">Mail Tax Statements and<br>When Recorded Mail To:</div>
                 <div class="recording-value">

--- a/templates/quitclaim_deed_ca/index.jinja2
+++ b/templates/quitclaim_deed_ca/index.jinja2
@@ -26,7 +26,8 @@
         .recording-value { margin-bottom: 0.12in; min-height: 0.35in; }
         .ref-line { font-size: 10pt; }
         .header-boundary { display: flex; justify-content: space-between; align-items: baseline; border-bottom: 0.75pt solid #000; padding-bottom: 0.03in; margin-bottom: 0.12in; }
-        .apn-ref { font-size: 10pt; }
+        /* D2: parcel id weighted like the parties. */
+        .apn-ref { font-weight: bold; font-size: 10pt; }
         .recorder-caption { font-size: 7.5pt; font-weight: bold; text-transform: uppercase; }
 
         .deed-title { text-align: center; font-size: 14pt; font-weight: bold; letter-spacing: 2px; text-transform: uppercase; margin: 0.08in 0 0.12in 0; }
@@ -45,7 +46,7 @@
         /* D1: description weighted like the parties. */
         .legal-content { font-weight: bold; white-space: pre-wrap; margin: 0.08in 0; }
         .legal-exhibit-ref { font-weight: bold; margin: 0.08in 0; }
-        .apn-line { margin-top: 0.08in; }
+        .apn-line { font-weight: bold; margin-top: 0.08in; }
 
         .execution-section { display: flex; justify-content: space-between; align-items: flex-start; margin-top: 0.25in; page-break-inside: avoid; }
         .execution-date { padding-top: 0.25in; }
@@ -73,7 +74,7 @@
         <header class="header-section">
             <div class="recording-info">
                 <div class="recording-label">Recording Requested By:</div>
-                <div class="recording-value">{{ requested_by or title_company or '' }}</div>
+                <div class="recording-value">{{ requested_by or title_company or '' }}{% if requested_by_address %}<br>{{ requested_by_address }}{% endif %}</div>
 
                 <div class="recording-label">Mail Tax Statements and<br>When Recorded Mail To:</div>
                 <div class="recording-value">

--- a/templates/tax_deed_ca/index.jinja2
+++ b/templates/tax_deed_ca/index.jinja2
@@ -26,7 +26,8 @@
         .recording-value { margin-bottom: 0.12in; min-height: 0.35in; }
         .ref-line { font-size: 10pt; }
         .header-boundary { display: flex; justify-content: space-between; align-items: baseline; border-bottom: 0.75pt solid #000; padding-bottom: 0.03in; margin-bottom: 0.12in; }
-        .apn-ref { font-size: 10pt; }
+        /* D2: parcel id weighted like the parties. */
+        .apn-ref { font-weight: bold; font-size: 10pt; }
         .recorder-caption { font-size: 7.5pt; font-weight: bold; text-transform: uppercase; }
 
         .deed-title { text-align: center; font-size: 14pt; font-weight: bold; letter-spacing: 2px; text-transform: uppercase; margin: 0.08in 0 0.12in 0; }
@@ -44,7 +45,7 @@
         /* D1: description weighted like the parties. */
         .legal-content { font-weight: bold; white-space: pre-wrap; margin: 0.08in 0; }
         .legal-exhibit-ref { font-weight: bold; margin: 0.08in 0; }
-        .apn-line { margin-top: 0.08in; }
+        .apn-line { font-weight: bold; margin-top: 0.08in; }
 
         .provisions-section { font-size: 10pt; line-height: 1.45; margin: 0.12in 0; }
         .provisions-header { font-weight: bold; text-transform: uppercase; }
@@ -82,7 +83,7 @@
         <header class="header-section">
             <div class="recording-info">
                 <div class="recording-label">Recording Requested By:</div>
-                <div class="recording-value">{{ requested_by or title_company or '' }}</div>
+                <div class="recording-value">{{ requested_by or title_company or '' }}{% if requested_by_address %}<br>{{ requested_by_address }}{% endif %}</div>
 
                 <div class="recording-label">Mail Tax Statements and<br>When Recorded Mail To:</div>
                 <div class="recording-value">

--- a/templates/warranty_deed_ca/index.jinja2
+++ b/templates/warranty_deed_ca/index.jinja2
@@ -26,7 +26,8 @@
         .recording-value { margin-bottom: 0.12in; min-height: 0.35in; }
         .ref-line { font-size: 10pt; }
         .header-boundary { display: flex; justify-content: space-between; align-items: baseline; border-bottom: 0.75pt solid #000; padding-bottom: 0.03in; margin-bottom: 0.12in; }
-        .apn-ref { font-size: 10pt; }
+        /* D2: parcel id weighted like the parties. */
+        .apn-ref { font-weight: bold; font-size: 10pt; }
         .recorder-caption { font-size: 7.5pt; font-weight: bold; text-transform: uppercase; }
 
         .deed-title { text-align: center; font-size: 14pt; font-weight: bold; letter-spacing: 2px; text-transform: uppercase; margin: 0.08in 0 0.12in 0; }
@@ -45,7 +46,7 @@
         /* D1: description weighted like the parties. */
         .legal-content { font-weight: bold; white-space: pre-wrap; margin: 0.08in 0; }
         .legal-exhibit-ref { font-weight: bold; margin: 0.08in 0; }
-        .apn-line { margin-top: 0.08in; }
+        .apn-line { font-weight: bold; margin-top: 0.08in; }
 
         .covenants-section { font-size: 10pt; line-height: 1.45; margin: 0.12in 0; }
         .covenants-header { font-weight: bold; text-transform: uppercase; }
@@ -76,7 +77,7 @@
         <header class="header-section">
             <div class="recording-info">
                 <div class="recording-label">Recording Requested By:</div>
-                <div class="recording-value">{{ requested_by or title_company or '' }}</div>
+                <div class="recording-value">{{ requested_by or title_company or '' }}{% if requested_by_address %}<br>{{ requested_by_address }}{% endif %}</div>
 
                 <div class="recording-label">Mail Tax Statements and<br>When Recorded Mail To:</div>
                 <div class="recording-value">


### PR DESCRIPTION
## D2 — the builder polish trio (one PR, Tier 2)

### 1. Next buttons on typed sections
Grantee → Vesting → Transfer Tax → Recording → "Done — review your deed" (collapses the accordion). Completes the confirm-advance flow for sections with no confirm affordance — and deliberately adds **no confirm buttons to officer-typed fields**: typing is the officer's act; "Confirm" stays reserved for external-source data. Pinned: `GranteeSection`/`RecordingSection` carry no `ConfirmableField`.

### 2. Requesting-party address — audit answer + full data path
**The address was captured all along — on the partner record** (`address_line1/city/state/postal_code`); the builder took only the partner's *name*, so the deed header printed "Recording Requested By" with nothing under it. Now carried end to end:

partner selectlist assembles a one-line address (response shape evolved; existing pin updated) → **selecting a partner fills name + address** → editable "Requesting Party Address" field for manual/non-partner cases → builder state → payload → both proxies → `DeedCreate`/`DraftSave` → metadata extras (all three write paths) → **template header under the name, all five chassis** (same treatment as D1's mail-to) → preview line with data-highlight → resume mapper restores it.

**Flagged follow-up:** the user's own profile (`user_profiles.business_address`) is a second prefill source not yet wired — needs a profile fetch in the builder; proposed as a small.

### 3. Bold APN
Both appearances (header boundary ref + body parcel line), preview + all five chassis — same weight as the parties and the D1 legal description. pdfplumber pin: every APN word renders in a Bold font. **All pre-existing geometry/furniture pins pass unchanged.**

### Gates
Backend **93** (88 + 5 new in `test_d2_display.py`; 1 selectlist pin evolved) · six-flow ✔ vs real Postgres · Jest **257** (249 + 8 new) · tsc **98**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_