### PR TITLE
FORMS-SPIKE: Affidavit of Death (Joint Tenancy) — first non-deed instrument on the chassis

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -280,7 +280,7 @@ def create_deed(user_id, deed_data):
             key: deed_data.get(key)
             for key in ('dtt', 'title_order_no', 'escrow_no', 'return_to', 'source', 'provenance',
                         'property_city', 'property_state', 'property_zip', 'current_owner',
-                        'requested_by_address')
+                        'requested_by_address', 'affidavit')
             if deed_data.get(key)
         }
 
@@ -337,7 +337,7 @@ def update_deed_draft(user_id, deed_id, deed_data):
             key: deed_data.get(key)
             for key in ('dtt', 'title_order_no', 'escrow_no', 'return_to', 'source', 'provenance',
                         'property_city', 'property_state', 'property_zip', 'current_owner',
-                        'requested_by_address')
+                        'requested_by_address', 'affidavit')
             if deed_data.get(key)
         }
         cursor.execute("""
@@ -392,7 +392,7 @@ def save_draft_row(user_id, deed_id, deed_data):
             key: deed_data.get(key)
             for key in ('dtt', 'title_order_no', 'escrow_no', 'return_to', 'source', 'provenance',
                         'property_city', 'property_state', 'property_zip', 'current_owner',
-                        'requested_by_address')
+                        'requested_by_address', 'affidavit')
             if deed_data.get(key)
         }
         if deed_id:

--- a/backend/routers/deeds_crud.py
+++ b/backend/routers/deeds_crud.py
@@ -59,6 +59,9 @@ class DeedCreate(BaseModel):
     property_state: Optional[str] = Field(default=None)
     property_zip: Optional[str] = Field(default=None)
     current_owner: Optional[str] = Field(default=None, description="Owner per county records (prefill source)")
+    # FORMS-SPIKE: affidavit-of-death facts (affiant, decedent, JT-deed
+    # recording reference) — persisted into metadata.affidavit.
+    affidavit: Optional[Dict] = Field(default=None, description="Affidavit facts for affidavit-type instruments")
     # Ticket R: present when regenerating a RESUMED DRAFT — updates that
     # row instead of inserting a new one. Drafts only; completed deeds are
     # immutable (their PDF is stored) and deleted stays deleted.
@@ -99,6 +102,7 @@ class DraftSave(BaseModel):
     property_state: Optional[str] = None
     property_zip: Optional[str] = None
     current_owner: Optional[str] = None
+    affidavit: Optional[Dict] = None
 
     class Config:
         extra = "ignore"

--- a/backend/services/deed_pdf.py
+++ b/backend/services/deed_pdf.py
@@ -37,6 +37,8 @@ TEMPLATE_BY_DEED_TYPE = {
     "interspousal-transfer": "interspousal_transfer_ca/index.jinja2",
     "warranty-deed": "warranty_deed_ca/index.jinja2",
     "tax-deed": "tax_deed_ca/index.jinja2",
+    # FORMS-SPIKE: first non-deed instrument on the chassis.
+    "affidavit-death-jt": "affidavit_death_jt_ca/index.jinja2",
 }
 DEFAULT_TEMPLATE = "grant_deed_ca/index.jinja2"
 
@@ -89,6 +91,9 @@ def build_context_from_row(row):
         "escrow_no": meta.get("escrow_no") or "",
         "return_to": return_to,
         "dtt": _map_dtt(meta.get("dtt")),
+        # FORMS-SPIKE: the affidavit's officer-supplied facts (decedent,
+        # JT-deed recording reference, affiant) ride in metadata.affidavit.
+        "affidavit": meta.get("affidavit") if isinstance(meta.get("affidavit"), dict) else None,
         "exhibit_threshold": 600,
         "execution_date": None,
         "now": datetime.now,

--- a/backend/tests/test_affidavit_form.py
+++ b/backend/tests/test_affidavit_form.py
@@ -1,0 +1,146 @@
+"""FORMS-SPIKE — Affidavit of Death (Joint Tenancy), pinned.
+
+The first non-deed instrument on the G2/G3 chassis, built against Pacific
+Coast Title's blank form #4 as the reference implementation. The doctrine
+canary: affidavits are SWORN statements — the notarial certificate is a
+JURAT (Gov C §8202, "subscribed and sworn"), never an acknowledgment
+(CC §1189, "personally appeared ... acknowledged"). Wrong-certificate is
+a real defect class; these pins make it structural.
+"""
+import io
+
+import pdfplumber
+
+from services.deed_pdf import render_deed_html, render_deed_pdf
+from tests.test_deed_pdf import _normalized
+
+AFF_META = {
+    "requested_by_address": "456 Escrow Way, Los Angeles, CA 90012",
+    "return_to": {"name": "JANE B. DOE", "address1": "1358 5TH ST",
+                  "city": "Santa Monica", "state": "CA", "zip": "90401"},
+    "affidavit": {
+        "affiant_name": "JANE B. DOE",
+        "decedent_name": "JOHN A. DOE",
+        "jt_deed_date": "June 1, 2015",
+        "jt_deed_grantor": "ROBERT SELLER",
+        "jt_deed_grantees": "JOHN A. DOE AND JANE B. DOE",
+        "recording_date": "June 15, 2015",
+        "instrument_no": "2015-0654321",
+    },
+}
+
+
+def aff_row(**overrides):
+    row = {
+        "id": 1,
+        "deed_type": "affidavit-death-jt",
+        "grantor_name": "JOHN A. DOE",   # display alias: decedent
+        "grantee_name": "JANE B. DOE",   # display alias: affiant
+        "legal_description": "LOT 7, BLOCK B, TRACT 12345",
+        "county": "Los Angeles",
+        "apn": "4290-012-034",
+        "property_address": "1358 5TH ST, Santa Monica, CA 90401",
+        "requested_by": "Pacific Coast Escrow",
+        "metadata": AFF_META,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_sworn_recital_furniture_present():
+    """The instrument-defining recitals (Flag-3 precedent: choosing the
+    instrument IS the officer's decision; its recitals are furniture)."""
+    html = _normalized(render_deed_html(aff_row()))
+    assert "AFFIDAVIT &mdash; DEATH OF JOINT TENANT" in html or "Affidavit &mdash; Death of Joint Tenant" in html
+    assert "of legal age, being first duly sworn, deposes and says" in html
+    assert "is the decedent mentioned in the attached certified copy of Certificate of Death" in html
+    assert "as joint tenants, recorded on" in html
+    assert "Official Records of" in html
+    assert "Attach Certified Copy of Death Certificate" in html
+
+
+def test_officer_facts_render():
+    html = _normalized(render_deed_html(aff_row()))
+    for fact in ("JANE B. DOE", "JOHN A. DOE", "June 1, 2015", "ROBERT SELLER",
+                 "June 15, 2015", "2015-0654321", "Los Angeles",
+                 "LOT 7, BLOCK B, TRACT 12345"):
+        assert fact in html, fact
+
+
+def test_missing_facts_render_as_blank_lines_never_invented():
+    html = render_deed_html(aff_row(metadata={}))
+    assert "fact-line" in html          # the reference's blank lines
+    assert "JOHN A. DOE" not in html.split("deed-title")[1] if "deed-title" in html else True
+    assert "2015-0654321" not in html
+
+
+def test_jurat_not_acknowledgment():
+    """THE doctrine canary. Exactly one notarial certificate, and it is a
+    jurat: 'subscribed and sworn', never 'personally appeared ...
+    acknowledged' (the §1189 acknowledgment body)."""
+    html = _normalized(render_deed_html(aff_row()))
+    assert html.count("Subscribed and sworn to (or affirmed) before me") == 1
+    assert "personally appeared" not in html
+    assert "acknowledged to me" not in html
+    assert "All-Purpose Acknowledgment" not in html
+    # §8202(b) disclaimer box present, once.
+    assert html.count("verifies only the identity") == 1
+
+
+def test_jurat_contents_are_blank_ticket_n_pattern():
+    """Blank-contents doctrine: no affiant or notary entry pre-fills — the
+    date, affiant name, and notary signature are the notary's. Only the
+    venue county renders."""
+    html = _normalized(render_deed_html(aff_row()))
+    jurat = html[html.index("Subscribed and sworn"):]
+    assert "JANE B. DOE" not in jurat        # affiant not pre-filled in the cert
+    assert "JOHN A. DOE" not in jurat
+    # Venue county pre-fills (data the officer supplied):
+    venue = html[html.index("COUNTY OF"):html.index("Subscribed and sworn")]
+    assert "Los Angeles" in venue
+
+
+def test_no_dtt_and_no_mail_tax_on_affidavit():
+    """Reference-faithful: an affidavit of death is not a conveyance — no
+    transfer-tax declaration, no mail-tax directive."""
+    html = _normalized(render_deed_html(aff_row()))
+    assert "DOCUMENTARY TRANSFER TAX" not in html.upper()
+    assert "UNDERSIGNED GRANTOR" not in html.upper()
+    assert "Mail Tax Statements" not in html
+    assert "And When Recorded Mail To" in html
+
+
+def test_chassis_geometry_and_no_chrome():
+    """G2/G3 discipline: recorder space open, caption at the boundary,
+    title below it, jurat in the lower half, one page, no chrome."""
+    pdf = render_deed_pdf(aff_row())
+    with pdfplumber.open(io.BytesIO(pdf)) as doc:
+        assert len(doc.pages) == 1  # the reference is a one-page instrument
+        page = doc.pages[0]
+        words = page.extract_words()
+
+        def top_of(needle):
+            hits = [w for w in words if needle.upper() in w["text"].upper()]
+            assert hits, needle
+            return hits[0]["top"]
+
+        def x_of(needle):
+            hits = [w for w in words if needle.upper() in w["text"].upper()]
+            return hits[0]["x0"]
+
+        caption_top = top_of("RECORDER’S")
+        title_top = top_of("AFFIDAVIT")
+        jurat_top = top_of("Subscribed")
+        assert caption_top > 100          # a real open recorder space above it
+        assert x_of("RECORDER’S") > 300   # caption sits right of center
+        assert title_top > caption_top    # title below the boundary
+        assert jurat_top > page.height / 2  # jurat in the lower half (reference ~596pt)
+
+    html = render_deed_html(aff_row())
+    for leaked in ("7C4DFF", "Generated by", "deedpro.com/verify", "recorder-box", "bg-brand"):
+        assert leaked not in html, leaked
+
+
+def test_registered_in_the_type_map():
+    from services.deed_pdf import TEMPLATE_BY_DEED_TYPE
+    assert TEMPLATE_BY_DEED_TYPE["affidavit-death-jt"] == "affidavit_death_jt_ca/index.jinja2"

--- a/docs/FORMS_SPIKE_REPORT.md
+++ b/docs/FORMS_SPIKE_REPORT.md
@@ -1,0 +1,96 @@
+# FORMS-SPIKE — Verdict Report: Affidavit of Death (Joint Tenancy)
+
+**Status: the form is built, pinned, and selectable. This report is the
+priced half of the deliverable.**
+
+## What was built
+
+One complete new instrument, end to end: PCT reference form #4 fetched and
+measured (pdfplumber: letter page, caption at ~192pt, jurat lower half,
+one page) → doctrine classification → chassis template
+(`templates/affidavit_death_jt_ca/`) → **new shared jurat partial**
+(`templates/_partials/notary_jurat.jinja2`, Gov C §8202) → type
+registration → builder path (Property → Affidavit Facts → Recording) →
+generation gate → stored hash-stamped PDF → resume. 8 backend pins +
+frontend pins; all pre-existing gates green.
+
+## Doctrine pass results
+
+| Classification | Elements |
+|---|---|
+| **Form furniture** (renders always) | Title; the sworn recitals ("…of legal age, being first duly sworn, deposes and says", "…is the decedent mentioned in the attached certified copy…as joint tenants, recorded on…"); ATTACH-DEATH-CERTIFICATE directive; recorder header; the §8202 jurat with its §8202(b) disclaimer box. Precedent applied: Flag-3 — instrument-defining recitals are furniture because *choosing the instrument is the officer's decision*. |
+| **Officer-supplied facts** (typed; missing facts render as the reference's blank lines, never invented) | Affiant, decedent, JT-deed date / grantor / grantees, recording date, instrument number; plus the standard chassis fields (APN, county, legal description — provenance-confirmed when county-sourced; requested-by ± address; mail-to; order/escrow). |
+| **Legal choices** | **None found.** No DTT (not a conveyance — title passes by survivorship; the reference carries no tax block, and the template renders none). No vesting. No exemption elections. |
+
+**Judgment calls flagged, not silently decided:**
+1. *Substantive gate strictness:* generation requires affiant + decedent +
+   legal description + the JT deed's recording reference (date +
+   instrument number). The other recital facts (JT deed date/grantor/
+   grantees) may print as blank lines, as the reference tolerates. Owner
+   may want them required too — one-line change.
+2. *Row-display aliasing:* the `deeds` table's party columns hold decedent
+   (grantor_name) and affiant (grantee_name) so Past Deeds rows read
+   sensibly and existing validation applies. The authoritative facts live
+   in `metadata.affidavit`. Fine at this scale; a `parties` JSONB column
+   is the eventual clean answer if the catalog grows past ~10 types.
+3. *Signature line:* reference-faithful bare line (no printed name
+   beneath) — the affiant signs at notarization.
+4. *Companion filings:* counties commonly want a **BOE-502-D** (change in
+   ownership — death of real property owner) with this affidavit. That is
+   PCOR-family — Tier B, owner-directed LAST. Noted, not designed.
+
+## What generalized from the deed chassis for FREE
+
+- The entire recorder page-one geometry (header block, open recorder
+  space, caption boundary, APN line) — copied conventions, zero rework,
+  and the G2/G3 pin discipline applied verbatim.
+- The whole persistence machine: metadata extras, autosave/draft rows,
+  resume with provenance, the generation gate, stored PDF + sha256,
+  honest pdf_error surfacing. **Zero backend flow changes** — one dict
+  key (`affidavit`) added to the extras tuple and models.
+- The builder shell: accordion, one-truth counter, Next buttons,
+  click-to-fix preview, property search with confirm-cards — all
+  type-parameterized rather than rebuilt.
+- WeasyPrint render path, no-chrome enforcement, six-flow untouched.
+
+## What did NOT generalize (the one-time builds)
+
+| Piece | Cost | Reusable for the catalog? |
+|---|---|---|
+| Jurat partial (§8202) | ~1 hr | **Yes — every sworn instrument** (entire affidavit family) now has it for free |
+| Type-branching in validation (`isAffidavitType`, per-type sections/substantive checks) | ~1 hr | Partially — the *pattern* now exists; each family adds a branch. At >3 families this should become a per-type config table (see below) |
+| Affidavit facts plumbing (types → section component → payload → proxies → resume → template context) | ~1.5 hr | The *shape* repeats per form; the mechanical steps are now a known checklist |
+| Template body + page-budget tuning | ~1 hr | Body is per-form by definition; the chassis CSS made it fast |
+
+**Total spike cost: roughly a half-day of focused work, most of it
+one-time.**
+
+## Projected marginal cost per additional Tier-A form
+
+- **Affidavit-family siblings** (Aff. Death – Trustee, – Community
+  Property w/ROS, – TOD beneficiary): **~1–2 hrs each.** Same jurat, same
+  section pattern, different recital text + 1–3 field differences.
+- **Deed variants** (JT Grant Deed, CP w/ROS Grant, Corporation Grantor,
+  etc.): **~1–2 hrs each** — the deed chassis already does everything;
+  these are mostly title/recital/vesting-default variants of the five
+  shipped types.
+- **New families** (homestead declaration, trust certification): **~half
+  day for the first of each family**, sibling rate after.
+
+**Architecture recommendation before wave 1:** promote the per-type
+branches into a small form-registry config (sections list, substantive
+checks, payload mapper, template name per type). The affidavit proved the
+branch pattern works; a registry keeps type #7 from costing more than
+type #2. Half-day refactor, pays for itself by the third form.
+
+## Surprises
+
+1. **No doctrine surprises** — the suggest→confirm→record machine and the
+   blank-contents rule mapped onto a sworn instrument without strain. The
+   jurat fork was exactly the shaped hole the ticket predicted.
+2. The **one-page budget** was the only real fight (the deed chassis
+   spends vertical space freely because deeds run two pages; the
+   affidavit must not). Worth a shared "compact chassis" CSS variant if
+   more one-pagers come.
+3. `is_test`-style aliasing debt (judgment call 2) is the only schema
+   smell — flagged above with its exit ramp.

--- a/docs/FORMS_TRIAGE.md
+++ b/docs/FORMS_TRIAGE.md
@@ -1,0 +1,50 @@
+# FORMS-TRIAGE — PCT Library (~76 CA forms), One Page
+
+**Tier A — recordable single instruments; fit the chassis (build these)**
+
+*Deed variants (chassis does ~everything already):* Grant Deed – Joint
+Tenancy · Grant Deed – Community Property w/Right of Survivorship · Grant
+Deed – Corporation/Partnership as Grantor · Inter-Domestic-Partner Grant ·
+Interspousal (shipped) · Quitclaim variants (shipped base). *Rationale:*
+title/recital/vesting-default variations on shipped templates.
+
+*Affidavit family (jurat partial now exists):* Affidavit of Death – Joint
+Tenant (SHIPPED, the spike) · – Surviving Spouse/CP w/ROS · – Trustee ·
+– TOD beneficiary. *Rationale:* same sworn-statement skeleton, 1–3 field
+deltas each; highest non-deed volume in escrow.
+
+*Other single recordables:* Declaration of Homestead (+ Abandonment) ·
+Certification of Trust (Prob C §18100.5 — sworn, jurat) · Revocation of
+Revocable TOD Deed · Power of Attorney (recordable, acknowledgment) ·
+Substitution of Trustee · Full/Partial Reconveyance. *Rationale:* one
+instrument, one signer-set, recorder-formatted — chassis-shaped.
+
+**Tier B — fillable government forms; need a form-fill pipeline (LAST, owner directive)**
+
+PCOR / BOE-502-A · BOE-502-D (death of owner — the affidavit's natural
+companion) · BOE-58-AH / BOE-19 family (parent-child etc.) · BOE-261-G
+(veterans) · county-specific exemption forms. *Rationale:* these are
+overlay-fill on government-issued PDFs with their own revisions — a
+different pipeline (form-field mapping, not chassis rendering). Explicitly
+sequenced last per owner; the BOE-502-D companionship is the reason B
+eventually matters.
+
+**Tier C — defer indefinitely**
+
+Promissory notes · payoff demands · mechanic's-lien questionnaires/
+releases · subordination agreements · escrow instructions/amendments ·
+lender packages. *Rationale:* multi-party contractual or lender documents,
+mostly not recorded instruments; drafting them edges toward practice-of-law
+territory the doctrine deliberately avoids.
+
+**Recommended first wave (owner to rank), 7 forms:**
+1. Affidavit of Death – Surviving Spouse (CP w/ROS) — sibling, ~1–2 hrs
+2. Affidavit of Death – Trustee — sibling, ~1–2 hrs
+3. Grant Deed – Joint Tenancy — deed variant, escrow staple
+4. Grant Deed – CP w/Right of Survivorship — deed variant, pairs with #1
+5. Declaration of Homestead — new family, high consumer demand, jurat reuse
+6. Certification of Trust — sworn instrument, title-company request magnet
+7. Revocation of Revocable TOD Deed — small, completes a common workflow
+
+*Pre-wave recommendation from the spike report: the half-day form-registry
+refactor, so type #7 costs what type #2 costs.*

--- a/frontend/src/__tests__/d3ClickToFix.test.ts
+++ b/frontend/src/__tests__/d3ClickToFix.test.ts
@@ -23,7 +23,7 @@ function readSource(...segments: string[]): string {
 const PREVIEW = readSource('components', 'builder', 'PreviewPanel.tsx');
 const BUILDER = readSource('features', 'builder', 'DeedBuilder.tsx');
 
-const KNOWN_SECTIONS = new Set(['property', 'grantor', 'grantee', 'vesting', 'transferTax', 'recording']);
+const KNOWN_SECTIONS = new Set(['property', 'grantor', 'grantee', 'vesting', 'transferTax', 'recording', 'affidavit']);
 const FIELD_ANCHORS: Array<[string, string[]]> = [
   ['grantee', ['components', 'builder', 'sections', 'GranteeSection.tsx']],
   ['dtt-value', ['components', 'builder', 'sections', 'TransferTaxSection.tsx']],
@@ -50,7 +50,16 @@ describe('D3 — every preview data region is clickable with a valid mapping', (
   it('every field-level mapping has a data-builder-field anchor', () => {
     const fields = gos.map((m) => m[2]).filter(Boolean) as string[];
     expect(fields.length).toBeGreaterThanOrEqual(5);
+    const affidavitSrc = readSource('components', 'builder', 'sections', 'AffidavitSection.tsx');
     for (const field of new Set(fields)) {
+      if (field.startsWith('affidavit-')) {
+        // FORMS-SPIKE: AffidavitSection stamps its anchors dynamically
+        // (data-builder-field={`affidavit-${key}`}); assert the pattern
+        // and that the key is a real AffidavitFacts field.
+        expect(affidavitSrc).toContain('data-builder-field={`affidavit-${key}`}');
+        expect(affidavitSrc).toContain(`'${field.replace('affidavit-', '')}'`);
+        continue;
+      }
       const anchor = FIELD_ANCHORS.find(([name]) => name === field);
       expect(anchor).toBeDefined();
       const src = readSource(...anchor![1]);

--- a/frontend/src/app/api/deeds/draft/route.ts
+++ b/frontend/src/app/api/deeds/draft/route.ts
@@ -37,6 +37,7 @@ export async function POST(req: NextRequest) {
       escrow_no: payload.escrow_no || null,
       return_to: payload.return_to || null,
       provenance: payload.provenance || null,
+      affidavit: payload.affidavit || null,
     };
 
     const authHeader = req.headers.get('authorization');

--- a/frontend/src/app/api/deeds/generate/route.ts
+++ b/frontend/src/app/api/deeds/generate/route.ts
@@ -37,6 +37,7 @@ export async function POST(req: NextRequest) {
       escrow_no: payload.escrow_no || null,
       return_to: payload.return_to || null,
       provenance: payload.provenance || null,
+      affidavit: payload.affidavit || null,
     };
 
     const authHeader = req.headers.get('authorization');

--- a/frontend/src/app/deed-builder/page.tsx
+++ b/frontend/src/app/deed-builder/page.tsx
@@ -36,6 +36,13 @@ const DEED_TYPES = [
     description: 'Transfer resulting from tax sale — typically used by government entities',
     popular: false,
   },
+  // FORMS-SPIKE: first non-deed instrument on the chassis.
+  {
+    id: 'affidavit-death-jt',
+    title: 'Affidavit — Death of Joint Tenant',
+    description: 'Clears a deceased joint tenant from title — sworn statement with jurat, death certificate attached',
+    popular: false,
+  },
 ];
 
 export default function DeedBuilderSelectPage() {

--- a/frontend/src/components/builder/InputPanel.tsx
+++ b/frontend/src/components/builder/InputPanel.tsx
@@ -10,6 +10,8 @@ import { GranteeSection } from './sections/GranteeSection';
 import { VestingSection } from './sections/VestingSection';
 import { TransferTaxSection } from './sections/TransferTaxSection';
 import { RecordingSection } from './sections/RecordingSection';
+import { AffidavitSection } from './sections/AffidavitSection';
+import { isAffidavitType } from '@/lib/deedValidation';
 import { DeedBuilderState } from '@/types/builder';
 
 interface InputPanelProps {
@@ -102,10 +104,26 @@ export function InputPanel({
           <PropertySection
             value={state.property}
             onChange={(property) => onChange({ property })}
-            onComplete={() => toggleSection('grantor')}
+            onComplete={() => toggleSection(isAffidavitType(state.deedType) ? 'affidavit' : 'grantor')}
           />
         </InputSection>
 
+        {isAffidavitType(state.deedType) ? (
+        <InputSection
+          id="affidavit"
+          title="Affidavit Facts"
+          status={statuses.affidavit}
+          preview={state.affidavit?.decedentName || 'Decedent, affiant, and the JT deed reference'}
+          isExpanded={expandedSection === 'affidavit'}
+          onToggle={() => toggleSection('affidavit')}
+        >
+          <AffidavitSection
+            value={state.affidavit}
+            onChange={(affidavit) => onChange({ affidavit })}
+          />
+          <SectionNext to="recording" label="Next: Recording Info" />
+        </InputSection>
+        ) : (<>
         <InputSection
           id="grantor"
           title="Grantor"
@@ -190,6 +208,7 @@ export function InputPanel({
           />
           <SectionNext to="recording" label="Next: Recording Info" />
         </InputSection>
+        </>)}
 
         <InputSection
           id="recording"

--- a/frontend/src/components/builder/PreviewPanel.tsx
+++ b/frontend/src/components/builder/PreviewPanel.tsx
@@ -35,6 +35,7 @@ const DEED_TITLES: Record<string, string> = {
   'interspousal-transfer': 'INTERSPOUSAL TRANSFER DEED',
   'warranty-deed': 'WARRANTY DEED',
   'tax-deed': 'TAX DEED',
+  'affidavit-death-jt': 'AFFIDAVIT — DEATH OF JOINT TENANT',
 };
 
 function Checkline({ marked }: { marked: boolean }) {
@@ -76,6 +77,12 @@ export function PreviewPanel({ state, activeSection, onRegionClick }: PreviewPan
   }), [state]);
 
   const deedTitle = DEED_TITLES[state.deedType] || 'DEED';
+  // FORMS-SPIKE: affidavit instruments render a sworn-statement body —
+  // no DTT declaration, no granting clause, jurat instead of an
+  // acknowledgment.
+  const isAffidavit = state.deedType === 'affidavit-death-jt';
+  const aff = state.affidavit;
+  const factOrBlank = (v: string | undefined) => v?.trim() || '________________';
   const operative = OPERATIVE_WORDS[state.deedType] || OPERATIVE_WORDS['grant-deed'];
   const exemptionRecital = EXEMPTION_RECITALS[state.deedType];
 
@@ -177,6 +184,70 @@ export function PreviewPanel({ state, activeSection, onRegionClick }: PreviewPan
               {deedTitle}
             </h1>
 
+            {isAffidavit ? (
+              <>
+                {/* Sworn-statement recital — form furniture; the FACTS are
+                    officer-typed and highlighted/clickable like deed data. */}
+                <div className={`text-[11pt] leading-relaxed mb-3 ${highlight('affidavit')}`}>
+                  <p className="mb-2">
+                    <span onClick={go('affidavit', 'affidavit-affiantName')} className={`font-bold uppercase ${CLICKABLE} ${dataHighlight(aff?.affiantName)}`}>{factOrBlank(aff?.affiantName)}</span>,
+                    {' '}of legal age, being first duly sworn, deposes and says:
+                  </p>
+                  <p className="mb-2">
+                    <span onClick={go('affidavit', 'affidavit-decedentName')} className={`font-bold uppercase ${CLICKABLE} ${dataHighlight(aff?.decedentName)}`}>{factOrBlank(aff?.decedentName)}</span>
+                    {' '}is the decedent mentioned in the attached certified copy of Certificate of Death,
+                    and is the same person who is named as one of the parties in that certain deed dated{' '}
+                    <span onClick={go('affidavit', 'affidavit-jtDeedDate')} className={`${CLICKABLE} ${dataHighlight(aff?.jtDeedDate)}`}>{factOrBlank(aff?.jtDeedDate)}</span>, executed by{' '}
+                    <span onClick={go('affidavit', 'affidavit-jtDeedGrantor')} className={`font-bold uppercase ${CLICKABLE} ${dataHighlight(aff?.jtDeedGrantor)}`}>{factOrBlank(aff?.jtDeedGrantor)}</span> to{' '}
+                    <span onClick={go('affidavit', 'affidavit-jtDeedGrantees')} className={`font-bold uppercase ${CLICKABLE} ${dataHighlight(aff?.jtDeedGrantees)}`}>{factOrBlank(aff?.jtDeedGrantees)}</span>
+                    {' '}as joint tenants, recorded on{' '}
+                    <span onClick={go('affidavit', 'affidavit-recordingDate')} className={`${CLICKABLE} ${dataHighlight(aff?.recordingDate)}`}>{factOrBlank(aff?.recordingDate)}</span>, as Instrument No.{' '}
+                    <span onClick={go('affidavit', 'affidavit-instrumentNo')} className={`${CLICKABLE} ${dataHighlight(aff?.instrumentNo)}`}>{factOrBlank(aff?.instrumentNo)}</span>,
+                    {' '}Official Records of{' '}
+                    <span onClick={go('property')} className={`font-bold ${CLICKABLE} ${placeholder(preview.county)} ${dataHighlight(preview.county)}`}>{preview.county}</span>
+                    {' '}County, California, describing the following real property:
+                  </p>
+                </div>
+
+                <div className={`mb-3 ${highlight('property')}`}>
+                  <span onClick={go('property')} className={`font-bold text-[10.5pt] whitespace-pre-wrap ${CLICKABLE} ${placeholder(preview.legalDescription)} ${dataHighlight(preview.legalDescription)}`}>
+                    {preview.legalDescription}
+                  </span>
+                </div>
+
+                <div className="mt-6 flex justify-between items-end gap-4">
+                  <div className="text-[11pt]">Dated: <span className="inline-block min-w-[1.6in] border-b border-black" /></div>
+                  <div className="w-[45%]"><div className="border-b border-black h-7" /></div>
+                </div>
+
+                {/* Jurat sketch — Gov C §8202: sworn, not acknowledged. All
+                    entries are the notary's; nothing pre-fills. */}
+                <div className="mt-5 text-[9.5px] border border-black p-2 leading-snug">
+                  A notary public or other officer completing this certificate verifies only the
+                  identity of the individual who signed the document to which this certificate is
+                  attached, and not the truthfulness, accuracy, or validity of that document.
+                </div>
+                <div className="mt-3 text-[10px]">
+                  <div>STATE OF CALIFORNIA&nbsp;&nbsp;)</div>
+                  <div>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;)&nbsp;&nbsp;SS.</div>
+                  <div>COUNTY OF <span className="inline-block min-w-[1.4in] border-b border-black">{preview.county.startsWith('[') ? '' : preview.county}</span>&nbsp;)</div>
+                  <p className="mt-2">
+                    Subscribed and sworn to (or affirmed) before me on this ____ day of
+                    ____________, ______, by ______________________________, proved to me on the
+                    basis of satisfactory evidence to be the person(s) who appeared before me.
+                  </p>
+                  <div className="mt-4 flex justify-between items-end">
+                    <div>Signature <span className="inline-block min-w-[2in] border-b border-black" /></div>
+                    <div className="border border-black w-[1.6in] h-[1.1in] flex items-center justify-center text-center text-[8px] uppercase text-gray-500">(This area for notary stamp)</div>
+                  </div>
+                </div>
+
+                <div className="text-center text-[9px] font-bold uppercase mt-5">
+                  Attach Certified Copy of Death Certificate
+                </div>
+              </>
+            ) : (
+              <>
             {/* DTT declaration or categorical exemption recital */}
             {exemptionRecital ? (
               <div className={`text-[10px] mb-4 ${highlight('transferTax')}`}>
@@ -276,6 +347,8 @@ export function PreviewPanel({ state, activeSection, onRegionClick }: PreviewPan
             <div className="text-center text-[9px] font-bold uppercase mt-6">
               {MAIL_TAX_DIRECTIVE}
             </div>
+              </>
+            )}
 
           </div>
         </div>

--- a/frontend/src/components/builder/sections/AffidavitSection.tsx
+++ b/frontend/src/components/builder/sections/AffidavitSection.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+// FORMS-SPIKE: the affidavit's officer-supplied facts. Every field here is
+// TYPED by the officer (names auto-uppercase like the deed parties) — no
+// confirm affordances: typing is the officer's act; "Confirm" stays
+// reserved for external-source data. The JT deed's recording reference
+// (date + instrument number) identifies the instrument being cleared.
+import type { AffidavitFacts } from '@/types/builder';
+
+interface AffidavitSectionProps {
+  value?: AffidavitFacts;
+  onChange: (affidavit: AffidavitFacts) => void;
+}
+
+const EMPTY: AffidavitFacts = {
+  affiantName: '',
+  decedentName: '',
+  jtDeedDate: '',
+  jtDeedGrantor: '',
+  jtDeedGrantees: '',
+  recordingDate: '',
+  instrumentNo: '',
+};
+
+export function AffidavitSection({ value, onChange }: AffidavitSectionProps) {
+  const facts = value ?? EMPTY;
+  const set = (patch: Partial<AffidavitFacts>) => onChange({ ...facts, ...patch });
+
+  const field = (
+    label: string,
+    key: keyof AffidavitFacts,
+    placeholder: string,
+    opts: { uppercase?: boolean; hint?: string } = {}
+  ) => (
+    <div>
+      <label className="block text-sm font-medium text-gray-700 mb-1">{label}</label>
+      <input
+        type="text"
+        data-builder-field={`affidavit-${key}`}
+        value={facts[key]}
+        onChange={(e) =>
+          set({ [key]: opts.uppercase ? e.target.value.toUpperCase() : e.target.value } as Partial<AffidavitFacts>)
+        }
+        placeholder={placeholder}
+        className={`w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500 ${
+          opts.uppercase ? 'uppercase' : ''
+        }`}
+      />
+      {opts.hint && <p className="text-xs text-gray-500 mt-1">{opts.hint}</p>}
+    </div>
+  );
+
+  return (
+    <div className="space-y-4">
+      {field('Affiant (person swearing the statement)', 'affiantName', 'JANE B. DOE', {
+        uppercase: true,
+        hint: 'Usually the surviving joint tenant. Signs before a notary.',
+      })}
+      {field('Decedent', 'decedentName', 'JOHN A. DOE', {
+        uppercase: true,
+        hint: 'As named on the certified copy of the Certificate of Death.',
+      })}
+
+      <div className="pt-2 border-t border-gray-200">
+        <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-3">
+          The joint-tenancy deed being cleared
+        </p>
+        <div className="space-y-4">
+          {field('Deed date', 'jtDeedDate', 'June 1, 2015')}
+          {field('Executed by (grantor on that deed)', 'jtDeedGrantor', 'ROBERT SELLER', { uppercase: true })}
+          {field('To (grantees, as joint tenants)', 'jtDeedGrantees', 'JOHN A. DOE AND JANE B. DOE', {
+            uppercase: true,
+          })}
+          {field('Recorded on', 'recordingDate', 'June 15, 2015')}
+          {field('Instrument No.', 'instrumentNo', '2015-0654321', {
+            hint: 'From the recorded JT deed — this is how the recorder ties the two documents.',
+          })}
+        </div>
+      </div>
+
+      <p className="text-xs text-gray-500 pt-1">
+        A certified copy of the death certificate must be attached to the
+        recorded affidavit — the generated form says so on its face.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/lib/deedPayload.ts
+++ b/frontend/src/lib/deedPayload.ts
@@ -15,6 +15,14 @@ import {
 } from '@/lib/provenance';
 
 export function buildDeedPayload(genState: DeedBuilderState) {
+  // FORMS-SPIKE: for affidavit instruments the deeds row's party columns
+  // are display aliases — grantor_name holds the DECEDENT (whose interest
+  // clears) and grantee_name the AFFIANT, so Past Deeds rows read
+  // sensibly and the backend's critical-field validation applies to the
+  // affidavit's real substance. The authoritative facts live in
+  // metadata.affidavit. Aliasing is FLAGGED in the spike report.
+  const isAffidavit = genState.deedType === 'affidavit-death-jt';
+  const aff = genState.affidavit;
   return {
     doc_type: genState.deedType,
     county: genState.property?.county || '',
@@ -25,8 +33,8 @@ export function buildDeedPayload(genState: DeedBuilderState) {
     property_zip: genState.property?.zip || '',
     current_owner: genState.property?.owner || '',
     legal_description: genState.property?.legalDescription || '',
-    grantors_text: genState.grantor,
-    grantees_text: genState.grantee,
+    grantors_text: isAffidavit ? (aff?.decedentName || '') : genState.grantor,
+    grantees_text: isAffidavit ? (aff?.affiantName || '') : genState.grantee,
     vesting: genState.vesting,
     requested_by: genState.requestedBy,
     requested_by_address: genState.requestedByAddress || '',
@@ -46,6 +54,17 @@ export function buildDeedPayload(genState: DeedBuilderState) {
       : genState.requestedBy,
     title_order_no: genState.titleOrderNo || '',
     escrow_no: genState.escrowNo || '',
+    affidavit: isAffidavit && aff
+      ? {
+          affiant_name: aff.affiantName || '',
+          decedent_name: aff.decedentName || '',
+          jt_deed_date: aff.jtDeedDate || '',
+          jt_deed_grantor: aff.jtDeedGrantor || '',
+          jt_deed_grantees: aff.jtDeedGrantees || '',
+          recording_date: aff.recordingDate || '',
+          instrument_no: aff.instrumentNo || '',
+        }
+      : null,
     dtt: {
       transfer_value: genState.dtt?.transferValue?.replace(/[^0-9]/g, '') || '',
       is_exempt: genState.dtt?.isExempt || false,

--- a/frontend/src/lib/deedResume.ts
+++ b/frontend/src/lib/deedResume.ts
@@ -167,6 +167,17 @@ export function hydrateStateFromDeedRow(row: Record<string, any>): ResumeResult 
         : undefined,
     requestedBy: row.requested_by || '',
     requestedByAddress: meta.requested_by_address || '',
+    affidavit: meta.affidavit
+      ? {
+          affiantName: meta.affidavit.affiant_name || '',
+          decedentName: meta.affidavit.decedent_name || '',
+          jtDeedDate: meta.affidavit.jt_deed_date || '',
+          jtDeedGrantor: meta.affidavit.jt_deed_grantor || '',
+          jtDeedGrantees: meta.affidavit.jt_deed_grantees || '',
+          recordingDate: meta.affidavit.recording_date || '',
+          instrumentNo: meta.affidavit.instrument_no || '',
+        }
+      : undefined,
     returnTo,
     titleOrderNo: meta.title_order_no || '',
     escrowNo: meta.escrow_no || '',

--- a/frontend/src/lib/deedTypes.ts
+++ b/frontend/src/lib/deedTypes.ts
@@ -9,6 +9,7 @@ export const DEED_LABELS: Record<string, string> = {
   'interspousal-transfer': 'Interspousal Transfer Deed',
   'warranty-deed': 'Warranty Deed',
   'tax-deed': 'Tax Deed',
+  'affidavit-death-jt': 'Affidavit — Death of Joint Tenant',
 };
 
 /** Slug → display label; unknown slugs title-case rather than leak raw. */

--- a/frontend/src/lib/deedValidation.ts
+++ b/frontend/src/lib/deedValidation.ts
@@ -32,7 +32,43 @@ const dttComplete = (state: DeedBuilderState): boolean => {
   return (dtt.isExempt && !!dtt.exemptReason) || !!dtt.transferValue;
 };
 
+/** FORMS-SPIKE: instrument families diverge here — affidavits have no
+ * grantor/grantee/vesting/DTT; their substance is the sworn facts. */
+export function isAffidavitType(deedType: string | undefined): boolean {
+  return deedType === 'affidavit-death-jt';
+}
+
 export function evaluateSubstantive(state: DeedBuilderState): CheckResult[] {
+  if (isAffidavitType(state.deedType)) {
+    const aff = state.affidavit;
+    return [
+      {
+        id: 'affiant_present',
+        label: 'Affiant stated',
+        ok: !!aff?.affiantName?.trim(),
+        sectionId: 'affidavit',
+      },
+      {
+        id: 'decedent_present',
+        label: 'Decedent stated',
+        ok: !!aff?.decedentName?.trim(),
+        sectionId: 'affidavit',
+      },
+      {
+        id: 'jt_deed_reference',
+        label: 'Joint-tenancy deed recording reference',
+        ok: !!aff?.instrumentNo?.trim() && !!aff?.recordingDate?.trim(),
+        detail: 'The recorded JT deed is identified by its recording date and instrument number.',
+        sectionId: 'affidavit',
+      },
+      {
+        id: 'legal_description_present',
+        label: 'Legal description present',
+        ok: !!state.property?.legalDescription?.trim(),
+        sectionId: 'property',
+      },
+    ];
+  }
   const pending = isDttSuggestionPending(state);
   // Decided = a recorded instruction exists, or (legacy drafts predating the
   // decision record) the section is complete with no suggestion pending.
@@ -96,12 +132,19 @@ export function evaluateRecorderPreflight(state: DeedBuilderState): CheckResult[
       detail: 'The "when recorded mail to" block should identify a recipient.',
       sectionId: 'recording',
     },
-    {
-      id: 'acknowledgment_page',
-      label: 'Acknowledgment page (CC §1189)',
-      ok: true, // included by every deed template (Ticket N); static template fact
-      detail: 'Included automatically in the generated document.',
-    },
+    isAffidavitType(state.deedType)
+      ? {
+          id: 'jurat_included',
+          label: 'Jurat (Gov C §8202)',
+          ok: true, // the affidavit template includes it; static template fact
+          detail: 'Affidavits are sworn statements — a jurat renders automatically.',
+        }
+      : {
+          id: 'acknowledgment_page',
+          label: 'Acknowledgment page (CC §1189)',
+          ok: true, // included by every deed template (Ticket N); static template fact
+          detail: 'Included automatically in the generated document.',
+        },
     {
       id: 'page_setup',
       label: 'Page size and recorder box',
@@ -166,6 +209,25 @@ export function deriveSectionTruth(state: DeedBuilderState): SectionTruth {
     }
     return 'complete';
   };
+
+  if (isAffidavitType(state.deedType)) {
+    const aff = state.affidavit;
+    const affFilled = !!(aff?.affiantName?.trim() && aff?.decedentName?.trim() &&
+      aff?.instrumentNo?.trim() && aff?.recordingDate?.trim());
+    const statuses: Record<string, SectionStatus> = {
+      property: status('property', !!state.property?.address),
+      affidavit: status('affidavit', affFilled),
+      recording: status('recording', !!state.requestedBy?.trim()),
+    };
+    const values = Object.values(statuses);
+    return {
+      statuses,
+      completedCount: values.filter((s) => s === 'complete').length,
+      totalSections: values.length,
+      readyForGate: !values.includes('empty') && failingSections.size === 0,
+      pendingConfirmations: candidates.length,
+    };
+  }
 
   const granteeEchoesGrantor =
     !!state.grantee?.trim() &&

--- a/frontend/src/types/builder.ts
+++ b/frontend/src/types/builder.ts
@@ -67,6 +67,16 @@ export interface DTTData {
   cityName?: string;
 }
 
+export interface AffidavitFacts {
+  affiantName: string;
+  decedentName: string;
+  jtDeedDate: string;
+  jtDeedGrantor: string;
+  jtDeedGrantees: string;
+  recordingDate: string;
+  instrumentNo: string;
+}
+
 export interface DeedBuilderState {
   deedType: string;
   property: PropertyData | null;
@@ -93,6 +103,8 @@ export interface DeedBuilderState {
    * confirmations.
    */
   preflightOverrides?: Record<string, string>;
+  /** FORMS-SPIKE: affidavit-of-death facts (affidavit-death-jt type). */
+  affidavit?: AffidavitFacts;
   requestedBy: string;
   /** D2: the requesting party's mailing address (one line, optional). */
   requestedByAddress?: string;

--- a/templates/_partials/notary_jurat.jinja2
+++ b/templates/_partials/notary_jurat.jinja2
@@ -1,0 +1,178 @@
+{#
+  CALIFORNIA JURAT — Government Code § 8202
+  FORMS-SPIKE: affidavits are SWORN statements — the notarial certificate
+  is a jurat ("subscribed and sworn to before me"), not an acknowledgment
+  ("personally appeared ... acknowledged"). Using § 1189 language on an
+  affidavit is the classic wrong-certificate defect; this partial is the
+  jurat sibling of _partials/notary_acknowledgment.jinja2.
+
+  Blank-contents doctrine (Ticket N) applies identically: we generate the
+  form, never the notary's entries — date, affiant name, notary signature,
+  and seal are all blank. Only the venue county pre-fills (it is the
+  property county the officer already supplied).
+
+  Include with:
+  {% include '_partials/notary_jurat.jinja2' %}
+  Variables: county (venue), document_title (optional footer note).
+#}
+
+<style>
+.jurat-block {
+    margin-top: 0.12in;
+    font-family: "Times New Roman", Times, serif;
+    font-size: 10.5pt;
+    line-height: 1.5;
+    color: #000;
+    page-break-inside: avoid;
+}
+
+/* Required disclaimer box — Gov. Code § 8202(b) (same verbatim text the
+   Legislature prescribes for § 1189 acknowledgments). */
+.jurat-disclaimer {
+    border: 2px solid #000;
+    padding: 8px 12px;
+    margin-bottom: 0.1in;
+    font-size: 9.5pt;
+    line-height: 1.4;
+    text-align: justify;
+}
+
+.jurat-venue {
+    margin-bottom: 0.12in;
+}
+
+.jurat-venue-row {
+    display: flex;
+    align-items: baseline;
+    margin-bottom: 2px;
+}
+
+.jurat-venue-label {
+    width: 2.2in;
+}
+
+.jurat-venue-bracket {
+    width: 0.25in;
+    text-align: center;
+}
+
+.jurat-venue-ss {
+    font-size: 9pt;
+    margin-left: 0.1in;
+}
+
+.jurat-county-line {
+    border-bottom: 1px solid #000;
+    min-width: 1.8in;
+    display: inline-block;
+    padding-left: 4px;
+}
+
+.jurat-body {
+    text-align: justify;
+    margin-bottom: 0.15in;
+}
+
+.jurat-field {
+    border-bottom: 1px solid #000;
+    display: inline-block;
+    padding: 0 4px;
+    min-width: 1in;
+}
+
+.jurat-field.tiny { min-width: 0.5in; }
+.jurat-field.long { min-width: 3in; }
+
+.jurat-signature-section {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    margin-top: 0.1in;
+}
+
+.jurat-signature-block {
+    width: 3.2in;
+}
+
+.jurat-signature-line {
+    border-bottom: 1px solid #000;
+    width: 3in;
+    height: 0.4in;
+    margin-bottom: 4px;
+}
+
+.jurat-signature-label {
+    font-size: 10pt;
+}
+
+.jurat-seal-area {
+    border: 2px solid #000;
+    width: 2in;
+    height: 1.3in;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    flex-shrink: 0;
+}
+
+.jurat-seal-label {
+    font-size: 9.5pt;
+    font-weight: bold;
+    text-transform: uppercase;
+    color: #666;
+    line-height: 1.3;
+}
+</style>
+
+<div class="jurat-block">
+
+    <!-- REQUIRED DISCLAIMER BOX — Gov. Code § 8202(b) -->
+    <div class="jurat-disclaimer">
+        A notary public or other officer completing this certificate verifies only the identity
+        of the individual who signed the document to which this certificate is attached, and not
+        the truthfulness, accuracy, or validity of that document.
+    </div>
+
+    <!-- VENUE -->
+    <div class="jurat-venue">
+        <div class="jurat-venue-row">
+            <span class="jurat-venue-label">STATE OF CALIFORNIA</span>
+            <span class="jurat-venue-bracket">)</span>
+        </div>
+        <div class="jurat-venue-row">
+            <span class="jurat-venue-label"></span>
+            <span class="jurat-venue-bracket">)</span>
+            <span class="jurat-venue-ss">SS.</span>
+        </div>
+        <div class="jurat-venue-row">
+            <span class="jurat-venue-label">COUNTY OF <span class="jurat-county-line">{{ county or '' }}</span></span>
+            <span class="jurat-venue-bracket">)</span>
+        </div>
+    </div>
+
+    <!-- JURAT BODY — Gov. Code § 8202: every entry is the NOTARY's to
+         complete; nothing pre-fills. -->
+    <div class="jurat-body">
+        Subscribed and sworn to (or affirmed) before me on this
+        <span class="jurat-field tiny">______</span> day of
+        <span class="jurat-field">____________________</span>,
+        <span class="jurat-field tiny">________</span>, by
+        <span class="jurat-field long">___________________________________________</span>,
+        proved to me on the basis of satisfactory evidence to be the
+        person(s) who appeared before me.
+    </div>
+
+    <!-- SIGNATURE AND SEAL -->
+    <div class="jurat-signature-section">
+        <div class="jurat-signature-block">
+            <div class="jurat-signature-line"></div>
+            <div class="jurat-signature-label">Signature of Notary Public</div>
+        </div>
+
+        <div class="jurat-seal-area">
+            <span class="jurat-seal-label">(This area for<br>notary stamp)</span>
+        </div>
+    </div>
+
+</div>

--- a/templates/affidavit_death_jt_ca/index.jinja2
+++ b/templates/affidavit_death_jt_ca/index.jinja2
@@ -1,0 +1,227 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Affidavit - Death of Joint Tenant - California</title>
+    <style>
+        /* ==========================================================================
+           AFFIDAVIT — DEATH OF JOINT TENANT (FORMS-SPIKE)
+
+           First non-deed instrument on the G2/G3 chassis. Reference
+           implementation: Pacific Coast Title blank form #4 (Aff_Death-JT),
+           measured with pdfplumber (letter page; recorder caption at the
+           header boundary ~192pt; title immediately below; jurat in the
+           lower half; ATTACH directive at the foot).
+
+           Chassis rules carried over verbatim:
+           - Gov. Code §27361.6 recorder's space top-right, open, caption at
+             the boundary; §27361.7 no chrome on recorded pages.
+           - Blank-contents doctrine: the affiant's execution and every
+             notarial entry stay blank — we generate the form, never the
+             sworn or notarial contents.
+           DELIBERATE DIFFERENCES from the deed chassis (reference-faithful):
+           - No DTT declaration: an affidavit of death is not a conveyance;
+             title passes by survivorship. The reference carries no tax block.
+           - No mail-tax directive; the header reads AND WHEN RECORDED MAIL
+             TO (there is no tax statement to direct).
+           - Jurat (Gov C §8202), NOT an acknowledgment (§1189): affidavits
+             are sworn statements — wrong-certificate is a real defect class.
+           ========================================================================== */
+
+        @page {
+            size: letter;
+            margin: 0.5in 0.5in 0.6in 0.6in;
+        }
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        body {
+            font-family: "Times New Roman", Times, Georgia, serif;
+            font-size: 11pt;
+            line-height: 1.35;
+            color: #000;
+            background: #fff;
+        }
+
+        .header-section { display: flex; min-height: 1.85in; }
+
+        .recording-info {
+            width: 3.4in;
+            flex-shrink: 0;
+            border-right: 0.75pt solid #000;
+            padding-right: 0.15in;
+            font-size: 10pt;
+            line-height: 1.35;
+        }
+
+        .recorder-space { flex-grow: 1; }
+
+        .recording-label {
+            font-weight: bold;
+            text-transform: uppercase;
+            font-size: 9pt;
+        }
+
+        .recording-value { margin-bottom: 0.12in; min-height: 0.35in; }
+
+        .ref-line { font-size: 10pt; }
+
+        .header-boundary {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            border-bottom: 0.75pt solid #000;
+            padding-bottom: 0.03in;
+            margin-bottom: 0.12in;
+        }
+
+        .apn-ref { font-weight: bold; font-size: 10pt; }
+
+        .recorder-caption {
+            font-size: 7.5pt;
+            font-weight: bold;
+            text-transform: uppercase;
+        }
+
+        .deed-title {
+            text-align: center;
+            font-size: 14pt;
+            font-weight: bold;
+            letter-spacing: 2px;
+            text-transform: uppercase;
+            margin: 0.1in 0 0.14in 0;
+        }
+
+        .affidavit-body {
+            font-size: 11pt;
+            line-height: 1.55;
+            text-align: justify;
+        }
+
+        .affidavit-body p { margin-bottom: 0.12in; }
+
+        .fact {
+            /* Officer-supplied facts render bold like the deed parties; a
+               missing fact renders as the reference's blank line so an
+               incomplete instrument LOOKS incomplete. */
+            font-weight: bold;
+        }
+
+        .fact-line {
+            display: inline-block;
+            min-width: 2.2in;
+            border-bottom: 1px solid #000;
+        }
+
+        .legal-content {
+            font-weight: bold;
+            white-space: pre-wrap;
+            margin: 0.1in 0;
+            min-height: 0.55in;
+        }
+
+        .execution-section {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-end;
+            margin-top: 0.12in;
+            margin-bottom: 0.05in;
+        }
+
+        .signature-line {
+            border-bottom: 1px solid #000;
+            width: 3.2in;
+            height: 0.35in;
+        }
+
+        .attach-directive {
+            text-align: center;
+            font-size: 10pt;
+            font-weight: bold;
+            text-transform: uppercase;
+            margin-top: 0.12in;
+        }
+    </style>
+</head>
+<body>
+    <div class="deed-page">
+
+        <header class="header-section">
+            <div class="recording-info">
+                <div class="recording-label">Recording Requested By:</div>
+                <div class="recording-value">{{ requested_by or '' }}{% if requested_by_address %}<br>{{ requested_by_address }}{% endif %}</div>
+
+                <div class="recording-label">And When Recorded Mail To:</div>
+                <div class="recording-value">
+                    {% if return_to %}
+                        {% if return_to.get('name') %}{{ return_to.get('name') }}<br>{% endif %}
+                        {% if return_to.get('company') %}{{ return_to.get('company') }}<br>{% endif %}
+                        {% if return_to.get('address1') %}{{ return_to.get('address1') }}<br>{% endif %}
+                        {% if return_to.get('address2') %}{{ return_to.get('address2') }}<br>{% endif %}
+                        {% set city = return_to.get('city', '') %}
+                        {% set state = return_to.get('state', '') %}
+                        {% set zip = return_to.get('zip', '') %}
+                        {% if city or state or zip %}
+                            {{ city }}{% if city and (state or zip) %}, {% endif %}{{ state }} {{ zip }}
+                        {% endif %}
+                    {% else %}
+                        _________________________________<br>
+                        _________________________________<br>
+                        _________________________________
+                    {% endif %}
+                </div>
+
+                <div class="ref-line">Order No.: {{ title_order_no or '____________________' }}</div>
+                <div class="ref-line">Escrow No.: {{ escrow_no or '____________________' }}</div>
+            </div>
+
+            <div class="recorder-space"><!-- Gov. Code §27361.6 — recorder's use only --></div>
+        </header>
+
+        <div class="header-boundary">
+            <span class="apn-ref">APN: {{ apn or '____________________' }}</span>
+            <span class="recorder-caption">Space Above This Line Is For Recorder&rsquo;s Use</span>
+        </div>
+
+        <h1 class="deed-title">Affidavit &mdash; Death of Joint Tenant</h1>
+
+        {% set aff = affidavit or {} %}
+        <div class="affidavit-body">
+            <p>
+                {% if aff.get('affiant_name') %}<span class="fact">{{ aff.get('affiant_name') }}</span>{% else %}<span class="fact-line">&nbsp;</span>{% endif %},
+                of legal age, being first duly sworn, deposes and says:
+            </p>
+            <p>
+                {% if aff.get('decedent_name') %}<span class="fact">{{ aff.get('decedent_name') }}</span>{% else %}<span class="fact-line">&nbsp;</span>{% endif %}
+                is the decedent mentioned in the attached certified copy of Certificate of Death,
+                and is the same person who is named as one of the parties in that certain deed
+                dated {% if aff.get('jt_deed_date') %}<span class="fact">{{ aff.get('jt_deed_date') }}</span>{% else %}<span class="fact-line" style="min-width:1.4in">&nbsp;</span>{% endif %},
+                executed by {% if aff.get('jt_deed_grantor') %}<span class="fact">{{ aff.get('jt_deed_grantor') }}</span>{% else %}<span class="fact-line">&nbsp;</span>{% endif %}
+                to {% if aff.get('jt_deed_grantees') %}<span class="fact">{{ aff.get('jt_deed_grantees') }}</span>{% else %}<span class="fact-line">&nbsp;</span>{% endif %}
+                as joint tenants, recorded on
+                {% if aff.get('recording_date') %}<span class="fact">{{ aff.get('recording_date') }}</span>{% else %}<span class="fact-line" style="min-width:1.4in">&nbsp;</span>{% endif %},
+                as Instrument No. {% if aff.get('instrument_no') %}<span class="fact">{{ aff.get('instrument_no') }}</span>{% else %}<span class="fact-line" style="min-width:1.4in">&nbsp;</span>{% endif %},
+                Official Records of
+                {% if county %}<span class="fact">{{ county }}</span>{% else %}<span class="fact-line" style="min-width:1.6in">&nbsp;</span>{% endif %}
+                County, California, describing the following real property:
+            </p>
+        </div>
+
+        <div class="legal-content">{{ legal_description or '' }}</div>
+
+        {# Execution: the affiant signs at the notarization — the date and
+           signature are theirs, not ours (blank-contents doctrine). #}
+        <div class="execution-section">
+            <div>Dated: <span class="fact-line" style="min-width:1.8in">&nbsp;</span></div>
+            <div>
+                <div class="signature-line"></div>
+            </div>
+        </div>
+
+        {% include '_partials/notary_jurat.jinja2' %}
+
+        <div class="attach-directive">Attach Certified Copy of Death Certificate</div>
+
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## FORMS-SPIKE — the canary flew

One real form end to end, priced. Reference: PCT blank form #4, fetched and pdfplumber-measured (one-page letter instrument, caption ~192pt, jurat in the lower half).

### Doctrine pass (before any template — full classification in `docs/FORMS_SPIKE_REPORT.md`)
- **Furniture:** the sworn recitals (Flag-3 precedent: instrument-defining recitals are furniture — choosing the instrument IS the officer's decision), the ATTACH-CERTIFICATE directive, the §8202 jurat.
- **Officer facts:** affiant, decedent, JT-deed date/grantor/grantees, recording date, instrument number — missing facts print as the reference's blank lines, never invented.
- **Legal choices: none.** No DTT (not a conveyance — title passes by survivorship; the reference carries no tax block, the template renders none).
- **Four judgment calls flagged, not silently decided** (gate strictness · party-column display aliasing · bare signature line · the BOE-502-D companion, which is Tier B and owner-directed last).

### The jurat fork — the doctrine test passed
New shared partial `_partials/notary_jurat.jinja2` (Gov C §8202): affidavits are **sworn**, never acknowledged. Ticket-N occurrence pins: exactly one notarial certificate · it says "Subscribed and sworn" · "personally appeared" is absent · **no affiant or notary entry pre-fills** (venue county only). The wrong-certificate defect class is now structural, and every future sworn instrument gets the jurat free.

### Chassis + builder
Recorder-compliant page one (open space, caption boundary, no chrome — geometry pins), one-page budget held. Builder: type selectable → Property → **Affidavit Facts** (typed inputs, auto-uppercase, deliberately **no confirm affordances** — typing is the officer's act) → Recording → gate → stored sha256 PDF. Autosave, resume, click-to-fix preview (with a jurat sketch), and the one-truth counter all reuse the existing machinery — the entire persistence/generation stack needed **one dict key**.

### The price tag (full report in `docs/FORMS_SPIKE_REPORT.md`)
- Spike total: **~half a day**, most of it one-time (jurat partial, type-branch pattern, plumbing checklist).
- Marginal cost per affidavit-family sibling or deed variant: **~1–2 hours.**
- New families (homestead, trust cert): ~half-day for the first, sibling rate after.
- **Pre-wave recommendation:** a half-day form-registry refactor (sections/checks/mapper/template per type as config) so type #7 costs what type #2 costs.

### FORMS-TRIAGE (`docs/FORMS_TRIAGE.md`, one page)
A/B/C tiers over the ~76-form PCT library, with the recommended **7-form first wave** for the owner to rank (two affidavit siblings, two deed variants, homestead, trust certification, TOD revocation). PCOR/BOE family confirmed Tier B, last, per directive.

### Gates
Backend **107** (99 + 8 new) · six-flow ✔ · jest **263** (pins evolved for the new type) · tsc **98**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_