### PR TITLE
D3: click-to-fix preview — the highlighted regions become a workbench

### DIFF
--- a/frontend/src/__tests__/d3ClickToFix.test.ts
+++ b/frontend/src/__tests__/d3ClickToFix.test.ts
@@ -1,0 +1,82 @@
+/**
+ * D3 — click-to-fix preview, pinned.
+ *
+ * The preview's highlighted data regions (D1) become a workbench: click
+ * any region and the corresponding builder section opens; where a plain
+ * input exists it also receives focus. One gesture covers fix (real
+ * value) and fill (placeholder). Scope: builder PreviewPanel ONLY — the
+ * stored-PDF preview remains a faithful document view.
+ *
+ * Mapping-shape decision (flagged, not guessed): provenance-card fields
+ * (grantor, APN, legal description, county) open at SECTION level — the
+ * confirm/edit card is the affordance there, and faking an input focus
+ * would mislead. Plain typed inputs get field-level focus anchors.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+
+function readSource(...segments: string[]): string {
+  return fs.readFileSync(path.join(__dirname, '..', ...segments), 'utf8');
+}
+
+const PREVIEW = readSource('components', 'builder', 'PreviewPanel.tsx');
+const BUILDER = readSource('features', 'builder', 'DeedBuilder.tsx');
+
+const KNOWN_SECTIONS = new Set(['property', 'grantor', 'grantee', 'vesting', 'transferTax', 'recording']);
+const FIELD_ANCHORS: Array<[string, string[]]> = [
+  ['grantee', ['components', 'builder', 'sections', 'GranteeSection.tsx']],
+  ['dtt-value', ['components', 'builder', 'sections', 'TransferTaxSection.tsx']],
+  ['dtt-city', ['components', 'builder', 'sections', 'TransferTaxSection.tsx']],
+  ['requested-by', ['components', 'builder', 'sections', 'RecordingSection.tsx']],
+  ['requested-by-address', ['components', 'builder', 'sections', 'RecordingSection.tsx']],
+  ['title-order-no', ['components', 'builder', 'sections', 'RecordingSection.tsx']],
+  ['escrow-no', ['components', 'builder', 'sections', 'RecordingSection.tsx']],
+];
+
+describe('D3 — every preview data region is clickable with a valid mapping', () => {
+  const gos = [...PREVIEW.matchAll(/go\('([^']+)'(?:,\s*'([^']+)')?\)/g)];
+
+  it('the regions carry click handlers (a plausible number of them)', () => {
+    expect(gos.length).toBeGreaterThanOrEqual(14);
+  });
+
+  it('every mapping targets a real section', () => {
+    for (const m of gos) {
+      expect(KNOWN_SECTIONS.has(m[1])).toBe(true);
+    }
+  });
+
+  it('every field-level mapping has a data-builder-field anchor', () => {
+    const fields = gos.map((m) => m[2]).filter(Boolean) as string[];
+    expect(fields.length).toBeGreaterThanOrEqual(5);
+    for (const field of new Set(fields)) {
+      const anchor = FIELD_ANCHORS.find(([name]) => name === field);
+      expect(anchor).toBeDefined();
+      const src = readSource(...anchor![1]);
+      expect(src).toContain(`data-builder-field="${field}"`);
+    }
+  });
+
+  it('provenance-card sections map at section level (no fake field focus)', () => {
+    // grantor / property regions carry no field id.
+    expect(PREVIEW).toContain("go('grantor')");
+    expect(PREVIEW).toContain("go('property')");
+    expect(PREVIEW).not.toMatch(/go\('grantor',/);
+    expect(PREVIEW).not.toMatch(/go\('property',/);
+  });
+});
+
+describe('D3 — the builder opens the section and focuses the anchor', () => {
+  it('handleRegionClick expands, then focuses via the anchor attribute', () => {
+    expect(BUILDER).toContain('const handleRegionClick');
+    expect(BUILDER).toContain('setExpandedSection(section)');
+    expect(BUILDER).toContain('data-builder-field="${field}"');
+    expect(BUILDER).toContain('onRegionClick={handleRegionClick}');
+  });
+
+  it('clicking is preview-panel scoped — the click affordance only exists when wired', () => {
+    expect(PREVIEW).toContain('onRegionClick ? ');
+    expect(PREVIEW).toContain('cursor-pointer');
+  });
+});

--- a/frontend/src/components/builder/PreviewPanel.tsx
+++ b/frontend/src/components/builder/PreviewPanel.tsx
@@ -24,6 +24,9 @@ import {
 interface PreviewPanelProps {
   state: DeedBuilderState;
   activeSection: string;
+  /** D3 click-to-fix: clicking a data region opens its section (and
+      focuses the matching input where one exists). Preview-only. */
+  onRegionClick?: (section: string, field?: string) => void;
 }
 
 const DEED_TITLES: Record<string, string> = {
@@ -42,7 +45,7 @@ function Checkline({ marked }: { marked: boolean }) {
   );
 }
 
-export function PreviewPanel({ state, activeSection }: PreviewPanelProps) {
+export function PreviewPanel({ state, activeSection, onRegionClick }: PreviewPanelProps) {
   const preview = useMemo(() => ({
     requestedBy: state.requestedBy || '[Recording Requested By]',
     requestedByAddress: state.requestedByAddress || '',
@@ -107,6 +110,15 @@ export function PreviewPanel({ state, activeSection }: PreviewPanelProps) {
       ? 'bg-brand-50 text-brand-900 px-0.5 rounded'
       : '';
 
+  // D3: click-to-fix. Every data region is clickable — real values jump
+  // to their field ("fix"), placeholders jump to the empty field ("fill");
+  // one gesture either way. Sections whose data lives in provenance cards
+  // (grantor, APN, legal description) open at SECTION level: the card IS
+  // the affordance there, and faking an input focus would mislead.
+  const go = (section: string, field?: string) =>
+    onRegionClick ? () => onRegionClick(section, field) : undefined;
+  const CLICKABLE = onRegionClick ? 'cursor-pointer hover:ring-1 hover:ring-brand-300' : '';
+
   return (
     <div className="h-full bg-gray-200 p-6 overflow-y-auto">
       <div className="max-w-3xl mx-auto">
@@ -118,11 +130,11 @@ export function PreviewPanel({ state, activeSection }: PreviewPanelProps) {
               <div className={`w-[55%] border-r border-black pr-3 ${highlight('recording')}`}>
                 <div className="text-[9px] font-bold uppercase tracking-wide">Recording Requested By:</div>
                 <div className="min-h-[0.3in] mb-2">
-                  <span className={`text-[10px] ${placeholder(preview.requestedBy)} ${dataHighlight(preview.requestedBy)}`}>{preview.requestedBy}</span>
+                  <span onClick={go('recording', 'requested-by')} className={`text-[10px] ${CLICKABLE} ${placeholder(preview.requestedBy)} ${dataHighlight(preview.requestedBy)}`}>{preview.requestedBy}</span>
                   {/* D2: the requesting party's address prints under their
                       name — same treatment as the mail-to block. */}
                   {preview.requestedByAddress && (
-                    <span className={`block text-[10px] ${dataHighlight(preview.requestedByAddress)}`}>{preview.requestedByAddress}</span>
+                    <span onClick={go('recording', 'requested-by-address')} className={`block text-[10px] ${CLICKABLE} ${dataHighlight(preview.requestedByAddress)}`}>{preview.requestedByAddress}</span>
                   )}
                 </div>
 
@@ -130,20 +142,20 @@ export function PreviewPanel({ state, activeSection }: PreviewPanelProps) {
                   Mail Tax Statements and<br />When Recorded Mail To:
                 </div>
                 <div className="min-h-[0.3in] mb-2">
-                  <span className={`text-[10px] ${placeholder(preview.returnTo)} ${dataHighlight(preview.returnTo)}`}>{preview.returnTo}</span>
+                  <span onClick={go('recording')} className={`text-[10px] ${CLICKABLE} ${placeholder(preview.returnTo)} ${dataHighlight(preview.returnTo)}`}>{preview.returnTo}</span>
                   {preview.returnToLines.map((line) => (
-                    <span key={line} className={`block text-[10px] ${dataHighlight(line)}`}>{line}</span>
+                    <span key={line} onClick={go('recording')} className={`block text-[10px] ${CLICKABLE} ${dataHighlight(line)}`}>{line}</span>
                   ))}
                 </div>
 
                 <div className="text-[10px]">
                   Order No.: {preview.titleOrderNo
-                    ? <span className={dataHighlight(preview.titleOrderNo)}>{preview.titleOrderNo}</span>
+                    ? <span onClick={go('recording', 'title-order-no')} className={`${CLICKABLE} ${dataHighlight(preview.titleOrderNo)}`}>{preview.titleOrderNo}</span>
                     : '____________'}
                 </div>
                 <div className="text-[10px]">
                   Escrow No.: {preview.escrowNo
-                    ? <span className={dataHighlight(preview.escrowNo)}>{preview.escrowNo}</span>
+                    ? <span onClick={go('recording', 'escrow-no')} className={`${CLICKABLE} ${dataHighlight(preview.escrowNo)}`}>{preview.escrowNo}</span>
                     : '____________'}
                 </div>
               </div>
@@ -155,7 +167,7 @@ export function PreviewPanel({ state, activeSection }: PreviewPanelProps) {
             {/* Boundary row: APN left, recorder caption right, rule under */}
             <div className="flex justify-between items-baseline border-b border-black pb-0.5 mb-3">
               <span className={`text-[10px] font-bold ${highlight('property')}`}>
-                APN: <span className={`font-mono tracking-wide ${dataHighlight(preview.apn)}`}>{preview.apn || '____________'}</span>
+                APN: <span onClick={go('property')} className={`font-mono tracking-wide ${CLICKABLE} ${dataHighlight(preview.apn)}`}>{preview.apn || '____________'}</span>
               </span>
               <span className="text-[7.5px] font-bold uppercase">{RECORDER_CAPTION}</span>
             </div>
@@ -177,7 +189,7 @@ export function PreviewPanel({ state, activeSection }: PreviewPanelProps) {
                   <span>{DTT_LEAD}</span>
                   <span>
                     {DTT_AMOUNT_LABEL}{' '}
-                    <span className={`inline-block min-w-[1.2in] border-b border-black text-center ${dataHighlight(dttAmount)}`}>
+                    <span onClick={go('transferTax', 'dtt-value')} className={`inline-block min-w-[1.2in] border-b border-black text-center ${CLICKABLE} ${dataHighlight(dttAmount)}`}>
                       ${dttAmount}
                     </span>
                   </span>
@@ -195,7 +207,7 @@ export function PreviewPanel({ state, activeSection }: PreviewPanelProps) {
                   {DTT_AREA_UNINCORPORATED}{'   '}
                   <Checkline marked={!!dtt && dtt.areaType === 'city'} />
                   City of{' '}
-                  <span className={`inline-block min-w-[1.2in] border-b border-black text-center ${dataHighlight(dtt?.areaType === 'city' ? dtt.cityName : '')}`}>
+                  <span onClick={go('transferTax', 'dtt-city')} className={`inline-block min-w-[1.2in] border-b border-black text-center ${CLICKABLE} ${dataHighlight(dtt?.areaType === 'city' ? dtt.cityName : '')}`}>
                     {dtt?.areaType === 'city' ? dtt.cityName || '' : ''}
                   </span>
                 </div>
@@ -211,35 +223,35 @@ export function PreviewPanel({ state, activeSection }: PreviewPanelProps) {
             </p>
 
             <div className={`mb-2 ${highlight('grantor')}`}>
-              <span className={`font-bold uppercase text-[11pt] ${placeholder(preview.grantor)} ${dataHighlight(preview.grantor)}`}>{preview.grantor}</span>
+              <span onClick={go('grantor')} className={`font-bold uppercase text-[11pt] ${CLICKABLE} ${placeholder(preview.grantor)} ${dataHighlight(preview.grantor)}`}>{preview.grantor}</span>
             </div>
 
             <p className="mb-2 text-[11pt]">{operative}</p>
 
             <div className={`mb-2 ${highlight('grantee')}`}>
-              <span className={`font-bold uppercase text-[11pt] ${placeholder(preview.grantee)} ${dataHighlight(preview.grantee)}`}>{preview.grantee}</span>
+              <span onClick={go('grantee', 'grantee')} className={`font-bold uppercase text-[11pt] ${CLICKABLE} ${placeholder(preview.grantee)} ${dataHighlight(preview.grantee)}`}>{preview.grantee}</span>
               {preview.vesting && (
-                <span className={`text-[11pt] ${highlight('vesting')} ${dataHighlight(preview.vesting)}`}>, {preview.vesting}</span>
+                <span onClick={go('vesting')} className={`text-[11pt] ${CLICKABLE} ${highlight('vesting')} ${dataHighlight(preview.vesting)}`}>, {preview.vesting}</span>
               )}
             </div>
 
             <p className="mb-2 text-[11pt]">
               the real property situated in the County of{' '}
-              <span className={`font-bold ${placeholder(preview.county)} ${dataHighlight(preview.county)}`}>{preview.county}</span>,
+              <span onClick={go('property')} className={`font-bold ${CLICKABLE} ${placeholder(preview.county)} ${dataHighlight(preview.county)}`}>{preview.county}</span>,
               State of California, more particularly described as follows:
             </p>
 
             {/* Legal description — plain text, no box; D1: bolded like the
                 parties, mirroring the chassis .legal-content weight. */}
             <div className={`mb-3 ${highlight('property')}`}>
-              <span className={`font-bold text-[10.5pt] whitespace-pre-wrap ${placeholder(preview.legalDescription)} ${dataHighlight(preview.legalDescription)}`}>
+              <span onClick={go('property')} className={`font-bold text-[10.5pt] whitespace-pre-wrap ${CLICKABLE} ${placeholder(preview.legalDescription)} ${dataHighlight(preview.legalDescription)}`}>
                 {preview.legalDescription}
               </span>
             </div>
 
             {preview.apn && (
               <div className={`mb-4 text-[10.5pt] font-bold ${highlight('property')}`}>
-                Assessor&rsquo;s Parcel Number: <span className={`font-mono tracking-wider ${dataHighlight(preview.apn)}`}>{preview.apn}</span>
+                Assessor&rsquo;s Parcel Number: <span onClick={go('property')} className={`font-mono tracking-wider ${CLICKABLE} ${dataHighlight(preview.apn)}`}>{preview.apn}</span>
               </div>
             )}
 

--- a/frontend/src/components/builder/sections/GranteeSection.tsx
+++ b/frontend/src/components/builder/sections/GranteeSection.tsx
@@ -37,6 +37,7 @@ export function GranteeSection({ value, onChange, grantorName }: GranteeSectionP
           <User className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
           <input
             type="text"
+            data-builder-field="grantee"
             value={value}
             onChange={(e) => onChange(e.target.value.toUpperCase())}
             placeholder="JANE DOE"

--- a/frontend/src/components/builder/sections/RecordingSection.tsx
+++ b/frontend/src/components/builder/sections/RecordingSection.tsx
@@ -102,6 +102,7 @@ export function RecordingSection({ requestedBy, requestedByAddress, returnTo, ti
         <div className="relative">
           <Building2 className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
           <select
+            data-builder-field="requested-by"
             value={requestedBy}
             onChange={handleSelectChange}
             className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 appearance-none bg-white"
@@ -146,6 +147,7 @@ export function RecordingSection({ requestedBy, requestedByAddress, returnTo, ti
         </label>
         <input
           type="text"
+          data-builder-field="requested-by-address"
           value={requestedByAddress || ''}
           onChange={(e) => onChange({ requestedByAddress: e.target.value })}
           placeholder="Street, City, ST ZIP"
@@ -194,6 +196,7 @@ export function RecordingSection({ requestedBy, requestedByAddress, returnTo, ti
           </label>
           <input
             type="text"
+            data-builder-field="title-order-no"
             value={titleOrderNo || ''}
             onChange={(e) => onChange({ titleOrderNo: e.target.value })}
             placeholder="TC-2026-12345"
@@ -206,6 +209,7 @@ export function RecordingSection({ requestedBy, requestedByAddress, returnTo, ti
           </label>
           <input
             type="text"
+            data-builder-field="escrow-no"
             value={escrowNo || ''}
             onChange={(e) => onChange({ escrowNo: e.target.value })}
             placeholder="ESC-789456"

--- a/frontend/src/components/builder/sections/TransferTaxSection.tsx
+++ b/frontend/src/components/builder/sections/TransferTaxSection.tsx
@@ -245,6 +245,7 @@ export function TransferTaxSection({
               <span className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-500">$</span>
               <input
                 type="text"
+                data-builder-field="dtt-value"
                 value={value.transferValue}
                 onChange={(e) => {
                   const raw = e.target.value.replace(/[^0-9]/g, "")
@@ -311,6 +312,7 @@ export function TransferTaxSection({
               </label>
               <input
                 id="dtt-city"
+                data-builder-field="dtt-city"
                 type="text"
                 value={value.cityName || ""}
                 onChange={(e) => manual({ ...value, cityName: e.target.value })}

--- a/frontend/src/features/builder/DeedBuilder.tsx
+++ b/frontend/src/features/builder/DeedBuilder.tsx
@@ -303,6 +303,23 @@ function DeedBuilderInner({ deedType, initialProperty, resumeDeedId }: DeedBuild
     setExpandedSection(sectionId);
   };
 
+  // D3 click-to-fix: a click on a preview data region opens its section;
+  // where a plain input exists it also receives focus (data-builder-field
+  // anchors). Provenance-card fields open at section level — the card is
+  // the affordance there.
+  const handleRegionClick = useCallback((section: string, field?: string) => {
+    setExpandedSection(section);
+    if (!field) return;
+    // Wait out the accordion expansion before focusing.
+    setTimeout(() => {
+      const el = document.querySelector<HTMLElement>(`[data-builder-field="${field}"]`);
+      if (el) {
+        el.focus();
+        el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      }
+    }, 350);
+  }, []);
+
   const performGenerate = async (genState: DeedBuilderState) => {
     setIsGenerating(true);
     try {
@@ -386,7 +403,11 @@ function DeedBuilderInner({ deedType, initialProperty, resumeDeedId }: DeedBuild
         </div>
 
         <div className="flex-1">
-          <PreviewPanel state={state} activeSection={expandedSection} />
+          <PreviewPanel
+            state={state}
+            activeSection={expandedSection}
+            onRegionClick={handleRegionClick}
+          />
         </div>
       </div>
 


### PR DESCRIPTION
## D3 — the preview stops being a picture

Every data region in the builder PreviewPanel (D1's purple highlights) is now **clickable**: the corresponding section opens, and where a plain input exists it receives focus + smooth scroll (via `data-builder-field` anchors: grantee, DTT value/city, requesting-party name/address, order/escrow). One gesture covers both **fix** (real value) and **fill** (placeholder) — 15 regions wired.

### The mapping-shape call (flagged per ticket, not guessed)
Provenance-card fields — grantor, APN, legal description, county — open at **section level** with no field focus: the confirm/edit card *is* the affordance there, and faking an input focus would mislead the officer about what kind of field they're touching. Pinned so those regions can't silently grow field ids.

### Scope held
Builder PreviewPanel only. The click affordance (cursor, hover ring, handler) exists only when `onRegionClick` is wired — the stored-PDF preview stays a faithful document view.

### Pins — `d3ClickToFix.test.ts` (6)
≥14 clickable regions · every mapping targets a real section · every field mapping has a matching anchor in its section file · provenance sections stay section-level · the builder handler expands-then-focuses · the affordance is wiring-gated.

### Gates
Jest **263** (257 + 6 new) · tsc **98** · frontend-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_