### PR TITLE
FORMS wave 1 (#3, #4): Joint Tenancy + CP w/ROS Grant Deeds

### DIFF
--- a/backend/services/deed_pdf.py
+++ b/backend/services/deed_pdf.py
@@ -42,6 +42,9 @@ TEMPLATE_BY_DEED_TYPE = {
     # FORMS wave 1 — affidavit siblings (PCT references #3 and #7).
     "affidavit-death-cp-spouse": "affidavit_death_cp_spouse_ca/index.jinja2",
     "affidavit-death-trustee": "affidavit_death_trustee_ca/index.jinja2",
+    # FORMS wave 1 — fixed-vesting deed variants (PCT references #28, #21).
+    "grant-deed-jt": "grant_deed_jt_ca/index.jinja2",
+    "grant-deed-cp-ros": "grant_deed_cp_ros_ca/index.jinja2",
 }
 DEFAULT_TEMPLATE = "grant_deed_ca/index.jinja2"
 

--- a/backend/tests/test_wave1_deed_variants.py
+++ b/backend/tests/test_wave1_deed_variants.py
@@ -1,0 +1,174 @@
+"""FORMS wave 1 — fixed-vesting deed variants, pinned.
+
+Forms #3 and #4 of the owner-ranked wave, built against Pacific Coast
+Title blank forms #28 (Deed-JointTenancy) and #21 (Deed-CPSurvivorship).
+
+The doctrine line these pins hold: the vesting phrase is printed on the
+instrument's face as FURNITURE — choosing the form IS the officer's
+vesting decision (Flag-3 precedent). The templates therefore never read
+the stored vesting value (a stray value must not contradict the face of
+the instrument), while EVERY other deed-chassis behavior — including the
+full documentary-transfer-tax declaration — is preserved: these ARE
+conveyances, unlike the affidavit family.
+"""
+import io
+
+import pdfplumber
+import pytest
+
+from services.deed_pdf import render_deed_html, render_deed_pdf
+from tests.test_deed_pdf import _normalized
+
+DEED_META = {
+    "requested_by_address": "456 Escrow Way, Los Angeles, CA 90012",
+    "return_to": {"name": "JOHN A. DOE AND JANE B. DOE", "address1": "1358 5TH ST",
+                  "city": "Santa Monica", "state": "CA", "zip": "90401"},
+    "dtt": {
+        "transfer_value": "500000",
+        "calculated_amount": "550.00",
+        "basis": "full_value",
+        "area_type": "city",
+        "city_name": "Santa Monica",
+        "is_exempt": False,
+        "exemption_reason": "",
+    },
+}
+
+FORMS = {
+    "grant-deed-jt": {
+        "template": "grant_deed_jt_ca/index.jinja2",
+        "title": "Joint Tenancy Grant Deed",
+        "vesting_furniture": "as JOINT TENANTS the real property situated in the County of",
+    },
+    "grant-deed-cp-ros": {
+        "template": "grant_deed_cp_ros_ca/index.jinja2",
+        "title": "Community Property with Right of Survivorship",
+        "vesting_furniture": "as COMMUNITY PROPERTY WITH RIGHT OF SURVIVORSHIP the real property situated in the County of",
+    },
+}
+
+
+def deed_row(deed_type, **overrides):
+    row = {
+        "id": 1,
+        "deed_type": deed_type,
+        "grantor_name": "ROBERT SELLER",
+        "grantee_name": "JOHN A. DOE AND JANE B. DOE",
+        "legal_description": "LOT 7, BLOCK B, TRACT 12345",
+        "county": "Los Angeles",
+        "apn": "4290-012-034",
+        "property_address": "1358 5TH ST, Santa Monica, CA 90401",
+        "requested_by": "Pacific Coast Escrow",
+        # Deliberately poisoned: the fixed-vesting templates must NEVER
+        # read this column (see test_stored_vesting_is_never_read).
+        "vesting": "SENTINEL VESTING TEXT",
+        "metadata": DEED_META,
+    }
+    row.update(overrides)
+    return row
+
+
+@pytest.fixture(params=sorted(FORMS))
+def deed_type(request):
+    return request.param
+
+
+def test_title_and_granting_furniture(deed_type):
+    html = _normalized(render_deed_html(deed_row(deed_type)))
+    assert FORMS[deed_type]["title"] in html
+    assert "For valuable consideration, receipt of which is hereby acknowledged," in html
+    assert "hereby GRANT(S) to" in html
+    assert FORMS[deed_type]["vesting_furniture"] in html
+    assert "State of California, more particularly described as follows:" in html
+
+
+def test_officer_facts_render(deed_type):
+    html = _normalized(render_deed_html(deed_row(deed_type)))
+    for fact in ("ROBERT SELLER", "JOHN A. DOE AND JANE B. DOE", "Los Angeles",
+                 "4290-012-034", "LOT 7, BLOCK B, TRACT 12345",
+                 "Pacific Coast Escrow"):
+        assert fact in html, fact
+
+
+def test_stored_vesting_is_never_read(deed_type):
+    """THE structural pin for the furniture ruling: even a poisoned stored
+    vesting value cannot reach the instrument — the printed phrase is the
+    only vesting on the face of the deed."""
+    html = render_deed_html(deed_row(deed_type))
+    assert "SENTINEL VESTING TEXT" not in html
+
+
+def test_full_dtt_declaration_present(deed_type):
+    """These ARE conveyances: the complete R&T §11932–11933 declaration
+    renders — lead-in, amount, basis checklines, area checklines — exactly
+    as on the standard grant deed. (Unlike the affidavit family.)"""
+    html = _normalized(render_deed_html(deed_row(deed_type)))
+    assert "THE UNDERSIGNED GRANTOR(S) DECLARE(S):" in html
+    assert "DOCUMENTARY TRANSFER TAX IS" in html
+    assert "Computed on full value of property conveyed, or" in html
+    assert "Computed on full value less liens and encumbrances remaining at time of sale." in html
+    assert "Unincorporated area" in html
+    assert "550.00" in html          # the officer's recorded DTT decision
+    assert "Santa Monica" in html    # city checkline value
+    assert "Mail Tax Statements" in html
+
+
+def test_dtt_never_prefilled_without_officer_data(deed_type):
+    """No DTT metadata → blank declaration: no amount, no checked lines
+    (suggest→confirm→record; the blank reference tolerates blanks)."""
+    html = _normalized(render_deed_html(deed_row(deed_type, metadata={})))
+    assert "DOCUMENTARY TRANSFER TAX IS" in html
+    assert "550.00" not in html
+    assert ">X<" not in html.replace(" ", "")
+
+
+def test_acknowledgment_not_jurat(deed_type):
+    """The doctrine canary, deed-family direction: acknowledged instruments
+    carry the §1189 certificate — never a jurat."""
+    html = _normalized(render_deed_html(deed_row(deed_type)))
+    assert "personally appeared" in html
+    assert "acknowledged to me" in html
+    assert "Subscribed and sworn to (or affirmed) before me" not in html
+    assert html.count("verifies only the identity") == 1
+
+
+def test_acknowledgment_contents_are_blank(deed_type):
+    """Blank-contents doctrine: the notary's entries never pre-fill; only
+    the venue county renders."""
+    html = _normalized(render_deed_html(deed_row(deed_type)))
+    ack = html[html.index("personally appeared"):]
+    assert "ROBERT SELLER" not in ack
+
+
+def test_chassis_geometry_and_no_chrome(deed_type):
+    """G2/G3 discipline: recorder space open, caption at the boundary,
+    title below it, acknowledgment present, no chrome."""
+    pdf = render_deed_pdf(deed_row(deed_type))
+    with pdfplumber.open(io.BytesIO(pdf)) as doc:
+        assert len(doc.pages) <= 2   # page one + acknowledgment page
+        page = doc.pages[0]
+        words = page.extract_words()
+
+        def top_of(needle):
+            hits = [w for w in words if needle.upper() in w["text"].upper()]
+            assert hits, needle
+            return hits[0]["top"]
+
+        def x_of(needle):
+            hits = [w for w in words if needle.upper() in w["text"].upper()]
+            return hits[0]["x0"]
+
+        caption_top = top_of("RECORDER’S")
+        title_top = top_of("GRANT")
+        assert caption_top > 100          # a real open recorder space above it
+        assert x_of("RECORDER’S") > 300   # caption sits right of center
+        assert title_top > caption_top    # title below the boundary
+
+    html = render_deed_html(deed_row(deed_type))
+    for leaked in ("7C4DFF", "Generated by", "deedpro.com/verify", "recorder-box", "bg-brand"):
+        assert leaked not in html, leaked
+
+
+def test_registered_in_the_type_map(deed_type):
+    from services.deed_pdf import TEMPLATE_BY_DEED_TYPE
+    assert TEMPLATE_BY_DEED_TYPE[deed_type] == FORMS[deed_type]["template"]

--- a/frontend/src/__tests__/formRegistry.test.ts
+++ b/frontend/src/__tests__/formRegistry.test.ts
@@ -10,7 +10,7 @@
 import { describe, expect, it } from '@jest/globals';
 import * as fs from 'fs';
 import * as path from 'path';
-import { FORM_REGISTRY, formConfig, formFamily } from '../lib/formRegistry';
+import { FORM_REGISTRY, formConfig, formFamily, hasVestingInput } from '../lib/formRegistry';
 import { DEED_LABELS, deedTypeLabel } from '../lib/deedTypes';
 import { isAffidavitType } from '../lib/deedValidation';
 
@@ -23,12 +23,15 @@ const KNOWN_SECTIONS = new Set(['property', 'grantor', 'grantee', 'vesting', 'tr
 describe('FORMS registry — completeness and coherence', () => {
   const entries = Object.values(FORM_REGISTRY);
 
-  it('carries the eight shipped types', () => {
-    expect(entries.length).toBe(8);
+  it('carries the ten shipped types', () => {
+    expect(entries.length).toBe(10);
     expect(formConfig('affidavit-death-jt')?.family).toBe('affidavit');
     // Wave 1 siblings (owner-ranked #1 and #2):
     expect(formConfig('affidavit-death-cp-spouse')?.family).toBe('affidavit');
     expect(formConfig('affidavit-death-trustee')?.family).toBe('affidavit');
+    // Wave 1 deed variants (owner-ranked #3 and #4):
+    expect(formConfig('grant-deed-jt')?.family).toBe('deed');
+    expect(formConfig('grant-deed-cp-ros')?.family).toBe('deed');
   });
 
   it('every entry is internally coherent', () => {
@@ -93,6 +96,19 @@ describe('FORMS registry — the consumers derive from it', () => {
     expect(isAffidavitType('affidavit-death-jt')).toBe(true);
     expect(isAffidavitType('grant-deed')).toBe(false);
     expect(formFamily('unknown-type')).toBe('deed'); // safe default
+  });
+
+  it('fixed-vesting variants drop the vesting section; the registry carries no phrase', () => {
+    for (const slug of ['grant-deed-jt', 'grant-deed-cp-ros']) {
+      expect(hasVestingInput(slug)).toBe(false);
+      expect(formConfig(slug)?.hasDtt).toBe(true); // still conveyances: full DTT gate
+      // The vesting phrase is TEMPLATE furniture (deedFurniture +
+      // chassis-conformance pins) — a registry entry must not carry it,
+      // or config would be deciding a legal question.
+      expect(JSON.stringify(formConfig(slug))).not.toMatch(/JOINT TENANTS|SURVIVORSHIP the real/);
+    }
+    expect(hasVestingInput('grant-deed')).toBe(true);
+    expect(hasVestingInput('unknown-type')).toBe(true); // safe default
   });
 
   it('the selection page and preview read the registry', () => {

--- a/frontend/src/__tests__/previewChassisConformance.test.ts
+++ b/frontend/src/__tests__/previewChassisConformance.test.ts
@@ -26,6 +26,7 @@ import {
   MAIL_TAX_DIRECTIVE,
   OPERATIVE_WORDS,
   EXEMPTION_RECITALS,
+  FIXED_VESTING_PHRASES,
 } from '../lib/deedFurniture';
 
 /** Strip // and /* comments so prose about a disease can't trip the scan. */
@@ -48,6 +49,8 @@ const TEMPLATE_DIRS: Record<string, string> = {
   'interspousal-transfer': 'interspousal_transfer_ca',
   'warranty-deed': 'warranty_deed_ca',
   'tax-deed': 'tax_deed_ca',
+  'grant-deed-jt': 'grant_deed_jt_ca',
+  'grant-deed-cp-ros': 'grant_deed_cp_ros_ca',
 };
 
 /** Normalize Jinja/HTML source for wording comparison. */
@@ -76,6 +79,7 @@ describe('preview uses the shared furniture constants', () => {
     'MAIL_TAX_DIRECTIVE',
     'OPERATIVE_WORDS',
     'EXEMPTION_RECITALS',
+    'FIXED_VESTING_PHRASES',
   ])('renders via %s, not a duplicated string', (identifier) => {
     expect(PANEL).toContain(identifier);
   });
@@ -106,7 +110,7 @@ describe('preview carries no dead pre-G2 furniture', () => {
 
 describe('the same wording lives in the backend chassis templates', () => {
   const allTypes = Object.keys(TEMPLATE_DIRS);
-  const dttTypes = ['grant-deed', 'quitclaim-deed', 'warranty-deed'];
+  const dttTypes = ['grant-deed', 'quitclaim-deed', 'warranty-deed', 'grant-deed-jt', 'grant-deed-cp-ros'];
 
   it.each(allTypes)('%s: recorder caption and mail-tax directive', (dt) => {
     const t = template(dt);
@@ -128,5 +132,16 @@ describe('the same wording lives in the backend chassis templates', () => {
 
   it.each(Object.keys(EXEMPTION_RECITALS))('%s: categorical exemption recital', (dt) => {
     expect(template(dt)).toContain(EXEMPTION_RECITALS[dt]);
+  });
+
+  // Wave 1 #3/#4: the fixed-vesting phrase is furniture printed by the
+  // template — preview and instrument must carry the identical wording,
+  // and the template must never read the stored vesting value (a stray
+  // value must not contradict the face of the instrument).
+  it.each(Object.keys(FIXED_VESTING_PHRASES))('%s: fixed-vesting furniture, stored vesting never read', (dt) => {
+    const t = template(dt);
+    expect(t).toContain(`${FIXED_VESTING_PHRASES[dt]} the real property situated in the County of`);
+    expect(t).not.toContain('{{ vesting }}');
+    expect(t).not.toContain('{% if vesting %}');
   });
 });

--- a/frontend/src/components/builder/InputPanel.tsx
+++ b/frontend/src/components/builder/InputPanel.tsx
@@ -12,6 +12,7 @@ import { TransferTaxSection } from './sections/TransferTaxSection';
 import { RecordingSection } from './sections/RecordingSection';
 import { AffidavitSection } from './sections/AffidavitSection';
 import { isAffidavitType } from '@/lib/deedValidation';
+import { hasVestingInput } from '@/lib/formRegistry';
 import { DeedBuilderState } from '@/types/builder';
 
 interface InputPanelProps {
@@ -156,9 +157,15 @@ export function InputPanel({
             onChange={(grantee) => onChange({ grantee })}
             grantorName={state.grantor}
           />
-          <SectionNext to="vesting" label="Next: Vesting" />
+          {hasVestingInput(state.deedType)
+            ? <SectionNext to="vesting" label="Next: Vesting" />
+            : <SectionNext to="transferTax" label="Next: Transfer Tax" />}
         </InputSection>
 
+        {/* Fixed-vesting variants (JT / CP w/ROS grant deeds) print their
+            vesting on the instrument's face — no vesting input, no
+            vestingDecision: choosing the form IS the decision (Flag-3). */}
+        {hasVestingInput(state.deedType) && (
         <InputSection
           id="vesting"
           title="Vesting"
@@ -179,6 +186,7 @@ export function InputPanel({
           />
           <SectionNext to="transferTax" label="Next: Transfer Tax" />
         </InputSection>
+        )}
 
         <InputSection
           id="transferTax"

--- a/frontend/src/components/builder/PreviewPanel.tsx
+++ b/frontend/src/components/builder/PreviewPanel.tsx
@@ -19,6 +19,7 @@ import {
   MAIL_TAX_DIRECTIVE,
   OPERATIVE_WORDS,
   EXEMPTION_RECITALS,
+  FIXED_VESTING_PHRASES,
 } from '@/lib/deedFurniture';
 // FORMS registry: document titles + family come from the one source of
 // type facts.
@@ -79,6 +80,7 @@ export function PreviewPanel({ state, activeSection, onRegionClick }: PreviewPan
   const factOrBlank = (v: string | undefined) => v?.trim() || '________________';
   const operative = OPERATIVE_WORDS[state.deedType] || OPERATIVE_WORDS['grant-deed'];
   const exemptionRecital = EXEMPTION_RECITALS[state.deedType];
+  const fixedVesting = FIXED_VESTING_PHRASES[state.deedType];
 
   // DTT honesty (G3's invariant, mock-up form): nothing is declared until
   // the officer's transfer-tax data exists — no pre-checked boxes, no $0.00.
@@ -359,12 +361,15 @@ export function PreviewPanel({ state, activeSection, onRegionClick }: PreviewPan
 
             <div className={`mb-2 ${highlight('grantee')}`}>
               <span onClick={go('grantee', 'grantee')} className={`font-bold uppercase text-[11pt] ${CLICKABLE} ${placeholder(preview.grantee)} ${dataHighlight(preview.grantee)}`}>{preview.grantee}</span>
-              {preview.vesting && (
+              {!fixedVesting && preview.vesting && (
                 <span onClick={go('vesting')} className={`text-[11pt] ${CLICKABLE} ${highlight('vesting')} ${dataHighlight(preview.vesting)}`}>, {preview.vesting}</span>
               )}
             </div>
 
             <p className="mb-2 text-[11pt]">
+              {/* Fixed-vesting furniture — instrument-defining, not data:
+                  no highlight, no click target, exactly as printed. */}
+              {fixedVesting && `${fixedVesting} `}
               the real property situated in the County of{' '}
               <span onClick={go('property')} className={`font-bold ${CLICKABLE} ${placeholder(preview.county)} ${dataHighlight(preview.county)}`}>{preview.county}</span>,
               State of California, more particularly described as follows:

--- a/frontend/src/lib/deedFurniture.ts
+++ b/frontend/src/lib/deedFurniture.ts
@@ -35,6 +35,18 @@ export const OPERATIVE_WORDS: Record<string, string> = {
   'interspousal-transfer': 'hereby GRANTS AND TRANSFERS to',
   'warranty-deed': 'hereby GRANTS, BARGAINS, SELLS AND CONVEYS to',
   'tax-deed': 'does hereby grant, bargain, sell and convey to',
+  'grant-deed-jt': 'hereby GRANT(S) to',
+  'grant-deed-cp-ros': 'hereby GRANT(S) to',
+};
+
+/** Fixed-vesting phrases printed on the instrument's face (wave 1 #3/#4).
+ * Instrument-defining furniture under the Flag-3 precedent: choosing the
+ * form IS the officer's vesting decision, so the phrase lives here and in
+ * the template — never as a stored vesting value. The clause reads
+ * "<phrase> the real property situated in ..." per the PCT references. */
+export const FIXED_VESTING_PHRASES: Record<string, string> = {
+  'grant-deed-jt': 'as JOINT TENANTS',
+  'grant-deed-cp-ros': 'as COMMUNITY PROPERTY WITH RIGHT OF SURVIVORSHIP',
 };
 
 /** Categorical exemption recitals (instrument-defining form furniture —

--- a/frontend/src/lib/deedValidation.ts
+++ b/frontend/src/lib/deedValidation.ts
@@ -35,7 +35,7 @@ const dttComplete = (state: DeedBuilderState): boolean => {
 /** FORMS: instrument families diverge here — affidavits have no
  * grantor/grantee/vesting/DTT; their substance is the sworn facts.
  * Family membership comes from the registry (one entry per type). */
-import { formFamily } from '@/lib/formRegistry';
+import { formFamily, hasVestingInput } from '@/lib/formRegistry';
 
 export function isAffidavitType(deedType: string | undefined): boolean {
   return formFamily(deedType) === 'affidavit';
@@ -98,12 +98,23 @@ export function evaluateSubstantive(state: DeedBuilderState): CheckResult[] {
       ok: !!state.property?.legalDescription?.trim(),
       sectionId: 'property',
     },
-    {
-      id: 'vesting_stated',
-      label: 'Vesting stated',
-      ok: !!state.vesting?.trim(),
-      sectionId: 'vesting',
-    },
+    hasVestingInput(state.deedType)
+      ? {
+          id: 'vesting_stated',
+          label: 'Vesting stated',
+          ok: !!state.vesting?.trim(),
+          sectionId: 'vesting',
+        }
+      : {
+          // Fixed-vesting variants (JT / CP w/ROS grant deeds): the vesting
+          // phrase is printed on the instrument's face — choosing the form
+          // IS the vesting decision (Flag-3). Structural fact, like the
+          // notarial certificate.
+          id: 'vesting_fixed_by_instrument',
+          label: 'Vesting fixed by the instrument',
+          ok: true,
+          detail: 'This form prints its vesting on its face; there is no vesting entry.',
+        },
     {
       id: 'dtt_decided',
       label: 'Transfer tax decided',
@@ -243,7 +254,12 @@ export function deriveSectionTruth(state: DeedBuilderState): SectionTruth {
     property: status('property', !!state.property?.address),
     grantor: status('grantor', !!state.grantor?.trim()),
     grantee: status('grantee', !!state.grantee?.trim(), granteeEchoesGrantor),
-    vesting: status('vesting', !!state.vesting?.trim()),
+    // Fixed-vesting variants have no vesting section — its status must not
+    // appear in the one-truth counter (a section that cannot be opened can
+    // never read "incomplete").
+    ...(hasVestingInput(state.deedType)
+      ? { vesting: status('vesting', !!state.vesting?.trim()) }
+      : {}),
     transferTax: status(
       'transferTax',
       !!(state.dtt?.isExempt && state.dtt?.exemptReason) || !!state.dtt?.transferValue

--- a/frontend/src/lib/formRegistry.ts
+++ b/frontend/src/lib/formRegistry.ts
@@ -66,6 +66,11 @@ export interface FormTypeConfig {
 }
 
 const DEED_SECTIONS = ['property', 'grantor', 'grantee', 'vesting', 'transferTax', 'recording'];
+/* Fixed-vesting deed variants (wave 1 #3/#4): the vesting phrase is printed
+   on the instrument's face as furniture — choosing the form IS the vesting
+   decision (Flag-3 precedent), so there is no vesting input. Everything
+   else, including the full transfer-tax decision gate, is unchanged. */
+const FIXED_VESTING_DEED_SECTIONS = ['property', 'grantor', 'grantee', 'transferTax', 'recording'];
 const AFFIDAVIT_SECTIONS = ['property', 'affidavit', 'recording'];
 
 /* Spike flag 4 ruling (applies to every affidavit-of-death variant):
@@ -160,6 +165,31 @@ export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
     notarial: 'acknowledgment',
     hasDtt: true,
   },
+  // Wave 1 form #3 — reference: PCT blank form #28 (Deed-JointTenancy).
+  'grant-deed-jt': {
+    slug: 'grant-deed-jt',
+    label: 'Grant Deed — Joint Tenancy',
+    title: 'JOINT TENANCY GRANT DEED',
+    description: 'Grant deed conveying to two or more grantees as joint tenants — vesting printed on the face of the form',
+    popular: false,
+    family: 'deed',
+    sections: FIXED_VESTING_DEED_SECTIONS,
+    notarial: 'acknowledgment',
+    hasDtt: true,
+  },
+  // Wave 1 form #4 — reference: PCT blank form #21 (Deed-CPSurvivorship).
+  'grant-deed-cp-ros': {
+    slug: 'grant-deed-cp-ros',
+    label: 'Grant Deed — Community Property w/ Right of Survivorship',
+    title: 'GRANT DEED',
+    subtitle: 'Community Property with Right of Survivorship',
+    description: 'Grant deed conveying to spouses as community property with right of survivorship — vesting printed on the face of the form',
+    popular: false,
+    family: 'deed',
+    sections: FIXED_VESTING_DEED_SECTIONS,
+    notarial: 'acknowledgment',
+    hasDtt: true,
+  },
   'affidavit-death-jt': {
     slug: 'affidavit-death-jt',
     label: 'Affidavit — Death of Joint Tenant',
@@ -231,4 +261,16 @@ export function formConfig(slug: string | undefined | null): FormTypeConfig | un
 
 export function formFamily(slug: string | undefined | null): FormFamily {
   return formConfig(slug)?.family ?? 'deed';
+}
+
+/**
+ * Whether the officer supplies vesting text for this type. Fixed-vesting
+ * instruments (JT / CP w/ROS grant deeds) print their vesting phrase as
+ * form furniture in the TEMPLATE — the registry carries no vesting value,
+ * only the absence of the input. Unknown slugs default to the standard
+ * deed behavior (officer-typed vesting).
+ */
+export function hasVestingInput(slug: string | undefined | null): boolean {
+  const cfg = formConfig(slug);
+  return cfg ? cfg.sections.includes('vesting') : true;
 }

--- a/templates/grant_deed_cp_ros_ca/index.jinja2
+++ b/templates/grant_deed_cp_ros_ca/index.jinja2
@@ -1,0 +1,504 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Grant Deed (Community Property with Right of Survivorship) - California</title>
+    <style>
+        /* ==========================================================================
+           GRANT DEED — CP W/ RIGHT OF SURVIVORSHIP — CALIFORNIA (wave 1 #4)
+
+           Fixed-vesting variant of the grant-deed chassis (PCT reference
+           blank form #21, Deed-CPSurvivorship: letter, stacked title
+           lines, full DTT block). The vesting phrase "as COMMUNITY
+           PROPERTY WITH RIGHT OF SURVIVORSHIP" is printed on the
+           instrument's face as furniture — choosing this form IS the
+           vesting decision (Flag-3 precedent); the template deliberately
+           never reads the stored vesting value, so a stray value can
+           never contradict the face of the instrument. Chassis notes
+           below are the grant deed's.
+
+           Geometry mirrors the owner's reference sample of a standard recorded
+           CA Grant Deed plus statute:
+           - Gov. Code §27361.6: recorder's space top-right of page one
+             (open space — no drawn box; a border invites rejection), caption
+             "SPACE ABOVE THIS LINE IS FOR RECORDER'S USE" at its bottom
+             boundary (~2.66" from the page top in the reference).
+           - R&T §11932–11933: DTT declaration opens with
+             "THE UNDERSIGNED GRANTOR(S) DECLARE(S):" and shows the
+             computed-on and unincorporated/City checklines.
+           - Gov. Code §27361.7 reproducibility: recorded pages carry no
+             color, no backgrounds, no branding. The QR/verification block
+             was REMOVED from recorded pages — the capability survives as
+             data (deed_pdfs.sha256 + metadata + the /api/verify portal).
+           ========================================================================== */
+
+        @page {
+            size: letter;
+            margin: 0.5in 0.5in 0.6in 0.6in;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: "Times New Roman", Times, Georgia, serif;
+            font-size: 11pt;
+            line-height: 1.35;
+            color: #000;
+            background: #fff;
+        }
+
+        /* --------------------------------------------------------------------------
+           PAGE-ONE HEADER — left info column beside the open recorder's space.
+           The vertical rule at 3.4in marks the left boundary of the recorder's
+           space, exactly as on the reference form. The space itself is empty.
+           -------------------------------------------------------------------------- */
+
+        .header-section {
+            display: flex;
+            min-height: 1.85in;
+        }
+
+        .recording-info {
+            width: 3.4in;
+            flex-shrink: 0;
+            border-right: 0.75pt solid #000;
+            padding-right: 0.15in;
+            font-size: 10pt;
+            line-height: 1.35;
+        }
+
+        .recorder-space {
+            /* Open space for the recorder — nothing renders here. */
+            flex-grow: 1;
+        }
+
+        .recording-label {
+            font-weight: bold;
+            text-transform: uppercase;
+            font-size: 9pt;
+        }
+
+        .recording-value {
+            margin-bottom: 0.12in;
+            min-height: 0.35in;
+        }
+
+        .ref-line {
+            font-size: 10pt;
+        }
+
+        /* Boundary row: APN left, recorder caption right, rule underneath. */
+        .header-boundary {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            border-bottom: 0.75pt solid #000;
+            padding-bottom: 0.03in;
+            margin-bottom: 0.12in;
+        }
+
+        .apn-ref {
+            /* D2: the parcel id carries the same weight as the parties. */
+            font-weight: bold;
+            font-size: 10pt;
+        }
+
+        .recorder-caption {
+            font-size: 7.5pt;
+            font-weight: bold;
+            text-transform: uppercase;
+        }
+
+        /* --------------------------------------------------------------------------
+           TITLE
+           -------------------------------------------------------------------------- */
+
+        .deed-title {
+            text-align: center;
+            font-size: 14pt;
+            font-weight: bold;
+            letter-spacing: 2px;
+            text-transform: uppercase;
+            margin: 0.08in 0 0.02in 0;
+        }
+
+        .deed-subtitle {
+            /* The reference stacks the qualifier line under the title. */
+            text-align: center;
+            font-size: 11pt;
+            font-weight: bold;
+            text-transform: uppercase;
+            margin-bottom: 0.1in;
+        }
+
+        /* --------------------------------------------------------------------------
+           DOCUMENTARY TRANSFER TAX DECLARATION — statutory wording, no chrome.
+           -------------------------------------------------------------------------- */
+
+        .dtt-section {
+            font-size: 10pt;
+            line-height: 1.5;
+            margin-bottom: 0.15in;
+        }
+
+        .dtt-lead {
+            display: flex;
+            justify-content: space-between;
+            gap: 0.2in;
+        }
+
+        .dtt-amount {
+            border-bottom: 0.75pt solid #000;
+            min-width: 1.6in;
+            display: inline-block;
+            text-align: center;
+        }
+
+        .checkline {
+            display: inline-block;
+            width: 0.35in;
+            border-bottom: 0.75pt solid #000;
+            text-align: center;
+            font-weight: bold;
+            margin-right: 0.06in;
+        }
+
+        .dtt-option {
+            margin-left: 0.15in;
+        }
+
+        .city-field {
+            border-bottom: 0.75pt solid #000;
+            min-width: 1.8in;
+            display: inline-block;
+            text-align: center;
+        }
+
+        .dtt-exempt {
+            margin-left: 0.15in;
+        }
+
+        /* --------------------------------------------------------------------------
+           DEED BODY
+           -------------------------------------------------------------------------- */
+
+        .deed-body {
+            font-size: 11pt;
+            line-height: 1.45;
+        }
+
+        .deed-body p {
+            margin-bottom: 0.08in;
+        }
+
+        .party-name {
+            font-weight: bold;
+            text-transform: uppercase;
+        }
+
+        .legal-content {
+            /* D1: the property description carries the same weight as the
+               parties — the three data blocks an examiner scans first. */
+            font-weight: bold;
+            white-space: pre-wrap;
+            margin: 0.08in 0 0.08in 0;
+        }
+
+        .legal-exhibit-ref {
+            font-weight: bold;
+            margin: 0.08in 0;
+        }
+
+        .apn-line { font-weight: bold;
+            margin-top: 0.08in;
+        }
+
+        /* --------------------------------------------------------------------------
+           EXECUTION — date left, signature lines right (reference layout).
+           -------------------------------------------------------------------------- */
+
+        .execution-section {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            margin-top: 0.25in;
+            page-break-inside: avoid;
+        }
+
+        .execution-date {
+            padding-top: 0.25in;
+        }
+
+        .date-value {
+            border-bottom: 0.75pt solid #000;
+            min-width: 1.8in;
+            display: inline-block;
+            text-align: center;
+        }
+
+        .signatures {
+            width: 3.4in;
+        }
+
+        .signature-entry {
+            margin-bottom: 0.35in;
+        }
+
+        .signature-line {
+            border-bottom: 0.75pt solid #000;
+            width: 3.4in;
+            height: 0.35in;
+        }
+
+        .signature-name {
+            font-size: 10pt;
+            text-transform: uppercase;
+        }
+
+        /* --------------------------------------------------------------------------
+           PAGE-ONE FOOTER — statutory mail-tax directive, nothing else.
+           -------------------------------------------------------------------------- */
+
+        .mail-tax-directive {
+            text-align: center;
+            font-size: 9pt;
+            font-weight: bold;
+            text-transform: uppercase;
+            margin-top: 0.3in;
+        }
+
+        /* --------------------------------------------------------------------------
+           EXHIBIT A (legal-description overflow) — plain page.
+           -------------------------------------------------------------------------- */
+
+        .page-break {
+            page-break-before: always;
+        }
+
+        .exhibit-page {
+            padding-top: 0.5in;
+        }
+
+        .exhibit-header {
+            text-align: center;
+            margin-bottom: 0.4in;
+        }
+
+        .exhibit-title {
+            font-size: 14pt;
+            font-weight: bold;
+            text-transform: uppercase;
+            letter-spacing: 2px;
+        }
+
+        .exhibit-subtitle {
+            font-size: 11pt;
+            margin-top: 0.08in;
+        }
+
+        .exhibit-reference {
+            font-size: 10pt;
+            margin-top: 0.12in;
+        }
+
+        .exhibit-content {
+            font-size: 11pt;
+            line-height: 1.5;
+            text-align: justify;
+            white-space: pre-wrap;
+        }
+
+        .exhibit-apn {
+            margin-top: 0.3in;
+            font-size: 10pt;
+        }
+
+        /* G3: the acknowledgment partial now carries its own single-page
+           spacing — the G2-era local overrides are retired. */
+    </style>
+</head>
+<body>
+    <div class="deed-page">
+
+        <!-- ================================================================
+             PAGE-ONE HEADER — info column + open recorder's space
+             ================================================================ -->
+
+        <header class="header-section">
+            <div class="recording-info">
+                <div class="recording-label">Recording Requested By:</div>
+                <div class="recording-value">{{ requested_by or title_company or '' }}{% if requested_by_address %}<br>{{ requested_by_address }}{% endif %}</div>
+
+                <div class="recording-label">Mail Tax Statements and<br>When Recorded Mail To:</div>
+                <div class="recording-value">
+                    {% if return_to %}
+                        {% if return_to.get('name') %}{{ return_to.get('name') }}<br>{% endif %}
+                        {% if return_to.get('company') %}{{ return_to.get('company') }}<br>{% endif %}
+                        {% if return_to.get('address1') %}{{ return_to.get('address1') }}<br>{% endif %}
+                        {% if return_to.get('address2') %}{{ return_to.get('address2') }}<br>{% endif %}
+                        {% set city = return_to.get('city', '') %}
+                        {% set state = return_to.get('state', '') %}
+                        {% set zip = return_to.get('zip', '') %}
+                        {% if city or state or zip %}
+                            {{ city }}{% if city and (state or zip) %}, {% endif %}{{ state }} {{ zip }}
+                        {% endif %}
+                    {% else %}
+                        _________________________________<br>
+                        _________________________________<br>
+                        _________________________________
+                    {% endif %}
+                </div>
+
+                <div class="ref-line">Order No.: {{ title_order_no or '____________________' }}</div>
+                <div class="ref-line">Escrow No.: {{ escrow_no or '____________________' }}</div>
+            </div>
+
+            <div class="recorder-space"><!-- Gov. Code §27361.6 — recorder's use only --></div>
+        </header>
+
+        <div class="header-boundary">
+            <span class="apn-ref">APN: {{ apn or '____________________' }}</span>
+            <span class="recorder-caption">Space Above This Line Is For Recorder&rsquo;s Use</span>
+        </div>
+
+        <!-- ================================================================
+             TITLE
+             ================================================================ -->
+
+        <h1 class="deed-title">Grant Deed</h1>
+        <div class="deed-subtitle">Community Property with Right of Survivorship</div>
+
+        <!-- ================================================================
+             DOCUMENTARY TRANSFER TAX — R&T §11932–11933 declaration
+             ================================================================ -->
+
+        <div class="dtt-section">
+            <div class="dtt-lead">
+                <span>THE UNDERSIGNED GRANTOR(S) DECLARE(S):</span>
+                <span>DOCUMENTARY TRANSFER TAX IS
+                    <span class="dtt-amount">${{ dtt.get('amount', '') if dtt else '' }}</span>
+                </span>
+            </div>
+            <div class="dtt-option">
+                <span class="checkline">{% if dtt and dtt.get('basis') == 'full' %}X{% endif %}</span>
+                Computed on full value of property conveyed, or
+            </div>
+            <div class="dtt-option">
+                <span class="checkline">{% if dtt and dtt.get('basis') == 'less_liens' %}X{% endif %}</span>
+                Computed on full value less liens and encumbrances remaining at time of sale.
+            </div>
+            <div class="dtt-option">
+                <span class="checkline">{% if dtt and dtt.get('area_type') == 'unincorporated' %}X{% endif %}</span>
+                Unincorporated area&nbsp;&nbsp;&nbsp;
+                <span class="checkline">{% if dtt and dtt.get('area_type') == 'city' %}X{% endif %}</span>
+                City of <span class="city-field">{{ dtt.get('city_name', '') if dtt else '' }}</span>
+            </div>
+            {% if dtt and dtt.get('is_exempt') and dtt.get('exemption_reason') %}
+            <div class="dtt-exempt">Exempt from transfer tax: {{ dtt.get('exemption_reason') }}</div>
+            {% endif %}
+        </div>
+
+        <!-- ================================================================
+             GRANTING CLAUSE — standard deed wording, no defined-term labels
+             ================================================================ -->
+
+        <div class="deed-body">
+            <p>For valuable consideration, receipt of which is hereby acknowledged,</p>
+
+            <p class="party-name">{{ grantors_text or '_________________________________________________' }}</p>
+
+            <p>hereby GRANT(S) to</p>
+
+            <p><span class="party-name">{{ grantees_text or '_________________________________________________' }}</span></p>
+
+            <p>
+                as COMMUNITY PROPERTY WITH RIGHT OF SURVIVORSHIP the real property situated in the County of
+                <strong>{{ county or '___________________________' }}</strong>,
+                State of California, more particularly described as follows:
+            </p>
+
+            {% if legal_description and legal_description|length > (exhibit_threshold or 600) %}
+                <p class="legal-exhibit-ref">
+                    See Exhibit &ldquo;A&rdquo; attached hereto and incorporated herein by this reference.
+                </p>
+            {% else %}
+                <div class="legal-content">{{ legal_description or 'LEGAL DESCRIPTION TO BE INSERTED' }}</div>
+            {% endif %}
+
+            {% if apn %}
+            <div class="apn-line">Assessor&rsquo;s Parcel Number: {{ apn }}</div>
+            {% endif %}
+        </div>
+
+        <!-- ================================================================
+             EXECUTION — date left, signatures right
+             ================================================================ -->
+
+        <div class="execution-section">
+            <div class="execution-date">
+                Dated: <span class="date-value">{{ execution_date or now().strftime('%B %d, %Y') }}</span>
+            </div>
+
+            <div class="signatures">
+                {% set signers = grantors_text.split(';') if grantors_text and ';' in grantors_text else [grantors_text] if grantors_text else [] %}
+
+                {% for signer in signers %}
+                    {% set signer_name = signer.strip() if signer else '' %}
+                    {% if signer_name %}
+                    <div class="signature-entry">
+                        <div class="signature-line"></div>
+                        <div class="signature-name">{{ signer_name }}</div>
+                    </div>
+                    {% endif %}
+                {% endfor %}
+
+                {% if not signers or signers|length == 0 %}
+                <div class="signature-entry">
+                    <div class="signature-line"></div>
+                    <div class="signature-name">Grantor</div>
+                </div>
+                {% endif %}
+            </div>
+        </div>
+
+        <!-- Statutory footer directive (pairs with the combined mail-to block) -->
+        <div class="mail-tax-directive">Mail Tax Statements As Directed Above</div>
+
+    </div>
+
+    <!-- ====================================================================
+         EXHIBIT A — Legal Description (if too long for page one)
+         ==================================================================== -->
+
+    {% if legal_description and legal_description|length > (exhibit_threshold or 600) %}
+    <div class="page-break"></div>
+    <div class="exhibit-page">
+        <div class="exhibit-header">
+            <div class="exhibit-title">Exhibit &ldquo;A&rdquo;</div>
+            <div class="exhibit-subtitle">Legal Description</div>
+            <div class="exhibit-reference">
+                Attached to and made a part of Grant Deed dated {{ execution_date or now().strftime('%B %d, %Y') }}
+            </div>
+        </div>
+
+        <div class="exhibit-content">{{ legal_description }}</div>
+
+        {% if apn %}
+        <div class="exhibit-apn">Assessor&rsquo;s Parcel Number: {{ apn }}</div>
+        {% endif %}
+    </div>
+    {% endif %}
+
+    <!-- ====================================================================
+         CALIFORNIA ALL-PURPOSE ACKNOWLEDGMENT — Civil Code §1189
+         (shared partial; the notary completes its contents, never us)
+         ==================================================================== -->
+    {% set document_title = 'Grant Deed (Community Property with Right of Survivorship)' %}
+    {% include '_partials/notary_acknowledgment.jinja2' %}
+
+</body>
+</html>

--- a/templates/grant_deed_jt_ca/index.jinja2
+++ b/templates/grant_deed_jt_ca/index.jinja2
@@ -1,0 +1,493 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Joint Tenancy Grant Deed - California</title>
+    <style>
+        /* ==========================================================================
+           JOINT TENANCY GRANT DEED — CALIFORNIA (wave 1 #3)
+
+           Fixed-vesting variant of the grant-deed chassis (PCT reference
+           blank form #28, Deed-JointTenancy: letter, one page + ack,
+           caption at the boundary, full DTT block). The vesting phrase
+           "as JOINT TENANTS" is printed on the instrument's face as
+           furniture — choosing this form IS the vesting decision (Flag-3
+           precedent); the template deliberately never reads the stored
+           vesting value, so a stray value can never contradict the face
+           of the instrument. Chassis notes below are the grant deed's.
+
+           Geometry mirrors the owner's reference sample of a standard recorded
+           CA Grant Deed plus statute:
+           - Gov. Code §27361.6: recorder's space top-right of page one
+             (open space — no drawn box; a border invites rejection), caption
+             "SPACE ABOVE THIS LINE IS FOR RECORDER'S USE" at its bottom
+             boundary (~2.66" from the page top in the reference).
+           - R&T §11932–11933: DTT declaration opens with
+             "THE UNDERSIGNED GRANTOR(S) DECLARE(S):" and shows the
+             computed-on and unincorporated/City checklines.
+           - Gov. Code §27361.7 reproducibility: recorded pages carry no
+             color, no backgrounds, no branding. The QR/verification block
+             was REMOVED from recorded pages — the capability survives as
+             data (deed_pdfs.sha256 + metadata + the /api/verify portal).
+           ========================================================================== */
+
+        @page {
+            size: letter;
+            margin: 0.5in 0.5in 0.6in 0.6in;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: "Times New Roman", Times, Georgia, serif;
+            font-size: 11pt;
+            line-height: 1.35;
+            color: #000;
+            background: #fff;
+        }
+
+        /* --------------------------------------------------------------------------
+           PAGE-ONE HEADER — left info column beside the open recorder's space.
+           The vertical rule at 3.4in marks the left boundary of the recorder's
+           space, exactly as on the reference form. The space itself is empty.
+           -------------------------------------------------------------------------- */
+
+        .header-section {
+            display: flex;
+            min-height: 1.85in;
+        }
+
+        .recording-info {
+            width: 3.4in;
+            flex-shrink: 0;
+            border-right: 0.75pt solid #000;
+            padding-right: 0.15in;
+            font-size: 10pt;
+            line-height: 1.35;
+        }
+
+        .recorder-space {
+            /* Open space for the recorder — nothing renders here. */
+            flex-grow: 1;
+        }
+
+        .recording-label {
+            font-weight: bold;
+            text-transform: uppercase;
+            font-size: 9pt;
+        }
+
+        .recording-value {
+            margin-bottom: 0.12in;
+            min-height: 0.35in;
+        }
+
+        .ref-line {
+            font-size: 10pt;
+        }
+
+        /* Boundary row: APN left, recorder caption right, rule underneath. */
+        .header-boundary {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            border-bottom: 0.75pt solid #000;
+            padding-bottom: 0.03in;
+            margin-bottom: 0.12in;
+        }
+
+        .apn-ref {
+            /* D2: the parcel id carries the same weight as the parties. */
+            font-weight: bold;
+            font-size: 10pt;
+        }
+
+        .recorder-caption {
+            font-size: 7.5pt;
+            font-weight: bold;
+            text-transform: uppercase;
+        }
+
+        /* --------------------------------------------------------------------------
+           TITLE
+           -------------------------------------------------------------------------- */
+
+        .deed-title {
+            text-align: center;
+            font-size: 14pt;
+            font-weight: bold;
+            letter-spacing: 2px;
+            text-transform: uppercase;
+            margin: 0.08in 0 0.12in 0;
+        }
+
+        /* --------------------------------------------------------------------------
+           DOCUMENTARY TRANSFER TAX DECLARATION — statutory wording, no chrome.
+           -------------------------------------------------------------------------- */
+
+        .dtt-section {
+            font-size: 10pt;
+            line-height: 1.5;
+            margin-bottom: 0.15in;
+        }
+
+        .dtt-lead {
+            display: flex;
+            justify-content: space-between;
+            gap: 0.2in;
+        }
+
+        .dtt-amount {
+            border-bottom: 0.75pt solid #000;
+            min-width: 1.6in;
+            display: inline-block;
+            text-align: center;
+        }
+
+        .checkline {
+            display: inline-block;
+            width: 0.35in;
+            border-bottom: 0.75pt solid #000;
+            text-align: center;
+            font-weight: bold;
+            margin-right: 0.06in;
+        }
+
+        .dtt-option {
+            margin-left: 0.15in;
+        }
+
+        .city-field {
+            border-bottom: 0.75pt solid #000;
+            min-width: 1.8in;
+            display: inline-block;
+            text-align: center;
+        }
+
+        .dtt-exempt {
+            margin-left: 0.15in;
+        }
+
+        /* --------------------------------------------------------------------------
+           DEED BODY
+           -------------------------------------------------------------------------- */
+
+        .deed-body {
+            font-size: 11pt;
+            line-height: 1.45;
+        }
+
+        .deed-body p {
+            margin-bottom: 0.08in;
+        }
+
+        .party-name {
+            font-weight: bold;
+            text-transform: uppercase;
+        }
+
+        .legal-content {
+            /* D1: the property description carries the same weight as the
+               parties — the three data blocks an examiner scans first. */
+            font-weight: bold;
+            white-space: pre-wrap;
+            margin: 0.08in 0 0.08in 0;
+        }
+
+        .legal-exhibit-ref {
+            font-weight: bold;
+            margin: 0.08in 0;
+        }
+
+        .apn-line { font-weight: bold;
+            margin-top: 0.08in;
+        }
+
+        /* --------------------------------------------------------------------------
+           EXECUTION — date left, signature lines right (reference layout).
+           -------------------------------------------------------------------------- */
+
+        .execution-section {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            margin-top: 0.25in;
+            page-break-inside: avoid;
+        }
+
+        .execution-date {
+            padding-top: 0.25in;
+        }
+
+        .date-value {
+            border-bottom: 0.75pt solid #000;
+            min-width: 1.8in;
+            display: inline-block;
+            text-align: center;
+        }
+
+        .signatures {
+            width: 3.4in;
+        }
+
+        .signature-entry {
+            margin-bottom: 0.35in;
+        }
+
+        .signature-line {
+            border-bottom: 0.75pt solid #000;
+            width: 3.4in;
+            height: 0.35in;
+        }
+
+        .signature-name {
+            font-size: 10pt;
+            text-transform: uppercase;
+        }
+
+        /* --------------------------------------------------------------------------
+           PAGE-ONE FOOTER — statutory mail-tax directive, nothing else.
+           -------------------------------------------------------------------------- */
+
+        .mail-tax-directive {
+            text-align: center;
+            font-size: 9pt;
+            font-weight: bold;
+            text-transform: uppercase;
+            margin-top: 0.3in;
+        }
+
+        /* --------------------------------------------------------------------------
+           EXHIBIT A (legal-description overflow) — plain page.
+           -------------------------------------------------------------------------- */
+
+        .page-break {
+            page-break-before: always;
+        }
+
+        .exhibit-page {
+            padding-top: 0.5in;
+        }
+
+        .exhibit-header {
+            text-align: center;
+            margin-bottom: 0.4in;
+        }
+
+        .exhibit-title {
+            font-size: 14pt;
+            font-weight: bold;
+            text-transform: uppercase;
+            letter-spacing: 2px;
+        }
+
+        .exhibit-subtitle {
+            font-size: 11pt;
+            margin-top: 0.08in;
+        }
+
+        .exhibit-reference {
+            font-size: 10pt;
+            margin-top: 0.12in;
+        }
+
+        .exhibit-content {
+            font-size: 11pt;
+            line-height: 1.5;
+            text-align: justify;
+            white-space: pre-wrap;
+        }
+
+        .exhibit-apn {
+            margin-top: 0.3in;
+            font-size: 10pt;
+        }
+
+        /* G3: the acknowledgment partial now carries its own single-page
+           spacing — the G2-era local overrides are retired. */
+    </style>
+</head>
+<body>
+    <div class="deed-page">
+
+        <!-- ================================================================
+             PAGE-ONE HEADER — info column + open recorder's space
+             ================================================================ -->
+
+        <header class="header-section">
+            <div class="recording-info">
+                <div class="recording-label">Recording Requested By:</div>
+                <div class="recording-value">{{ requested_by or title_company or '' }}{% if requested_by_address %}<br>{{ requested_by_address }}{% endif %}</div>
+
+                <div class="recording-label">Mail Tax Statements and<br>When Recorded Mail To:</div>
+                <div class="recording-value">
+                    {% if return_to %}
+                        {% if return_to.get('name') %}{{ return_to.get('name') }}<br>{% endif %}
+                        {% if return_to.get('company') %}{{ return_to.get('company') }}<br>{% endif %}
+                        {% if return_to.get('address1') %}{{ return_to.get('address1') }}<br>{% endif %}
+                        {% if return_to.get('address2') %}{{ return_to.get('address2') }}<br>{% endif %}
+                        {% set city = return_to.get('city', '') %}
+                        {% set state = return_to.get('state', '') %}
+                        {% set zip = return_to.get('zip', '') %}
+                        {% if city or state or zip %}
+                            {{ city }}{% if city and (state or zip) %}, {% endif %}{{ state }} {{ zip }}
+                        {% endif %}
+                    {% else %}
+                        _________________________________<br>
+                        _________________________________<br>
+                        _________________________________
+                    {% endif %}
+                </div>
+
+                <div class="ref-line">Order No.: {{ title_order_no or '____________________' }}</div>
+                <div class="ref-line">Escrow No.: {{ escrow_no or '____________________' }}</div>
+            </div>
+
+            <div class="recorder-space"><!-- Gov. Code §27361.6 — recorder's use only --></div>
+        </header>
+
+        <div class="header-boundary">
+            <span class="apn-ref">APN: {{ apn or '____________________' }}</span>
+            <span class="recorder-caption">Space Above This Line Is For Recorder&rsquo;s Use</span>
+        </div>
+
+        <!-- ================================================================
+             TITLE
+             ================================================================ -->
+
+        <h1 class="deed-title">Joint Tenancy Grant Deed</h1>
+
+        <!-- ================================================================
+             DOCUMENTARY TRANSFER TAX — R&T §11932–11933 declaration
+             ================================================================ -->
+
+        <div class="dtt-section">
+            <div class="dtt-lead">
+                <span>THE UNDERSIGNED GRANTOR(S) DECLARE(S):</span>
+                <span>DOCUMENTARY TRANSFER TAX IS
+                    <span class="dtt-amount">${{ dtt.get('amount', '') if dtt else '' }}</span>
+                </span>
+            </div>
+            <div class="dtt-option">
+                <span class="checkline">{% if dtt and dtt.get('basis') == 'full' %}X{% endif %}</span>
+                Computed on full value of property conveyed, or
+            </div>
+            <div class="dtt-option">
+                <span class="checkline">{% if dtt and dtt.get('basis') == 'less_liens' %}X{% endif %}</span>
+                Computed on full value less liens and encumbrances remaining at time of sale.
+            </div>
+            <div class="dtt-option">
+                <span class="checkline">{% if dtt and dtt.get('area_type') == 'unincorporated' %}X{% endif %}</span>
+                Unincorporated area&nbsp;&nbsp;&nbsp;
+                <span class="checkline">{% if dtt and dtt.get('area_type') == 'city' %}X{% endif %}</span>
+                City of <span class="city-field">{{ dtt.get('city_name', '') if dtt else '' }}</span>
+            </div>
+            {% if dtt and dtt.get('is_exempt') and dtt.get('exemption_reason') %}
+            <div class="dtt-exempt">Exempt from transfer tax: {{ dtt.get('exemption_reason') }}</div>
+            {% endif %}
+        </div>
+
+        <!-- ================================================================
+             GRANTING CLAUSE — standard deed wording, no defined-term labels
+             ================================================================ -->
+
+        <div class="deed-body">
+            <p>For valuable consideration, receipt of which is hereby acknowledged,</p>
+
+            <p class="party-name">{{ grantors_text or '_________________________________________________' }}</p>
+
+            <p>hereby GRANT(S) to</p>
+
+            <p><span class="party-name">{{ grantees_text or '_________________________________________________' }}</span></p>
+
+            <p>
+                as JOINT TENANTS the real property situated in the County of
+                <strong>{{ county or '___________________________' }}</strong>,
+                State of California, more particularly described as follows:
+            </p>
+
+            {% if legal_description and legal_description|length > (exhibit_threshold or 600) %}
+                <p class="legal-exhibit-ref">
+                    See Exhibit &ldquo;A&rdquo; attached hereto and incorporated herein by this reference.
+                </p>
+            {% else %}
+                <div class="legal-content">{{ legal_description or 'LEGAL DESCRIPTION TO BE INSERTED' }}</div>
+            {% endif %}
+
+            {% if apn %}
+            <div class="apn-line">Assessor&rsquo;s Parcel Number: {{ apn }}</div>
+            {% endif %}
+        </div>
+
+        <!-- ================================================================
+             EXECUTION — date left, signatures right
+             ================================================================ -->
+
+        <div class="execution-section">
+            <div class="execution-date">
+                Dated: <span class="date-value">{{ execution_date or now().strftime('%B %d, %Y') }}</span>
+            </div>
+
+            <div class="signatures">
+                {% set signers = grantors_text.split(';') if grantors_text and ';' in grantors_text else [grantors_text] if grantors_text else [] %}
+
+                {% for signer in signers %}
+                    {% set signer_name = signer.strip() if signer else '' %}
+                    {% if signer_name %}
+                    <div class="signature-entry">
+                        <div class="signature-line"></div>
+                        <div class="signature-name">{{ signer_name }}</div>
+                    </div>
+                    {% endif %}
+                {% endfor %}
+
+                {% if not signers or signers|length == 0 %}
+                <div class="signature-entry">
+                    <div class="signature-line"></div>
+                    <div class="signature-name">Grantor</div>
+                </div>
+                {% endif %}
+            </div>
+        </div>
+
+        <!-- Statutory footer directive (pairs with the combined mail-to block) -->
+        <div class="mail-tax-directive">Mail Tax Statements As Directed Above</div>
+
+    </div>
+
+    <!-- ====================================================================
+         EXHIBIT A — Legal Description (if too long for page one)
+         ==================================================================== -->
+
+    {% if legal_description and legal_description|length > (exhibit_threshold or 600) %}
+    <div class="page-break"></div>
+    <div class="exhibit-page">
+        <div class="exhibit-header">
+            <div class="exhibit-title">Exhibit &ldquo;A&rdquo;</div>
+            <div class="exhibit-subtitle">Legal Description</div>
+            <div class="exhibit-reference">
+                Attached to and made a part of Joint Tenancy Grant Deed dated {{ execution_date or now().strftime('%B %d, %Y') }}
+            </div>
+        </div>
+
+        <div class="exhibit-content">{{ legal_description }}</div>
+
+        {% if apn %}
+        <div class="exhibit-apn">Assessor&rsquo;s Parcel Number: {{ apn }}</div>
+        {% endif %}
+    </div>
+    {% endif %}
+
+    <!-- ====================================================================
+         CALIFORNIA ALL-PURPOSE ACKNOWLEDGMENT — Civil Code §1189
+         (shared partial; the notary completes its contents, never us)
+         ==================================================================== -->
+    {% set document_title = 'Joint Tenancy Grant Deed' %}
+    {% include '_partials/notary_acknowledgment.jinja2' %}
+
+</body>
+</html>


### PR DESCRIPTION
## Wave 1, forms #3 and #4 (owner-ranked order) — fixed-vesting deed variants, paired

### References fetched and measured
- **#3 Joint Tenancy Grant Deed**: PCT blank form #28 (`Deed-JointTenancy.pdf`) — one page, standard grant-deed geometry, full DTT block, §1189 acknowledgment, granting clause "hereby GRANT(S) to ___ **as JOINT TENANTS** the real property situated in…".
- **#4 CP w/ROS Grant Deed**: PCT blank form #21 (`Deed-CPSurvivorship.pdf`) — same chassis, stacked title ("GRANT DEED" / "COMMUNITY PROPERTY WITH RIGHT OF SURVIVORSHIP"), clause "…**as COMMUNITY PROPERTY WITH RIGHT OF SURVIVORSHIP** the real property situated in…".

### Doctrine pass — the one judgment call, flagged (built on precedent, not silently decided)
**The vesting phrase is printed on the blank reference's face.** Classification: **instrument-defining furniture** under the Flag-3 precedent — choosing "Grant Deed – Joint Tenancy" from the catalog IS the officer's vesting decision, exactly as choosing an affidavit form IS the decision its recitals describe. This is the existing vesting legal-choice class resolved by instrument selection, not a new class — so no automatic hold; flagging it here for the owner's eyes since vesting is the codebase's canonical legal choice.

What that means concretely, and how it's pinned:
- The phrase lives in **`deedFurniture.FIXED_VESTING_PHRASES` + the two templates** (chassis-conformance drift pins hold preview and instrument to identical wording). The **registry carries no phrase** — pinned, so config can never decide a legal question.
- The variant templates **never read the stored vesting column** — pinned with a poisoned sentinel (`vesting: "SENTINEL VESTING TEXT"` must not render), so a stray value can never contradict the face of the instrument.
- The vesting builder section and `vestingDecision` machinery are **skipped** for these types; the substantive check becomes structural ("Vesting fixed by the instrument"), mirroring the jurat/acknowledgment pattern. The one-truth section counter drops the section it can't open.

### Deed-chassis behavior preserved in full (per the wave order)
These ARE conveyances: the complete **R&T §11932–11933 DTT declaration and decision gate** apply unchanged (pinned: full block renders with the officer's recorded decision; nothing pre-fills without one). §1189 acknowledgment (never a jurat — canary pinned), suggest→confirm→record, grantor provenance, exhibit-A overflow, mail-tax directives, no-chrome — all inherited untouched from the grant-deed chassis; the templates are the chassis with title + granting-clause deltas only.

### Pins
18 new backend tests (`test_wave1_deed_variants.py`) parameterized over both forms; chassis-conformance drift suite extended to both templates (recorder caption, mail-tax, DTT declaration, operative words, fixed-vesting clause, `{{ vesting }}` absent); registry pins now cover 10 types.

### Gates
- Backend: **141 passed** (was 123; +18)
- Six-flow baseline: ✔ (snapshot unchanged)
- Jest: **282 passed** (was 272)
- tsc: frozen baseline **98** (unchanged)

### Per-form actuals vs. the 1–2 hr projection
~1 hr for the pair (~30 min/form) — the deed chassis needed zero rework; the cost was the vesting-doctrine surface (validation/builder/preview gating + pins). **Well under projection.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_