### PR TITLE
S1 follow-up: the email failure reason survives — transport present, errors were swallowed

### DIFF
--- a/backend/routers/sharing.py
+++ b/backend/routers/sharing.py
@@ -131,12 +131,16 @@ def share_deed_for_approval(share_data: ShareDeedCreate, user_id: int = Depends(
         "apn": apn
     }
 
-    # Phase 7: Send sharing notification email
+    # Phase 7: Send sharing notification email. S1 follow-up: the failure
+    # REASON travels — logged with a [SHARE-EMAIL] prefix and carried in
+    # the response so the modal's amber panel can say why ("from address
+    # not verified" is actionable; "email not configured" was wrong).
     email_sent = False
+    email_error = None
     try:
-        from utils.notifications import send_share_notification
+        from utils.notifications import send_share_notification_with_reason
 
-        email_sent = send_share_notification(
+        email_sent, email_error = send_share_notification_with_reason(
             recipient_email=share_data.recipient_email,
             recipient_name=share_data.recipient_name,
             owner_name=owner_name,
@@ -145,22 +149,20 @@ def share_deed_for_approval(share_data: ShareDeedCreate, user_id: int = Depends(
         )
 
         if email_sent:
-            print(f"[Phase 7] ✅ Sharing notification sent to {share_data.recipient_email}")
+            print(f"[SHARE-EMAIL] ✅ Sent to {share_data.recipient_email}")
         else:
-            print(f"[Phase 7] ⚠️ Failed to send sharing notification")
+            print(f"[SHARE-EMAIL] ❌ Not sent: {email_error}")
     except Exception as notif_error:
-        # Don't fail the request if notification fails
-        print(f"[Phase 7] ⚠️ Sharing notification error (non-blocking): {notif_error}")
-
-    if not email_sent:
-        # Still return success but indicate email issue
-        print("[Phase 7] Warning: Deed shared but email notification failed")
+        # Don't fail the request if notification fails — but never lose why.
+        email_error = f"{type(notif_error).__name__}: {str(notif_error)[:200]}"
+        print(f"[SHARE-EMAIL] ❌ Exception (non-blocking): {email_error}")
 
     return {
         "success": True,
-        "message": "Deed shared successfully! Approval email sent." if email_sent else "Deed shared, but email notification failed.",
+        "message": "Deed shared successfully! Approval email sent." if email_sent else "Deed shared, but the notification email was not sent.",
         "shared_deed": shared_deed,
-        "email_sent": email_sent
+        "email_sent": email_sent,
+        "email_error": email_error
     }
 
 @router.get("/shared-deeds")

--- a/backend/tests/snapshots/six_flow_baseline.json
+++ b/backend/tests/snapshots/six_flow_baseline.json
@@ -79,6 +79,7 @@
   },
   "5_share_create": {
     "keys": [
+      "email_error",
       "email_sent",
       "message",
       "shared_deed",

--- a/backend/tests/test_share_email_truth.py
+++ b/backend/tests/test_share_email_truth.py
@@ -1,0 +1,97 @@
+"""S1 follow-up — transport present but failing silently.
+
+Owner report: SendGrid key + from-address exist on Render, yet shares
+return email_sent: false. The old send path swallowed every failure into
+`print(e)` + False — a valid key with an unverified sender looked
+identical to "not configured," which is exactly what S1's first verdict
+(wrongly) concluded. Pinned here:
+
+- the failure REASON survives: send_email_with_reason returns (ok, why),
+  SendGrid's 4xx body (the actual diagnosis) is extracted, and the
+  silently-defaulted from-address is named in the reason;
+- the env contract is explicit: SENDGRID_API_KEY + SENDGRID_FROM_EMAIL
+  (fallback FROM_EMAIL) — the names the owner must match on Render;
+- the share response carries email_error so the modal can say why.
+"""
+from unittest.mock import MagicMock, patch
+
+from utils.email import send_email, send_email_with_reason
+
+
+def test_env_contract_names_are_pinned(monkeypatch):
+    """The exact names the code reads — rename these and production email
+    dies silently again. Owner-side names on Render must match."""
+    import inspect
+    from utils import email as mod
+    src = inspect.getsource(mod)
+    assert "os.getenv('SENDGRID_API_KEY')" in src
+    assert "os.getenv('SENDGRID_FROM_EMAIL')" in src
+    assert "os.getenv('FROM_EMAIL')" in src
+
+
+def test_unconfigured_reason_names_the_missing_var(monkeypatch):
+    monkeypatch.delenv('SENDGRID_API_KEY', raising=False)
+    ok, reason = send_email_with_reason('to@test.dev', 's', '<p>b</p>')
+    assert ok is False
+    assert 'SENDGRID_API_KEY' in reason
+
+
+def test_sendgrid_4xx_body_survives_as_the_reason(monkeypatch):
+    """SendGrid rejections (unverified sender = 403) arrive as exceptions
+    whose .body names the cause — the diagnosis must not be swallowed."""
+    monkeypatch.setenv('SENDGRID_API_KEY', 'SG.test')
+    monkeypatch.setenv('SENDGRID_FROM_EMAIL', 'owner@example.com')
+
+    class FakeHTTPError(Exception):
+        body = b'{"errors":[{"message":"The from address does not match a verified Sender Identity"}]}'
+
+    fake_client = MagicMock()
+    fake_client.return_value.send.side_effect = FakeHTTPError('403')
+    with patch.dict('sys.modules', {}, clear=False):
+        with patch('sendgrid.SendGridAPIClient', fake_client):
+            ok, reason = send_email_with_reason('to@test.dev', 's', '<p>b</p>')
+    assert ok is False
+    assert 'verified Sender Identity' in reason
+    assert 'owner@example.com' in reason
+
+
+def test_defaulted_from_address_is_named_in_failures(monkeypatch):
+    """No from-var set → the hardcoded default is used AND called out —
+    an unverified default sender is the classic silent 403."""
+    monkeypatch.setenv('SENDGRID_API_KEY', 'SG.test')
+    monkeypatch.delenv('SENDGRID_FROM_EMAIL', raising=False)
+    monkeypatch.delenv('FROM_EMAIL', raising=False)
+
+    fake_client = MagicMock()
+    fake_client.return_value.send.side_effect = Exception('boom')
+    with patch('sendgrid.SendGridAPIClient', fake_client):
+        ok, reason = send_email_with_reason('to@test.dev', 's', '<p>b</p>')
+    assert ok is False
+    assert 'noreply@deedpro.com' in reason
+    assert 'SENDGRID_FROM_EMAIL' in reason  # tells the operator the fix
+
+
+def test_success_returns_true_none(monkeypatch):
+    monkeypatch.setenv('SENDGRID_API_KEY', 'SG.test')
+    monkeypatch.setenv('SENDGRID_FROM_EMAIL', 'owner@example.com')
+    resp = MagicMock()
+    resp.status_code = 202
+    fake_client = MagicMock()
+    fake_client.return_value.send.return_value = resp
+    with patch('sendgrid.SendGridAPIClient', fake_client):
+        ok, reason = send_email_with_reason('to@test.dev', 's', '<p>b</p>')
+    assert ok is True and reason is None
+    # back-compat wrapper agrees
+    with patch('sendgrid.SendGridAPIClient', fake_client):
+        assert send_email('to@test.dev', 's', '<p>b</p>') is True
+
+
+def test_share_endpoint_carries_the_reason():
+    """Source pin: the share response includes email_error and the log
+    line carries the [SHARE-EMAIL] prefix the ticket names."""
+    import inspect
+    import routers.sharing as mod
+    src = inspect.getsource(mod)
+    assert '"email_error": email_error' in src
+    assert '[SHARE-EMAIL]' in src
+    assert 'send_share_notification_with_reason' in src

--- a/backend/utils/email.py
+++ b/backend/utils/email.py
@@ -6,26 +6,62 @@ def email_configured() -> bool:
     return bool(os.getenv('SENDGRID_API_KEY'))
 
 
-def send_email(to: str, subject: str, body: str) -> bool:
-    """Send email via SendGrid if configured; otherwise log and report failure.
+def send_email_with_reason(to: str, subject: str, body: str):
+    """Send email via SendGrid. Returns (ok, reason) — reason is None on
+    success and a human-actionable string on failure.
 
-    Invariant #4 (doctrine sweep): returning True while only printing to the
-    console is a fabricated success — it let /users/forgot-password tell
-    users "reset link sent" with no email infrastructure configured at all.
-    Callers that treat email as optional already handle False.
+    S1 follow-up: the old path swallowed every failure into a bare
+    `print(e)` + False, so a valid key with an unverified sender looked
+    identical to "not configured." Invariant #4 cuts both ways: a failure
+    must carry its WHY. SendGrid's 4xx errors arrive as exceptions whose
+    .body names the cause (e.g. "from address does not match a verified
+    Sender Identity") — that body is the diagnosis and must survive.
+
+    Env contract (names the deployment must use):
+      SENDGRID_API_KEY    — the API key (required)
+      SENDGRID_FROM_EMAIL — verified sender (falls back to FROM_EMAIL;
+                            if NEITHER is set the hardcoded default
+                            noreply@deedpro.com is used and named in any
+                            failure, because an unverified default sender
+                            is the classic silent 403).
     """
     api_key = os.getenv('SENDGRID_API_KEY')
-    from_email = os.getenv('SENDGRID_FROM_EMAIL') or os.getenv('FROM_EMAIL', 'noreply@deedpro.com')
+    from_email = os.getenv('SENDGRID_FROM_EMAIL') or os.getenv('FROM_EMAIL') or ''
+    from_defaulted = not from_email
+    if from_defaulted:
+        from_email = 'noreply@deedpro.com'
     if not api_key:
-        print(f"[email:unconfigured] Would send To={to} Subject={subject} — SENDGRID_API_KEY not set")
-        return False
+        reason = "SENDGRID_API_KEY is not set in the environment"
+        print(f"[email:unconfigured] Would send To={to} Subject={subject} — {reason}")
+        return False, reason
     try:
         from sendgrid import SendGridAPIClient
         from sendgrid.helpers.mail import Mail
         msg = Mail(from_email=from_email, to_emails=to, subject=subject, html_content=body)
         sg = SendGridAPIClient(api_key)
         resp = sg.send(msg)
-        return 200 <= resp.status_code < 300
+        if 200 <= resp.status_code < 300:
+            return True, None
+        reason = f"SendGrid responded {resp.status_code} (from={from_email})"
+        print(f"[email:error] {reason}")
+        return False, reason
     except Exception as e:
-        print(f"[email:error] {e}")
-        return False
+        detail = getattr(e, 'body', None)
+        if isinstance(detail, bytes):
+            detail = detail.decode('utf-8', 'replace')
+        reason = f"{type(e).__name__}: {str(detail or e)[:300]} (from={from_email}"
+        reason += ", DEFAULT sender — set SENDGRID_FROM_EMAIL)" if from_defaulted else ")"
+        print(f"[email:error] {reason}")
+        return False, reason
+
+
+def send_email(to: str, subject: str, body: str) -> bool:
+    """Back-compat boolean wrapper over send_email_with_reason.
+
+    Invariant #4 (doctrine sweep): returning True while only printing to the
+    console is a fabricated success — it let /users/forgot-password tell
+    users "reset link sent" with no email infrastructure configured at all.
+    Callers that treat email as optional already handle False.
+    """
+    ok, _ = send_email_with_reason(to, subject, body)
+    return ok

--- a/backend/utils/notifications.py
+++ b/backend/utils/notifications.py
@@ -111,9 +111,16 @@ def render_share_email(recipient_name: str, owner_name: str, deed_type: str, sha
 
 def send_share_notification(recipient_email: str, recipient_name: str, owner_name: str, deed_type: str, share_link: str) -> bool:
     """Send deed sharing notification email."""
+    ok, _ = send_share_notification_with_reason(recipient_email, recipient_name, owner_name, deed_type, share_link)
+    return ok
+
+
+def send_share_notification_with_reason(recipient_email: str, recipient_name: str, owner_name: str, deed_type: str, share_link: str):
+    """S1 follow-up: the share path needs the WHY, not just False."""
+    from utils.email import send_email_with_reason
     subject = f"🤝 {owner_name} shared a deed with you"
     html = render_share_email(recipient_name, owner_name, deed_type, share_link)
-    return send_email(recipient_email, subject, html)
+    return send_email_with_reason(recipient_email, subject, html)
 
 def render_deed_completion_email(user_name: str, deed_type: str, property_address: str, deed_id: int, preview_link: str) -> str:
     """Render HTML email for deed completion notification."""

--- a/frontend/src/app/past-deeds/page.tsx
+++ b/frontend/src/app/past-deeds/page.tsx
@@ -55,7 +55,7 @@ export default function PastDeedsPageV0() {
   // S1: the share result panel — email status reported truthfully, and the
   // review link surfaced for manual sending (shares must be usable even
   // with no email transport configured).
-  const [shareResult, setShareResult] = useState<{ approvalUrl: string; emailSent: boolean } | null>(null)
+  const [shareResult, setShareResult] = useState<{ approvalUrl: string; emailSent: boolean; emailError?: string } | null>(null)
   const [linkCopied, setLinkCopied] = useState(false)
   // X2.7: find a deed without scrolling — text search + status filter.
   const [searchQuery, setSearchQuery] = useState("")
@@ -172,6 +172,7 @@ export default function PastDeedsPageV0() {
       setShareResult({
         approvalUrl: data?.shared_deed?.approval_url || "",
         emailSent: !!data?.email_sent,
+        emailError: typeof data?.email_error === "string" ? data.email_error : undefined,
       })
     } catch (err) {
       setShareError(err instanceof Error ? err.message : "Failed to share deed")
@@ -489,11 +490,17 @@ export default function PastDeedsPageV0() {
                 ) : (
                   <div className="flex items-start gap-3 p-4 bg-amber-50 border border-amber-200 rounded-lg">
                     <AlertCircle className="w-5 h-5 text-amber-600 flex-shrink-0 mt-0.5" />
-                    <p className="text-sm text-amber-800">
-                      The notification email could <strong>not</strong> be sent (email
-                      isn&apos;t configured on the server). Copy the review link below
-                      and send it to the recipient yourself.
-                    </p>
+                    <div className="text-sm text-amber-800">
+                      <p>
+                        The notification email could <strong>not</strong> be sent.
+                        Copy the review link below and send it to the recipient yourself.
+                      </p>
+                      {shareResult.emailError && (
+                        <p className="mt-1 text-xs font-mono text-amber-700 break-words">
+                          {shareResult.emailError}
+                        </p>
+                      )}
+                    </div>
                   </div>
                 )}
 


### PR DESCRIPTION
## S1 follow-up — verdict shift confirmed in code

### What the code reads (item 1 — the names to confirm on Render)
- **`SENDGRID_API_KEY`** — the key
- **`SENDGRID_FROM_EMAIL`** — the sender (fallback: `FROM_EMAIL`)

### The two defects that made "configured" look like "not configured" (item 2)
1. **Every failure was swallowed** into a bare `print(e)` + `False`. SendGrid 4xx errors arrive as exceptions whose `.body` *names the cause* ("The from address does not match a verified Sender Identity") — the diagnosis existed and was thrown away.
2. **The silent default sender**: with neither from-var set (or spelled differently on Render), the code quietly falls back to `noreply@deedpro.com` — not a verified sender in your account, so a *perfectly valid key* 403s on every send. This composite is odds-on your exact symptom.

### Fixes
- `send_email_with_reason` → `(ok, reason)`: SendGrid error bodies extracted; the from-address used is named in every failure; a defaulted sender is called out **with its fix** ("set SENDGRID_FROM_EMAIL"). `send_email` stays as the back-compat wrapper.
- Sharing endpoint: `[SHARE-EMAIL] ✅/❌` logs with the reason; **`email_error` in the response**.
- The share modal's amber panel now shows the reason verbatim. "Email isn't configured" (which was wrong) is gone.
- Six-flow baseline re-recorded — one-line diff (`email_error` key), justified, verified green.

### Call-shape audit (item 3)
`sendgrid==6.11.0`'s canonical shape — `SendGridAPIClient(key).send(Mail(...))`, library-managed Bearer auth — is exactly what the code uses. No PDFShift-style stowaways; the failure class here is sender verification + var naming, not payload shape.

### Owner checklist (env side)
1. Render var names must match **exactly**: `SENDGRID_API_KEY`, `SENDGRID_FROM_EMAIL` (or `FROM_EMAIL`).
2. SendGrid → Settings → **Sender Authentication**: the from-address must be verified (unverified = 403 no matter how valid the key).

**After this deploys, the share modal is the live test** — green when it truly sends, and the amber panel now tells you exactly why when it doesn't.

### Pins — `test_share_email_truth.py` (6)
Env-contract names pinned · missing key names itself · 4xx body survives as the reason incl. from-address · defaulted sender named with its fix · success `(True, None)` + wrapper agreement · share endpoint carries `email_error` + `[SHARE-EMAIL]`.

### Gates
Backend **99** (93 + 6 new) · six-flow ✔ (re-recorded, one-line diff) · jest **263** · tsc **98**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_