### PR TITLE
docs: canonical owner ledger — corrections persist here, not in chat

### DIFF
--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -1,0 +1,43 @@
+# Owner ledger — canonical open/closed list
+
+**This file is the ledger.** Agent reports cite it; corrections land HERE
+(not only in chat) so the list survives context windows. No credential
+values ever appear in this file — item names and status only.
+
+_Last corrected: 2026-07-30 (owner corrections relayed post-wave-1)._
+
+## Open — owner's card
+
+- **Demo password rotation** (X0 follow-up).
+- **Junk seed cleanup** (test rows in production data).
+- **TitlePoint / SiteX credential rotations.**
+- **DTT city-rates review** (`frontend/src/lib/dttCalc.ts`) — owner's
+  escrow review is authoritative.
+- **HM2 inputs**: sales/contact email → `CONTACT_SALES_EMAIL` constant;
+  footer entity details.
+- **Counsel review** of the DRAFT `/terms` + `/privacy` pages.
+- **PDFShift account closure** (code removal shipped in PR #71; Render
+  env vars `PDFSHIFT_API_KEY`/`PDF_ENGINE` deletion rides with it).
+
+## Closed — do not re-report
+
+- **SendGrid** — RESOLVED 2026-07-30: `info@deedpro.io` verified, key
+  refreshed, production share test green with delivery confirmed.
+- **W0 §3** — DECIDED (Model 2, asserted confirmations). PR #79 closed
+  as decided; the W1 draft stays parked pending the owner's lane call.
+- **Demo-card Vercel env vars** — closed 2026-07-30: owner has not
+  requested the demo card back; reopen only on owner request.
+- **PS2/PS3 engine flip** — WeasyPrint sole engine; production parity
+  PASSED; PDFShift code removed (account closure remains open, above).
+- **T7 drops** — done (owner-executed).
+- **HM2 copy** — approved as-is and merged (#75).
+- **Wave-1 rulings** — all implemented as structural pins (fixed-vesting
+  furniture; blank execution marks; parties-JSONB migration; declaration
+  family; FORMS_TRIAGE correction note).
+
+## Ledgered triggers (machine-side, fire on condition)
+
+- ~~Parties JSONB migration~~ — FIRED and executed (PR #86).
+- **"Compact chassis" CSS variant** — consider if more one-page
+  instruments accumulate (spike report note; the inline-acknowledgment
+  mode of PR #87 covers the current cases).


### PR DESCRIPTION
## Why a file

The owner-side open/closed list has gone stale across agent context windows twice — corrections relayed in chat don't survive compaction, so closed items (SendGrid, demo-card) kept reappearing in reports. This file is now the canonical ledger: agent reports cite it, corrections edit it. **No credential values ever appear in it** — item names and status only.

## What it records (the 2026-07-30 corrections)

- **Closed permanently**: SendGrid (sender verified, key refreshed, production delivery confirmed); W0 §3 decided (Model 2) with PR #79 closed as decided; demo-card env vars (owner has not requested the card back).
- **Open card**: demo password rotation · junk seed cleanup · TitlePoint/SiteX rotations · DTT rates review · HM2 contact/entity inputs · counsel review of legal drafts · PDFShift account closure.
- **Triggers**: parties-JSONB marked FIRED (executed in #86); the compact-chassis note carried forward.

Docs-only change; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_