### PR TITLE
FORMS registry + flag rulings: one entry per type; BOE-502-D passive notice

### DIFF
--- a/docs/FORMS_SPIKE_REPORT.md
+++ b/docs/FORMS_SPIKE_REPORT.md
@@ -94,3 +94,22 @@ type #2. Half-day refactor, pays for itself by the third form.
    more one-pagers come.
 3. `is_test`-style aliasing debt (judgment call 2) is the only schema
    smell — flagged above with its exit ramp.
+
+---
+
+## Addendum — owner rulings on the four flags (2026-07-30)
+
+1. **Gate strictness:** stays as built — reference-faithful; tolerated
+   blanks stand. Owner may tighten later (one-line change).
+2. **Party-column aliasing:** accepted. **LEDGERED:** migrate to a
+   `parties` JSONB column when EITHER trigger fires — catalog exceeds
+   10 types, OR the first form arrives whose parties cannot map onto
+   grantor_name/grantee_name.
+3. **Bare signature line:** approved as built.
+4. **BOE-502-D:** stays Tier B, last. A PASSIVE success-page notice now
+   ships (registry `companionNotice`) linking the state BOE forms page —
+   guidance only, no form-fill work.
+
+Registry refactor: executed (lib/formRegistry.ts; labels, titles,
+sections, family, notarial cert, DTT flag, and companion guidance all
+derive from one entry per type). Wave 1 fires on the owner's ranking.

--- a/frontend/src/__tests__/formRegistry.test.ts
+++ b/frontend/src/__tests__/formRegistry.test.ts
@@ -1,0 +1,108 @@
+/**
+ * FORMS registry — one entry per instrument type, pinned.
+ *
+ * The registry is the single source of type facts (labels, titles,
+ * sections, family, notarial certificate, DTT, companion guidance). The
+ * consumers derive from it, so adding a Tier-A sibling is one entry +
+ * one template — and a config can never smuggle in a legal choice (there
+ * is deliberately no field for one).
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+import { FORM_REGISTRY, formConfig, formFamily } from '../lib/formRegistry';
+import { DEED_LABELS, deedTypeLabel } from '../lib/deedTypes';
+import { isAffidavitType } from '../lib/deedValidation';
+
+function readSource(...segments: string[]): string {
+  return fs.readFileSync(path.join(__dirname, '..', ...segments), 'utf8');
+}
+
+const KNOWN_SECTIONS = new Set(['property', 'grantor', 'grantee', 'vesting', 'transferTax', 'recording', 'affidavit']);
+
+describe('FORMS registry — completeness and coherence', () => {
+  const entries = Object.values(FORM_REGISTRY);
+
+  it('carries the six shipped types', () => {
+    expect(entries.length).toBe(6);
+    expect(formConfig('affidavit-death-jt')?.family).toBe('affidavit');
+  });
+
+  it('every entry is internally coherent', () => {
+    for (const f of entries) {
+      expect(FORM_REGISTRY[f.slug].slug).toBe(f.slug);
+      expect(f.label.length).toBeGreaterThan(3);
+      expect(f.title.length).toBeGreaterThan(3);
+      for (const section of f.sections) {
+        expect(KNOWN_SECTIONS.has(section)).toBe(true);
+      }
+      // Doctrine coupling: sworn instruments carry a jurat, deed family
+      // an acknowledgment; only deed family declares DTT.
+      if (f.family === 'affidavit') {
+        expect(f.notarial).toBe('jurat');
+        expect(f.hasDtt).toBe(false);
+        expect(f.sections).toContain('affidavit');
+      } else {
+        expect(f.notarial).toBe('acknowledgment');
+        expect(f.hasDtt).toBe(true);
+        expect(f.sections).toContain('transferTax');
+      }
+    }
+  });
+
+  it('a registry entry cannot smuggle a legal choice (no auto-apply field)', () => {
+    // Strip comments first — the doctrine note ABOUT auto-apply must not
+    // trip the scan for auto-apply code (the stripComments lesson).
+    const src = readSource('lib', 'formRegistry.ts')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/\/\/[^\n]*/g, '');
+    expect(src).not.toMatch(/auto[_-]?apply/i);
+    for (const f of Object.values(FORM_REGISTRY)) {
+      expect(Object.keys(f)).not.toContain('autoApply');
+      expect(Object.keys(f)).not.toContain('defaults');
+    }
+  });
+});
+
+describe('FORMS registry — the consumers derive from it', () => {
+  it('labels: DEED_LABELS is the registry projection', () => {
+    for (const f of Object.values(FORM_REGISTRY)) {
+      expect(DEED_LABELS[f.slug]).toBe(f.label);
+      expect(deedTypeLabel(f.slug)).toBe(f.label);
+    }
+  });
+
+  it('family checks route through the registry', () => {
+    expect(isAffidavitType('affidavit-death-jt')).toBe(true);
+    expect(isAffidavitType('grant-deed')).toBe(false);
+    expect(formFamily('unknown-type')).toBe('deed'); // safe default
+  });
+
+  it('the selection page and preview read the registry', () => {
+    expect(readSource('app', 'deed-builder', 'page.tsx')).toContain('FORM_REGISTRY');
+    const preview = readSource('components', 'builder', 'PreviewPanel.tsx');
+    expect(preview).toContain("formConfig(state.deedType)?.title");
+    expect(preview).toContain("formFamily(state.deedType)");
+  });
+});
+
+describe('FORMS flag-4 ruling — the companion notice is passive guidance', () => {
+  it('the affidavit carries the BOE-502-D notice with the state link', () => {
+    const notice = formConfig('affidavit-death-jt')?.companionNotice;
+    expect(notice).toBeDefined();
+    expect(notice!.text).toContain('BOE-502-D');
+    expect(notice!.href).toContain('boe.ca.gov');
+  });
+
+  it('the success page renders it as guidance — never a block', () => {
+    const src = readSource('app', 'deed-builder', '[type]', 'success', 'success-content.tsx');
+    expect(src).toContain('companionNotice');
+    expect(src).toContain('rel="noopener noreferrer"');
+    // Guidance only: the notice must not gate any action.
+    expect(src).not.toMatch(/companionNotice[^}]*disabled/);
+  });
+
+  it('deed types carry no companion notice', () => {
+    expect(formConfig('grant-deed')?.companionNotice).toBeUndefined();
+  });
+});

--- a/frontend/src/app/deed-builder/[type]/success/success-content.tsx
+++ b/frontend/src/app/deed-builder/[type]/success/success-content.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useSearchParams, useParams, useRouter } from 'next/navigation';
+import { formConfig } from '@/lib/formRegistry';
 import { useEffect, useState } from 'react';
 import { 
   CheckCircle, Download, FileText, Share2, Printer, Copy, 
@@ -252,6 +253,22 @@ export function SuccessContent() {
                 <p className="text-slate-500 truncate">{propertyAddress}</p>
               </div>
             </div>
+
+            {/* FORMS flag-4 ruling: companion-filing guidance — passive,
+                links the state form, never a block and never form-fill. */}
+            {formConfig(type)?.companionNotice && (
+              <div className="mb-6 p-4 bg-blue-50 border border-blue-200 rounded-xl text-sm text-blue-900">
+                <p>{formConfig(type)!.companionNotice!.text}</p>
+                <a
+                  href={formConfig(type)!.companionNotice!.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="font-semibold underline hover:text-blue-700"
+                >
+                  {formConfig(type)!.companionNotice!.linkText} ↗
+                </a>
+              </div>
+            )}
 
             {/* Document ID + stored-PDF fingerprint (X2.8: downloads fetch
                 the server-stored bytes; the fingerprint makes "stored

--- a/frontend/src/app/deed-builder/page.tsx
+++ b/frontend/src/app/deed-builder/page.tsx
@@ -4,46 +4,16 @@ import { useRouter } from 'next/navigation';
 import { FileText, ArrowRight } from 'lucide-react';
 import Sidebar from '@/components/Sidebar';
 import { useRequireAuth } from '@/hooks/useRequireAuth';
+import { FORM_REGISTRY } from '@/lib/formRegistry';
 
-const DEED_TYPES = [
-  {
-    id: 'grant-deed',
-    title: 'Grant Deed',
-    description: 'Standard transfer of property ownership with implied warranties',
-    popular: true,
-  },
-  {
-    id: 'quitclaim-deed',
-    title: 'Quitclaim Deed',
-    description: 'Transfer ownership without warranties — commonly used between family members',
-    popular: true,
-  },
-  {
-    id: 'interspousal-transfer',
-    title: 'Interspousal Transfer Deed',
-    description: 'Transfer between spouses — exempt from documentary transfer tax',
-    popular: true,
-  },
-  {
-    id: 'warranty-deed',
-    title: 'Warranty Deed',
-    description: 'Provides the strongest buyer protections with full title guarantees',
-    popular: false,
-  },
-  {
-    id: 'tax-deed',
-    title: 'Tax Deed',
-    description: 'Transfer resulting from tax sale — typically used by government entities',
-    popular: false,
-  },
-  // FORMS-SPIKE: first non-deed instrument on the chassis.
-  {
-    id: 'affidavit-death-jt',
-    title: 'Affidavit — Death of Joint Tenant',
-    description: 'Clears a deceased joint tenant from title — sworn statement with jurat, death certificate attached',
-    popular: false,
-  },
-];
+// FORMS registry: the selectable catalog IS the registry — adding a
+// type there adds its card here.
+const DEED_TYPES = Object.values(FORM_REGISTRY).map((f) => ({
+  id: f.slug,
+  title: f.label,
+  description: f.description,
+  popular: f.popular,
+}));
 
 export default function DeedBuilderSelectPage() {
   // HX0: internal tool — no session, no shell.

--- a/frontend/src/components/builder/PreviewPanel.tsx
+++ b/frontend/src/components/builder/PreviewPanel.tsx
@@ -20,6 +20,9 @@ import {
   OPERATIVE_WORDS,
   EXEMPTION_RECITALS,
 } from '@/lib/deedFurniture';
+// FORMS registry: document titles + family come from the one source of
+// type facts.
+import { formConfig, formFamily } from '@/lib/formRegistry';
 
 interface PreviewPanelProps {
   state: DeedBuilderState;
@@ -28,15 +31,6 @@ interface PreviewPanelProps {
       focuses the matching input where one exists). Preview-only. */
   onRegionClick?: (section: string, field?: string) => void;
 }
-
-const DEED_TITLES: Record<string, string> = {
-  'grant-deed': 'GRANT DEED',
-  'quitclaim-deed': 'QUITCLAIM DEED',
-  'interspousal-transfer': 'INTERSPOUSAL TRANSFER DEED',
-  'warranty-deed': 'WARRANTY DEED',
-  'tax-deed': 'TAX DEED',
-  'affidavit-death-jt': 'AFFIDAVIT — DEATH OF JOINT TENANT',
-};
 
 function Checkline({ marked }: { marked: boolean }) {
   return (
@@ -76,11 +70,11 @@ export function PreviewPanel({ state, activeSection, onRegionClick }: PreviewPan
     county: state.property?.county || '[County]',
   }), [state]);
 
-  const deedTitle = DEED_TITLES[state.deedType] || 'DEED';
-  // FORMS-SPIKE: affidavit instruments render a sworn-statement body —
+  const deedTitle = formConfig(state.deedType)?.title || 'DEED';
+  // FORMS: affidavit instruments render a sworn-statement body —
   // no DTT declaration, no granting clause, jurat instead of an
-  // acknowledgment.
-  const isAffidavit = state.deedType === 'affidavit-death-jt';
+  // acknowledgment. Family from the registry.
+  const isAffidavit = formFamily(state.deedType) === 'affidavit';
   const aff = state.affidavit;
   const factOrBlank = (v: string | undefined) => v?.trim() || '________________';
   const operative = OPERATIVE_WORDS[state.deedType] || OPERATIVE_WORDS['grant-deed'];

--- a/frontend/src/lib/deedPayload.ts
+++ b/frontend/src/lib/deedPayload.ts
@@ -13,6 +13,7 @@ import {
   buildPreflightOverridesPayload,
   buildProvenancePayload,
 } from '@/lib/provenance';
+import { formFamily } from '@/lib/formRegistry';
 
 export function buildDeedPayload(genState: DeedBuilderState) {
   // FORMS-SPIKE: for affidavit instruments the deeds row's party columns
@@ -21,7 +22,7 @@ export function buildDeedPayload(genState: DeedBuilderState) {
   // sensibly and the backend's critical-field validation applies to the
   // affidavit's real substance. The authoritative facts live in
   // metadata.affidavit. Aliasing is FLAGGED in the spike report.
-  const isAffidavit = genState.deedType === 'affidavit-death-jt';
+  const isAffidavit = formFamily(genState.deedType) === 'affidavit';
   const aff = genState.affidavit;
   return {
     doc_type: genState.deedType,

--- a/frontend/src/lib/deedTypes.ts
+++ b/frontend/src/lib/deedTypes.ts
@@ -1,16 +1,12 @@
 /**
- * U3 — one place for deed-type naming. The builder header already showed
- * "Grant Deed" while Past Deeds rows showed the raw slug ("grant-deed");
- * both now read from here.
+ * U3 — one place for deed-type naming; since the FORMS registry landed,
+ * the labels derive from it (registry = single source of type facts).
  */
-export const DEED_LABELS: Record<string, string> = {
-  'grant-deed': 'Grant Deed',
-  'quitclaim-deed': 'Quitclaim Deed',
-  'interspousal-transfer': 'Interspousal Transfer Deed',
-  'warranty-deed': 'Warranty Deed',
-  'tax-deed': 'Tax Deed',
-  'affidavit-death-jt': 'Affidavit — Death of Joint Tenant',
-};
+import { FORM_REGISTRY } from '@/lib/formRegistry';
+
+export const DEED_LABELS: Record<string, string> = Object.fromEntries(
+  Object.values(FORM_REGISTRY).map((f) => [f.slug, f.label])
+);
 
 /** Slug → display label; unknown slugs title-case rather than leak raw. */
 export function deedTypeLabel(slug: string | undefined | null): string {

--- a/frontend/src/lib/deedValidation.ts
+++ b/frontend/src/lib/deedValidation.ts
@@ -32,10 +32,13 @@ const dttComplete = (state: DeedBuilderState): boolean => {
   return (dtt.isExempt && !!dtt.exemptReason) || !!dtt.transferValue;
 };
 
-/** FORMS-SPIKE: instrument families diverge here — affidavits have no
- * grantor/grantee/vesting/DTT; their substance is the sworn facts. */
+/** FORMS: instrument families diverge here — affidavits have no
+ * grantor/grantee/vesting/DTT; their substance is the sworn facts.
+ * Family membership comes from the registry (one entry per type). */
+import { formFamily } from '@/lib/formRegistry';
+
 export function isAffidavitType(deedType: string | undefined): boolean {
-  return deedType === 'affidavit-death-jt';
+  return formFamily(deedType) === 'affidavit';
 }
 
 export function evaluateSubstantive(state: DeedBuilderState): CheckResult[] {

--- a/frontend/src/lib/formRegistry.ts
+++ b/frontend/src/lib/formRegistry.ts
@@ -1,0 +1,131 @@
+/**
+ * FORMS registry — ONE entry per instrument type (owner-approved before
+ * wave 1, so type #7 costs what type #2 costs).
+ *
+ * The spike proved the chassis generalizes but left type facts scattered
+ * (labels here, titles there, family branches in validation). This
+ * registry is the single source: adding a Tier-A sibling means one entry
+ * here + a template + (usually) an existing section list.
+ *
+ * What a config CANNOT do: add legal choices. Anything beyond furniture +
+ * officer-supplied facts still requires the decision-gate treatment and a
+ * doctrine pass — the registry deliberately has no field for "auto-apply".
+ */
+
+export type NotarialCertificate = 'acknowledgment' | 'jurat';
+export type FormFamily = 'deed' | 'affidavit';
+
+export interface CompanionNotice {
+  /** Passive guidance ONLY — never a block, never form-fill work. */
+  text: string;
+  linkText: string;
+  href: string;
+}
+
+export interface FormTypeConfig {
+  slug: string;
+  /** List/table display label. */
+  label: string;
+  /** Document title as rendered on the instrument/preview. */
+  title: string;
+  /** Card copy on the type-selection page. */
+  description: string;
+  popular: boolean;
+  family: FormFamily;
+  /** Ordered builder sections for this type. */
+  sections: string[];
+  /** Which notarial certificate the template includes (informational —
+      templates own their includes; pinned in backend tests). */
+  notarial: NotarialCertificate;
+  /** Whether the instrument carries a documentary-transfer-tax block. */
+  hasDtt: boolean;
+  /** Success-page companion-filing guidance (owner ruling, spike flag 4). */
+  companionNotice?: CompanionNotice;
+}
+
+const DEED_SECTIONS = ['property', 'grantor', 'grantee', 'vesting', 'transferTax', 'recording'];
+const AFFIDAVIT_SECTIONS = ['property', 'affidavit', 'recording'];
+
+export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
+  'grant-deed': {
+    slug: 'grant-deed',
+    label: 'Grant Deed',
+    title: 'GRANT DEED',
+    description: 'Standard transfer of property ownership with implied warranties',
+    popular: true,
+    family: 'deed',
+    sections: DEED_SECTIONS,
+    notarial: 'acknowledgment',
+    hasDtt: true,
+  },
+  'quitclaim-deed': {
+    slug: 'quitclaim-deed',
+    label: 'Quitclaim Deed',
+    title: 'QUITCLAIM DEED',
+    description: 'Transfer ownership without warranties — commonly used between family members',
+    popular: true,
+    family: 'deed',
+    sections: DEED_SECTIONS,
+    notarial: 'acknowledgment',
+    hasDtt: true,
+  },
+  'interspousal-transfer': {
+    slug: 'interspousal-transfer',
+    label: 'Interspousal Transfer Deed',
+    title: 'INTERSPOUSAL TRANSFER DEED',
+    description: 'Transfer between spouses — exempt from documentary transfer tax',
+    popular: true,
+    family: 'deed',
+    sections: DEED_SECTIONS,
+    notarial: 'acknowledgment',
+    hasDtt: true,
+  },
+  'warranty-deed': {
+    slug: 'warranty-deed',
+    label: 'Warranty Deed',
+    title: 'WARRANTY DEED',
+    description: 'Provides the strongest buyer protections with full title guarantees',
+    popular: false,
+    family: 'deed',
+    sections: DEED_SECTIONS,
+    notarial: 'acknowledgment',
+    hasDtt: true,
+  },
+  'tax-deed': {
+    slug: 'tax-deed',
+    label: 'Tax Deed',
+    title: 'TAX DEED',
+    description: 'Transfer resulting from tax sale — typically used by government entities',
+    popular: false,
+    family: 'deed',
+    sections: DEED_SECTIONS,
+    notarial: 'acknowledgment',
+    hasDtt: true,
+  },
+  'affidavit-death-jt': {
+    slug: 'affidavit-death-jt',
+    label: 'Affidavit — Death of Joint Tenant',
+    title: 'AFFIDAVIT — DEATH OF JOINT TENANT',
+    description: 'Clears a deceased joint tenant from title — sworn statement with jurat, death certificate attached',
+    popular: false,
+    family: 'affidavit',
+    sections: AFFIDAVIT_SECTIONS,
+    notarial: 'jurat',
+    hasDtt: false,
+    // Spike flag 4 ruling: passive guidance only. The BOE-502-D itself is
+    // Tier B (form-fill pipeline), owner-directed LAST — no form-fill work.
+    companionNotice: {
+      text: 'Counties commonly require a BOE-502-D (Change in Ownership Statement — Death of Real Property Owner) filed with this affidavit.',
+      linkText: 'Get the form from the California BOE',
+      href: 'https://www.boe.ca.gov/proptaxes/forms.htm',
+    },
+  },
+};
+
+export function formConfig(slug: string | undefined | null): FormTypeConfig | undefined {
+  return slug ? FORM_REGISTRY[slug] : undefined;
+}
+
+export function formFamily(slug: string | undefined | null): FormFamily {
+  return formConfig(slug)?.family ?? 'deed';
+}


### PR DESCRIPTION
## The assembly-line prerequisite — registry executed, all four rulings implemented

### Registry (`lib/formRegistry.ts`)
One entry per instrument type carries: slug, label, document title, selection-card copy, family, ordered builder sections, notarial certificate (jurat vs acknowledgment), DTT flag, companion guidance. **Consumers derive from it** — `DEED_LABELS` is a projection, the type-selection page maps it, PreviewPanel titles/family read it, validation's family check routes through it, the payload's family branch too. **Adding a Tier-A sibling = one registry entry + one template.**

Doctrine guard: a registry entry **cannot** carry a legal choice — there is deliberately no auto-apply/defaults field, and a pin (comment-stripped scan + per-entry key check) keeps it structural. Coherence pins couple family↔certificate↔DTT: sworn instruments get jurats and no DTT; deed family gets acknowledgments and the DTT block.

### Flag rulings implemented
1. **Gate strictness** — stays as built (recorded in the report addendum).
2. **Aliasing accepted + ledgered** — the `parties` JSONB migration trigger is now explicit: catalog >10 types OR the first unmappable form.
3. **Bare signature line** — approved as built.
4. **BOE-502-D notice** — the affidavit's success page now shows passive guidance ("counties commonly require BOE-502-D filed with this affidavit") linking the state BOE forms page. External link, never a block, zero form-fill work; BOE-502-D itself stays Tier B, last. Pinned: present on the affidavit, absent on deeds, gates nothing.

### Gates
Jest **272** (263 + 9 new) · tsc **98** · backend **107** · frontend + docs change set

**Wave 1 is armed** — it fires on the owner's ranking of the seven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_