### PR TITLE
FORMS wave 1 (#7): Revocation of Revocable TOD Deed — the statutory form

### DIFF
--- a/backend/services/deed_pdf.py
+++ b/backend/services/deed_pdf.py
@@ -49,6 +49,8 @@ TEMPLATE_BY_DEED_TYPE = {
     "homestead-declaration": "homestead_declaration_ca/index.jinja2",
     # FORMS wave 1 #6 — property-less (PCT reference #72; Prob C §18100.5).
     "trust-certification": "trust_certification_ca/index.jinja2",
+    # FORMS wave 1 #7 — statutory revocation form (Prob C §§5600/5644).
+    "tod-revocation": "tod_revocation_ca/index.jinja2",
 }
 DEFAULT_TEMPLATE = "grant_deed_ca/index.jinja2"
 

--- a/backend/services/form_families.py
+++ b/backend/services/form_families.py
@@ -32,6 +32,7 @@ FAMILY_BY_DEED_TYPE = {
     "affidavit-death-trustee": "affidavit",
     "homestead-declaration": "declaration",
     "trust-certification": "declaration",
+    "tod-revocation": "declaration",
 }
 
 SINGLE_PARTY_FAMILIES = {"declaration"}

--- a/backend/tests/test_wave1_tod_revocation.py
+++ b/backend/tests/test_wave1_tod_revocation.py
@@ -1,0 +1,151 @@
+"""FORMS wave 1 #7 — Revocation of Revocable TOD Deed, pinned.
+
+The STATUTORY form (Prob C §§5600/5644; the PCT blank mirrors it): three
+pages — header + categorical exemption recitals + the statute's notice +
+APN + property description; the revocation statement + signature/date +
+the TWO-WITNESS block; the §1189 acknowledgment.
+
+Doctrine: the DTT/PCOR exemption recitals are categorical statutory
+furniture (interspousal-recital precedent — no decision gate, no DTT
+block). The grantor is named ONLY at signature ("Sign and print your
+name" — an execution act): nothing pre-prints, pinned with a sentinel.
+"""
+import io
+
+import pdfplumber
+
+from services.deed_pdf import render_deed_html, render_deed_pdf
+from tests.test_deed_pdf import _normalized
+
+TOD_META = {
+    "requested_by_address": "456 Escrow Way, Los Angeles, CA 90012",
+    "return_to": {"name": "ROBERT OWNER", "address1": "1358 5TH ST",
+                  "city": "Santa Monica", "state": "CA", "zip": "90401"},
+    "title_order_no": "TO-9921",
+    "escrow_no": "ESC-4410",
+    "affidavit": {
+        # Record identification only — must NOT render on the instrument.
+        "revoking_grantor": "SENTINEL GRANTOR NAME",
+    },
+}
+
+
+def tod_row(**overrides):
+    row = {
+        "id": 1,
+        "deed_type": "tod-revocation",
+        "grantor_name": "",
+        "grantee_name": "",
+        "parties": {"grantor": "SENTINEL GRANTOR NAME"},
+        "legal_description": "LOT 7, BLOCK B, TRACT 12345",
+        "county": "Los Angeles",
+        "apn": "4290-012-034",
+        "property_address": "1358 5TH ST, Santa Monica, CA 90401",
+        "requested_by": "Pacific Coast Escrow",
+        "metadata": TOD_META,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_statutory_furniture_present():
+    html = _normalized(render_deed_html(tod_row()))
+    assert "Revocation of" in html
+    assert "Revocable Transfer on Death (TOD) Deed" in html
+    assert "California Probate Code &sect; 5600" in html or "California Probate Code § 5600" in html
+    assert "THE UNDERSIGNED GRANTOR(s) DECLARE(s):" in html
+    assert "exempt from Documentary Transfer Tax under Revenue and Taxation Code &sect;11930" in html \
+        or "exempt from Documentary Transfer Tax under Revenue and Taxation Code §11930" in html
+    assert "Preliminary Change of Ownership Report" in html
+    assert "IMPORTANT NOTICE: THIS FORM MUST BE RECORDED TO BE EFFECTIVE" in html
+    assert "60 days after the date it is notarized" in html
+    assert "I revoke any TOD deed to transfer the described property that I executed before executing this form." in html
+    assert "signed by two persons, both present at the same time" in html
+    assert "Witness #1" in html
+    assert "Witness #2" in html
+
+
+def test_property_facts_render():
+    html = _normalized(render_deed_html(tod_row()))
+    assert "4290-012-034" in html
+    assert "LOT 7, BLOCK B, TRACT 12345" in html
+    assert "TO-9921" in html
+    assert "ESC-4410" in html
+
+
+def test_grantor_name_never_preprints():
+    """The statutory form is signed AND printed by the grantor at
+    notarization — the typed name identifies the record only."""
+    html = render_deed_html(tod_row())
+    assert "SENTINEL GRANTOR NAME" not in html
+    assert "(Sign Name)" in html
+    assert "(Print Name)" in html
+
+
+def test_no_dtt_block_categorical_recitals_only():
+    """Exemption recitals are furniture — the DTT declaration/decision
+    machinery must not render (no amount, no checklines)."""
+    html = _normalized(render_deed_html(tod_row()))
+    assert "DOCUMENTARY TRANSFER TAX IS" not in html
+    assert "Computed on full value" not in html
+    assert "Unincorporated area" not in html
+
+
+def test_acknowledgment_not_jurat():
+    html = _normalized(render_deed_html(tod_row()))
+    assert "personally appeared" in html
+    assert "acknowledged to me" in html
+    assert "Subscribed and sworn to (or affirmed) before me" not in html
+    # The §1189 disclaimer appears once (the attached certificate page).
+    assert html.count("verifies only the identity") == 1
+
+
+def test_missing_property_facts_render_blank():
+    html = render_deed_html(tod_row(apn="", legal_description="", metadata={}))
+    assert "fact-line" in html
+    assert "4290-012-034" not in html
+
+
+def test_three_page_statutory_layout_and_no_chrome():
+    """Page 1: recitals/notice/property. Page 2: revocation + signatures +
+    witnesses. Page 3: acknowledgment. Chassis geometry on page one."""
+    pdf = render_deed_pdf(tod_row())
+    with pdfplumber.open(io.BytesIO(pdf)) as doc:
+        assert len(doc.pages) == 3
+        p1, p2, p3 = (p.extract_text() for p in doc.pages)
+        assert "IMPORTANT NOTICE" in p1
+        assert "PARCEL NUMBER" in p1.upper()
+        assert "REVOCATION" in p2.upper()
+        assert "WITNESSES" in p2.upper()
+        assert "personally" in p3
+        assert "personally" not in p1 and "personally" not in p2
+
+        words = doc.pages[0].extract_words()
+
+        def top_of(needle):
+            hits = [w for w in words if needle.upper() in w["text"].upper()]
+            assert hits, needle
+            return hits[0]["top"]
+
+        def x_of(needle):
+            hits = [w for w in words if needle.upper() in w["text"].upper()]
+            return hits[0]["x0"]
+
+        caption_top = top_of("RECORDER’S")
+        title_top = top_of("REVOCATION")
+        assert caption_top > 100
+        assert x_of("RECORDER’S") > 300
+        assert title_top > caption_top
+
+    html = render_deed_html(tod_row())
+    for leaked in ("7C4DFF", "Generated by", "deedpro.com/verify", "recorder-box", "bg-brand"):
+        assert leaked not in html, leaked
+
+
+def test_registered_in_the_type_and_family_maps():
+    from services.deed_pdf import TEMPLATE_BY_DEED_TYPE
+    from services.form_families import family_of, is_single_party, requires_legal_description
+    assert TEMPLATE_BY_DEED_TYPE["tod-revocation"] == "tod_revocation_ca/index.jinja2"
+    assert family_of("tod-revocation") == "declaration"
+    assert is_single_party("tod-revocation")
+    assert requires_legal_description("tod-revocation")  # parcel-tied

--- a/frontend/src/__tests__/formRegistry.test.ts
+++ b/frontend/src/__tests__/formRegistry.test.ts
@@ -23,8 +23,8 @@ const KNOWN_SECTIONS = new Set(['property', 'grantor', 'grantee', 'vesting', 'tr
 describe('FORMS registry — completeness and coherence', () => {
   const entries = Object.values(FORM_REGISTRY);
 
-  it('carries the twelve shipped types', () => {
-    expect(entries.length).toBe(12);
+  it('carries the thirteen shipped types', () => {
+    expect(entries.length).toBe(13);
     expect(formConfig('affidavit-death-jt')?.family).toBe('affidavit');
     // Wave 1 siblings (owner-ranked #1 and #2):
     expect(formConfig('affidavit-death-cp-spouse')?.family).toBe('affidavit');
@@ -37,6 +37,9 @@ describe('FORMS registry — completeness and coherence', () => {
     expect(formConfig('homestead-declaration')?.family).toBe('declaration');
     expect(formConfig('trust-certification')?.family).toBe('declaration');
     expect(formConfig('trust-certification')?.sections).not.toContain('property');
+    // Wave 1 #7 — the statutory revocation (single-party, parcel-tied):
+    expect(formConfig('tod-revocation')?.family).toBe('declaration');
+    expect(formConfig('tod-revocation')?.sections).toContain('property');
   });
 
   it('every entry is internally coherent', () => {

--- a/frontend/src/__tests__/previewChassisConformance.test.ts
+++ b/frontend/src/__tests__/previewChassisConformance.test.ts
@@ -27,6 +27,9 @@ import {
   OPERATIVE_WORDS,
   EXEMPTION_RECITALS,
   FIXED_VESTING_PHRASES,
+  TOD_NOTICE_HEAD,
+  TOD_REVOCATION_STATEMENT,
+  TOD_WITNESS_INSTRUCTION,
 } from '../lib/deedFurniture';
 
 /** Strip // and /* comments so prose about a disease can't trip the scan. */
@@ -143,5 +146,19 @@ describe('the same wording lives in the backend chassis templates', () => {
     expect(t).toContain(`${FIXED_VESTING_PHRASES[dt]} the real property situated in the County of`);
     expect(t).not.toContain('{{ vesting }}');
     expect(t).not.toContain('{% if vesting %}');
+  });
+
+  // Wave 1 #7: the statutory revocation text renders verbatim in both the
+  // preview (by identifier) and the template (by value).
+  it('tod-revocation: statutory notice, revocation statement, witness instruction', () => {
+    const t = normalized(
+      fs.readFileSync(path.join(TEMPLATE_ROOT, 'tod_revocation_ca', 'index.jinja2'), 'utf8')
+    );
+    expect(t).toContain(TOD_NOTICE_HEAD);
+    expect(t).toContain(TOD_REVOCATION_STATEMENT);
+    expect(t).toContain(TOD_WITNESS_INSTRUCTION);
+    for (const id of ['TOD_NOTICE_HEAD', 'TOD_REVOCATION_STATEMENT', 'TOD_WITNESS_INSTRUCTION']) {
+      expect(PANEL).toContain(id);
+    }
   });
 });

--- a/frontend/src/components/builder/PreviewPanel.tsx
+++ b/frontend/src/components/builder/PreviewPanel.tsx
@@ -20,6 +20,12 @@ import {
   OPERATIVE_WORDS,
   EXEMPTION_RECITALS,
   FIXED_VESTING_PHRASES,
+  TOD_DTT_EXEMPTION,
+  TOD_PCOR_EXEMPTION,
+  TOD_NOTICE_HEAD,
+  TOD_NOTICE_BODY,
+  TOD_REVOCATION_STATEMENT,
+  TOD_WITNESS_INSTRUCTION,
 } from '@/lib/deedFurniture';
 // FORMS registry: document titles + family come from the one source of
 // type facts.
@@ -191,7 +197,65 @@ export function PreviewPanel({ state, activeSection, onRegionClick }: PreviewPan
               </div>
             )}
 
-            {isDeclaration && state.deedType === 'trust-certification' ? (
+            {isDeclaration && state.deedType === 'tod-revocation' ? (
+              <>
+                {/* Statutory revocation form (Prob C §§5600/5644) — the
+                    exemption recitals and notice are the statute's own
+                    furniture; the grantor is named only at signature
+                    (execution act — nothing pre-prints). */}
+                <div className={`text-[10px] mb-3 ${highlight('transferTax')}`}>
+                  <div className="font-bold">THE UNDERSIGNED GRANTOR(s) DECLARE(s):</div>
+                  <div>{TOD_DTT_EXEMPTION}</div>
+                  <div>{TOD_PCOR_EXEMPTION}</div>
+                </div>
+
+                <div className="border border-black p-2 text-[10px] mb-3">
+                  <div className="font-bold text-center mb-1">{TOD_NOTICE_HEAD}</div>
+                  {TOD_NOTICE_BODY}
+                </div>
+
+                <div className="text-[11pt] font-bold uppercase mb-1">Property Assessor&rsquo;s Parcel Number</div>
+                <div className={`mb-2 ${highlight('property')}`}>
+                  <span onClick={go('property')} className={`font-mono tracking-wide ${CLICKABLE} ${dataHighlight(preview.apn)}`}>{preview.apn || '____________'}</span>
+                </div>
+
+                <div className="text-[11pt] font-bold uppercase mb-1">Property Description</div>
+                <div className={`mb-3 ${highlight('property')}`}>
+                  <span onClick={go('property')} className={`font-bold text-[10.5pt] whitespace-pre-wrap ${CLICKABLE} ${placeholder(preview.legalDescription)} ${dataHighlight(preview.legalDescription)}`}>
+                    {preview.legalDescription}
+                  </span>
+                </div>
+
+                <div className="text-[11pt] font-bold uppercase mb-1">Revocation</div>
+                <p className="mb-3 text-[11pt]">{TOD_REVOCATION_STATEMENT}</p>
+
+                <div className="text-[11pt] font-bold uppercase mb-1">Signature and Date</div>
+                <p className={`mb-2 text-[10px] italic ${highlight('affidavit')}`}>
+                  Signed and printed by{' '}
+                  <span onClick={go('affidavit', 'affidavit-revokingGrantor')} className={`font-bold uppercase not-italic ${CLICKABLE} ${dataHighlight(aff?.revokingGrantor)}`}>{factOrBlank(aff?.revokingGrantor)}</span>
+                  {' '}at notarization — the statutory form pre-prints no name.
+                </p>
+                <div className="mb-3">
+                  <div className="border-b border-black h-6 w-[60%]" />
+                  <div className="text-[9px]">(Sign Name) / (Print Name)</div>
+                </div>
+
+                <div className="text-[11pt] font-bold uppercase mb-1">Witnesses</div>
+                <p className="mb-2 text-[10px]">{TOD_WITNESS_INSTRUCTION}</p>
+                <div className="flex gap-6 mb-2">
+                  <div className="flex-1">
+                    <div className="text-[10px] font-bold">Witness #1</div>
+                    <div className="border-b border-black h-6" />
+                    <div className="text-[9px]">(Sign Name) / (Print Name)</div>
+                  </div>
+                  <div className="flex-1">
+                    <div className="text-[10px] font-bold">Witness #2</div>
+                    <div className="border-b border-black h-6" />
+                    <div className="text-[9px]">(Sign Name) / (Print Name)</div>
+                  </div>
+                </div>
+              </>
+            ) : isDeclaration && state.deedType === 'trust-certification' ? (
               <>
                 {/* Certification of trust (PCT #72, Prob C §18100.5).
                     Owner ruling: initial lines and checkboxes are EXECUTION

--- a/frontend/src/lib/deedFurniture.ts
+++ b/frontend/src/lib/deedFurniture.ts
@@ -49,6 +49,27 @@ export const FIXED_VESTING_PHRASES: Record<string, string> = {
   'grant-deed-cp-ros': 'as COMMUNITY PROPERTY WITH RIGHT OF SURVIVORSHIP',
 };
 
+/** TOD revocation (Prob C §§5600/5644) — statutory furniture shared by
+ * preview and template (drift-pinned). The exemption recitals are
+ * categorical (no decision gate); the notice is the statute's own. */
+export const TOD_DTT_EXEMPTION =
+  'This conveyance is exempt from Documentary Transfer Tax under Revenue and Taxation Code §11930.';
+export const TOD_PCOR_EXEMPTION =
+  'This conveyance is exempt from Preliminary Change of Ownership Report under Revenue and Taxation Code § 480.3.';
+export const TOD_NOTICE_HEAD = 'IMPORTANT NOTICE: THIS FORM MUST BE RECORDED TO BE EFFECTIVE';
+export const TOD_NOTICE_BODY =
+  'This revocation form MUST be RECORDED on or before 60 days after the date it is notarized ' +
+  'or it will not be effective. This revocation form only affects a transfer on death deed that YOU ' +
+  'made. A transfer on death deed made by a co-owner of your property is not affected by this ' +
+  'revocation form. A co-owner who wants to revoke a transfer on death deed that they made must ' +
+  'complete and RECORD a SEPARATE revocation form.';
+export const TOD_REVOCATION_STATEMENT =
+  'I revoke any TOD deed to transfer the described property that I executed before executing this form.';
+export const TOD_WITNESS_INSTRUCTION =
+  'To be valid, this form must be signed by two persons, both present at the same time, who witness ' +
+  'your signing of the deed or your acknowledgment that it is your deed. The signatures of the ' +
+  'witnesses do not need to be acknowledged by a notary public.';
+
 /** Categorical exemption recitals (instrument-defining form furniture —
  * see docs/DOCTRINE_CONFORMANCE.md §7.3). */
 export const EXEMPTION_RECITALS: Record<string, string> = {

--- a/frontend/src/lib/deedPayload.ts
+++ b/frontend/src/lib/deedPayload.ts
@@ -46,6 +46,7 @@ function buildFactsBlock(aff: AffidavitFacts | undefined) {
     signer_count: aff.signerCount || '',
     signer_names: aff.signerNames || '',
     title_vesting: aff.titleVesting || '',
+    revoking_grantor: aff.revokingGrantor || '',
   };
   return Object.values(block).some((v) => v) ? block : null;
 }
@@ -79,7 +80,9 @@ export function buildDeedPayload(genState: DeedBuilderState) {
     parties: isSingleParty
       ? genState.deedType === 'trust-certification'
         ? { trustee: aff?.trustees || '' }
-        : { declarant: aff?.declarantName || '' }
+        : genState.deedType === 'tod-revocation'
+          ? { grantor: aff?.revokingGrantor || '' }
+          : { declarant: aff?.declarantName || '' }
       : null,
     vesting: genState.vesting,
     requested_by: genState.requestedBy,

--- a/frontend/src/lib/deedResume.ts
+++ b/frontend/src/lib/deedResume.ts
@@ -193,6 +193,7 @@ export function hydrateStateFromDeedRow(row: Record<string, any>): ResumeResult 
           signerCount: meta.affidavit?.signer_count || '',
           signerNames: meta.affidavit?.signer_names || '',
           titleVesting: meta.affidavit?.title_vesting || '',
+          revokingGrantor: meta.affidavit?.revoking_grantor || '',
         }
       : undefined,
     returnTo,

--- a/frontend/src/lib/deedValidation.ts
+++ b/frontend/src/lib/deedValidation.ts
@@ -68,6 +68,25 @@ export function evaluateSubstantive(state: DeedBuilderState): CheckResult[] {
         },
       ];
     }
+    if (state.deedType === 'tod-revocation') {
+      // The statutory form names the grantor only at signature; the typed
+      // name identifies the record (and the parties column) — plus the
+      // affected property's description.
+      return [
+        {
+          id: 'revoking_grantor_named',
+          label: 'Revoking grantor named',
+          ok: !!state.affidavit?.revokingGrantor?.trim(),
+          sectionId: 'affidavit',
+        },
+        {
+          id: 'legal_description_present',
+          label: 'Legal description present',
+          ok: !!state.property?.legalDescription?.trim(),
+          sectionId: 'property',
+        },
+      ];
+    }
     // Homestead: the declarant plus the premises.
     return [
       {
@@ -282,10 +301,12 @@ export function deriveSectionTruth(state: DeedBuilderState): SectionTruth {
     // affidavit's affiant/decedent/recording reference.
     const affFilled = state.deedType === 'trust-certification'
       ? !!(aff?.trustName?.trim() && aff?.trustees?.trim())
-      : isDeclarationType(state.deedType)
-        ? !!aff?.declarantName?.trim()
-        : !!(aff?.affiantName?.trim() && aff?.decedentName?.trim() &&
-          aff?.instrumentNo?.trim() && aff?.recordingDate?.trim());
+      : state.deedType === 'tod-revocation'
+        ? !!aff?.revokingGrantor?.trim()
+        : isDeclarationType(state.deedType)
+          ? !!aff?.declarantName?.trim()
+          : !!(aff?.affiantName?.trim() && aff?.decedentName?.trim() &&
+            aff?.instrumentNo?.trim() && aff?.recordingDate?.trim());
     const statuses: Record<string, SectionStatus> = {
       // Property-less instruments (certification of trust) have no
       // property section — the one-truth counter must not count it.

--- a/frontend/src/lib/formRegistry.ts
+++ b/frontend/src/lib/formRegistry.ts
@@ -332,6 +332,34 @@ export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
       },
     ],
   },
+  // Wave 1 form #7 — the STATUTORY revocation form (Prob C §§5600/5644;
+  // PCT's blank mirrors it). Single-party, acknowledged; the DTT/PCOR
+  // exemption recitals are pre-printed statutory furniture (no decision
+  // gate — R&T §11930 / §480.3 apply categorically). The grantor is named
+  // only at signature on the statutory form ("Sign and print your name" —
+  // an execution act), so the typed name identifies the record and the
+  // Past Deeds row; it never pre-prints on the instrument.
+  'tod-revocation': {
+    slug: 'tod-revocation',
+    label: 'Revocation of Revocable TOD Deed',
+    title: 'REVOCATION OF REVOCABLE TRANSFER ON DEATH (TOD) DEED',
+    subtitle: '(California Probate Code § 5600)',
+    description: 'Revokes a recorded transfer on death deed — statutory form; must be recorded within 60 days of notarization',
+    popular: false,
+    family: 'declaration',
+    sections: DECLARATION_SECTIONS,
+    notarial: 'acknowledgment',
+    hasDtt: false,
+    affidavitFields: [
+      {
+        key: 'revokingGrantor',
+        label: 'Revoking grantor (as named on the recorded TOD deed)',
+        placeholder: 'ROBERT OWNER',
+        uppercase: true,
+        hint: 'Identifies this record and the Past Deeds row. The statutory form itself is signed AND printed by the grantor at notarization — no name pre-prints.',
+      },
+    ],
+  },
 };
 
 export function formConfig(slug: string | undefined | null): FormTypeConfig | undefined {

--- a/frontend/src/types/builder.ts
+++ b/frontend/src/types/builder.ts
@@ -101,6 +101,10 @@ export interface AffidavitFacts {
   signerCount?: string;
   signerNames?: string;
   titleVesting?: string;
+  /* TOD revocation (Prob C §5600): the revoking grantor — record
+     identification only; the statutory form is signed AND printed by the
+     grantor at notarization (execution act; nothing pre-prints). */
+  revokingGrantor?: string;
 }
 
 export interface DeedBuilderState {

--- a/templates/tod_revocation_ca/index.jinja2
+++ b/templates/tod_revocation_ca/index.jinja2
@@ -1,0 +1,298 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Revocation of Revocable Transfer on Death (TOD) Deed - California</title>
+    <style>
+        /* ==========================================================================
+           REVOCATION OF REVOCABLE TOD DEED — Prob C §§5600/5644 — wave 1 #7
+
+           This is the STATUTORY form (the PCT blank mirrors the §5644
+           prescription): three pages — (1) header + exemption recitals +
+           the statute's IMPORTANT NOTICE + APN + property description;
+           (2) the revocation statement + signature/date + the TWO-WITNESS
+           block; (3) the §1189 acknowledgment. Statutory text renders
+           VERBATIM (drift-pinned against lib/deedFurniture).
+
+           Doctrine notes:
+           - The DTT/PCOR exemption recitals are categorical statutory
+             furniture (R&T §11930 / §480.3) — no decision gate, exactly
+             like the interspousal recital precedent. No DTT block.
+           - The grantor is named ONLY at signature ("Sign and print your
+             name") — an execution act: nothing pre-prints (pinned). The
+             witness signatures are likewise blank furniture.
+           - Chassis rules (G2/G3): open recorder space, boundary caption,
+             no chrome, blank notarial contents.
+           ========================================================================== */
+
+        @page {
+            size: letter;
+            margin: 0.5in 0.5in 0.6in 0.6in;
+        }
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        body {
+            font-family: "Times New Roman", Times, Georgia, serif;
+            font-size: 11pt;
+            line-height: 1.4;
+            color: #000;
+            background: #fff;
+        }
+
+        .header-section { display: flex; min-height: 1.85in; }
+
+        .recording-info {
+            width: 3.4in;
+            flex-shrink: 0;
+            border-right: 0.75pt solid #000;
+            padding-right: 0.15in;
+            font-size: 10pt;
+            line-height: 1.35;
+        }
+
+        .recorder-space { flex-grow: 1; }
+
+        .recording-label {
+            font-weight: bold;
+            text-transform: uppercase;
+            font-size: 9pt;
+        }
+
+        .recording-value { margin-bottom: 0.12in; min-height: 0.35in; }
+
+        .header-boundary {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            border-bottom: 0.75pt solid #000;
+            padding-bottom: 0.03in;
+            margin-bottom: 0.12in;
+            font-size: 10pt;
+        }
+
+        .recorder-caption {
+            font-size: 7.5pt;
+            font-weight: bold;
+            text-transform: uppercase;
+        }
+
+        .deed-title {
+            text-align: center;
+            font-size: 13pt;
+            font-weight: bold;
+            letter-spacing: 1px;
+            text-transform: uppercase;
+            margin: 0.08in 0 0.02in 0;
+        }
+
+        .deed-subtitle {
+            text-align: center;
+            font-size: 10.5pt;
+            font-weight: bold;
+            margin-bottom: 0.1in;
+        }
+
+        .exemption-recitals {
+            font-size: 10pt;
+            margin-bottom: 0.12in;
+        }
+
+        .exemption-recitals .lead { font-weight: bold; }
+
+        .notice-box {
+            /* The statute's own warning — form content, not chrome. */
+            border: 1.5pt solid #000;
+            padding: 0.08in 0.12in;
+            font-size: 10pt;
+            margin-bottom: 0.14in;
+        }
+
+        .notice-head {
+            font-weight: bold;
+            text-align: center;
+            margin-bottom: 0.05in;
+        }
+
+        .section-head {
+            font-weight: bold;
+            text-transform: uppercase;
+            font-size: 11pt;
+            margin: 0.14in 0 0.05in 0;
+        }
+
+        .section-note { font-size: 9.5pt; font-style: italic; }
+
+        .fact { font-weight: bold; }
+
+        .fact-line {
+            display: inline-block;
+            min-width: 2.2in;
+            border-bottom: 1px solid #000;
+        }
+
+        .legal-content {
+            font-weight: bold;
+            white-space: pre-wrap;
+            margin: 0.08in 0;
+            min-height: 1.2in;
+        }
+
+        .page-break { page-break-before: always; }
+
+        .sig-block { margin: 0.1in 0 0.18in 0; }
+
+        .sig-row {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-end;
+            margin-bottom: 0.04in;
+        }
+
+        .sig-line {
+            border-bottom: 1px solid #000;
+            width: 3.4in;
+            height: 0.32in;
+        }
+
+        .sig-caption { font-size: 9pt; }
+    </style>
+</head>
+<body>
+    <div class="deed-page">
+
+        <header class="header-section">
+            <div class="recording-info">
+                <div class="recording-label">Recording Requested By:</div>
+                <div class="recording-value">{{ requested_by or '' }}{% if requested_by_address %}<br>{{ requested_by_address }}{% endif %}</div>
+
+                <div class="recording-label">When Recorded Mail To<br>And Mail Tax Statements To:</div>
+                <div class="recording-value">
+                    {% if return_to %}
+                        {% if return_to.get('name') %}{{ return_to.get('name') }}<br>{% endif %}
+                        {% if return_to.get('company') %}{{ return_to.get('company') }}<br>{% endif %}
+                        {% if return_to.get('address1') %}{{ return_to.get('address1') }}<br>{% endif %}
+                        {% if return_to.get('address2') %}{{ return_to.get('address2') }}<br>{% endif %}
+                        {% set city = return_to.get('city', '') %}
+                        {% set state = return_to.get('state', '') %}
+                        {% set zip = return_to.get('zip', '') %}
+                        {% if city or state or zip %}
+                            {{ city }}{% if city and (state or zip) %}, {% endif %}{{ state }} {{ zip }}
+                        {% endif %}
+                    {% else %}
+                        _________________________________<br>
+                        _________________________________<br>
+                        _________________________________
+                    {% endif %}
+                </div>
+            </div>
+
+            <div class="recorder-space"><!-- Gov. Code §27361.6 — recorder's use only --></div>
+        </header>
+
+        <div class="header-boundary">
+            <span>Title Order No.: {{ title_order_no or '______________' }}&nbsp;&nbsp;Escrow No.: {{ escrow_no or '______________' }}</span>
+            <span class="recorder-caption">Space Above This Line Is For Recorder&rsquo;s Use</span>
+        </div>
+
+        <h1 class="deed-title">Revocation of<br>Revocable Transfer on Death (TOD) Deed</h1>
+        <div class="deed-subtitle">(California Probate Code &sect; 5600)</div>
+
+        {# Categorical statutory exemptions — furniture, no decision gate
+           (R&T §11930 conveyance-without-consideration-at-death family;
+           §480.3 PCOR exclusion). Interspousal-recital precedent. #}
+        <div class="exemption-recitals">
+            <div class="lead">THE UNDERSIGNED GRANTOR(s) DECLARE(s):</div>
+            <div>This conveyance is exempt from Documentary Transfer Tax under Revenue and Taxation Code &sect;11930.</div>
+            <div>This conveyance is exempt from Preliminary Change of Ownership Report under Revenue and Taxation Code &sect; 480.3.</div>
+        </div>
+
+        <div class="notice-box">
+            <div class="notice-head">IMPORTANT NOTICE: THIS FORM MUST BE RECORDED TO BE EFFECTIVE</div>
+            This revocation form MUST be RECORDED on or before 60 days after the date it is notarized
+            or it will not be effective. This revocation form only affects a transfer on death deed that YOU
+            made. A transfer on death deed made by a co-owner of your property is not affected by this
+            revocation form. A co-owner who wants to revoke a transfer on death deed that they made must
+            complete and RECORD a SEPARATE revocation form.
+        </div>
+
+        <div class="section-head">Property Assessor&rsquo;s Parcel Number</div>
+        <div>{% if apn %}<span class="fact">{{ apn }}</span>{% else %}<span class="fact-line">&nbsp;</span>{% endif %}</div>
+
+        <div class="section-head">Property Description</div>
+        <div class="section-note">(Legal description of the property affected by this revocation)</div>
+        <div class="legal-content">{{ legal_description or '' }}</div>
+
+    </div>
+
+    <div class="page-break"></div>
+    <div class="deed-page">
+
+        <div class="section-head">Revocation</div>
+        <p>I revoke any TOD deed to transfer the described property that I executed before executing this form.</p>
+
+        <div class="section-head">Signature and Date</div>
+        <div class="section-note">
+            (Sign and print your name below (your name should exactly match the name shown on your title documents)
+        </div>
+        {# Execution acts, twice over (statutory form provides two grantor
+           blocks): the grantor signs AND prints their own name at
+           notarization — nothing pre-prints (pinned). #}
+        {% for _ in range(2) %}
+        <div class="sig-block">
+            <div class="sig-row">
+                <span>Date: <span class="fact-line" style="min-width:1.4in">&nbsp;</span></span>
+                <span class="sig-line"></span>
+            </div>
+            <div class="sig-row">
+                <span></span>
+                <span class="sig-caption">(Sign Name)</span>
+            </div>
+            <div class="sig-row">
+                <span></span>
+                <span class="sig-line"></span>
+            </div>
+            <div class="sig-row">
+                <span></span>
+                <span class="sig-caption">(Print Name)</span>
+            </div>
+        </div>
+        {% endfor %}
+
+        <div class="section-head">Witnesses</div>
+        <p>
+            To be valid, this form must be signed by two persons, both present at the same time, who witness
+            your signing of the deed or your acknowledgment that it is your deed. The signatures of the
+            witnesses do not need to be acknowledged by a notary public.
+        </p>
+
+        {% for n in [1, 2] %}
+        <div class="sig-block">
+            <div style="font-weight:bold">Witness #{{ n }}</div>
+            <div class="sig-row">
+                <span>Date: <span class="fact-line" style="min-width:1.4in">&nbsp;</span></span>
+                <span class="sig-line"></span>
+            </div>
+            <div class="sig-row">
+                <span></span>
+                <span class="sig-caption">(Sign Name)</span>
+            </div>
+            <div class="sig-row">
+                <span></span>
+                <span class="sig-line"></span>
+            </div>
+            <div class="sig-row">
+                <span></span>
+                <span class="sig-caption">(Print Name)</span>
+            </div>
+        </div>
+        {% endfor %}
+
+    </div>
+
+    {# Page 3 — the §1189 acknowledgment (own-page default mode). #}
+    {% set document_title = 'Revocation of Revocable Transfer on Death (TOD) Deed' %}
+    {% include '_partials/notary_acknowledgment.jinja2' %}
+
+</body>
+</html>


### PR DESCRIPTION
## Wave 1, form #7 (owner-ranked order) — the closing form

### Reference: the statutory form itself
Prob C §§5600/5644 prescribe this instrument; the PCT blank mirrors it. Three pages, all pinned: (1) header + categorical exemption recitals + the statute's IMPORTANT NOTICE (60-day recording requirement, verbatim) + APN + property description; (2) the revocation statement + signature/date + the **two-witness block** (furniture + blank lines, per the ruling); (3) the §1189 acknowledgment. **The prescribed format did not fight the chassis** — no flag; the recorder header adapts cleanly and the statutory text renders verbatim, drift-pinned against `deedFurniture` in both preview and template.

### Doctrine pass — no legal choices, no hold
- **Exemption recitals are categorical statutory furniture** (R&T §11930 DTT / §480.3 PCOR) — the interspousal-recital precedent. No decision gate, and the DTT declaration machinery must not render (pinned: no amount line, no checklines).
- **The grantor is named only at signature** — the statutory form's own instruction ("Sign and print your name") makes naming an execution act. Nothing pre-prints (sentinel-pinned); the builder's typed name identifies the record, feeds `parties` JSONB, and gives the Past Deeds row its display. Family `declaration`, parcel-tied (legal description still required — pinned).

### Pins
8 new backend tests: statutory furniture (title, §5600, both exemption recitals, notice, revocation statement, witness instruction, both witness blocks), property facts, grantor-never-preprints sentinel, no-DTT-block, acknowledgment-not-jurat, blanks, 3-page layout (revocation on p2, certificate on p3, chassis geometry on p1) + no-chrome, type/family maps. Registry pins now cover **13 types**; a new drift pin holds the statutory strings identical between preview and template.

### Gates
- Backend: **177 passed** (was 169; +8)
- Six-flow: ✔ (snapshot unchanged)
- Jest: **284 passed** (+1)
- tsc: frozen baseline **98** (unchanged)

### Per-form actuals vs. the 1–2 hr projection
~1 hr — inside projection; the declaration-family machinery from #5/#6 absorbed everything except the statutory layout itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_