### PR TITLE
FORMS wave 1 (#5): Declaration of Homestead — first declaration-family form

### DIFF
--- a/backend/services/deed_pdf.py
+++ b/backend/services/deed_pdf.py
@@ -45,6 +45,8 @@ TEMPLATE_BY_DEED_TYPE = {
     # FORMS wave 1 — fixed-vesting deed variants (PCT references #28, #21).
     "grant-deed-jt": "grant_deed_jt_ca/index.jinja2",
     "grant-deed-cp-ros": "grant_deed_cp_ros_ca/index.jinja2",
+    # FORMS wave 1 — declaration family (PCT reference #33; CCP §704.930).
+    "homestead-declaration": "homestead_declaration_ca/index.jinja2",
 }
 DEFAULT_TEMPLATE = "grant_deed_ca/index.jinja2"
 

--- a/backend/services/form_families.py
+++ b/backend/services/form_families.py
@@ -30,6 +30,7 @@ FAMILY_BY_DEED_TYPE = {
     "affidavit-death-jt": "affidavit",
     "affidavit-death-cp-spouse": "affidavit",
     "affidavit-death-trustee": "affidavit",
+    "homestead-declaration": "declaration",
 }
 
 SINGLE_PARTY_FAMILIES = {"declaration"}

--- a/backend/tests/test_wave1_homestead.py
+++ b/backend/tests/test_wave1_homestead.py
@@ -1,0 +1,139 @@
+"""FORMS wave 1 #5 — Declaration of Homestead (Individual), pinned.
+
+First declaration-family instrument, built against Pacific Coast Title
+blank form #33 (Homestead_Dec-Indiv). Family facts, per the FORMS_TRIAGE
+correction note (owner-acknowledged): ACKNOWLEDGED per CCP §704.930 —
+the §1189 certificate, never a jurat (the memo's "jurat reuse" prediction
+was wrong; the reference outranks it). Single-party: the declarant rides
+in the deeds.parties JSONB column (owner-ledgered migration). Not a
+conveyance: no DTT, no mail-tax directive.
+"""
+import io
+
+import pdfplumber
+
+from services.deed_pdf import render_deed_html, render_deed_pdf
+from tests.test_deed_pdf import _normalized
+
+HOMESTEAD_META = {
+    "requested_by_address": "456 Escrow Way, Los Angeles, CA 90012",
+    "return_to": {"name": "ROBERT OWNER", "address1": "1358 5TH ST",
+                  "city": "Santa Monica", "state": "CA", "zip": "90401"},
+}
+
+
+def homestead_row(**overrides):
+    row = {
+        "id": 1,
+        "deed_type": "homestead-declaration",
+        # Single-party: grantor/grantee legitimately EMPTY (parties column
+        # is authoritative — the migration's whole point).
+        "grantor_name": "",
+        "grantee_name": "",
+        "parties": {"declarant": "ROBERT OWNER"},
+        "legal_description": "LOT 7, BLOCK B, TRACT 12345",
+        "county": "Los Angeles",
+        "apn": "4290-012-034",
+        "property_address": "1358 5TH ST, Santa Monica, CA 90401",
+        "requested_by": "Pacific Coast Escrow",
+        "metadata": HOMESTEAD_META,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_declaration_furniture_present():
+    """Clauses 2–4 are instrument-defining recitals (Flag-3: furniture)."""
+    html = _normalized(render_deed_html(homestead_row()))
+    assert "Declaration of Homestead" in html
+    assert "(Individual)" in html
+    assert "hereby certify and declare as follows:" in html
+    assert "I hereby claim as a declared homestead the premises described as follows:" in html
+    assert "I am the owner of the above described homestead." in html
+    assert "principal dwelling" in html
+    assert "known to be true as of my personal knowledge" in html
+
+
+def test_declarant_renders_from_the_parties_column():
+    html = _normalized(render_deed_html(homestead_row()))
+    assert "ROBERT OWNER" in html
+    assert "LOT 7, BLOCK B, TRACT 12345" in html
+    # The printed name identifies the signer (deed-chassis precedent).
+    assert "Print Name:" in html
+
+
+def test_missing_declarant_renders_blank_never_invented():
+    # metadata cleared too: the mail-to block legitimately repeats the
+    # declarant's name — the pin targets the recital and Print Name only.
+    html = render_deed_html(homestead_row(parties=None, metadata={}))
+    assert "fact-line" in html
+    assert "ROBERT OWNER" not in html
+
+
+def test_acknowledgment_not_jurat():
+    """THE family canary, corrected direction: CCP §704.930 requires an
+    ACKNOWLEDGED declaration — §1189 body present, jurat absent."""
+    html = _normalized(render_deed_html(homestead_row()))
+    assert "personally appeared" in html
+    assert "acknowledged to me" in html
+    assert "Subscribed and sworn to (or affirmed) before me" not in html
+    assert html.count("verifies only the identity") == 1
+
+
+def test_acknowledgment_contents_are_blank():
+    """Blank-contents: the notary's entries never pre-fill; the declarant's
+    name appears in the body and Print Name, never inside the cert."""
+    html = _normalized(render_deed_html(homestead_row()))
+    ack = html[html.index("personally appeared"):]
+    assert "ROBERT OWNER" not in ack
+
+
+def test_no_dtt_no_mail_tax_no_vesting():
+    """Not a conveyance: no transfer-tax block, no mail-tax directive; and
+    no vesting can leak (single-party instrument)."""
+    html = _normalized(render_deed_html(homestead_row(vesting="SENTINEL VESTING TEXT")))
+    assert "DOCUMENTARY TRANSFER TAX" not in html.upper()
+    assert "UNDERSIGNED GRANTOR" not in html.upper()
+    assert "Mail Tax Statements" not in html
+    assert "And When Recorded Mail To" in html
+    assert "SENTINEL VESTING TEXT" not in html
+
+
+def test_one_page_with_inline_acknowledgment():
+    """The reference is ONE page with the §1189 certificate in the lower
+    half — the partial's inline mode keeps it there (deed templates keep
+    their own-page behavior, pinned by the existing deed suites)."""
+    pdf = render_deed_pdf(homestead_row())
+    with pdfplumber.open(io.BytesIO(pdf)) as doc:
+        assert len(doc.pages) == 1
+        page = doc.pages[0]
+        words = page.extract_words()
+
+        def top_of(needle):
+            hits = [w for w in words if needle.upper() in w["text"].upper()]
+            assert hits, needle
+            return hits[0]["top"]
+
+        def x_of(needle):
+            hits = [w for w in words if needle.upper() in w["text"].upper()]
+            return hits[0]["x0"]
+
+        caption_top = top_of("RECORDER’S")
+        title_top = top_of("DECLARATION")
+        ack_top = top_of("personally")
+        assert caption_top > 100
+        assert x_of("RECORDER’S") > 300
+        assert title_top > caption_top
+        assert ack_top > page.height / 2   # certificate in the lower half
+
+    html = render_deed_html(homestead_row())
+    for leaked in ("7C4DFF", "Generated by", "deedpro.com/verify", "recorder-box", "bg-brand"):
+        assert leaked not in html, leaked
+
+
+def test_registered_in_the_type_and_family_maps():
+    from services.deed_pdf import TEMPLATE_BY_DEED_TYPE
+    from services.form_families import family_of, is_single_party
+    assert TEMPLATE_BY_DEED_TYPE["homestead-declaration"] == "homestead_declaration_ca/index.jinja2"
+    assert family_of("homestead-declaration") == "declaration"
+    assert is_single_party("homestead-declaration")

--- a/frontend/src/__tests__/formRegistry.test.ts
+++ b/frontend/src/__tests__/formRegistry.test.ts
@@ -23,8 +23,8 @@ const KNOWN_SECTIONS = new Set(['property', 'grantor', 'grantee', 'vesting', 'tr
 describe('FORMS registry — completeness and coherence', () => {
   const entries = Object.values(FORM_REGISTRY);
 
-  it('carries the ten shipped types', () => {
-    expect(entries.length).toBe(10);
+  it('carries the eleven shipped types', () => {
+    expect(entries.length).toBe(11);
     expect(formConfig('affidavit-death-jt')?.family).toBe('affidavit');
     // Wave 1 siblings (owner-ranked #1 and #2):
     expect(formConfig('affidavit-death-cp-spouse')?.family).toBe('affidavit');
@@ -32,6 +32,9 @@ describe('FORMS registry — completeness and coherence', () => {
     // Wave 1 deed variants (owner-ranked #3 and #4):
     expect(formConfig('grant-deed-jt')?.family).toBe('deed');
     expect(formConfig('grant-deed-cp-ros')?.family).toBe('deed');
+    // Wave 1 #5 — the third family (correction note: ACKNOWLEDGED,
+    // CCP §704.930, single-party):
+    expect(formConfig('homestead-declaration')?.family).toBe('declaration');
   });
 
   it('every entry is internally coherent', () => {
@@ -42,9 +45,21 @@ describe('FORMS registry — completeness and coherence', () => {
       for (const section of f.sections) {
         expect(KNOWN_SECTIONS.has(section)).toBe(true);
       }
-      // Doctrine coupling: sworn instruments carry a jurat, deed family
-      // an acknowledgment; only deed family declares DTT.
-      if (f.family === 'affidavit') {
+      // Doctrine coupling, all three families enforced structurally:
+      //   affidavit   → jurat, no DTT (sworn statement)
+      //   declaration → acknowledgment, no DTT (single-party, CCP §704.930)
+      //   deed        → acknowledgment, DTT (conveyance)
+      if (f.family === 'declaration') {
+        expect(f.notarial).toBe('acknowledgment');
+        expect(f.hasDtt).toBe(false);
+        expect(f.sections).toContain('affidavit'); // the shared typed-facts section
+        expect(f.sections).not.toContain('vesting');
+        expect((f.affidavitFields ?? []).length).toBeGreaterThan(0);
+        for (const spec of f.affidavitFields ?? []) {
+          expect(Object.keys(spec)).not.toContain('value');
+          expect(Object.keys(spec)).not.toContain('default');
+        }
+      } else if (f.family === 'affidavit') {
         expect(f.notarial).toBe('jurat');
         expect(f.hasDtt).toBe(false);
         expect(f.sections).toContain('affidavit');

--- a/frontend/src/components/builder/InputPanel.tsx
+++ b/frontend/src/components/builder/InputPanel.tsx
@@ -11,8 +11,7 @@ import { VestingSection } from './sections/VestingSection';
 import { TransferTaxSection } from './sections/TransferTaxSection';
 import { RecordingSection } from './sections/RecordingSection';
 import { AffidavitSection } from './sections/AffidavitSection';
-import { isAffidavitType } from '@/lib/deedValidation';
-import { hasVestingInput } from '@/lib/formRegistry';
+import { formFamily, hasVestingInput, usesFactsSection } from '@/lib/formRegistry';
 import { DeedBuilderState } from '@/types/builder';
 
 interface InputPanelProps {
@@ -105,16 +104,16 @@ export function InputPanel({
           <PropertySection
             value={state.property}
             onChange={(property) => onChange({ property })}
-            onComplete={() => toggleSection(isAffidavitType(state.deedType) ? 'affidavit' : 'grantor')}
+            onComplete={() => toggleSection(usesFactsSection(state.deedType) ? 'affidavit' : 'grantor')}
           />
         </InputSection>
 
-        {isAffidavitType(state.deedType) ? (
+        {usesFactsSection(state.deedType) ? (
         <InputSection
           id="affidavit"
-          title="Affidavit Facts"
+          title={formFamily(state.deedType) === 'declaration' ? 'Declaration Facts' : 'Affidavit Facts'}
           status={statuses.affidavit}
-          preview={state.affidavit?.decedentName || 'Decedent, affiant, and the recorded-instrument reference'}
+          preview={state.affidavit?.declarantName || state.affidavit?.decedentName || 'The instrument’s typed facts'}
           isExpanded={expandedSection === 'affidavit'}
           onToggle={() => toggleSection('affidavit')}
         >

--- a/frontend/src/components/builder/PreviewPanel.tsx
+++ b/frontend/src/components/builder/PreviewPanel.tsx
@@ -76,6 +76,7 @@ export function PreviewPanel({ state, activeSection, onRegionClick }: PreviewPan
   // no DTT declaration, no granting clause, jurat instead of an
   // acknowledgment. Family from the registry.
   const isAffidavit = formFamily(state.deedType) === 'affidavit';
+  const isDeclaration = formFamily(state.deedType) === 'declaration';
   const aff = state.affidavit;
   const factOrBlank = (v: string | undefined) => v?.trim() || '________________';
   const operative = OPERATIVE_WORDS[state.deedType] || OPERATIVE_WORDS['grant-deed'];
@@ -187,7 +188,75 @@ export function PreviewPanel({ state, activeSection, onRegionClick }: PreviewPan
               </div>
             )}
 
-            {isAffidavit ? (
+            {isDeclaration ? (
+              <>
+                {/* Homestead declaration recital (PCT #33) — numbered
+                    clauses 2–4 are instrument-defining furniture; the
+                    declarant is the single typed fact. */}
+                <div className={`text-[11pt] leading-relaxed mb-3 ${highlight('affidavit')}`}>
+                  <p className="mb-2">
+                    I, <span onClick={go('affidavit', 'affidavit-declarantName')} className={`font-bold uppercase ${CLICKABLE} ${dataHighlight(aff?.declarantName)}`}>{factOrBlank(aff?.declarantName)}</span>,
+                    {' '}hereby certify and declare as follows:
+                  </p>
+                  <p className="mb-2">
+                    1. I hereby claim as a declared homestead the premises described as follows:
+                  </p>
+                </div>
+
+                <div className={`mb-3 ${highlight('property')}`}>
+                  <span onClick={go('property')} className={`font-bold text-[10.5pt] whitespace-pre-wrap ${CLICKABLE} ${placeholder(preview.legalDescription)} ${dataHighlight(preview.legalDescription)}`}>
+                    {preview.legalDescription}
+                  </span>
+                </div>
+
+                <div className={`text-[11pt] leading-relaxed mb-3 ${highlight('affidavit')}`}>
+                  <p className="mb-2">2. I am the owner of the above described homestead.</p>
+                  <p className="mb-2">
+                    3. The above described homestead is my principal dwelling or the principal
+                    dwelling of my spouse and I am, or my spouse is, currently residing thereon.
+                  </p>
+                  <p className="mb-2">
+                    4. The facts stated in this declaration are known to be true as of my
+                    personal knowledge.
+                  </p>
+                </div>
+
+                <div className="mt-6 flex justify-between items-end gap-4">
+                  <div className="text-[11pt]">Dated: <span className="inline-block min-w-[1.6in] border-b border-black" /></div>
+                  <div className="w-[45%]">
+                    <div className="border-b border-black h-7" />
+                    <div className="text-[9px] uppercase">
+                      Print Name: <span className={`font-bold ${dataHighlight(aff?.declarantName)}`}>{aff?.declarantName || ''}</span>
+                    </div>
+                  </div>
+                </div>
+
+                {/* Acknowledgment sketch — CC §1189 (CCP §704.930: a homestead
+                    declaration is ACKNOWLEDGED, not sworn). All entries are
+                    the notary's; nothing pre-fills. */}
+                <div className="mt-5 text-[9.5px] border border-black p-2 leading-snug">
+                  A notary public or other officer completing this certificate verifies only the
+                  identity of the individual who signed the document to which this certificate is
+                  attached, and not the truthfulness, accuracy, or validity of that document.
+                </div>
+                <div className="mt-3 text-[10px]">
+                  <div>STATE OF CALIFORNIA&nbsp;&nbsp;)</div>
+                  <div>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;)&nbsp;&nbsp;SS.</div>
+                  <div>COUNTY OF <span className="inline-block min-w-[1.4in] border-b border-black">{preview.county.startsWith('[') ? '' : preview.county}</span>&nbsp;)</div>
+                  <p className="mt-2">
+                    On ____________ before me, ______________________________, Notary Public,
+                    personally appeared ______________________________, who proved to me on the
+                    basis of satisfactory evidence to be the person(s) whose name(s) is/are
+                    subscribed to the within instrument and acknowledged to me that he/she/they
+                    executed the same in his/her/their authorized capacity(ies)…
+                  </p>
+                  <div className="mt-4 flex justify-between items-end">
+                    <div>Signature <span className="inline-block min-w-[2in] border-b border-black" /></div>
+                    <div className="border border-black w-[1.6in] h-[1.1in] flex items-center justify-center text-center text-[8px] uppercase text-gray-500">(This area for notary stamp)</div>
+                  </div>
+                </div>
+              </>
+            ) : isAffidavit ? (
               <>
                 {/* Sworn-statement recital — form furniture; the FACTS are
                     officer-typed and highlighted/clickable like deed data. */}

--- a/frontend/src/lib/deedPayload.ts
+++ b/frontend/src/lib/deedPayload.ts
@@ -13,7 +13,7 @@ import {
   buildPreflightOverridesPayload,
   buildProvenancePayload,
 } from '@/lib/provenance';
-import { formFamily } from '@/lib/formRegistry';
+import { formFamily, isSinglePartyType } from '@/lib/formRegistry';
 
 export function buildDeedPayload(genState: DeedBuilderState) {
   // FORMS-SPIKE: for affidavit instruments the deeds row's party columns
@@ -23,6 +23,9 @@ export function buildDeedPayload(genState: DeedBuilderState) {
   // affidavit's real substance. The authoritative facts live in
   // metadata.affidavit. Aliasing is FLAGGED in the spike report.
   const isAffidavit = formFamily(genState.deedType) === 'affidavit';
+  // Declaration family (parties migration): the single party rides in the
+  // deeds.parties JSONB column — grantor/grantee stay legitimately empty.
+  const isSingleParty = isSinglePartyType(genState.deedType);
   const aff = genState.affidavit;
   return {
     doc_type: genState.deedType,
@@ -34,8 +37,9 @@ export function buildDeedPayload(genState: DeedBuilderState) {
     property_zip: genState.property?.zip || '',
     current_owner: genState.property?.owner || '',
     legal_description: genState.property?.legalDescription || '',
-    grantors_text: isAffidavit ? (aff?.decedentName || '') : genState.grantor,
-    grantees_text: isAffidavit ? (aff?.affiantName || '') : genState.grantee,
+    grantors_text: isSingleParty ? '' : isAffidavit ? (aff?.decedentName || '') : genState.grantor,
+    grantees_text: isSingleParty ? '' : isAffidavit ? (aff?.affiantName || '') : genState.grantee,
+    parties: isSingleParty ? { declarant: aff?.declarantName || '' } : null,
     vesting: genState.vesting,
     requested_by: genState.requestedBy,
     requested_by_address: genState.requestedByAddress || '',
@@ -109,6 +113,9 @@ export function hasMeaningfulData(s: DeedBuilderState): boolean {
     s.dtt ||
     s.requestedBy?.trim() ||
     s.titleOrderNo?.trim() ||
-    s.escrowNo?.trim()
+    s.escrowNo?.trim() ||
+    // Typed instrument facts (affidavit/declaration families) are work
+    // worth keeping too — a declarant name alone must autosave.
+    Object.values(s.affidavit ?? {}).some((v) => v?.trim())
   );
 }

--- a/frontend/src/lib/deedResume.ts
+++ b/frontend/src/lib/deedResume.ts
@@ -167,21 +167,24 @@ export function hydrateStateFromDeedRow(row: Record<string, any>): ResumeResult 
         : undefined,
     requestedBy: row.requested_by || '',
     requestedByAddress: meta.requested_by_address || '',
-    affidavit: meta.affidavit
+    affidavit: meta.affidavit || row.parties
       ? {
-          affiantName: meta.affidavit.affiant_name || '',
-          decedentName: meta.affidavit.decedent_name || '',
-          jtDeedDate: meta.affidavit.jt_deed_date || '',
-          jtDeedGrantor: meta.affidavit.jt_deed_grantor || '',
-          jtDeedGrantees: meta.affidavit.jt_deed_grantees || '',
-          deathDate: meta.affidavit.death_date || '',
-          deathPlace: meta.affidavit.death_place || '',
-          deedDate: meta.affidavit.deed_date || '',
-          deedGrantor: meta.affidavit.deed_grantor || '',
-          trustDate: meta.affidavit.trust_date || '',
-          trustors: meta.affidavit.trustors || '',
-          recordingDate: meta.affidavit.recording_date || '',
-          instrumentNo: meta.affidavit.instrument_no || '',
+          // Declaration family: the single party lives in the parties
+          // JSONB column (parties migration), not metadata.affidavit.
+          declarantName: (row.parties && row.parties.declarant) || '',
+          affiantName: meta.affidavit?.affiant_name || '',
+          decedentName: meta.affidavit?.decedent_name || '',
+          jtDeedDate: meta.affidavit?.jt_deed_date || '',
+          jtDeedGrantor: meta.affidavit?.jt_deed_grantor || '',
+          jtDeedGrantees: meta.affidavit?.jt_deed_grantees || '',
+          deathDate: meta.affidavit?.death_date || '',
+          deathPlace: meta.affidavit?.death_place || '',
+          deedDate: meta.affidavit?.deed_date || '',
+          deedGrantor: meta.affidavit?.deed_grantor || '',
+          trustDate: meta.affidavit?.trust_date || '',
+          trustors: meta.affidavit?.trustors || '',
+          recordingDate: meta.affidavit?.recording_date || '',
+          instrumentNo: meta.affidavit?.instrument_no || '',
         }
       : undefined,
     returnTo,

--- a/frontend/src/lib/deedValidation.ts
+++ b/frontend/src/lib/deedValidation.ts
@@ -41,7 +41,29 @@ export function isAffidavitType(deedType: string | undefined): boolean {
   return formFamily(deedType) === 'affidavit';
 }
 
+export function isDeclarationType(deedType: string | undefined): boolean {
+  return formFamily(deedType) === 'declaration';
+}
+
 export function evaluateSubstantive(state: DeedBuilderState): CheckResult[] {
+  if (isDeclarationType(state.deedType)) {
+    // Declaration family (homestead): one party — the declarant — plus the
+    // premises. No grantee, no vesting, no DTT (not a conveyance).
+    return [
+      {
+        id: 'declarant_present',
+        label: 'Declarant stated',
+        ok: !!state.affidavit?.declarantName?.trim(),
+        sectionId: 'affidavit',
+      },
+      {
+        id: 'legal_description_present',
+        label: 'Legal description present',
+        ok: !!state.property?.legalDescription?.trim(),
+        sectionId: 'property',
+      },
+    ];
+  }
   if (isAffidavitType(state.deedType)) {
     const aff = state.affidavit;
     return [
@@ -227,10 +249,15 @@ export function deriveSectionTruth(state: DeedBuilderState): SectionTruth {
     return 'complete';
   };
 
-  if (isAffidavitType(state.deedType)) {
+  if (isAffidavitType(state.deedType) || isDeclarationType(state.deedType)) {
     const aff = state.affidavit;
-    const affFilled = !!(aff?.affiantName?.trim() && aff?.decedentName?.trim() &&
-      aff?.instrumentNo?.trim() && aff?.recordingDate?.trim());
+    // The typed-facts section is complete when its family's substantive
+    // facts are present: the declaration's single declarant, or the
+    // affidavit's affiant/decedent/recording reference.
+    const affFilled = isDeclarationType(state.deedType)
+      ? !!aff?.declarantName?.trim()
+      : !!(aff?.affiantName?.trim() && aff?.decedentName?.trim() &&
+        aff?.instrumentNo?.trim() && aff?.recordingDate?.trim());
     const statuses: Record<string, SectionStatus> = {
       property: status('property', !!state.property?.address),
       affidavit: status('affidavit', affFilled),

--- a/frontend/src/lib/formRegistry.ts
+++ b/frontend/src/lib/formRegistry.ts
@@ -13,7 +13,16 @@
  */
 
 export type NotarialCertificate = 'acknowledgment' | 'jurat';
-export type FormFamily = 'deed' | 'affidavit';
+/**
+ * deed        — two-party conveyance: acknowledgment + DTT declaration.
+ * affidavit   — sworn statement: jurat, no DTT; parties aliased onto the
+ *               grantor/grantee columns (decedent/affiant).
+ * declaration — single-party acknowledged instrument (homestead declarant,
+ *               certifying trustee): acknowledgment, no DTT; parties live
+ *               in the deeds.parties JSONB column (owner-ledgered
+ *               migration), not the grantor/grantee pair.
+ */
+export type FormFamily = 'deed' | 'affidavit' | 'declaration';
 
 export interface CompanionNotice {
   /** Passive guidance ONLY — never a block, never form-fill work. */
@@ -71,7 +80,11 @@ const DEED_SECTIONS = ['property', 'grantor', 'grantee', 'vesting', 'transferTax
    decision (Flag-3 precedent), so there is no vesting input. Everything
    else, including the full transfer-tax decision gate, is unchanged. */
 const FIXED_VESTING_DEED_SECTIONS = ['property', 'grantor', 'grantee', 'transferTax', 'recording'];
+/* The 'affidavit' section id names the shared TYPED-FACTS section — every
+   non-deed family (sworn affidavits AND acknowledged declarations) uses it
+   for its officer-typed instrument facts. */
 const AFFIDAVIT_SECTIONS = ['property', 'affidavit', 'recording'];
+const DECLARATION_SECTIONS = ['property', 'affidavit', 'recording'];
 
 /* Spike flag 4 ruling (applies to every affidavit-of-death variant):
    passive guidance only. The BOE-502-D itself is Tier B (form-fill
@@ -253,6 +266,29 @@ export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
       ...RECORDING_REF_FIELDS("The deed by which the trustee acquired title"),
     ],
   },
+  // Wave 1 form #5 — reference: PCT blank form #33 (Homestead_Dec-Indiv).
+  // Correction-note family: ACKNOWLEDGED per CCP §704.930, not a jurat.
+  'homestead-declaration': {
+    slug: 'homestead-declaration',
+    label: 'Declaration of Homestead',
+    title: 'DECLARATION OF HOMESTEAD',
+    subtitle: '(Individual)',
+    description: 'Declares a homestead on the owner’s principal dwelling (CCP §704.930) — acknowledged and recorded',
+    popular: false,
+    family: 'declaration',
+    sections: DECLARATION_SECTIONS,
+    notarial: 'acknowledgment',
+    hasDtt: false,
+    affidavitFields: [
+      {
+        key: 'declarantName',
+        label: 'Declarant (owner claiming the homestead)',
+        placeholder: 'ROBERT OWNER',
+        uppercase: true,
+        hint: 'The owner residing in the dwelling. Signs before a notary.',
+      },
+    ],
+  },
 };
 
 export function formConfig(slug: string | undefined | null): FormTypeConfig | undefined {
@@ -261,6 +297,18 @@ export function formConfig(slug: string | undefined | null): FormTypeConfig | un
 
 export function formFamily(slug: string | undefined | null): FormFamily {
   return formConfig(slug)?.family ?? 'deed';
+}
+
+/** Non-deed families (affidavit, declaration) collect their instrument
+ * facts in the shared typed-facts section (section id 'affidavit'). */
+export function usesFactsSection(slug: string | undefined | null): boolean {
+  return formFamily(slug) !== 'deed';
+}
+
+/** Declaration-family instruments have ONE party — stored in the
+ * deeds.parties JSONB column, never the grantor/grantee pair. */
+export function isSinglePartyType(slug: string | undefined | null): boolean {
+  return formFamily(slug) === 'declaration';
 }
 
 /**

--- a/frontend/src/types/builder.ts
+++ b/frontend/src/types/builder.ts
@@ -87,6 +87,9 @@ export interface AffidavitFacts {
   /* Trustee variant — the declaration of trust. */
   trustDate?: string;
   trustors?: string;
+  /* Declaration family (homestead): the single party. Persisted to the
+     deeds.parties JSONB column, not metadata.affidavit. */
+  declarantName?: string;
 }
 
 export interface DeedBuilderState {

--- a/templates/_partials/notary_acknowledgment.jinja2
+++ b/templates/_partials/notary_acknowledgment.jinja2
@@ -11,6 +11,10 @@
   - document_title: string (e.g., "Grant Deed")
   - execution_date: string (optional, for optional section)
   - page_count: int (optional, for optional section)
+  - ack_inline: bool (optional) — set true BEFORE the include when the
+    certificate belongs on the SAME page as the instrument (one-page
+    references like the homestead declaration, PCT #33). Default (unset)
+    keeps the deed-chassis behavior: the certificate opens its own page.
 #}
 
 <style>
@@ -19,7 +23,8 @@
    ========================================================================== */
 
 .notary-page {
-    page-break-before: always;
+    page-break-before: {{ 'auto' if ack_inline else 'always' }};
+    {% if ack_inline %}page-break-inside: avoid;{% endif %}
     /* G3: the including template's @page margins already frame the page —
        the old 0.75in padding doubled them and pushed the certificate onto
        two pages. Compressed spacing keeps it to one. */
@@ -260,6 +265,24 @@
     font-size: 9pt;
     color: #333;
 }
+
+{% if ack_inline %}
+/* Inline (same-page) mode — the compact certificate exactly as one-page
+   references print it: statutory text unchanged, headline and optional
+   document-description section omitted, spacing tightened. */
+.notary-page { font-size: 9.5pt; line-height: 1.35; padding-top: 0.06in; }
+.notary-disclaimer { font-size: 9pt; padding: 6px 10px; margin-bottom: 0.08in; }
+.notary-venue { margin-bottom: 0.08in; }
+.notary-body { margin-bottom: 0.06in; }
+.notary-body p { margin-bottom: 0.05in; }
+.notary-certification { margin-bottom: 0.06in; }
+.notary-witness { margin-bottom: 0.08in; }
+.notary-signature-section { margin-bottom: 0; }
+.notary-signature-line { height: 0.32in; margin-bottom: 2px; }
+.notary-signature-label { margin-bottom: 0.08in; }
+.notary-print-name { margin-bottom: 0.06in; }
+.notary-seal-area { width: 1.8in; height: 1.15in; }
+{% endif %}
 </style>
 
 <!-- ========================================================================
@@ -275,9 +298,11 @@
         the truthfulness, accuracy, or validity of that document.
     </div>
 
-    <!-- TITLE -->
+    {% if not ack_inline %}
+    <!-- TITLE (own-page mode only; one-page references print no headline) -->
     <div class="notary-main-title">California All-Purpose Acknowledgment</div>
     <div class="notary-subtitle">Civil Code § 1189</div>
+    {% endif %}
 
     <!-- VENUE -->
     <div class="notary-venue">
@@ -332,14 +357,17 @@
         <div class="notary-signature-block">
             <div class="notary-signature-line"></div>
             <div class="notary-signature-label">Signature of Notary Public</div>
-            
+            {% if not ack_inline %}
+            {# One-page references print only the signature line — the
+               printed-name/commission rows belong to own-page mode. #}
             <div class="notary-print-name">
                 Name (Printed): <span class="notary-field">__________________________</span>
             </div>
-            
+
             <div class="notary-commission">
                 My Commission Expires: <span class="notary-field short">________________</span>
             </div>
+            {% endif %}
         </div>
 
         <div class="notary-seal-area">
@@ -347,10 +375,12 @@
         </div>
     </div>
 
+    {% if not ack_inline %}
     <!-- DIVIDER -->
     <div class="notary-divider"></div>
 
-    <!-- OPTIONAL SECTION -->
+    <!-- OPTIONAL SECTION (own-page mode only — §1189's optional
+         document-description block; absent from one-page references) -->
     <div class="notary-optional-section">
         <div class="notary-optional-header">Optional Section</div>
         <div class="notary-optional-note">
@@ -377,6 +407,7 @@
             <span class="notary-optional-value"></span>
         </div>
     </div>
+    {% endif %}
 
     {% if document_id %}
     <!-- QR VERIFICATION SECTION (Phase 4) -->

--- a/templates/homestead_declaration_ca/index.jinja2
+++ b/templates/homestead_declaration_ca/index.jinja2
@@ -1,0 +1,241 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Declaration of Homestead (Individual) - California</title>
+    <style>
+        /* ==========================================================================
+           DECLARATION OF HOMESTEAD (INDIVIDUAL) — wave 1 #5
+
+           First declaration-family instrument. Reference implementation:
+           Pacific Coast Title blank form #33 (Homestead_Dec-Indiv),
+           measured with pdfplumber (letter page; recorder caption ~192pt;
+           title ~204pt; §1189 acknowledgment lower half ~570pt; one page).
+
+           Family facts (per the FORMS_TRIAGE correction note):
+           - ACKNOWLEDGED, not sworn — CCP §704.930 requires a homestead
+             declaration to be acknowledged. The certificate is the §1189
+             acknowledgment partial, NOT the jurat.
+           - Single-party instrument: the declarant rides in the
+             deeds.parties JSONB column (owner-ledgered migration) — no
+             grantor/grantee, no vesting.
+           - Not a conveyance: no DTT declaration, no mail-tax directive
+             ("AND WHEN RECORDED MAIL TO"). The reference carries no
+             Order/Escrow lines either (consumer instrument) — they render
+             only when the officer supplies values.
+           Chassis rules (G2/G3) carried over verbatim: §27361.6 open
+           recorder space + boundary caption; §27361.7 no chrome;
+           blank-contents doctrine (execution and notarial entries blank).
+           ========================================================================== */
+
+        @page {
+            size: letter;
+            margin: 0.5in 0.5in 0.6in 0.6in;
+        }
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        body {
+            font-family: "Times New Roman", Times, Georgia, serif;
+            font-size: 11pt;
+            line-height: 1.35;
+            color: #000;
+            background: #fff;
+        }
+
+        .header-section { display: flex; min-height: 1.85in; }
+
+        .recording-info {
+            width: 3.4in;
+            flex-shrink: 0;
+            border-right: 0.75pt solid #000;
+            padding-right: 0.15in;
+            font-size: 10pt;
+            line-height: 1.35;
+        }
+
+        .recorder-space { flex-grow: 1; }
+
+        .recording-label {
+            font-weight: bold;
+            text-transform: uppercase;
+            font-size: 9pt;
+        }
+
+        .recording-value { margin-bottom: 0.12in; min-height: 0.35in; }
+
+        .ref-line { font-size: 10pt; }
+
+        .header-boundary {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            border-bottom: 0.75pt solid #000;
+            padding-bottom: 0.03in;
+            margin-bottom: 0.12in;
+        }
+
+        .apn-ref { font-weight: bold; font-size: 10pt; }
+
+        .recorder-caption {
+            font-size: 7.5pt;
+            font-weight: bold;
+            text-transform: uppercase;
+        }
+
+        .deed-title {
+            text-align: center;
+            font-size: 14pt;
+            font-weight: bold;
+            letter-spacing: 2px;
+            text-transform: uppercase;
+            margin: 0.08in 0 0.02in 0;
+        }
+
+        .deed-subtitle {
+            text-align: center;
+            font-size: 11pt;
+            font-weight: bold;
+            margin-bottom: 0.1in;
+        }
+
+        .declaration-body {
+            font-size: 11pt;
+            line-height: 1.35;
+            text-align: justify;
+        }
+
+        .declaration-body p { margin-bottom: 0.07in; }
+
+        .fact {
+            /* Officer-supplied facts render bold; a missing fact renders as
+               the reference's blank line so an incomplete instrument LOOKS
+               incomplete. */
+            font-weight: bold;
+        }
+
+        .fact-line {
+            display: inline-block;
+            min-width: 2.2in;
+            border-bottom: 1px solid #000;
+        }
+
+        .legal-content {
+            font-weight: bold;
+            white-space: pre-wrap;
+            margin: 0.08in 0;
+            min-height: 0.5in;
+        }
+
+        .execution-section {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-end;
+            margin-top: 0.12in;
+            margin-bottom: 0.05in;
+        }
+
+        .signature-block { width: 3.2in; }
+
+        .signature-line {
+            border-bottom: 1px solid #000;
+            width: 3.2in;
+            height: 0.35in;
+        }
+
+        .print-name {
+            font-size: 10pt;
+            text-transform: uppercase;
+        }
+    </style>
+</head>
+<body>
+    <div class="deed-page">
+
+        <header class="header-section">
+            <div class="recording-info">
+                <div class="recording-label">Recording Requested By:</div>
+                <div class="recording-value">{{ requested_by or '' }}{% if requested_by_address %}<br>{{ requested_by_address }}{% endif %}</div>
+
+                <div class="recording-label">And When Recorded Mail To:</div>
+                <div class="recording-value">
+                    {% if return_to %}
+                        {% if return_to.get('name') %}{{ return_to.get('name') }}<br>{% endif %}
+                        {% if return_to.get('company') %}{{ return_to.get('company') }}<br>{% endif %}
+                        {% if return_to.get('address1') %}{{ return_to.get('address1') }}<br>{% endif %}
+                        {% if return_to.get('address2') %}{{ return_to.get('address2') }}<br>{% endif %}
+                        {% set city = return_to.get('city', '') %}
+                        {% set state = return_to.get('state', '') %}
+                        {% set zip = return_to.get('zip', '') %}
+                        {% if city or state or zip %}
+                            {{ city }}{% if city and (state or zip) %}, {% endif %}{{ state }} {{ zip }}
+                        {% endif %}
+                    {% else %}
+                        _________________________________<br>
+                        _________________________________<br>
+                        _________________________________
+                    {% endif %}
+                </div>
+
+                {# The reference carries no Order/Escrow lines (consumer
+                   instrument) — render only when the officer supplied one. #}
+                {% if title_order_no %}<div class="ref-line">Order No.: {{ title_order_no }}</div>{% endif %}
+                {% if escrow_no %}<div class="ref-line">Escrow No.: {{ escrow_no }}</div>{% endif %}
+            </div>
+
+            <div class="recorder-space"><!-- Gov. Code §27361.6 — recorder's use only --></div>
+        </header>
+
+        <div class="header-boundary">
+            <span class="apn-ref">APN: {{ apn or '____________________' }}</span>
+            <span class="recorder-caption">Space Above This Line Is For Recorder&rsquo;s Use</span>
+        </div>
+
+        <h1 class="deed-title">Declaration of Homestead</h1>
+        <div class="deed-subtitle">(Individual)</div>
+
+        {% set declarant = (parties or {}).get('declarant') %}
+        <div class="declaration-body">
+            <p>
+                I, {% if declarant %}<span class="fact">{{ declarant }}</span>{% else %}<span class="fact-line">&nbsp;</span>{% endif %},
+                hereby certify and declare as follows:
+            </p>
+            <p>
+                1. I hereby claim as a declared homestead the premises described as follows:
+            </p>
+        </div>
+
+        <div class="legal-content">{{ legal_description or '' }}</div>
+
+        <div class="declaration-body">
+            <p>2. I am the owner of the above described homestead.</p>
+            <p>
+                3. The above described homestead is my principal dwelling or the principal
+                dwelling of my spouse and I am, or my spouse is, currently residing thereon.
+            </p>
+            <p>
+                4. The facts stated in this declaration are known to be true as of my
+                personal knowledge.
+            </p>
+        </div>
+
+        {# Execution: the declarant signs at the notarization — date and
+           signature stay blank (blank-contents doctrine). The printed name
+           identifies the signer, as the deed chassis prints signer names. #}
+        <div class="execution-section">
+            <div>Dated: <span class="fact-line" style="min-width:1.8in">&nbsp;</span></div>
+            <div class="signature-block">
+                <div class="signature-line"></div>
+                <div class="print-name">Print Name: {% if declarant %}<span class="fact">{{ declarant }}</span>{% endif %}</div>
+            </div>
+        </div>
+
+        {# CCP §704.930: ACKNOWLEDGED, not sworn — §1189 certificate,
+           on the SAME page as the reference lays it out. #}
+        {% set document_title = 'Declaration of Homestead' %}
+        {% set ack_inline = true %}
+        {% include '_partials/notary_acknowledgment.jinja2' %}
+
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Wave 1, form #5 (owner-ranked order) — the first declaration-family instrument

### Reference fetched and measured
PCT blank form #33 (`Homestead_Dec-Indiv.pdf`) — letter, **one page**, caption at 192pt, title 204pt, §1189 acknowledgment in the lower half (~570pt). Built per the FORMS_TRIAGE correction note (owner-acknowledged): **acknowledged under CCP §704.930**, never a jurat.

### Doctrine pass — no legal choices, no hold
| | |
|---|---|
| **Furniture** | Title + "(Individual)"; "I, ___, hereby certify and declare as follows:"; clause 1 lead-in; clauses 2–4 verbatim (ownership, principal-dwelling, personal-knowledge — instrument-defining, Flag-3); §1189 certificate |
| **Officer facts** | Declarant name (single typed fact) + chassis fields (premises/legal description, APN, county, mail-to). Print Name renders the declarant, per the deed chassis's signer-name precedent |
| **Legal choices** | **None.** Not a conveyance: no DTT, no mail-tax, no vesting (sentinel-pinned) |

### The third registry family + first parties-JSONB user
`declaration` (acknowledgment + no DTT + single-party) lands with structural coherence pins alongside deed and affidavit. The declarant flows through the #86 migration end to end: registry-driven facts section → payload `parties: {declarant}` → `deeds.parties` column → template context → resume. `grantor_name`/`grantee_name` stay legitimately empty; Past Deeds rows read by the party projection.

### Acknowledgment partial: opt-in inline mode
The §1189 partial always opened its own page (right for deeds). One-page references print a **compact on-page certificate** — so the partial gains `ack_inline`: same statutory text, headline/optional-section/commission rows omitted (the reference prints only "Signature ___"), spacing tightened. **Own-page mode is unchanged** — the full deed suites pin it; the homestead pin asserts one page with the certificate in the lower half.

### Pins
8 new backend tests (`test_wave1_homestead.py`): furniture, declarant-from-parties + Print Name, blanks never invented, acknowledgment-not-jurat canary, blank-contents, no-DTT/no-mail-tax + vesting sentinel, one-page geometry + no-chrome, type+family maps. Registry pins extended to 11 types with the three-family coherence matrix; the registry↔backend family mirror pin covers the new type automatically.

### Gates
- Backend: **159 passed** (was 151; +8)
- Six-flow: ✔ (snapshot unchanged)
- Jest: **283 passed**
- tsc: frozen baseline **98** (unchanged)

### Per-form actuals vs. the 1–2 hr projection
~1.25 hr — inside projection for a new family (spike projected ~half day for a family-first; the registry + parties machinery absorbed most of it). The inline-ack mode is one-time: form #6 reuses it for free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_