### PR TITLE
FORMS wave 1 (#1, #2): Affidavit of Death — CP w/ROS Spouse + Trustee

### DIFF
--- a/backend/services/deed_pdf.py
+++ b/backend/services/deed_pdf.py
@@ -39,6 +39,9 @@ TEMPLATE_BY_DEED_TYPE = {
     "tax-deed": "tax_deed_ca/index.jinja2",
     # FORMS-SPIKE: first non-deed instrument on the chassis.
     "affidavit-death-jt": "affidavit_death_jt_ca/index.jinja2",
+    # FORMS wave 1 — affidavit siblings (PCT references #3 and #7).
+    "affidavit-death-cp-spouse": "affidavit_death_cp_spouse_ca/index.jinja2",
+    "affidavit-death-trustee": "affidavit_death_trustee_ca/index.jinja2",
 }
 DEFAULT_TEMPLATE = "grant_deed_ca/index.jinja2"
 

--- a/backend/tests/test_wave1_affidavits.py
+++ b/backend/tests/test_wave1_affidavits.py
@@ -1,0 +1,200 @@
+"""FORMS wave 1 — affidavit siblings, pinned.
+
+Forms #1 and #2 of the owner-ranked wave, built against Pacific Coast
+Title blank forms #3 (Aff_Death-CP_Rt_Surv) and #7 (Aff_Death-Trustee) as
+the reference implementations. Same doctrine as the spike: affidavits are
+SWORN statements — the notarial certificate is a JURAT (Gov C §8202),
+never an acknowledgment (CC §1189); no DTT (not conveyances); missing
+facts render as the reference's blank lines, never invented.
+"""
+import io
+
+import pdfplumber
+import pytest
+
+from services.deed_pdf import render_deed_html, render_deed_pdf
+from tests.test_deed_pdf import _normalized
+
+CP_SPOUSE_META = {
+    "requested_by_address": "456 Escrow Way, Los Angeles, CA 90012",
+    "return_to": {"name": "JANE B. DOE", "address1": "1358 5TH ST",
+                  "city": "Santa Monica", "state": "CA", "zip": "90401"},
+    "affidavit": {
+        "affiant_name": "JANE B. DOE",
+        "decedent_name": "JOHN A. DOE",
+        "death_date": "March 3, 2026",
+        "death_place": "Los Angeles, California",
+        "deed_date": "June 1, 2015",
+        "deed_grantor": "ROBERT SELLER",
+        "recording_date": "June 15, 2015",
+        "instrument_no": "2015-0654321",
+    },
+}
+
+TRUSTEE_META = {
+    "requested_by_address": "456 Escrow Way, Los Angeles, CA 90012",
+    "return_to": {"name": "JANE B. DOE", "address1": "1358 5TH ST",
+                  "city": "Santa Monica", "state": "CA", "zip": "90401"},
+    "affidavit": {
+        "affiant_name": "JANE B. DOE",
+        "decedent_name": "JOHN A. DOE",
+        "trust_date": "January 10, 2010",
+        "trustors": "JOHN A. DOE AND JANE B. DOE",
+        "recording_date": "June 15, 2015",
+        "instrument_no": "2015-0654321",
+    },
+}
+
+FORMS = {
+    "affidavit-death-cp-spouse": {
+        "meta": CP_SPOUSE_META,
+        "template": "affidavit_death_cp_spouse_ca/index.jinja2",
+        # Instrument-defining recitals (Flag-3 precedent: furniture).
+        "furniture": (
+            "Affidavit of Death",
+            "Community Property with Right of Survivorship",
+            "of legal age, being first duly sworn, deposes and says",
+            "is the decedent mentioned in the attached certified copy of Certificate of Death",
+            "I am the surviving spouse of Decedent and was married to Decedent on the date of death",
+            "in favor of the grantees as community property with right of survivorship",
+            "Official Records of",
+            "Attach Certified Copy of Death Certificate",
+        ),
+        "facts": ("JANE B. DOE", "JOHN A. DOE", "March 3, 2026",
+                  "Los Angeles, California", "June 1, 2015", "ROBERT SELLER",
+                  "June 15, 2015", "2015-0654321", "LOT 7, BLOCK B, TRACT 12345"),
+    },
+    "affidavit-death-trustee": {
+        "meta": TRUSTEE_META,
+        "template": "affidavit_death_trustee_ca/index.jinja2",
+        "furniture": (
+            "Affidavit &mdash; Death of Trustee",
+            "of legal age, being first duly sworn, deposes and says",
+            "is the decedent mentioned in the attached certified copy of Certificate of Death",
+            "named as Trustee in that certain Declaration of Trust",
+            "as trustor(s)",
+            "decedent was the owner, as Trustee",
+            "I am the surviving or successor Trustee of the same trust",
+            "designated and empowered pursuant to the terms of said trust",
+            "Official Records of",
+            "Attach Certified Copy of Death Certificate",
+        ),
+        "facts": ("JANE B. DOE", "JOHN A. DOE", "January 10, 2010",
+                  "JOHN A. DOE AND JANE B. DOE", "June 15, 2015",
+                  "2015-0654321", "LOT 7, BLOCK B, TRACT 12345"),
+    },
+}
+
+
+def aff_row(deed_type, **overrides):
+    row = {
+        "id": 1,
+        "deed_type": deed_type,
+        "grantor_name": "JOHN A. DOE",   # display alias: decedent
+        "grantee_name": "JANE B. DOE",   # display alias: affiant
+        "legal_description": "LOT 7, BLOCK B, TRACT 12345",
+        "county": "Los Angeles",
+        "apn": "4290-012-034",
+        "property_address": "1358 5TH ST, Santa Monica, CA 90401",
+        "requested_by": "Pacific Coast Escrow",
+        "metadata": FORMS[deed_type]["meta"],
+    }
+    row.update(overrides)
+    return row
+
+
+@pytest.fixture(params=sorted(FORMS))
+def deed_type(request):
+    return request.param
+
+
+def test_sworn_recital_furniture_present(deed_type):
+    html = _normalized(render_deed_html(aff_row(deed_type)))
+    for needle in FORMS[deed_type]["furniture"]:
+        assert needle in html, needle
+
+
+def test_officer_facts_render(deed_type):
+    html = _normalized(render_deed_html(aff_row(deed_type)))
+    for fact in FORMS[deed_type]["facts"]:
+        assert fact in html, fact
+
+
+def test_missing_facts_render_as_blank_lines_never_invented(deed_type):
+    html = render_deed_html(aff_row(deed_type, metadata={}))
+    assert "fact-line" in html          # the reference's blank lines
+    assert "2015-0654321" not in html
+    assert "March 3, 2026" not in html
+    assert "January 10, 2010" not in html
+
+
+def test_jurat_not_acknowledgment(deed_type):
+    """THE doctrine canary, per sibling: exactly one notarial certificate,
+    and it is a jurat — never the §1189 acknowledgment body."""
+    html = _normalized(render_deed_html(aff_row(deed_type)))
+    assert html.count("Subscribed and sworn to (or affirmed) before me") == 1
+    assert "personally appeared" not in html
+    assert "acknowledged to me" not in html
+    assert "All-Purpose Acknowledgment" not in html
+    # §8202(b) disclaimer box present, once.
+    assert html.count("verifies only the identity") == 1
+
+
+def test_jurat_contents_are_blank_ticket_n_pattern(deed_type):
+    """Blank-contents doctrine: no affiant or notary entry pre-fills — the
+    date, affiant name, and notary signature are the notary's. Only the
+    venue county renders."""
+    html = _normalized(render_deed_html(aff_row(deed_type)))
+    jurat = html[html.index("Subscribed and sworn"):]
+    assert "JANE B. DOE" not in jurat        # affiant not pre-filled in the cert
+    assert "JOHN A. DOE" not in jurat
+    # Venue county pre-fills (data the officer supplied):
+    venue = html[html.index("COUNTY OF"):html.index("Subscribed and sworn")]
+    assert "Los Angeles" in venue
+
+
+def test_no_dtt_and_no_mail_tax(deed_type):
+    """Reference-faithful: neither instrument is a conveyance — no
+    transfer-tax declaration, no mail-tax directive."""
+    html = _normalized(render_deed_html(aff_row(deed_type)))
+    assert "DOCUMENTARY TRANSFER TAX" not in html.upper()
+    assert "UNDERSIGNED GRANTOR" not in html.upper()
+    assert "Mail Tax Statements" not in html
+    assert "And When Recorded Mail To" in html
+
+
+def test_chassis_geometry_and_no_chrome(deed_type):
+    """G2/G3 discipline: recorder space open, caption at the boundary,
+    title below it, jurat in the lower half, one page, no chrome. The
+    references measure: caption ~192pt, jurat ~600/620pt, one page."""
+    pdf = render_deed_pdf(aff_row(deed_type))
+    with pdfplumber.open(io.BytesIO(pdf)) as doc:
+        assert len(doc.pages) == 1  # both references are one-page instruments
+        page = doc.pages[0]
+        words = page.extract_words()
+
+        def top_of(needle):
+            hits = [w for w in words if needle.upper() in w["text"].upper()]
+            assert hits, needle
+            return hits[0]["top"]
+
+        def x_of(needle):
+            hits = [w for w in words if needle.upper() in w["text"].upper()]
+            return hits[0]["x0"]
+
+        caption_top = top_of("RECORDER’S")
+        title_top = top_of("AFFIDAVIT")
+        jurat_top = top_of("Subscribed")
+        assert caption_top > 100          # a real open recorder space above it
+        assert x_of("RECORDER’S") > 300   # caption sits right of center
+        assert title_top > caption_top    # title below the boundary
+        assert jurat_top > page.height / 2  # jurat in the lower half
+
+    html = render_deed_html(aff_row(deed_type))
+    for leaked in ("7C4DFF", "Generated by", "deedpro.com/verify", "recorder-box", "bg-brand"):
+        assert leaked not in html, leaked
+
+
+def test_registered_in_the_type_map(deed_type):
+    from services.deed_pdf import TEMPLATE_BY_DEED_TYPE
+    assert TEMPLATE_BY_DEED_TYPE[deed_type] == FORMS[deed_type]["template"]

--- a/frontend/src/__tests__/d3ClickToFix.test.ts
+++ b/frontend/src/__tests__/d3ClickToFix.test.ts
@@ -51,13 +51,15 @@ describe('D3 — every preview data region is clickable with a valid mapping', (
     const fields = gos.map((m) => m[2]).filter(Boolean) as string[];
     expect(fields.length).toBeGreaterThanOrEqual(5);
     const affidavitSrc = readSource('components', 'builder', 'sections', 'AffidavitSection.tsx');
+    const registrySrc = readSource('lib', 'formRegistry.ts');
     for (const field of new Set(fields)) {
       if (field.startsWith('affidavit-')) {
-        // FORMS-SPIKE: AffidavitSection stamps its anchors dynamically
-        // (data-builder-field={`affidavit-${key}`}); assert the pattern
-        // and that the key is a real AffidavitFacts field.
+        // FORMS: AffidavitSection stamps its anchors dynamically
+        // (data-builder-field={`affidavit-${key}`}) from the registry's
+        // affidavitFields specs; assert the pattern and that the key is
+        // a declared spec key.
         expect(affidavitSrc).toContain('data-builder-field={`affidavit-${key}`}');
-        expect(affidavitSrc).toContain(`'${field.replace('affidavit-', '')}'`);
+        expect(registrySrc).toContain(`'${field.replace('affidavit-', '')}'`);
         continue;
       }
       const anchor = FIELD_ANCHORS.find(([name]) => name === field);

--- a/frontend/src/__tests__/formRegistry.test.ts
+++ b/frontend/src/__tests__/formRegistry.test.ts
@@ -23,9 +23,12 @@ const KNOWN_SECTIONS = new Set(['property', 'grantor', 'grantee', 'vesting', 'tr
 describe('FORMS registry — completeness and coherence', () => {
   const entries = Object.values(FORM_REGISTRY);
 
-  it('carries the six shipped types', () => {
-    expect(entries.length).toBe(6);
+  it('carries the eight shipped types', () => {
+    expect(entries.length).toBe(8);
     expect(formConfig('affidavit-death-jt')?.family).toBe('affidavit');
+    // Wave 1 siblings (owner-ranked #1 and #2):
+    expect(formConfig('affidavit-death-cp-spouse')?.family).toBe('affidavit');
+    expect(formConfig('affidavit-death-trustee')?.family).toBe('affidavit');
   });
 
   it('every entry is internally coherent', () => {
@@ -42,6 +45,20 @@ describe('FORMS registry — completeness and coherence', () => {
         expect(f.notarial).toBe('jurat');
         expect(f.hasDtt).toBe(false);
         expect(f.sections).toContain('affidavit');
+        // The shared AffidavitSection renders from these specs — every
+        // sworn form must declare its officer-typed facts, always
+        // including the common four (who swears, who died, and the
+        // recorded instrument's date + number).
+        const keys = (f.affidavitFields ?? []).map((s) => s.key);
+        for (const common of ['affiantName', 'decedentName', 'recordingDate', 'instrumentNo']) {
+          expect(keys).toContain(common);
+        }
+        // Field specs describe INPUTS (label/placeholder/grouping) — a
+        // spec with a value would be a smuggled prefill.
+        for (const spec of f.affidavitFields ?? []) {
+          expect(Object.keys(spec)).not.toContain('value');
+          expect(Object.keys(spec)).not.toContain('default');
+        }
       } else {
         expect(f.notarial).toBe('acknowledgment');
         expect(f.hasDtt).toBe(true);
@@ -87,11 +104,13 @@ describe('FORMS registry — the consumers derive from it', () => {
 });
 
 describe('FORMS flag-4 ruling — the companion notice is passive guidance', () => {
-  it('the affidavit carries the BOE-502-D notice with the state link', () => {
-    const notice = formConfig('affidavit-death-jt')?.companionNotice;
-    expect(notice).toBeDefined();
-    expect(notice!.text).toContain('BOE-502-D');
-    expect(notice!.href).toContain('boe.ca.gov');
+  it('every death affidavit carries the BOE-502-D notice with the state link', () => {
+    for (const slug of ['affidavit-death-jt', 'affidavit-death-cp-spouse', 'affidavit-death-trustee']) {
+      const notice = formConfig(slug)?.companionNotice;
+      expect(notice).toBeDefined();
+      expect(notice!.text).toContain('BOE-502-D');
+      expect(notice!.href).toContain('boe.ca.gov');
+    }
   });
 
   it('the success page renders it as guidance — never a block', () => {

--- a/frontend/src/components/builder/InputPanel.tsx
+++ b/frontend/src/components/builder/InputPanel.tsx
@@ -113,11 +113,12 @@ export function InputPanel({
           id="affidavit"
           title="Affidavit Facts"
           status={statuses.affidavit}
-          preview={state.affidavit?.decedentName || 'Decedent, affiant, and the JT deed reference'}
+          preview={state.affidavit?.decedentName || 'Decedent, affiant, and the recorded-instrument reference'}
           isExpanded={expandedSection === 'affidavit'}
           onToggle={() => toggleSection('affidavit')}
         >
           <AffidavitSection
+            deedType={state.deedType}
             value={state.affidavit}
             onChange={(affidavit) => onChange({ affidavit })}
           />

--- a/frontend/src/components/builder/PreviewPanel.tsx
+++ b/frontend/src/components/builder/PreviewPanel.tsx
@@ -174,9 +174,16 @@ export function PreviewPanel({ state, activeSection, onRegionClick }: PreviewPan
             </div>
 
             {/* Title */}
-            <h1 className="text-[14pt] font-bold text-center mb-3 tracking-[2px] uppercase">
+            <h1 className={`text-[14pt] font-bold text-center tracking-[2px] uppercase ${formConfig(state.deedType)?.subtitle ? 'mb-0.5' : 'mb-3'}`}>
               {deedTitle}
             </h1>
+            {/* Reference-faithful qualifier lines under the title, when the
+                blank form carries them (e.g. the CP w/ROS affidavit) */}
+            {formConfig(state.deedType)?.subtitle && (
+              <div className="text-center font-bold text-[11pt] mb-3">
+                {formConfig(state.deedType)?.subtitle}
+              </div>
+            )}
 
             {isAffidavit ? (
               <>
@@ -187,6 +194,51 @@ export function PreviewPanel({ state, activeSection, onRegionClick }: PreviewPan
                     <span onClick={go('affidavit', 'affidavit-affiantName')} className={`font-bold uppercase ${CLICKABLE} ${dataHighlight(aff?.affiantName)}`}>{factOrBlank(aff?.affiantName)}</span>,
                     {' '}of legal age, being first duly sworn, deposes and says:
                   </p>
+                  {state.deedType === 'affidavit-death-cp-spouse' ? (
+                    <>
+                      {/* PCT #3 recital — numbered clauses, reference-faithful.
+                          Clause 2 is instrument-defining furniture (Flag-3). */}
+                      <p className="mb-2">
+                        1. <span onClick={go('affidavit', 'affidavit-decedentName')} className={`font-bold uppercase ${CLICKABLE} ${dataHighlight(aff?.decedentName)}`}>{factOrBlank(aff?.decedentName)}</span>
+                        {' '}is the decedent mentioned in the attached certified copy of Certificate of Death, who died on{' '}
+                        <span onClick={go('affidavit', 'affidavit-deathDate')} className={`${CLICKABLE} ${dataHighlight(aff?.deathDate)}`}>{factOrBlank(aff?.deathDate)}</span>, at{' '}
+                        <span onClick={go('affidavit', 'affidavit-deathPlace')} className={`${CLICKABLE} ${dataHighlight(aff?.deathPlace)}`}>{factOrBlank(aff?.deathPlace)}</span> (insert place of death).
+                      </p>
+                      <p className="mb-2">
+                        2. I am the surviving spouse of Decedent and was married to Decedent on the date of death.
+                      </p>
+                      <p className="mb-2">
+                        3. Decedent and I are the same persons who are named as grantees in that certain deed dated{' '}
+                        <span onClick={go('affidavit', 'affidavit-deedDate')} className={`${CLICKABLE} ${dataHighlight(aff?.deedDate)}`}>{factOrBlank(aff?.deedDate)}</span>, executed by{' '}
+                        <span onClick={go('affidavit', 'affidavit-deedGrantor')} className={`font-bold uppercase ${CLICKABLE} ${dataHighlight(aff?.deedGrantor)}`}>{factOrBlank(aff?.deedGrantor)}</span>
+                        {' '}in favor of the grantees as community property with right of survivorship, recorded on{' '}
+                        <span onClick={go('affidavit', 'affidavit-recordingDate')} className={`${CLICKABLE} ${dataHighlight(aff?.recordingDate)}`}>{factOrBlank(aff?.recordingDate)}</span>, as Instrument No.{' '}
+                        <span onClick={go('affidavit', 'affidavit-instrumentNo')} className={`${CLICKABLE} ${dataHighlight(aff?.instrumentNo)}`}>{factOrBlank(aff?.instrumentNo)}</span>,
+                        {' '}Official Records of{' '}
+                        <span onClick={go('property')} className={`font-bold ${CLICKABLE} ${placeholder(preview.county)} ${dataHighlight(preview.county)}`}>{preview.county}</span>
+                        {' '}County, California, describing the following real property:
+                      </p>
+                    </>
+                  ) : state.deedType === 'affidavit-death-trustee' ? (
+                    <>
+                      {/* PCT #7 recital — clause 3 (successor-trustee assertion,
+                          instrument-defining furniture) renders BELOW the legal
+                          description, as the reference lays it out. */}
+                      <p className="mb-2">
+                        1. <span onClick={go('affidavit', 'affidavit-decedentName')} className={`font-bold uppercase ${CLICKABLE} ${dataHighlight(aff?.decedentName)}`}>{factOrBlank(aff?.decedentName)}</span>
+                        {' '}is the decedent mentioned in the attached certified copy of Certificate of Death, and is the same person named as Trustee in that certain Declaration of Trust dated{' '}
+                        <span onClick={go('affidavit', 'affidavit-trustDate')} className={`${CLICKABLE} ${dataHighlight(aff?.trustDate)}`}>{factOrBlank(aff?.trustDate)}</span>, executed by{' '}
+                        <span onClick={go('affidavit', 'affidavit-trustors')} className={`font-bold uppercase ${CLICKABLE} ${dataHighlight(aff?.trustors)}`}>{factOrBlank(aff?.trustors)}</span> as trustor(s).
+                      </p>
+                      <p className="mb-2">
+                        2. At the time of decedent&rsquo;s death, decedent was the owner, as Trustee, of certain real property acquired by a deed recorded on{' '}
+                        <span onClick={go('affidavit', 'affidavit-recordingDate')} className={`${CLICKABLE} ${dataHighlight(aff?.recordingDate)}`}>{factOrBlank(aff?.recordingDate)}</span>, as Instrument No.{' '}
+                        <span onClick={go('affidavit', 'affidavit-instrumentNo')} className={`${CLICKABLE} ${dataHighlight(aff?.instrumentNo)}`}>{factOrBlank(aff?.instrumentNo)}</span>, in Official Records of{' '}
+                        <span onClick={go('property')} className={`font-bold ${CLICKABLE} ${placeholder(preview.county)} ${dataHighlight(preview.county)}`}>{preview.county}</span>
+                        {' '}County, California, describing the following real property:
+                      </p>
+                    </>
+                  ) : (
                   <p className="mb-2">
                     <span onClick={go('affidavit', 'affidavit-decedentName')} className={`font-bold uppercase ${CLICKABLE} ${dataHighlight(aff?.decedentName)}`}>{factOrBlank(aff?.decedentName)}</span>
                     {' '}is the decedent mentioned in the attached certified copy of Certificate of Death,
@@ -201,6 +253,7 @@ export function PreviewPanel({ state, activeSection, onRegionClick }: PreviewPan
                     <span onClick={go('property')} className={`font-bold ${CLICKABLE} ${placeholder(preview.county)} ${dataHighlight(preview.county)}`}>{preview.county}</span>
                     {' '}County, California, describing the following real property:
                   </p>
+                  )}
                 </div>
 
                 <div className={`mb-3 ${highlight('property')}`}>
@@ -208,6 +261,17 @@ export function PreviewPanel({ state, activeSection, onRegionClick }: PreviewPan
                     {preview.legalDescription}
                   </span>
                 </div>
+
+                {state.deedType === 'affidavit-death-trustee' && (
+                  <div className={`text-[11pt] leading-relaxed mb-3 ${highlight('affidavit')}`}>
+                    <p>
+                      3. I am the surviving or successor Trustee of the same trust under which said
+                      decedent held title as trustee pursuant to the deed described above, and am
+                      designated and empowered pursuant to the terms of said trust to serve as
+                      Trustee thereof.
+                    </p>
+                  </div>
+                )}
 
                 <div className="mt-6 flex justify-between items-end gap-4">
                   <div className="text-[11pt]">Dated: <span className="inline-block min-w-[1.6in] border-b border-black" /></div>

--- a/frontend/src/components/builder/sections/AffidavitSection.tsx
+++ b/frontend/src/components/builder/sections/AffidavitSection.tsx
@@ -1,13 +1,16 @@
 'use client';
 
-// FORMS-SPIKE: the affidavit's officer-supplied facts. Every field here is
+// FORMS: the affidavit family's officer-supplied facts. Every field here is
 // TYPED by the officer (names auto-uppercase like the deed parties) — no
 // confirm affordances: typing is the officer's act; "Confirm" stays
-// reserved for external-source data. The JT deed's recording reference
-// (date + instrument number) identifies the instrument being cleared.
+// reserved for external-source data. WHICH facts render is registry data
+// (affidavitFields), so a sibling form is one registry entry + a template.
+import type { ReactNode } from 'react';
 import type { AffidavitFacts } from '@/types/builder';
+import { formConfig, type AffidavitFieldSpec } from '@/lib/formRegistry';
 
 interface AffidavitSectionProps {
+  deedType: string;
   value?: AffidavitFacts;
   onChange: (affidavit: AffidavitFacts) => void;
 }
@@ -15,69 +18,57 @@ interface AffidavitSectionProps {
 const EMPTY: AffidavitFacts = {
   affiantName: '',
   decedentName: '',
-  jtDeedDate: '',
-  jtDeedGrantor: '',
-  jtDeedGrantees: '',
   recordingDate: '',
   instrumentNo: '',
 };
 
-export function AffidavitSection({ value, onChange }: AffidavitSectionProps) {
+export function AffidavitSection({ deedType, value, onChange }: AffidavitSectionProps) {
   const facts = value ?? EMPTY;
+  const specs: AffidavitFieldSpec[] = formConfig(deedType)?.affidavitFields ?? [];
   const set = (patch: Partial<AffidavitFacts>) => onChange({ ...facts, ...patch });
 
-  const field = (
-    label: string,
-    key: keyof AffidavitFacts,
-    placeholder: string,
-    opts: { uppercase?: boolean; hint?: string } = {}
-  ) => (
-    <div>
-      <label className="block text-sm font-medium text-gray-700 mb-1">{label}</label>
-      <input
-        type="text"
-        data-builder-field={`affidavit-${key}`}
-        value={facts[key]}
-        onChange={(e) =>
-          set({ [key]: opts.uppercase ? e.target.value.toUpperCase() : e.target.value } as Partial<AffidavitFacts>)
-        }
-        placeholder={placeholder}
-        className={`w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500 ${
-          opts.uppercase ? 'uppercase' : ''
-        }`}
-      />
-      {opts.hint && <p className="text-xs text-gray-500 mt-1">{opts.hint}</p>}
-    </div>
-  );
+  const field = (spec: AffidavitFieldSpec) => {
+    const key = spec.key as keyof AffidavitFacts;
+    return (
+      <div key={spec.key}>
+        <label className="block text-sm font-medium text-gray-700 mb-1">{spec.label}</label>
+        <input
+          type="text"
+          data-builder-field={`affidavit-${key}`}
+          value={facts[key] ?? ''}
+          onChange={(e) =>
+            set({ [key]: spec.uppercase ? e.target.value.toUpperCase() : e.target.value } as Partial<AffidavitFacts>)
+          }
+          placeholder={spec.placeholder}
+          className={`w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500 ${
+            spec.uppercase ? 'uppercase' : ''
+          }`}
+        />
+        {spec.hint && <p className="text-xs text-gray-500 mt-1">{spec.hint}</p>}
+      </div>
+    );
+  };
+
+  // Render a group heading each time the spec's group label changes.
+  const blocks: ReactNode[] = [];
+  let lastGroup: string | undefined;
+  for (const spec of specs) {
+    if (spec.group && spec.group !== lastGroup) {
+      blocks.push(
+        <div key={`group-${spec.group}`} className="pt-2 border-t border-gray-200">
+          <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-3">
+            {spec.group}
+          </p>
+        </div>
+      );
+    }
+    lastGroup = spec.group;
+    blocks.push(field(spec));
+  }
 
   return (
     <div className="space-y-4">
-      {field('Affiant (person swearing the statement)', 'affiantName', 'JANE B. DOE', {
-        uppercase: true,
-        hint: 'Usually the surviving joint tenant. Signs before a notary.',
-      })}
-      {field('Decedent', 'decedentName', 'JOHN A. DOE', {
-        uppercase: true,
-        hint: 'As named on the certified copy of the Certificate of Death.',
-      })}
-
-      <div className="pt-2 border-t border-gray-200">
-        <p className="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-3">
-          The joint-tenancy deed being cleared
-        </p>
-        <div className="space-y-4">
-          {field('Deed date', 'jtDeedDate', 'June 1, 2015')}
-          {field('Executed by (grantor on that deed)', 'jtDeedGrantor', 'ROBERT SELLER', { uppercase: true })}
-          {field('To (grantees, as joint tenants)', 'jtDeedGrantees', 'JOHN A. DOE AND JANE B. DOE', {
-            uppercase: true,
-          })}
-          {field('Recorded on', 'recordingDate', 'June 15, 2015')}
-          {field('Instrument No.', 'instrumentNo', '2015-0654321', {
-            hint: 'From the recorded JT deed — this is how the recorder ties the two documents.',
-          })}
-        </div>
-      </div>
-
+      {blocks}
       <p className="text-xs text-gray-500 pt-1">
         A certified copy of the death certificate must be attached to the
         recorded affidavit — the generated form says so on its face.

--- a/frontend/src/lib/deedPayload.ts
+++ b/frontend/src/lib/deedPayload.ts
@@ -57,11 +57,19 @@ export function buildDeedPayload(genState: DeedBuilderState) {
     escrow_no: genState.escrowNo || '',
     affidavit: isAffidavit && aff
       ? {
+          // Superset of all affidavit variants — each template reads only
+          // the keys its recital carries; unused keys stay empty strings.
           affiant_name: aff.affiantName || '',
           decedent_name: aff.decedentName || '',
           jt_deed_date: aff.jtDeedDate || '',
           jt_deed_grantor: aff.jtDeedGrantor || '',
           jt_deed_grantees: aff.jtDeedGrantees || '',
+          death_date: aff.deathDate || '',
+          death_place: aff.deathPlace || '',
+          deed_date: aff.deedDate || '',
+          deed_grantor: aff.deedGrantor || '',
+          trust_date: aff.trustDate || '',
+          trustors: aff.trustors || '',
           recording_date: aff.recordingDate || '',
           instrument_no: aff.instrumentNo || '',
         }

--- a/frontend/src/lib/deedResume.ts
+++ b/frontend/src/lib/deedResume.ts
@@ -174,6 +174,12 @@ export function hydrateStateFromDeedRow(row: Record<string, any>): ResumeResult 
           jtDeedDate: meta.affidavit.jt_deed_date || '',
           jtDeedGrantor: meta.affidavit.jt_deed_grantor || '',
           jtDeedGrantees: meta.affidavit.jt_deed_grantees || '',
+          deathDate: meta.affidavit.death_date || '',
+          deathPlace: meta.affidavit.death_place || '',
+          deedDate: meta.affidavit.deed_date || '',
+          deedGrantor: meta.affidavit.deed_grantor || '',
+          trustDate: meta.affidavit.trust_date || '',
+          trustors: meta.affidavit.trustors || '',
           recordingDate: meta.affidavit.recording_date || '',
           instrumentNo: meta.affidavit.instrument_no || '',
         }

--- a/frontend/src/lib/deedValidation.ts
+++ b/frontend/src/lib/deedValidation.ts
@@ -58,10 +58,13 @@ export function evaluateSubstantive(state: DeedBuilderState): CheckResult[] {
         sectionId: 'affidavit',
       },
       {
-        id: 'jt_deed_reference',
-        label: 'Joint-tenancy deed recording reference',
+        // Common to every affidavit-of-death variant: the recorded
+        // instrument the decedent held title under (JT deed, CP deed, or
+        // the deed to the trustee) is identified by its recording data.
+        id: 'recorded_instrument_reference',
+        label: 'Recorded deed reference',
         ok: !!aff?.instrumentNo?.trim() && !!aff?.recordingDate?.trim(),
-        detail: 'The recorded JT deed is identified by its recording date and instrument number.',
+        detail: 'The recorded deed is identified by its recording date and instrument number.',
         sectionId: 'affidavit',
       },
       {

--- a/frontend/src/lib/formRegistry.ts
+++ b/frontend/src/lib/formRegistry.ts
@@ -22,12 +22,31 @@ export interface CompanionNotice {
   href: string;
 }
 
+/**
+ * One officer-typed fact input on an affidavit-family form. These are DATA
+ * descriptors (label/placeholder/grouping) for the shared AffidavitSection —
+ * a field spec can describe an input, never decide a legal question.
+ */
+export interface AffidavitFieldSpec {
+  /** AffidavitFacts key (camelCase; serialized snake_case in metadata). */
+  key: string;
+  label: string;
+  placeholder: string;
+  uppercase?: boolean;
+  hint?: string;
+  /** Group heading rendered when it differs from the previous field's. */
+  group?: string;
+}
+
 export interface FormTypeConfig {
   slug: string;
   /** List/table display label. */
   label: string;
   /** Document title as rendered on the instrument/preview. */
   title: string;
+  /** Reference-faithful subtitle line(s) under the title, when the blank
+      form carries one (e.g. the CP w/ROS affidavit's qualifier lines). */
+  subtitle?: string;
   /** Card copy on the type-selection page. */
   description: string;
   popular: boolean;
@@ -41,10 +60,49 @@ export interface FormTypeConfig {
   hasDtt: boolean;
   /** Success-page companion-filing guidance (owner ruling, spike flag 4). */
   companionNotice?: CompanionNotice;
+  /** Officer-typed fact inputs (affidavit family only) — drives the shared
+      AffidavitSection so a sibling form is registry data + a template. */
+  affidavitFields?: AffidavitFieldSpec[];
 }
 
 const DEED_SECTIONS = ['property', 'grantor', 'grantee', 'vesting', 'transferTax', 'recording'];
 const AFFIDAVIT_SECTIONS = ['property', 'affidavit', 'recording'];
+
+/* Spike flag 4 ruling (applies to every affidavit-of-death variant):
+   passive guidance only. The BOE-502-D itself is Tier B (form-fill
+   pipeline), owner-directed LAST — no form-fill work. */
+const BOE_502D_NOTICE: CompanionNotice = {
+  text: 'Counties commonly require a BOE-502-D (Change in Ownership Statement — Death of Real Property Owner) filed with this affidavit.',
+  linkText: 'Get the form from the California BOE',
+  href: 'https://www.boe.ca.gov/proptaxes/forms.htm',
+};
+
+/* Common affidavit facts: every death-affidavit swears WHO and identifies
+   the recorded instrument the decedent held title under. */
+const AFFIANT_FIELD: AffidavitFieldSpec = {
+  key: 'affiantName',
+  label: 'Affiant (person swearing the statement)',
+  placeholder: 'JANE B. DOE',
+  uppercase: true,
+  hint: 'Signs before a notary.',
+};
+const DECEDENT_FIELD: AffidavitFieldSpec = {
+  key: 'decedentName',
+  label: 'Decedent',
+  placeholder: 'JOHN A. DOE',
+  uppercase: true,
+  hint: 'As named on the certified copy of the Certificate of Death.',
+};
+const RECORDING_REF_FIELDS = (group: string): AffidavitFieldSpec[] => [
+  { key: 'recordingDate', label: 'Recorded on', placeholder: 'June 15, 2015', group },
+  {
+    key: 'instrumentNo',
+    label: 'Instrument No.',
+    placeholder: '2015-0654321',
+    group,
+    hint: 'From the recorded instrument — this is how the recorder ties the documents.',
+  },
+];
 
 export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
   'grant-deed': {
@@ -112,13 +170,58 @@ export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
     sections: AFFIDAVIT_SECTIONS,
     notarial: 'jurat',
     hasDtt: false,
-    // Spike flag 4 ruling: passive guidance only. The BOE-502-D itself is
-    // Tier B (form-fill pipeline), owner-directed LAST — no form-fill work.
-    companionNotice: {
-      text: 'Counties commonly require a BOE-502-D (Change in Ownership Statement — Death of Real Property Owner) filed with this affidavit.',
-      linkText: 'Get the form from the California BOE',
-      href: 'https://www.boe.ca.gov/proptaxes/forms.htm',
-    },
+    companionNotice: BOE_502D_NOTICE,
+    affidavitFields: [
+      { ...AFFIANT_FIELD, hint: 'Usually the surviving joint tenant. Signs before a notary.' },
+      DECEDENT_FIELD,
+      { key: 'jtDeedDate', label: 'Deed date', placeholder: 'June 1, 2015', group: 'The joint-tenancy deed being cleared' },
+      { key: 'jtDeedGrantor', label: 'Executed by (grantor on that deed)', placeholder: 'ROBERT SELLER', uppercase: true, group: 'The joint-tenancy deed being cleared' },
+      { key: 'jtDeedGrantees', label: 'To (grantees, as joint tenants)', placeholder: 'JOHN A. DOE AND JANE B. DOE', uppercase: true, group: 'The joint-tenancy deed being cleared' },
+      ...RECORDING_REF_FIELDS('The joint-tenancy deed being cleared'),
+    ],
+  },
+  // Wave 1 form #1 — reference: PCT blank form #3 (Aff_Death-CP_Rt_Surv).
+  'affidavit-death-cp-spouse': {
+    slug: 'affidavit-death-cp-spouse',
+    label: 'Affidavit — Death of Spouse (CP w/ Right of Survivorship)',
+    title: 'AFFIDAVIT OF DEATH',
+    subtitle: 'Community Property with Right of Survivorship — Spouse',
+    description: 'Clears a deceased spouse from community-property-with-survivorship title — sworn statement with jurat, death certificate attached',
+    popular: false,
+    family: 'affidavit',
+    sections: AFFIDAVIT_SECTIONS,
+    notarial: 'jurat',
+    hasDtt: false,
+    companionNotice: BOE_502D_NOTICE,
+    affidavitFields: [
+      { ...AFFIANT_FIELD, hint: 'The surviving spouse. Signs before a notary.' },
+      DECEDENT_FIELD,
+      { key: 'deathDate', label: 'Date of death', placeholder: 'March 3, 2026', group: 'Death particulars' },
+      { key: 'deathPlace', label: 'Place of death', placeholder: 'Los Angeles, California', group: 'Death particulars' },
+      { key: 'deedDate', label: 'Deed date', placeholder: 'June 1, 2015', group: 'The community-property deed being cleared' },
+      { key: 'deedGrantor', label: 'Executed by (grantor on that deed)', placeholder: 'ROBERT SELLER', uppercase: true, group: 'The community-property deed being cleared' },
+      ...RECORDING_REF_FIELDS('The community-property deed being cleared'),
+    ],
+  },
+  // Wave 1 form #2 — reference: PCT blank form #7 (Aff_Death-Trustee).
+  'affidavit-death-trustee': {
+    slug: 'affidavit-death-trustee',
+    label: 'Affidavit — Death of Trustee',
+    title: 'AFFIDAVIT — DEATH OF TRUSTEE',
+    description: 'Clears a deceased trustee from title held in trust — sworn by the surviving or successor trustee, death certificate attached',
+    popular: false,
+    family: 'affidavit',
+    sections: AFFIDAVIT_SECTIONS,
+    notarial: 'jurat',
+    hasDtt: false,
+    companionNotice: BOE_502D_NOTICE,
+    affidavitFields: [
+      { ...AFFIANT_FIELD, hint: 'The surviving or successor trustee. Signs before a notary.' },
+      { ...DECEDENT_FIELD, hint: 'As named on the death certificate — the trustee whose interest is cleared.' },
+      { key: 'trustDate', label: 'Declaration of Trust dated', placeholder: 'January 10, 2010', group: 'The declaration of trust' },
+      { key: 'trustors', label: 'Executed by (trustor(s))', placeholder: 'JOHN A. DOE AND JANE B. DOE', uppercase: true, group: 'The declaration of trust' },
+      ...RECORDING_REF_FIELDS("The deed by which the trustee acquired title"),
+    ],
   },
 };
 

--- a/frontend/src/types/builder.ts
+++ b/frontend/src/types/builder.ts
@@ -68,13 +68,25 @@ export interface DTTData {
 }
 
 export interface AffidavitFacts {
+  /* Common to every affidavit-of-death variant: who swears, who died, and
+     the recording reference of the instrument under which the decedent
+     held title (how the recorder ties the documents together). */
   affiantName: string;
   decedentName: string;
-  jtDeedDate: string;
-  jtDeedGrantor: string;
-  jtDeedGrantees: string;
   recordingDate: string;
   instrumentNo: string;
+  /* JT variant — the joint-tenancy deed being cleared. */
+  jtDeedDate?: string;
+  jtDeedGrantor?: string;
+  jtDeedGrantees?: string;
+  /* CP w/ROS (spouse) variant — death particulars + the CP deed. */
+  deathDate?: string;
+  deathPlace?: string;
+  deedDate?: string;
+  deedGrantor?: string;
+  /* Trustee variant — the declaration of trust. */
+  trustDate?: string;
+  trustors?: string;
 }
 
 export interface DeedBuilderState {

--- a/templates/affidavit_death_cp_spouse_ca/index.jinja2
+++ b/templates/affidavit_death_cp_spouse_ca/index.jinja2
@@ -1,0 +1,246 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Affidavit of Death - Community Property with Right of Survivorship (Spouse) - California</title>
+    <style>
+        /* ==========================================================================
+           AFFIDAVIT OF DEATH — CP W/ RIGHT OF SURVIVORSHIP (SPOUSE) — wave 1 #1
+
+           Sibling of the FORMS-SPIKE affidavit chassis. Reference
+           implementation: Pacific Coast Title blank form #3
+           (Aff_Death-CP_Rt_Surv), measured with pdfplumber (letter page;
+           recorder caption ~192pt; title ~204pt; jurat lower half ~600pt;
+           ATTACH directive at the foot; one page).
+
+           Chassis rules carried over verbatim from the JT sibling:
+           - Gov. Code §27361.6 recorder's space top-right, open, caption at
+             the boundary; §27361.7 no chrome on recorded pages.
+           - Blank-contents doctrine: the affiant's execution and every
+             notarial entry stay blank — we generate the form, never the
+             sworn or notarial contents.
+           - No DTT declaration (title passes by survivorship — not a
+             conveyance; the reference carries no tax block), no mail-tax
+             directive.
+           - Jurat (Gov C §8202), NOT an acknowledgment (§1189).
+           Reference-specific: three numbered clauses; clause 2 ("I am the
+           surviving spouse ... married to Decedent on the date of death")
+           is instrument-defining furniture (Flag-3 precedent).
+           ========================================================================== */
+
+        @page {
+            size: letter;
+            margin: 0.5in 0.5in 0.6in 0.6in;
+        }
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        body {
+            font-family: "Times New Roman", Times, Georgia, serif;
+            font-size: 11pt;
+            line-height: 1.35;
+            color: #000;
+            background: #fff;
+        }
+
+        .header-section { display: flex; min-height: 1.85in; }
+
+        .recording-info {
+            width: 3.4in;
+            flex-shrink: 0;
+            border-right: 0.75pt solid #000;
+            padding-right: 0.15in;
+            font-size: 10pt;
+            line-height: 1.35;
+        }
+
+        .recorder-space { flex-grow: 1; }
+
+        .recording-label {
+            font-weight: bold;
+            text-transform: uppercase;
+            font-size: 9pt;
+        }
+
+        .recording-value { margin-bottom: 0.12in; min-height: 0.35in; }
+
+        .ref-line { font-size: 10pt; }
+
+        .header-boundary {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            border-bottom: 0.75pt solid #000;
+            padding-bottom: 0.03in;
+            margin-bottom: 0.12in;
+        }
+
+        .apn-ref { font-weight: bold; font-size: 10pt; }
+
+        .recorder-caption {
+            font-size: 7.5pt;
+            font-weight: bold;
+            text-transform: uppercase;
+        }
+
+        .deed-title {
+            text-align: center;
+            font-size: 14pt;
+            font-weight: bold;
+            letter-spacing: 2px;
+            text-transform: uppercase;
+            margin: 0.08in 0 0.02in 0;
+        }
+
+        .deed-subtitle {
+            /* The reference stacks its qualifier lines under the title.
+               One-page budget: the CP recital runs three clauses, so the
+               vertical spend here is tighter than the JT sibling's. */
+            text-align: center;
+            font-size: 10pt;
+            font-weight: bold;
+            line-height: 1.25;
+            margin-bottom: 0.06in;
+        }
+
+        .affidavit-body {
+            font-size: 11pt;
+            line-height: 1.3;
+            text-align: justify;
+        }
+
+        .affidavit-body p { margin-bottom: 0.05in; }
+
+        .fact {
+            /* Officer-supplied facts render bold like the deed parties; a
+               missing fact renders as the reference's blank line so an
+               incomplete instrument LOOKS incomplete. */
+            font-weight: bold;
+        }
+
+        .fact-line {
+            display: inline-block;
+            min-width: 2.2in;
+            border-bottom: 1px solid #000;
+        }
+
+        .legal-content {
+            font-weight: bold;
+            white-space: pre-wrap;
+            margin: 0.05in 0;
+            min-height: 0.35in;
+        }
+
+        .execution-section {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-end;
+            margin-top: 0.05in;
+            margin-bottom: 0.03in;
+        }
+
+        .signature-line {
+            border-bottom: 1px solid #000;
+            width: 3.2in;
+            height: 0.3in;
+        }
+
+        .attach-directive {
+            text-align: center;
+            font-size: 10pt;
+            font-weight: bold;
+            text-transform: uppercase;
+            margin-top: 0.06in;
+        }
+    </style>
+</head>
+<body>
+    <div class="deed-page">
+
+        <header class="header-section">
+            <div class="recording-info">
+                <div class="recording-label">Recording Requested By:</div>
+                <div class="recording-value">{{ requested_by or '' }}{% if requested_by_address %}<br>{{ requested_by_address }}{% endif %}</div>
+
+                <div class="recording-label">And When Recorded Mail To:</div>
+                <div class="recording-value">
+                    {% if return_to %}
+                        {% if return_to.get('name') %}{{ return_to.get('name') }}<br>{% endif %}
+                        {% if return_to.get('company') %}{{ return_to.get('company') }}<br>{% endif %}
+                        {% if return_to.get('address1') %}{{ return_to.get('address1') }}<br>{% endif %}
+                        {% if return_to.get('address2') %}{{ return_to.get('address2') }}<br>{% endif %}
+                        {% set city = return_to.get('city', '') %}
+                        {% set state = return_to.get('state', '') %}
+                        {% set zip = return_to.get('zip', '') %}
+                        {% if city or state or zip %}
+                            {{ city }}{% if city and (state or zip) %}, {% endif %}{{ state }} {{ zip }}
+                        {% endif %}
+                    {% else %}
+                        _________________________________<br>
+                        _________________________________<br>
+                        _________________________________
+                    {% endif %}
+                </div>
+
+                <div class="ref-line">Order No.: {{ title_order_no or '____________________' }}</div>
+                <div class="ref-line">Escrow No.: {{ escrow_no or '____________________' }}</div>
+            </div>
+
+            <div class="recorder-space"><!-- Gov. Code §27361.6 — recorder's use only --></div>
+        </header>
+
+        <div class="header-boundary">
+            <span class="apn-ref">APN: {{ apn or '____________________' }}</span>
+            <span class="recorder-caption">Space Above This Line Is For Recorder&rsquo;s Use</span>
+        </div>
+
+        <h1 class="deed-title">Affidavit of Death</h1>
+        <div class="deed-subtitle">Community Property with Right of Survivorship<br>Spouse</div>
+
+        {% set aff = affidavit or {} %}
+        <div class="affidavit-body">
+            <p>
+                {% if aff.get('affiant_name') %}<span class="fact">{{ aff.get('affiant_name') }}</span>{% else %}<span class="fact-line">&nbsp;</span>{% endif %},
+                of legal age, being first duly sworn, deposes and says:
+            </p>
+            <p>
+                1. {% if aff.get('decedent_name') %}<span class="fact">{{ aff.get('decedent_name') }}</span>{% else %}<span class="fact-line">&nbsp;</span>{% endif %}
+                is the decedent mentioned in the attached certified copy of Certificate of Death,
+                who died on {% if aff.get('death_date') %}<span class="fact">{{ aff.get('death_date') }}</span>{% else %}<span class="fact-line" style="min-width:1.4in">&nbsp;</span>{% endif %},
+                at {% if aff.get('death_place') %}<span class="fact">{{ aff.get('death_place') }}</span>{% else %}<span class="fact-line" style="min-width:1.6in">&nbsp;</span>{% endif %}
+                (insert place of death).
+            </p>
+            <p>
+                2. I am the surviving spouse of Decedent and was married to Decedent on the date of death.
+            </p>
+            <p>
+                3. Decedent and I are the same persons who are named as grantees in that certain deed
+                dated {% if aff.get('deed_date') %}<span class="fact">{{ aff.get('deed_date') }}</span>{% else %}<span class="fact-line" style="min-width:1.4in">&nbsp;</span>{% endif %},
+                executed by {% if aff.get('deed_grantor') %}<span class="fact">{{ aff.get('deed_grantor') }}</span>{% else %}<span class="fact-line">&nbsp;</span>{% endif %}
+                in favor of the grantees as community property with right of survivorship, recorded on
+                {% if aff.get('recording_date') %}<span class="fact">{{ aff.get('recording_date') }}</span>{% else %}<span class="fact-line" style="min-width:1.4in">&nbsp;</span>{% endif %},
+                as Instrument No. {% if aff.get('instrument_no') %}<span class="fact">{{ aff.get('instrument_no') }}</span>{% else %}<span class="fact-line" style="min-width:1.4in">&nbsp;</span>{% endif %},
+                Official Records of
+                {% if county %}<span class="fact">{{ county }}</span>{% else %}<span class="fact-line" style="min-width:1.6in">&nbsp;</span>{% endif %}
+                County, California, describing the following real property:
+            </p>
+        </div>
+
+        <div class="legal-content">{{ legal_description or '' }}</div>
+
+        {# Execution: the affiant signs at the notarization — the date and
+           signature are theirs, not ours (blank-contents doctrine). #}
+        <div class="execution-section">
+            <div>Dated: <span class="fact-line" style="min-width:1.8in">&nbsp;</span></div>
+            <div>
+                <div class="signature-line"></div>
+            </div>
+        </div>
+
+        {% include '_partials/notary_jurat.jinja2' %}
+
+        <div class="attach-directive">Attach Certified Copy of Death Certificate</div>
+
+    </div>
+</body>
+</html>

--- a/templates/affidavit_death_trustee_ca/index.jinja2
+++ b/templates/affidavit_death_trustee_ca/index.jinja2
@@ -1,0 +1,240 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Affidavit - Death of Trustee - California</title>
+    <style>
+        /* ==========================================================================
+           AFFIDAVIT — DEATH OF TRUSTEE — wave 1 #2
+
+           Sibling of the FORMS-SPIKE affidavit chassis. Reference
+           implementation: Pacific Coast Title blank form #7
+           (Aff_Death-Trustee), measured with pdfplumber (letter page;
+           recorder caption ~192pt; title ~204pt; jurat lower half ~620pt;
+           ATTACH directive at the foot; one page).
+
+           Chassis rules carried over verbatim from the JT sibling:
+           - Gov. Code §27361.6 recorder's space top-right, open, caption at
+             the boundary; §27361.7 no chrome on recorded pages.
+           - Blank-contents doctrine: the affiant's execution and every
+             notarial entry stay blank — we generate the form, never the
+             sworn or notarial contents.
+           - No DTT declaration (clearing a deceased trustee from title is
+             not a conveyance; the reference carries no tax block), no
+             mail-tax directive.
+           - Jurat (Gov C §8202), NOT an acknowledgment (§1189).
+           Reference-specific: three numbered clauses; clause 3 ("I am the
+           surviving or successor Trustee ...") is instrument-defining
+           furniture (Flag-3 precedent) and renders BELOW the legal
+           description, as the reference lays it out.
+           ========================================================================== */
+
+        @page {
+            size: letter;
+            margin: 0.5in 0.5in 0.6in 0.6in;
+        }
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        body {
+            font-family: "Times New Roman", Times, Georgia, serif;
+            font-size: 11pt;
+            line-height: 1.35;
+            color: #000;
+            background: #fff;
+        }
+
+        .header-section { display: flex; min-height: 1.85in; }
+
+        .recording-info {
+            width: 3.4in;
+            flex-shrink: 0;
+            border-right: 0.75pt solid #000;
+            padding-right: 0.15in;
+            font-size: 10pt;
+            line-height: 1.35;
+        }
+
+        .recorder-space { flex-grow: 1; }
+
+        .recording-label {
+            font-weight: bold;
+            text-transform: uppercase;
+            font-size: 9pt;
+        }
+
+        .recording-value { margin-bottom: 0.12in; min-height: 0.35in; }
+
+        .ref-line { font-size: 10pt; }
+
+        .header-boundary {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            border-bottom: 0.75pt solid #000;
+            padding-bottom: 0.03in;
+            margin-bottom: 0.12in;
+        }
+
+        .apn-ref { font-weight: bold; font-size: 10pt; }
+
+        .recorder-caption {
+            font-size: 7.5pt;
+            font-weight: bold;
+            text-transform: uppercase;
+        }
+
+        .deed-title {
+            text-align: center;
+            font-size: 14pt;
+            font-weight: bold;
+            letter-spacing: 2px;
+            text-transform: uppercase;
+            margin: 0.1in 0 0.12in 0;
+        }
+
+        .affidavit-body {
+            font-size: 11pt;
+            line-height: 1.35;
+            text-align: justify;
+        }
+
+        .affidavit-body p { margin-bottom: 0.07in; }
+
+        .fact {
+            /* Officer-supplied facts render bold like the deed parties; a
+               missing fact renders as the reference's blank line so an
+               incomplete instrument LOOKS incomplete. */
+            font-weight: bold;
+        }
+
+        .fact-line {
+            display: inline-block;
+            min-width: 2.2in;
+            border-bottom: 1px solid #000;
+        }
+
+        .legal-content {
+            font-weight: bold;
+            white-space: pre-wrap;
+            margin: 0.05in 0;
+            min-height: 0.4in;
+        }
+
+        .execution-section {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-end;
+            margin-top: 0.06in;
+            margin-bottom: 0.03in;
+        }
+
+        .signature-line {
+            border-bottom: 1px solid #000;
+            width: 3.2in;
+            height: 0.3in;
+        }
+
+        .attach-directive {
+            text-align: center;
+            font-size: 10pt;
+            font-weight: bold;
+            text-transform: uppercase;
+            margin-top: 0.06in;
+        }
+    </style>
+</head>
+<body>
+    <div class="deed-page">
+
+        <header class="header-section">
+            <div class="recording-info">
+                <div class="recording-label">Recording Requested By:</div>
+                <div class="recording-value">{{ requested_by or '' }}{% if requested_by_address %}<br>{{ requested_by_address }}{% endif %}</div>
+
+                <div class="recording-label">And When Recorded Mail To:</div>
+                <div class="recording-value">
+                    {% if return_to %}
+                        {% if return_to.get('name') %}{{ return_to.get('name') }}<br>{% endif %}
+                        {% if return_to.get('company') %}{{ return_to.get('company') }}<br>{% endif %}
+                        {% if return_to.get('address1') %}{{ return_to.get('address1') }}<br>{% endif %}
+                        {% if return_to.get('address2') %}{{ return_to.get('address2') }}<br>{% endif %}
+                        {% set city = return_to.get('city', '') %}
+                        {% set state = return_to.get('state', '') %}
+                        {% set zip = return_to.get('zip', '') %}
+                        {% if city or state or zip %}
+                            {{ city }}{% if city and (state or zip) %}, {% endif %}{{ state }} {{ zip }}
+                        {% endif %}
+                    {% else %}
+                        _________________________________<br>
+                        _________________________________<br>
+                        _________________________________
+                    {% endif %}
+                </div>
+
+                <div class="ref-line">Order No.: {{ title_order_no or '____________________' }}</div>
+                <div class="ref-line">Escrow No.: {{ escrow_no or '____________________' }}</div>
+            </div>
+
+            <div class="recorder-space"><!-- Gov. Code §27361.6 — recorder's use only --></div>
+        </header>
+
+        <div class="header-boundary">
+            <span class="apn-ref">APN: {{ apn or '____________________' }}</span>
+            <span class="recorder-caption">Space Above This Line Is For Recorder&rsquo;s Use</span>
+        </div>
+
+        <h1 class="deed-title">Affidavit &mdash; Death of Trustee</h1>
+
+        {% set aff = affidavit or {} %}
+        <div class="affidavit-body">
+            <p>
+                {% if aff.get('affiant_name') %}<span class="fact">{{ aff.get('affiant_name') }}</span>{% else %}<span class="fact-line">&nbsp;</span>{% endif %},
+                of legal age, being first duly sworn, deposes and says:
+            </p>
+            <p>
+                1. {% if aff.get('decedent_name') %}<span class="fact">{{ aff.get('decedent_name') }}</span>{% else %}<span class="fact-line">&nbsp;</span>{% endif %}
+                is the decedent mentioned in the attached certified copy of Certificate of Death,
+                and is the same person named as Trustee in that certain Declaration of Trust
+                dated {% if aff.get('trust_date') %}<span class="fact">{{ aff.get('trust_date') }}</span>{% else %}<span class="fact-line" style="min-width:1.4in">&nbsp;</span>{% endif %},
+                executed by {% if aff.get('trustors') %}<span class="fact">{{ aff.get('trustors') }}</span>{% else %}<span class="fact-line">&nbsp;</span>{% endif %}
+                as trustor(s).
+            </p>
+            <p>
+                2. At the time of decedent&rsquo;s death, decedent was the owner, as Trustee, of
+                certain real property acquired by a deed recorded on
+                {% if aff.get('recording_date') %}<span class="fact">{{ aff.get('recording_date') }}</span>{% else %}<span class="fact-line" style="min-width:1.4in">&nbsp;</span>{% endif %},
+                as Instrument No. {% if aff.get('instrument_no') %}<span class="fact">{{ aff.get('instrument_no') }}</span>{% else %}<span class="fact-line" style="min-width:1.4in">&nbsp;</span>{% endif %},
+                in Official Records of
+                {% if county %}<span class="fact">{{ county }}</span>{% else %}<span class="fact-line" style="min-width:1.6in">&nbsp;</span>{% endif %}
+                County, California, describing the following real property:
+            </p>
+        </div>
+
+        <div class="legal-content">{{ legal_description or '' }}</div>
+
+        <div class="affidavit-body">
+            <p>
+                3. I am the surviving or successor Trustee of the same trust under which said
+                decedent held title as trustee pursuant to the deed described above, and am
+                designated and empowered pursuant to the terms of said trust to serve as
+                Trustee thereof.
+            </p>
+        </div>
+
+        {# Execution: the affiant signs at the notarization — the date and
+           signature are theirs, not ours (blank-contents doctrine). #}
+        <div class="execution-section">
+            <div>Dated: <span class="fact-line" style="min-width:1.8in">&nbsp;</span></div>
+            <div>
+                <div class="signature-line"></div>
+            </div>
+        </div>
+
+        {% include '_partials/notary_jurat.jinja2' %}
+
+        <div class="attach-directive">Attach Certified Copy of Death Certificate</div>
+
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Wave 1, forms #1 and #2 (owner-ranked order) — paired as siblings

Both forms follow the spike pipeline end to end.

### References fetched and measured
- **#1 CP w/ROS (Spouse)**: PCT blank form #3 (`Aff_Death-CP_Rt_Surv.pdf`) — letter, one page, caption at 192pt, title 204pt, jurat at ~600pt, ATTACH at foot.
- **#2 Trustee**: PCT blank form #7 (`Aff_Death-Trustee.pdf`) — same chassis, jurat at ~620pt.

### Doctrine pass — no new legal-choice class (no hold)
| | Furniture | Officer facts | Legal choices |
|---|---|---|---|
| **CP w/ROS Spouse** | Title + stacked qualifier lines; sworn opener; clause 2 verbatim ("I am the surviving spouse of Decedent and was married to Decedent on the date of death" — instrument-defining, Flag-3 precedent); "in favor of the grantees as community property with right of survivorship"; ATTACH directive; §8202 jurat | affiant, decedent, **death date, place of death** (new), CP-deed date + executed-by, recording date, instrument no. | **None.** No DTT (not a conveyance), no vesting, no elections |
| **Trustee** | Title; sworn opener; clause 3 verbatim ("I am the surviving or successor Trustee… designated and empowered pursuant to the terms of said trust" — instrument-defining, renders below the legal description as the reference lays it out); "as trustor(s)"; ATTACH; jurat | affiant, decedent, **trust date, trustor(s)** (new), recording date, instrument no. | **None.** |

Both new-fact classes are officer-typed facts, same class as the spike's — nothing doctrine-shaped surfaced.

### Assembly-line change (pays forward)
`AffidavitSection` now renders from registry field specs (`affidavitFields` on the entry), so the next affidavit sibling is **one registry entry + one Jinja template**. Registry pins enforce: every affidavit entry declares the common four keys (affiant, decedent, recording date, instrument no.) and a spec cannot carry a `value`/`default` (no smuggled prefill). `AffidavitFacts` is now the variant superset; payload/resume carry all keys snake-case; the recording-reference substantive check is generalized across the family.

### Pins
16 new backend tests (`test_wave1_affidavits.py`), parameterized over both forms: furniture strings, facts render, missing facts → blank lines never invented, **jurat-not-acknowledgment canary** (exactly one certificate, §8202 body, §1189 absent), blank-contents (nothing pre-fills in the jurat but venue county), no-DTT/no-mail-tax, chassis geometry via pdfplumber (one page, open recorder space, caption right of center, jurat lower half) + no-chrome leaks, type-map registration. Registry test extended to 8 types; D3 anchor pin now checks spec keys against the registry.

### One-page budget
Both siblings initially rendered 2 pages (the spike's predicted fight — CP runs three numbered clauses plus qualifier lines). Tightened line-heights/margins per template until pdfplumber confirms 1 page each; the shared jurat partial is untouched.

### Gates
- Backend: **123 passed** (was 107; +16)
- Six-flow baseline: ✔ (snapshot unchanged)
- Jest: **272 passed**
- tsc: frozen baseline **98** (unchanged)

### Per-form actuals vs. the 1–2 hr projection
~1.5 hr for the pair (~45 min/form), including the one-time registry-driven-section refactor and the page-budget fight — **under projection**; the next siblings should be cheaper still since the section refactor is done.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_