### PR TITLE
FORMS wave 2 (#2, #3): domestic-partner affidavit variants + §3 ledger correction

### DIFF
--- a/backend/services/deed_pdf.py
+++ b/backend/services/deed_pdf.py
@@ -42,6 +42,9 @@ TEMPLATE_BY_DEED_TYPE = {
     # FORMS wave 1 — affidavit siblings (PCT references #3 and #7).
     "affidavit-death-cp-spouse": "affidavit_death_cp_spouse_ca/index.jinja2",
     "affidavit-death-trustee": "affidavit_death_trustee_ca/index.jinja2",
+    # FORMS wave 2 — domestic-partner variants (PCT references #5 and #2).
+    "affidavit-death-jt-dp": "affidavit_death_jt_dp_ca/index.jinja2",
+    "affidavit-death-cp-dp": "affidavit_death_cp_dp_ca/index.jinja2",
     # FORMS wave 1 — fixed-vesting deed variants (PCT references #28, #21).
     "grant-deed-jt": "grant_deed_jt_ca/index.jinja2",
     "grant-deed-cp-ros": "grant_deed_cp_ros_ca/index.jinja2",

--- a/backend/services/form_families.py
+++ b/backend/services/form_families.py
@@ -30,6 +30,8 @@ FAMILY_BY_DEED_TYPE = {
     "affidavit-death-jt": "affidavit",
     "affidavit-death-cp-spouse": "affidavit",
     "affidavit-death-trustee": "affidavit",
+    "affidavit-death-jt-dp": "affidavit",
+    "affidavit-death-cp-dp": "affidavit",
     "homestead-declaration": "declaration",
     "trust-certification": "declaration",
     "tod-revocation": "declaration",

--- a/backend/tests/test_wave2_affidavits.py
+++ b/backend/tests/test_wave2_affidavits.py
@@ -1,0 +1,178 @@
+"""FORMS wave 2 — domestic-partner affidavit variants (#2, #3), pinned.
+
+Built against Pacific Coast Title blank forms #5 (Aff_Death-JT-DomPart)
+and #2 (Aff_Death-CP_Rt_Surv-DomPart). Drift review, per the wave-2
+mandate: JURAT VERIFIED FROM BOTH REFERENCES ("Subscribed and sworn"),
+not from the family label; the Fam C §297 registered-domestic-partnership
+recital is instrument-defining furniture — Flag-3 precedent, same class
+as the wave-1 CP-spouse clause 2; every other element maps onto wave-1
+officer-fact classes (death particulars, deed reference, tolerated
+blanks). No uncovered element; no new AffidavitFacts keys.
+"""
+import io
+
+import pdfplumber
+import pytest
+
+from services.deed_pdf import render_deed_html, render_deed_pdf
+from tests.test_deed_pdf import _normalized
+
+BASE_AFF = {
+    "affiant_name": "JAMES C. ROE",
+    "decedent_name": "JOHN A. DOE",
+    "death_date": "March 3, 2026",
+    "death_place": "Los Angeles, California",
+    "deed_date": "June 1, 2015",
+    "deed_grantor": "ROBERT SELLER",
+    "recording_date": "June 15, 2015",
+    "instrument_no": "2015-0654321",
+}
+
+FORMS = {
+    "affidavit-death-jt-dp": {
+        "template": "affidavit_death_jt_dp_ca/index.jinja2",
+        "aff": {**BASE_AFF, "jt_deed_grantees": "JOHN A. DOE AND JAMES C. ROE"},
+        "furniture": (
+            "Affidavit &mdash; Death of Joint Tenant",
+            "By Surviving Domestic Partner",
+            "of legal age, being first duly sworn, deposes and says",
+            "is the decedent mentioned in the attached certified copy of Certificate of Death",
+            # The §297 recital — statutory string, verbatim:
+            "registered domestic partnership under California Family Code Section 297",
+            "as joint tenants, recorded on",
+            "Official Records of",
+            "Attach Certified Copy of Death Certificate",
+        ),
+        "facts": ("JAMES C. ROE", "JOHN A. DOE", "March 3, 2026",
+                  "Los Angeles, California", "June 1, 2015", "ROBERT SELLER",
+                  "JOHN A. DOE AND JAMES C. ROE", "June 15, 2015",
+                  "2015-0654321", "LOT 7, BLOCK B, TRACT 12345"),
+    },
+    "affidavit-death-cp-dp": {
+        "template": "affidavit_death_cp_dp_ca/index.jinja2",
+        "aff": dict(BASE_AFF),
+        "furniture": (
+            "Affidavit of Death",
+            "Community Property with Right of Survivorship",
+            "Domestic Partner",
+            "of legal age, being first duly sworn, deposes and says",
+            "registered domestic partnership under California Family Code Section 297",
+            "in favor of the grantees as community property with right of survivorship",
+            "Official Records of",
+            "Attach Certified Copy of Death Certificate",
+        ),
+        "facts": ("JAMES C. ROE", "JOHN A. DOE", "March 3, 2026",
+                  "Los Angeles, California", "June 1, 2015", "ROBERT SELLER",
+                  "June 15, 2015", "2015-0654321", "LOT 7, BLOCK B, TRACT 12345"),
+    },
+}
+
+
+def aff_row(deed_type, **overrides):
+    row = {
+        "id": 1,
+        "deed_type": deed_type,
+        "grantor_name": "JOHN A. DOE",   # display alias: decedent
+        "grantee_name": "JAMES C. ROE",  # display alias: affiant
+        "legal_description": "LOT 7, BLOCK B, TRACT 12345",
+        "county": "Los Angeles",
+        "apn": "4290-012-034",
+        "property_address": "1358 5TH ST, Santa Monica, CA 90401",
+        "requested_by": "Pacific Coast Escrow",
+        "metadata": {
+            "requested_by_address": "456 Escrow Way, Los Angeles, CA 90012",
+            "return_to": {"name": "JAMES C. ROE", "address1": "1358 5TH ST",
+                          "city": "Santa Monica", "state": "CA", "zip": "90401"},
+            "affidavit": FORMS[deed_type]["aff"],
+        },
+    }
+    row.update(overrides)
+    return row
+
+
+@pytest.fixture(params=sorted(FORMS))
+def deed_type(request):
+    return request.param
+
+
+def test_sworn_recital_furniture_present(deed_type):
+    html = _normalized(render_deed_html(aff_row(deed_type)))
+    for needle in FORMS[deed_type]["furniture"]:
+        assert needle in html, needle
+
+
+def test_officer_facts_render(deed_type):
+    html = _normalized(render_deed_html(aff_row(deed_type)))
+    for fact in FORMS[deed_type]["facts"]:
+        assert fact in html, fact
+
+
+def test_missing_facts_render_as_blank_lines_never_invented(deed_type):
+    html = render_deed_html(aff_row(deed_type, metadata={}))
+    assert "fact-line" in html
+    assert "2015-0654321" not in html
+    assert "March 3, 2026" not in html
+
+
+def test_jurat_not_acknowledgment(deed_type):
+    """Certificate verified from the REFERENCE (drift check 1): both
+    blanks print the §8202 jurat body — exactly one, never the §1189
+    acknowledgment."""
+    html = _normalized(render_deed_html(aff_row(deed_type)))
+    assert html.count("Subscribed and sworn to (or affirmed) before me") == 1
+    assert "personally appeared" not in html
+    assert "acknowledged to me" not in html
+    assert html.count("verifies only the identity") == 1
+
+
+def test_jurat_contents_are_blank_ticket_n_pattern(deed_type):
+    html = _normalized(render_deed_html(aff_row(deed_type)))
+    jurat = html[html.index("Subscribed and sworn"):]
+    assert "JAMES C. ROE" not in jurat
+    assert "JOHN A. DOE" not in jurat
+    venue = html[html.index("COUNTY OF"):html.index("Subscribed and sworn")]
+    assert "Los Angeles" in venue
+
+
+def test_no_dtt_and_no_mail_tax(deed_type):
+    html = _normalized(render_deed_html(aff_row(deed_type)))
+    assert "DOCUMENTARY TRANSFER TAX" not in html.upper()
+    assert "Mail Tax Statements" not in html
+    assert "And When Recorded Mail To" in html
+
+
+def test_chassis_geometry_and_no_chrome(deed_type):
+    """References: one page, caption ~192pt, jurat lower half."""
+    pdf = render_deed_pdf(aff_row(deed_type))
+    with pdfplumber.open(io.BytesIO(pdf)) as doc:
+        assert len(doc.pages) == 1
+        page = doc.pages[0]
+        words = page.extract_words()
+
+        def top_of(needle):
+            hits = [w for w in words if needle.upper() in w["text"].upper()]
+            assert hits, needle
+            return hits[0]["top"]
+
+        def x_of(needle):
+            hits = [w for w in words if needle.upper() in w["text"].upper()]
+            return hits[0]["x0"]
+
+        caption_top = top_of("RECORDER’S")
+        title_top = top_of("AFFIDAVIT")
+        jurat_top = top_of("Subscribed")
+        assert caption_top > 100
+        assert x_of("RECORDER’S") > 300
+        assert title_top > caption_top
+        assert jurat_top > page.height / 2
+
+    html = render_deed_html(aff_row(deed_type))
+    for leaked in ("7C4DFF", "Generated by", "deedpro.com/verify", "recorder-box", "bg-brand"):
+        assert leaked not in html, leaked
+
+
+def test_registered_in_the_type_and_family_maps(deed_type):
+    from services.deed_pdf import TEMPLATE_BY_DEED_TYPE
+    from services.form_families import family_of
+    assert TEMPLATE_BY_DEED_TYPE[deed_type] == FORMS[deed_type]["template"]
+    assert family_of(deed_type) == "affidavit"

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -18,13 +18,18 @@ _Last corrected: 2026-07-30 (owner corrections relayed post-wave-1)._
 - **Counsel review** of the DRAFT `/terms` + `/privacy` pages.
 - **PDFShift account closure** (code removal shipped in PR #71; Render
   env vars `PDFSHIFT_API_KEY`/`PDF_ENGINE` deletion rides with it).
+- **Full/Partial Reconveyance — HOLD** (wave-2 ruling): lender-side
+  paper adjacent to Tier C; needs a separate owner decision before any
+  build. Not part of wave 2.
 
 ## Closed — do not re-report
 
 - **SendGrid** — RESOLVED 2026-07-30: `info@deedpro.io` verified, key
   refreshed, production share test green with delivery confirmed.
-- **W0 §3** — DECIDED (Model 2, asserted confirmations). PR #79 closed
-  as decided; the W1 draft stays parked pending the owner's lane call.
+- **W0 §3** — DECIDED: **Model 2 = confirmation in our UI** (corrected
+  2026-07-30; an earlier ledger entry inverted this as "asserted
+  confirmations" — the owner's definition governs). PR #79 closed as
+  decided; the W1 draft stays parked pending the owner's lane call.
 - **Demo-card Vercel env vars** — closed 2026-07-30: owner has not
   requested the demo card back; reopen only on owner request.
 - **PS2/PS3 engine flip** — WeasyPrint sole engine; production parity

--- a/frontend/src/__tests__/formRegistry.test.ts
+++ b/frontend/src/__tests__/formRegistry.test.ts
@@ -23,8 +23,12 @@ const KNOWN_SECTIONS = new Set(['property', 'grantor', 'grantee', 'vesting', 'tr
 describe('FORMS registry — completeness and coherence', () => {
   const entries = Object.values(FORM_REGISTRY);
 
-  it('carries the thirteen shipped types', () => {
-    expect(entries.length).toBe(13);
+  it('carries the fifteen shipped types', () => {
+    expect(entries.length).toBe(15);
+    // Wave 2 #2/#3 — domestic-partner affidavit variants (jurat verified
+    // from the references; §297 recital is Flag-3 furniture):
+    expect(formConfig('affidavit-death-jt-dp')?.family).toBe('affidavit');
+    expect(formConfig('affidavit-death-cp-dp')?.family).toBe('affidavit');
     expect(formConfig('affidavit-death-jt')?.family).toBe('affidavit');
     // Wave 1 siblings (owner-ranked #1 and #2):
     expect(formConfig('affidavit-death-cp-spouse')?.family).toBe('affidavit');

--- a/frontend/src/components/builder/PreviewPanel.tsx
+++ b/frontend/src/components/builder/PreviewPanel.tsx
@@ -410,24 +410,43 @@ export function PreviewPanel({ state, activeSection, onRegionClick }: PreviewPan
                     <span onClick={go('affidavit', 'affidavit-affiantName')} className={`font-bold uppercase ${CLICKABLE} ${dataHighlight(aff?.affiantName)}`}>{factOrBlank(aff?.affiantName)}</span>,
                     {' '}of legal age, being first duly sworn, deposes and says:
                   </p>
-                  {state.deedType === 'affidavit-death-cp-spouse' ? (
+                  {['affidavit-death-cp-spouse', 'affidavit-death-cp-dp', 'affidavit-death-jt-dp'].includes(state.deedType) ? (
                     <>
-                      {/* PCT #3 recital — numbered clauses, reference-faithful.
-                          Clause 2 is instrument-defining furniture (Flag-3). */}
+                      {/* PCT #3/#2/#5 recitals — numbered clauses, reference-
+                          faithful. Clause 2 (spouse or the Fam C §297
+                          domestic-partner recital) is instrument-defining
+                          furniture (Flag-3); clause 3 carries the CP phrase
+                          or the JT grantees list per the reference. */}
                       <p className="mb-2">
                         1. <span onClick={go('affidavit', 'affidavit-decedentName')} className={`font-bold uppercase ${CLICKABLE} ${dataHighlight(aff?.decedentName)}`}>{factOrBlank(aff?.decedentName)}</span>
                         {' '}is the decedent mentioned in the attached certified copy of Certificate of Death, who died on{' '}
                         <span onClick={go('affidavit', 'affidavit-deathDate')} className={`${CLICKABLE} ${dataHighlight(aff?.deathDate)}`}>{factOrBlank(aff?.deathDate)}</span>, at{' '}
                         <span onClick={go('affidavit', 'affidavit-deathPlace')} className={`${CLICKABLE} ${dataHighlight(aff?.deathPlace)}`}>{factOrBlank(aff?.deathPlace)}</span> (insert place of death).
                       </p>
-                      <p className="mb-2">
-                        2. I am the surviving spouse of Decedent and was married to Decedent on the date of death.
-                      </p>
+                      {state.deedType === 'affidavit-death-cp-spouse' ? (
+                        <p className="mb-2">
+                          2. I am the surviving spouse of Decedent and was married to Decedent on the date of death.
+                        </p>
+                      ) : (
+                        <p className="mb-2">
+                          2. I am the surviving registered domestic partner of Decedent and on the date of
+                          decedent&rsquo;s death, we were in a registered domestic partnership under California
+                          Family Code Section 297.
+                        </p>
+                      )}
                       <p className="mb-2">
                         3. Decedent and I are the same persons who are named as grantees in that certain deed dated{' '}
                         <span onClick={go('affidavit', 'affidavit-deedDate')} className={`${CLICKABLE} ${dataHighlight(aff?.deedDate)}`}>{factOrBlank(aff?.deedDate)}</span>, executed by{' '}
                         <span onClick={go('affidavit', 'affidavit-deedGrantor')} className={`font-bold uppercase ${CLICKABLE} ${dataHighlight(aff?.deedGrantor)}`}>{factOrBlank(aff?.deedGrantor)}</span>
-                        {' '}in favor of the grantees as community property with right of survivorship, recorded on{' '}
+                        {state.deedType === 'affidavit-death-jt-dp' ? (
+                          <>
+                            {' '}to{' '}
+                            <span onClick={go('affidavit', 'affidavit-jtDeedGrantees')} className={`font-bold uppercase ${CLICKABLE} ${dataHighlight(aff?.jtDeedGrantees)}`}>{factOrBlank(aff?.jtDeedGrantees)}</span>
+                            {' '}as joint tenants, recorded on{' '}
+                          </>
+                        ) : (
+                          <>{' '}in favor of the grantees as community property with right of survivorship, recorded on{' '}</>
+                        )}
                         <span onClick={go('affidavit', 'affidavit-recordingDate')} className={`${CLICKABLE} ${dataHighlight(aff?.recordingDate)}`}>{factOrBlank(aff?.recordingDate)}</span>, as Instrument No.{' '}
                         <span onClick={go('affidavit', 'affidavit-instrumentNo')} className={`${CLICKABLE} ${dataHighlight(aff?.instrumentNo)}`}>{factOrBlank(aff?.instrumentNo)}</span>,
                         {' '}Official Records of{' '}

--- a/frontend/src/lib/formRegistry.ts
+++ b/frontend/src/lib/formRegistry.ts
@@ -269,6 +269,56 @@ export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
       ...RECORDING_REF_FIELDS("The deed by which the trustee acquired title"),
     ],
   },
+  // Wave 2 form #2 — reference: PCT blank form #5 (Aff_Death-JT-DomPart).
+  // Jurat verified from the reference; the §297 registered-domestic-
+  // partnership recital is instrument-defining furniture (Flag-3, same
+  // class as the CP-spouse clause 2).
+  'affidavit-death-jt-dp': {
+    slug: 'affidavit-death-jt-dp',
+    label: 'Affidavit — Death of Joint Tenant (Domestic Partner)',
+    title: 'AFFIDAVIT — DEATH OF JOINT TENANT',
+    subtitle: 'By Surviving Domestic Partner',
+    description: 'Clears a deceased joint tenant from title, sworn by the surviving registered domestic partner (Fam C §297) — jurat, death certificate attached',
+    popular: false,
+    family: 'affidavit',
+    sections: AFFIDAVIT_SECTIONS,
+    notarial: 'jurat',
+    hasDtt: false,
+    companionNotice: BOE_502D_NOTICE,
+    affidavitFields: [
+      { ...AFFIANT_FIELD, hint: 'The surviving registered domestic partner. Signs before a notary.' },
+      DECEDENT_FIELD,
+      { key: 'deathDate', label: 'Date of death', placeholder: 'March 3, 2026', group: 'Death particulars' },
+      { key: 'deathPlace', label: 'Place of death', placeholder: 'Los Angeles, California', group: 'Death particulars' },
+      { key: 'deedDate', label: 'Deed date', placeholder: 'June 1, 2015', group: 'The joint-tenancy deed being cleared' },
+      { key: 'deedGrantor', label: 'Executed by (grantor on that deed)', placeholder: 'ROBERT SELLER', uppercase: true, group: 'The joint-tenancy deed being cleared' },
+      { key: 'jtDeedGrantees', label: 'To (grantees, as joint tenants)', placeholder: 'JOHN A. DOE AND JAMES C. ROE', uppercase: true, group: 'The joint-tenancy deed being cleared' },
+      ...RECORDING_REF_FIELDS('The joint-tenancy deed being cleared'),
+    ],
+  },
+  // Wave 2 form #3 — reference: PCT blank form #2 (Aff_Death-CP_Rt_Surv-DomPart).
+  'affidavit-death-cp-dp': {
+    slug: 'affidavit-death-cp-dp',
+    label: 'Affidavit — Death of Domestic Partner (CP w/ Right of Survivorship)',
+    title: 'AFFIDAVIT OF DEATH',
+    subtitle: 'Community Property with Right of Survivorship — Domestic Partner',
+    description: 'Clears a deceased registered domestic partner from community-property-with-survivorship title (Fam C §297) — jurat, death certificate attached',
+    popular: false,
+    family: 'affidavit',
+    sections: AFFIDAVIT_SECTIONS,
+    notarial: 'jurat',
+    hasDtt: false,
+    companionNotice: BOE_502D_NOTICE,
+    affidavitFields: [
+      { ...AFFIANT_FIELD, hint: 'The surviving registered domestic partner. Signs before a notary.' },
+      DECEDENT_FIELD,
+      { key: 'deathDate', label: 'Date of death', placeholder: 'March 3, 2026', group: 'Death particulars' },
+      { key: 'deathPlace', label: 'Place of death', placeholder: 'Los Angeles, California', group: 'Death particulars' },
+      { key: 'deedDate', label: 'Deed date', placeholder: 'June 1, 2015', group: 'The community-property deed being cleared' },
+      { key: 'deedGrantor', label: 'Executed by (grantor on that deed)', placeholder: 'ROBERT SELLER', uppercase: true, group: 'The community-property deed being cleared' },
+      ...RECORDING_REF_FIELDS('The community-property deed being cleared'),
+    ],
+  },
   // Wave 1 form #5 — reference: PCT blank form #33 (Homestead_Dec-Indiv).
   // Correction-note family: ACKNOWLEDGED per CCP §704.930, not a jurat.
   'homestead-declaration': {

--- a/templates/affidavit_death_cp_dp_ca/index.jinja2
+++ b/templates/affidavit_death_cp_dp_ca/index.jinja2
@@ -1,0 +1,249 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Affidavit of Death - Community Property with Right of Survivorship (Domestic Partner) - California</title>
+    <style>
+        /* ==========================================================================
+           AFFIDAVIT OF DEATH — CP W/ ROS (DOMESTIC PARTNER) — wave 2 #3
+
+           Sibling of the FORMS-SPIKE affidavit chassis. Reference
+           implementation: Pacific Coast Title blank form #2
+           (Aff_Death-CP_Rt_Surv-DomPart), measured with pdfplumber (letter page;
+           recorder caption ~192pt; title ~204pt; jurat lower half ~600pt;
+           ATTACH directive at the foot; one page).
+
+           Chassis rules carried over verbatim from the JT sibling:
+           - Gov. Code §27361.6 recorder's space top-right, open, caption at
+             the boundary; §27361.7 no chrome on recorded pages.
+           - Blank-contents doctrine: the affiant's execution and every
+             notarial entry stay blank — we generate the form, never the
+             sworn or notarial contents.
+           - No DTT declaration (title passes by survivorship — not a
+             conveyance; the reference carries no tax block), no mail-tax
+             directive.
+           - Jurat (Gov C §8202), NOT an acknowledgment (§1189).
+           Reference-specific: three numbered clauses; clause 2 (the Fam C
+           §297 registered-domestic-partnership recital) is instrument-
+           defining furniture — Flag-3 precedent, same class as the
+           CP-spouse sibling's clause 2.
+           ========================================================================== */
+
+        @page {
+            size: letter;
+            margin: 0.5in 0.5in 0.6in 0.6in;
+        }
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        body {
+            font-family: "Times New Roman", Times, Georgia, serif;
+            font-size: 11pt;
+            line-height: 1.35;
+            color: #000;
+            background: #fff;
+        }
+
+        .header-section { display: flex; min-height: 1.85in; }
+
+        .recording-info {
+            width: 3.4in;
+            flex-shrink: 0;
+            border-right: 0.75pt solid #000;
+            padding-right: 0.15in;
+            font-size: 10pt;
+            line-height: 1.35;
+        }
+
+        .recorder-space { flex-grow: 1; }
+
+        .recording-label {
+            font-weight: bold;
+            text-transform: uppercase;
+            font-size: 9pt;
+        }
+
+        .recording-value { margin-bottom: 0.12in; min-height: 0.35in; }
+
+        .ref-line { font-size: 10pt; }
+
+        .header-boundary {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            border-bottom: 0.75pt solid #000;
+            padding-bottom: 0.03in;
+            margin-bottom: 0.12in;
+        }
+
+        .apn-ref { font-weight: bold; font-size: 10pt; }
+
+        .recorder-caption {
+            font-size: 7.5pt;
+            font-weight: bold;
+            text-transform: uppercase;
+        }
+
+        .deed-title {
+            text-align: center;
+            font-size: 14pt;
+            font-weight: bold;
+            letter-spacing: 2px;
+            text-transform: uppercase;
+            margin: 0.08in 0 0.02in 0;
+        }
+
+        .deed-subtitle {
+            /* The reference stacks its qualifier lines under the title.
+               One-page budget: the CP recital runs three clauses, so the
+               vertical spend here is tighter than the JT sibling's. */
+            text-align: center;
+            font-size: 10pt;
+            font-weight: bold;
+            line-height: 1.25;
+            margin-bottom: 0.06in;
+        }
+
+        .affidavit-body {
+            font-size: 11pt;
+            line-height: 1.3;
+            text-align: justify;
+        }
+
+        .affidavit-body p { margin-bottom: 0.05in; }
+
+        .fact {
+            /* Officer-supplied facts render bold like the deed parties; a
+               missing fact renders as the reference's blank line so an
+               incomplete instrument LOOKS incomplete. */
+            font-weight: bold;
+        }
+
+        .fact-line {
+            display: inline-block;
+            min-width: 2.2in;
+            border-bottom: 1px solid #000;
+        }
+
+        .legal-content {
+            font-weight: bold;
+            white-space: pre-wrap;
+            margin: 0.05in 0;
+            min-height: 0.35in;
+        }
+
+        .execution-section {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-end;
+            margin-top: 0.05in;
+            margin-bottom: 0.03in;
+        }
+
+        .signature-line {
+            border-bottom: 1px solid #000;
+            width: 3.2in;
+            height: 0.3in;
+        }
+
+        .attach-directive {
+            text-align: center;
+            font-size: 10pt;
+            font-weight: bold;
+            text-transform: uppercase;
+            margin-top: 0.06in;
+        }
+    </style>
+</head>
+<body>
+    <div class="deed-page">
+
+        <header class="header-section">
+            <div class="recording-info">
+                <div class="recording-label">Recording Requested By:</div>
+                <div class="recording-value">{{ requested_by or '' }}{% if requested_by_address %}<br>{{ requested_by_address }}{% endif %}</div>
+
+                <div class="recording-label">And When Recorded Mail To:</div>
+                <div class="recording-value">
+                    {% if return_to %}
+                        {% if return_to.get('name') %}{{ return_to.get('name') }}<br>{% endif %}
+                        {% if return_to.get('company') %}{{ return_to.get('company') }}<br>{% endif %}
+                        {% if return_to.get('address1') %}{{ return_to.get('address1') }}<br>{% endif %}
+                        {% if return_to.get('address2') %}{{ return_to.get('address2') }}<br>{% endif %}
+                        {% set city = return_to.get('city', '') %}
+                        {% set state = return_to.get('state', '') %}
+                        {% set zip = return_to.get('zip', '') %}
+                        {% if city or state or zip %}
+                            {{ city }}{% if city and (state or zip) %}, {% endif %}{{ state }} {{ zip }}
+                        {% endif %}
+                    {% else %}
+                        _________________________________<br>
+                        _________________________________<br>
+                        _________________________________
+                    {% endif %}
+                </div>
+
+                <div class="ref-line">Order No.: {{ title_order_no or '____________________' }}</div>
+                <div class="ref-line">Escrow No.: {{ escrow_no or '____________________' }}</div>
+            </div>
+
+            <div class="recorder-space"><!-- Gov. Code §27361.6 — recorder's use only --></div>
+        </header>
+
+        <div class="header-boundary">
+            <span class="apn-ref">APN: {{ apn or '____________________' }}</span>
+            <span class="recorder-caption">Space Above This Line Is For Recorder&rsquo;s Use</span>
+        </div>
+
+        <h1 class="deed-title">Affidavit of Death</h1>
+        <div class="deed-subtitle">Community Property with Right of Survivorship<br>Domestic Partner</div>
+
+        {% set aff = affidavit or {} %}
+        <div class="affidavit-body">
+            <p>
+                {% if aff.get('affiant_name') %}<span class="fact">{{ aff.get('affiant_name') }}</span>{% else %}<span class="fact-line">&nbsp;</span>{% endif %},
+                of legal age, being first duly sworn, deposes and says:
+            </p>
+            <p>
+                1. {% if aff.get('decedent_name') %}<span class="fact">{{ aff.get('decedent_name') }}</span>{% else %}<span class="fact-line">&nbsp;</span>{% endif %}
+                is the decedent mentioned in the attached certified copy of Certificate of Death,
+                who died on {% if aff.get('death_date') %}<span class="fact">{{ aff.get('death_date') }}</span>{% else %}<span class="fact-line" style="min-width:1.4in">&nbsp;</span>{% endif %},
+                at {% if aff.get('death_place') %}<span class="fact">{{ aff.get('death_place') }}</span>{% else %}<span class="fact-line" style="min-width:1.6in">&nbsp;</span>{% endif %}
+                (insert place of death).
+            </p>
+            <p>
+                2. I am the surviving registered domestic partner of Decedent and on the date of
+                decedent&rsquo;s death, we were in a registered domestic partnership under California
+                Family Code Section 297.
+            </p>
+            <p>
+                3. Decedent and I are the same persons who are named as grantees in that certain deed
+                dated {% if aff.get('deed_date') %}<span class="fact">{{ aff.get('deed_date') }}</span>{% else %}<span class="fact-line" style="min-width:1.4in">&nbsp;</span>{% endif %},
+                executed by {% if aff.get('deed_grantor') %}<span class="fact">{{ aff.get('deed_grantor') }}</span>{% else %}<span class="fact-line">&nbsp;</span>{% endif %}
+                in favor of the grantees as community property with right of survivorship, recorded on
+                {% if aff.get('recording_date') %}<span class="fact">{{ aff.get('recording_date') }}</span>{% else %}<span class="fact-line" style="min-width:1.4in">&nbsp;</span>{% endif %},
+                as Instrument No. {% if aff.get('instrument_no') %}<span class="fact">{{ aff.get('instrument_no') }}</span>{% else %}<span class="fact-line" style="min-width:1.4in">&nbsp;</span>{% endif %},
+                Official Records of
+                {% if county %}<span class="fact">{{ county }}</span>{% else %}<span class="fact-line" style="min-width:1.6in">&nbsp;</span>{% endif %}
+                County, California, describing the following real property:
+            </p>
+        </div>
+
+        <div class="legal-content">{{ legal_description or '' }}</div>
+
+        {# Execution: the affiant signs at the notarization — the date and
+           signature are theirs, not ours (blank-contents doctrine). #}
+        <div class="execution-section">
+            <div>Dated: <span class="fact-line" style="min-width:1.8in">&nbsp;</span></div>
+            <div>
+                <div class="signature-line"></div>
+            </div>
+        </div>
+
+        {% include '_partials/notary_jurat.jinja2' %}
+
+        <div class="attach-directive">Attach Certified Copy of Death Certificate</div>
+
+    </div>
+</body>
+</html>

--- a/templates/affidavit_death_jt_dp_ca/index.jinja2
+++ b/templates/affidavit_death_jt_dp_ca/index.jinja2
@@ -1,0 +1,250 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Affidavit - Death of Joint Tenant (Domestic Partner) - California</title>
+    <style>
+        /* ==========================================================================
+           AFFIDAVIT — DEATH OF JOINT TENANT (DOMESTIC PARTNER) — wave 2 #2
+
+           Sibling of the FORMS-SPIKE affidavit chassis. Reference
+           implementation: Pacific Coast Title blank form #5
+           (Aff_Death-JT-DomPart), measured with pdfplumber (letter page;
+           recorder caption ~192pt; title ~204pt; jurat lower half ~600pt;
+           ATTACH directive at the foot; one page).
+
+           Chassis rules carried over verbatim from the JT sibling:
+           - Gov. Code §27361.6 recorder's space top-right, open, caption at
+             the boundary; §27361.7 no chrome on recorded pages.
+           - Blank-contents doctrine: the affiant's execution and every
+             notarial entry stay blank — we generate the form, never the
+             sworn or notarial contents.
+           - No DTT declaration (title passes by survivorship — not a
+             conveyance; the reference carries no tax block), no mail-tax
+             directive.
+           - Jurat (Gov C §8202), NOT an acknowledgment (§1189).
+           Reference-specific: three numbered clauses; clause 2 (the Fam C
+           §297 registered-domestic-partnership recital) is instrument-
+           defining furniture (Flag-3); clause 3 carries the JT grantees
+           list, as the reference prints it.
+           ========================================================================== */
+
+        @page {
+            size: letter;
+            margin: 0.5in 0.5in 0.6in 0.6in;
+        }
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        body {
+            font-family: "Times New Roman", Times, Georgia, serif;
+            font-size: 11pt;
+            line-height: 1.35;
+            color: #000;
+            background: #fff;
+        }
+
+        .header-section { display: flex; min-height: 1.85in; }
+
+        .recording-info {
+            width: 3.4in;
+            flex-shrink: 0;
+            border-right: 0.75pt solid #000;
+            padding-right: 0.15in;
+            font-size: 10pt;
+            line-height: 1.35;
+        }
+
+        .recorder-space { flex-grow: 1; }
+
+        .recording-label {
+            font-weight: bold;
+            text-transform: uppercase;
+            font-size: 9pt;
+        }
+
+        .recording-value { margin-bottom: 0.12in; min-height: 0.35in; }
+
+        .ref-line { font-size: 10pt; }
+
+        .header-boundary {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            border-bottom: 0.75pt solid #000;
+            padding-bottom: 0.03in;
+            margin-bottom: 0.12in;
+        }
+
+        .apn-ref { font-weight: bold; font-size: 10pt; }
+
+        .recorder-caption {
+            font-size: 7.5pt;
+            font-weight: bold;
+            text-transform: uppercase;
+        }
+
+        .deed-title {
+            text-align: center;
+            font-size: 14pt;
+            font-weight: bold;
+            letter-spacing: 2px;
+            text-transform: uppercase;
+            margin: 0.08in 0 0.02in 0;
+        }
+
+        .deed-subtitle {
+            /* The reference stacks its qualifier lines under the title.
+               One-page budget: the CP recital runs three clauses, so the
+               vertical spend here is tighter than the JT sibling's. */
+            text-align: center;
+            font-size: 10pt;
+            font-weight: bold;
+            line-height: 1.25;
+            margin-bottom: 0.06in;
+        }
+
+        .affidavit-body {
+            font-size: 11pt;
+            line-height: 1.3;
+            text-align: justify;
+        }
+
+        .affidavit-body p { margin-bottom: 0.05in; }
+
+        .fact {
+            /* Officer-supplied facts render bold like the deed parties; a
+               missing fact renders as the reference's blank line so an
+               incomplete instrument LOOKS incomplete. */
+            font-weight: bold;
+        }
+
+        .fact-line {
+            display: inline-block;
+            min-width: 2.2in;
+            border-bottom: 1px solid #000;
+        }
+
+        .legal-content {
+            font-weight: bold;
+            white-space: pre-wrap;
+            margin: 0.05in 0;
+            min-height: 0.35in;
+        }
+
+        .execution-section {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-end;
+            margin-top: 0.05in;
+            margin-bottom: 0.03in;
+        }
+
+        .signature-line {
+            border-bottom: 1px solid #000;
+            width: 3.2in;
+            height: 0.3in;
+        }
+
+        .attach-directive {
+            text-align: center;
+            font-size: 10pt;
+            font-weight: bold;
+            text-transform: uppercase;
+            margin-top: 0.06in;
+        }
+    </style>
+</head>
+<body>
+    <div class="deed-page">
+
+        <header class="header-section">
+            <div class="recording-info">
+                <div class="recording-label">Recording Requested By:</div>
+                <div class="recording-value">{{ requested_by or '' }}{% if requested_by_address %}<br>{{ requested_by_address }}{% endif %}</div>
+
+                <div class="recording-label">And When Recorded Mail To:</div>
+                <div class="recording-value">
+                    {% if return_to %}
+                        {% if return_to.get('name') %}{{ return_to.get('name') }}<br>{% endif %}
+                        {% if return_to.get('company') %}{{ return_to.get('company') }}<br>{% endif %}
+                        {% if return_to.get('address1') %}{{ return_to.get('address1') }}<br>{% endif %}
+                        {% if return_to.get('address2') %}{{ return_to.get('address2') }}<br>{% endif %}
+                        {% set city = return_to.get('city', '') %}
+                        {% set state = return_to.get('state', '') %}
+                        {% set zip = return_to.get('zip', '') %}
+                        {% if city or state or zip %}
+                            {{ city }}{% if city and (state or zip) %}, {% endif %}{{ state }} {{ zip }}
+                        {% endif %}
+                    {% else %}
+                        _________________________________<br>
+                        _________________________________<br>
+                        _________________________________
+                    {% endif %}
+                </div>
+
+                <div class="ref-line">Order No.: {{ title_order_no or '____________________' }}</div>
+                <div class="ref-line">Escrow No.: {{ escrow_no or '____________________' }}</div>
+            </div>
+
+            <div class="recorder-space"><!-- Gov. Code §27361.6 — recorder's use only --></div>
+        </header>
+
+        <div class="header-boundary">
+            <span class="apn-ref">APN: {{ apn or '____________________' }}</span>
+            <span class="recorder-caption">Space Above This Line Is For Recorder&rsquo;s Use</span>
+        </div>
+
+        <h1 class="deed-title">Affidavit &mdash; Death of Joint Tenant</h1>
+        <div class="deed-subtitle">By Surviving Domestic Partner</div>
+
+        {% set aff = affidavit or {} %}
+        <div class="affidavit-body">
+            <p>
+                {% if aff.get('affiant_name') %}<span class="fact">{{ aff.get('affiant_name') }}</span>{% else %}<span class="fact-line">&nbsp;</span>{% endif %},
+                of legal age, being first duly sworn, deposes and says:
+            </p>
+            <p>
+                1. {% if aff.get('decedent_name') %}<span class="fact">{{ aff.get('decedent_name') }}</span>{% else %}<span class="fact-line">&nbsp;</span>{% endif %}
+                is the decedent mentioned in the attached certified copy of Certificate of Death,
+                who died on {% if aff.get('death_date') %}<span class="fact">{{ aff.get('death_date') }}</span>{% else %}<span class="fact-line" style="min-width:1.4in">&nbsp;</span>{% endif %},
+                at {% if aff.get('death_place') %}<span class="fact">{{ aff.get('death_place') }}</span>{% else %}<span class="fact-line" style="min-width:1.6in">&nbsp;</span>{% endif %}
+                (insert place of death).
+            </p>
+            <p>
+                2. I am the surviving registered domestic partner of Decedent and on the date of
+                decedent&rsquo;s death, we were in a registered domestic partnership under California
+                Family Code Section 297.
+            </p>
+            <p>
+                3. Decedent and I are the same persons who are named as grantees in that certain deed
+                dated {% if aff.get('deed_date') %}<span class="fact">{{ aff.get('deed_date') }}</span>{% else %}<span class="fact-line" style="min-width:1.4in">&nbsp;</span>{% endif %},
+                executed by {% if aff.get('deed_grantor') %}<span class="fact">{{ aff.get('deed_grantor') }}</span>{% else %}<span class="fact-line">&nbsp;</span>{% endif %}
+                to {% if aff.get('jt_deed_grantees') %}<span class="fact">{{ aff.get('jt_deed_grantees') }}</span>{% else %}<span class="fact-line">&nbsp;</span>{% endif %}
+                as joint tenants, recorded on
+                {% if aff.get('recording_date') %}<span class="fact">{{ aff.get('recording_date') }}</span>{% else %}<span class="fact-line" style="min-width:1.4in">&nbsp;</span>{% endif %},
+                as Instrument No. {% if aff.get('instrument_no') %}<span class="fact">{{ aff.get('instrument_no') }}</span>{% else %}<span class="fact-line" style="min-width:1.4in">&nbsp;</span>{% endif %},
+                Official Records of
+                {% if county %}<span class="fact">{{ county }}</span>{% else %}<span class="fact-line" style="min-width:1.6in">&nbsp;</span>{% endif %}
+                County, California, describing the following real property:
+            </p>
+        </div>
+
+        <div class="legal-content">{{ legal_description or '' }}</div>
+
+        {# Execution: the affiant signs at the notarization — the date and
+           signature are theirs, not ours (blank-contents doctrine). #}
+        <div class="execution-section">
+            <div>Dated: <span class="fact-line" style="min-width:1.8in">&nbsp;</span></div>
+            <div>
+                <div class="signature-line"></div>
+            </div>
+        </div>
+
+        {% include '_partials/notary_jurat.jinja2' %}
+
+        <div class="attach-directive">Attach Certified Copy of Death Certificate</div>
+
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Wave 2, forms #2 and #3 — paired siblings (form #1 is HELD, reported to the owner separately: **no PCT reference exists** for an Affidavit of Death — TOD Beneficiary; sourcing it is a doctrine-shaped decision)

First commit: the owner-ordered **W0 §3 ledger correction** (Model 2 = confirmation in our UI; the prior entry inverted it) plus the reconveyance HOLD, persisted in `docs/OWNER_LEDGER.md`.

### References fetched and measured
PCT #5 (`Aff_Death-JT-DomPart`) and PCT #2 (`Aff_Death-CP_Rt_Surv-DomPart`) — one page each, caption ~192pt, jurat lower half, numbered clauses.

## Drift review (all six attestations)

**1. Certificate from the reference.** Both blanks print the §8202 jurat body ("Subscribed and sworn to (or affirmed) before me") — verified in the extracted text before family assignment, pinned per form. No reference-vs-expectation mismatch.

**2. Doctrine-pass diff against precedent.** Every element cites a covering ruling: the Fam C §297 registered-domestic-partnership recital → Flag-3 instrument-defining furniture (same class as wave-1's CP-spouse clause 2); death date/place, deed date/executed-by, JT grantees list, recording reference → wave-1 officer-fact classes; blanks tolerated → gate-strictness ruling. **No uncovered element → no hold.** Zero new `AffidavitFacts` keys — both forms compose from existing fields.

**3. Coherence pins before template.** Registry entries land inside the family matrix (affidavit ⇒ jurat + no DTT + common four fact keys + no smuggled value), count pin 13 → 15, and the registry↔backend family mirror covers both slugs — a miswired entry fails CI before rendering.

**4. Ledger consistency.** §3 inversion corrected in this PR (and a correcting comment posted on closed PR #79); reconveyance HOLD ledgered.

**5. No silent scope absorption.** PCT also carries `#8/#9 Aff_Death-Succeed-*` (spousal/DP succession — a different instrument) — noted here, not built, not ledgered as work.

**6. Per-form gate attestation.**
- [x] Geometry pins vs. reference: 1 page, caption top >100pt / x >300pt, title below caption, jurat lower half — both forms
- [x] Statutory strings verbatim: "registered domestic partnership under California Family Code Section 297" pinned in both
- [x] Blank-contents occurrence pins: exactly one jurat, affiant/decedent absent from the certificate, venue county only
- [x] Backend **193 passed** (was 177; +16) · six-flow ✔ unchanged · jest **284** · tsc frozen **98**

### Per-form actuals vs. 1–2 hr projection
~50 min for the pair (~25 min/form) — sibling rate, well under projection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_