### PR TITLE
FORMS wave 2 (#4, #5): Homestead — Spouses + Abandonment

### DIFF
--- a/backend/services/deed_pdf.py
+++ b/backend/services/deed_pdf.py
@@ -54,6 +54,9 @@ TEMPLATE_BY_DEED_TYPE = {
     "trust-certification": "trust_certification_ca/index.jinja2",
     # FORMS wave 1 #7 — statutory revocation form (Prob C §§5600/5644).
     "tod-revocation": "tod_revocation_ca/index.jinja2",
+    # FORMS wave 2 — homestead pair (PCT references #34 and #32).
+    "homestead-declaration-spouses": "homestead_declaration_spouses_ca/index.jinja2",
+    "homestead-abandonment": "homestead_abandonment_ca/index.jinja2",
 }
 DEFAULT_TEMPLATE = "grant_deed_ca/index.jinja2"
 
@@ -99,6 +102,9 @@ def build_context_from_row(row):
         "legal_description": row.get("legal_description") or "",
         "county": row.get("county") or "",
         "apn": row.get("apn") or "",
+        # Street address — the homestead abandonment's "commonly known as"
+        # line (other chassis templates don't read it).
+        "property_address": row.get("property_address") or "",
         "vesting": row.get("vesting") or "",
         "requested_by": row.get("requested_by") or "",
         "requested_by_address": meta.get("requested_by_address") or "",

--- a/backend/services/form_families.py
+++ b/backend/services/form_families.py
@@ -35,6 +35,8 @@ FAMILY_BY_DEED_TYPE = {
     "homestead-declaration": "declaration",
     "trust-certification": "declaration",
     "tod-revocation": "declaration",
+    "homestead-declaration-spouses": "declaration",
+    "homestead-abandonment": "declaration",
 }
 
 SINGLE_PARTY_FAMILIES = {"declaration"}

--- a/backend/tests/test_wave2_homestead_pair.py
+++ b/backend/tests/test_wave2_homestead_pair.py
@@ -1,0 +1,175 @@
+"""FORMS wave 2 — homestead pair (#4 Spouses, #5 Abandonment), pinned.
+
+Built against Pacific Coast Title blank forms #34 (Homestead_Dec-Spouses)
+and #32 (Homestead-Abandon). Drift review: ACKNOWLEDGMENT VERIFIED FROM
+BOTH REFERENCES (§1189 body printed on each blank) — matching the
+corrected family facts, never the memo. Precedent diff: "We are husband
+and wife" → Flag-3 instrument-defining recital (CP-spouse class); the
+operative "hereby abandon(s)" → the TOD-revocation operative-statement
+class; the prior declaration's identification → the recorded-instrument
+class; two declared owners → a parties-JSONB shape (the migration's
+design), not a new class. No uncovered element.
+"""
+import io
+
+import pdfplumber
+import pytest
+
+from services.deed_pdf import render_deed_html, render_deed_pdf
+from tests.test_deed_pdf import _normalized
+
+FORMS = {
+    "homestead-declaration-spouses": {
+        "template": "homestead_declaration_spouses_ca/index.jinja2",
+        "parties": {"declarant": "ROBERT OWNER", "second_declarant": "MARIA OWNER"},
+        "meta": {
+            "return_to": {"name": "ROBERT OWNER", "address1": "1358 5TH ST",
+                          "city": "Santa Monica", "state": "CA", "zip": "90401"},
+        },
+        "furniture": (
+            "Declaration of Homestead",
+            "(Spouses as Declared Owners)",
+            "hereby certify and declare as follows:",
+            "We are husband and wife.",
+            "We hereby claim as a declared homestead the premises described as follows:",
+            "We are the owners of the above described homestead.",
+            "our principal dwelling and we currently reside thereon",
+            "known to be true as of our personal knowledge",
+        ),
+        "facts": ("ROBERT OWNER", "MARIA OWNER", "LOT 7, BLOCK B, TRACT 12345"),
+    },
+    "homestead-abandonment": {
+        "template": "homestead_abandonment_ca/index.jinja2",
+        "parties": {"declarant": "ROBERT OWNER"},
+        "meta": {
+            "title_order_no": "TO-9921",
+            "escrow_no": "ESC-4410",
+            "return_to": {"name": "ROBERT OWNER", "address1": "1358 5TH ST",
+                          "city": "Santa Monica", "state": "CA", "zip": "90401"},
+            "affidavit": {
+                "prior_declarant": "ROBERT OWNER",
+                "declaration_date": "June 1, 2015",
+                "recording_date": "June 15, 2015",
+                "instrument_no": "2015-0654321",
+            },
+        },
+        "furniture": (
+            "Declaration of Abandonment of Declared Homestead",
+            "hereby abandon(s) the homestead",
+            "previously declared in the Homestead Declaration executed by",
+            "in the Official Records of the County Recorder of",
+            "pertaining to the following real property:",
+            "and commonly known as (Street address)",
+        ),
+        "facts": ("ROBERT OWNER", "June 1, 2015", "June 15, 2015",
+                  "2015-0654321", "LOT 7, BLOCK B, TRACT 12345",
+                  "1358 5TH ST, Santa Monica, CA 90401", "TO-9921", "ESC-4410"),
+    },
+}
+
+
+def row(deed_type, **overrides):
+    r = {
+        "id": 1,
+        "deed_type": deed_type,
+        "grantor_name": "",
+        "grantee_name": "",
+        "parties": FORMS[deed_type]["parties"],
+        "legal_description": "LOT 7, BLOCK B, TRACT 12345",
+        "county": "Los Angeles",
+        "apn": "4290-012-034",
+        "property_address": "1358 5TH ST, Santa Monica, CA 90401",
+        "requested_by": "Pacific Coast Escrow",
+        "metadata": FORMS[deed_type]["meta"],
+    }
+    r.update(overrides)
+    return r
+
+
+@pytest.fixture(params=sorted(FORMS))
+def deed_type(request):
+    return request.param
+
+
+def test_declaration_furniture_present(deed_type):
+    html = _normalized(render_deed_html(row(deed_type)))
+    for needle in FORMS[deed_type]["furniture"]:
+        assert needle in html, needle
+
+
+def test_officer_facts_render(deed_type):
+    html = _normalized(render_deed_html(row(deed_type)))
+    for fact in FORMS[deed_type]["facts"]:
+        assert fact in html, fact
+
+
+def test_missing_facts_render_blank_never_invented(deed_type):
+    html = render_deed_html(row(deed_type, parties=None, metadata={}))
+    assert "fact-line" in html
+    assert "ROBERT OWNER" not in html
+    assert "MARIA OWNER" not in html
+
+
+def test_acknowledgment_not_jurat(deed_type):
+    """Certificate verified from the REFERENCE (drift check 1): both
+    blanks print the §1189 acknowledgment — never a jurat."""
+    html = _normalized(render_deed_html(row(deed_type)))
+    assert "personally appeared" in html
+    assert "acknowledged to me" in html
+    assert "Subscribed and sworn to (or affirmed) before me" not in html
+    assert html.count("verifies only the identity") == 1
+
+
+def test_acknowledgment_contents_are_blank(deed_type):
+    html = _normalized(render_deed_html(row(deed_type)))
+    ack = html[html.index("personally appeared"):]
+    assert "ROBERT OWNER" not in ack
+    assert "MARIA OWNER" not in ack
+
+
+def test_no_dtt_no_mail_tax_no_vesting(deed_type):
+    html = _normalized(render_deed_html(row(deed_type, vesting="SENTINEL VESTING TEXT")))
+    assert "DOCUMENTARY TRANSFER TAX" not in html.upper()
+    assert "Mail Tax Statements" not in html
+    assert "And When Recorded Mail To" in html
+    assert "SENTINEL VESTING TEXT" not in html
+
+
+def test_one_page_with_inline_acknowledgment(deed_type):
+    """Both references are ONE page with the certificate in the lower
+    half (the ack_inline partial mode from wave 1 #5)."""
+    pdf = render_deed_pdf(row(deed_type))
+    with pdfplumber.open(io.BytesIO(pdf)) as doc:
+        assert len(doc.pages) == 1
+        page = doc.pages[0]
+        words = page.extract_words()
+
+        def top_of(needle):
+            hits = [w for w in words if needle.upper() in w["text"].upper()]
+            assert hits, needle
+            return hits[0]["top"]
+
+        def x_of(needle):
+            hits = [w for w in words if needle.upper() in w["text"].upper()]
+            return hits[0]["x0"]
+
+        caption_top = top_of("RECORDER’S")
+        title_top = top_of("DECLARATION")
+        ack_top = top_of("personally")
+        assert caption_top > 100
+        assert x_of("RECORDER’S") > 300
+        assert title_top > caption_top
+        assert ack_top > page.height / 2
+
+    html = render_deed_html(row(deed_type))
+    for leaked in ("7C4DFF", "Generated by", "deedpro.com/verify", "recorder-box", "bg-brand"):
+        assert leaked not in html, leaked
+
+
+def test_registered_in_the_type_and_family_maps(deed_type):
+    from services.deed_pdf import TEMPLATE_BY_DEED_TYPE
+    from services.form_families import family_of, is_single_party, requires_legal_description
+    assert TEMPLATE_BY_DEED_TYPE[deed_type] == FORMS[deed_type]["template"]
+    assert family_of(deed_type) == "declaration"
+    assert is_single_party(deed_type)          # parties-JSONB family
+    assert requires_legal_description(deed_type)  # both parcel-tied

--- a/frontend/src/__tests__/formRegistry.test.ts
+++ b/frontend/src/__tests__/formRegistry.test.ts
@@ -23,8 +23,12 @@ const KNOWN_SECTIONS = new Set(['property', 'grantor', 'grantee', 'vesting', 'tr
 describe('FORMS registry — completeness and coherence', () => {
   const entries = Object.values(FORM_REGISTRY);
 
-  it('carries the fifteen shipped types', () => {
-    expect(entries.length).toBe(15);
+  it('carries the seventeen shipped types', () => {
+    expect(entries.length).toBe(17);
+    // Wave 2 #4/#5 — homestead pair (acknowledgment verified from the
+    // references; spouses = two declarants in parties JSONB):
+    expect(formConfig('homestead-declaration-spouses')?.family).toBe('declaration');
+    expect(formConfig('homestead-abandonment')?.family).toBe('declaration');
     // Wave 2 #2/#3 — domestic-partner affidavit variants (jurat verified
     // from the references; §297 recital is Flag-3 furniture):
     expect(formConfig('affidavit-death-jt-dp')?.family).toBe('affidavit');

--- a/frontend/src/components/builder/PreviewPanel.tsx
+++ b/frontend/src/components/builder/PreviewPanel.tsx
@@ -89,6 +89,35 @@ export function PreviewPanel({ state, activeSection, onRegionClick }: PreviewPan
   const exemptionRecital = EXEMPTION_RECITALS[state.deedType];
   const fixedVesting = FIXED_VESTING_PHRASES[state.deedType];
 
+  // §1189 acknowledgment sketch shared by the one-page declaration
+  // previews (homestead family) — all entries are the notary's; nothing
+  // pre-fills but the venue county.
+  const ackSketch = (
+    <>
+      <div className="mt-5 text-[9.5px] border border-black p-2 leading-snug">
+        A notary public or other officer completing this certificate verifies only the
+        identity of the individual who signed the document to which this certificate is
+        attached, and not the truthfulness, accuracy, or validity of that document.
+      </div>
+      <div className="mt-3 text-[10px]">
+        <div>STATE OF CALIFORNIA&nbsp;&nbsp;)</div>
+        <div>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;)&nbsp;&nbsp;SS.</div>
+        <div>COUNTY OF <span className="inline-block min-w-[1.4in] border-b border-black">{(state.property?.county || '').trim()}</span>&nbsp;)</div>
+        <p className="mt-2">
+          On ____________ before me, ______________________________, Notary Public,
+          personally appeared ______________________________, who proved to me on the
+          basis of satisfactory evidence to be the person(s) whose name(s) is/are
+          subscribed to the within instrument and acknowledged to me that he/she/they
+          executed the same in his/her/their authorized capacity(ies)…
+        </p>
+        <div className="mt-4 flex justify-between items-end">
+          <div>Signature <span className="inline-block min-w-[2in] border-b border-black" /></div>
+          <div className="border border-black w-[1.6in] h-[1.1in] flex items-center justify-center text-center text-[8px] uppercase text-gray-500">(This area for notary stamp)</div>
+        </div>
+      </div>
+    </>
+  );
+
   // DTT honesty (G3's invariant, mock-up form): nothing is declared until
   // the officer's transfer-tax data exists — no pre-checked boxes, no $0.00.
   const dtt = state.dtt;
@@ -333,6 +362,83 @@ export function PreviewPanel({ state, activeSection, onRegionClick }: PreviewPan
                   (Acknowledgement must be attached)
                 </div>
               </>
+            ) : isDeclaration && state.deedType === 'homestead-declaration-spouses' ? (
+              <>
+                {/* PCT #34 — spouses variant: "We are husband and wife" is
+                    Flag-3 furniture; both names are officer-typed facts. */}
+                <div className={`text-[11pt] leading-relaxed mb-3 ${highlight('affidavit')}`}>
+                  <p className="mb-2">
+                    We, <span onClick={go('affidavit', 'affidavit-declarantName')} className={`font-bold uppercase ${CLICKABLE} ${dataHighlight(aff?.declarantName)}`}>{factOrBlank(aff?.declarantName)}</span>
+                    {' '}and <span onClick={go('affidavit', 'affidavit-declarant2Name')} className={`font-bold uppercase ${CLICKABLE} ${dataHighlight(aff?.declarant2Name)}`}>{factOrBlank(aff?.declarant2Name)}</span>,
+                    {' '}hereby certify and declare as follows:
+                  </p>
+                  <p className="mb-2">1. We are husband and wife.</p>
+                  <p className="mb-2">2. We hereby claim as a declared homestead the premises described as follows:</p>
+                </div>
+
+                <div className={`mb-3 ${highlight('property')}`}>
+                  <span onClick={go('property')} className={`font-bold text-[10.5pt] whitespace-pre-wrap ${CLICKABLE} ${placeholder(preview.legalDescription)} ${dataHighlight(preview.legalDescription)}`}>
+                    {preview.legalDescription}
+                  </span>
+                </div>
+
+                <div className={`text-[11pt] leading-relaxed mb-3 ${highlight('affidavit')}`}>
+                  <p className="mb-2">3. We are the owners of the above described homestead.</p>
+                  <p className="mb-2">4. The above described homestead is our principal dwelling and we currently reside thereon.</p>
+                  <p className="mb-2">5. The facts stated in this declaration are known to be true as of our personal knowledge.</p>
+                </div>
+
+                <div className="mt-6 flex justify-between items-end gap-4">
+                  <div className="text-[11pt]">Dated: <span className="inline-block min-w-[1.6in] border-b border-black" /></div>
+                  <div className="w-[45%]">
+                    <div className="border-b border-black h-7" />
+                    <div className="text-[9px] uppercase mb-2">Print Name: <span className={`font-bold ${dataHighlight(aff?.declarantName)}`}>{aff?.declarantName || ''}</span></div>
+                    <div className="border-b border-black h-7" />
+                    <div className="text-[9px] uppercase">Print Name: <span className={`font-bold ${dataHighlight(aff?.declarant2Name)}`}>{aff?.declarant2Name || ''}</span></div>
+                  </div>
+                </div>
+                {ackSketch}
+              </>
+            ) : isDeclaration && state.deedType === 'homestead-abandonment' ? (
+              <>
+                {/* PCT #32 — the operative abandonment recital is furniture
+                    (TOD-revocation precedent); the prior declaration's
+                    identifying facts are officer-typed. */}
+                <div className={`text-[11pt] leading-relaxed mb-3 ${highlight('affidavit')}`}>
+                  <p className="mb-2">
+                    The undersigned declare(s) that he/she/they hereby abandon(s) the homestead
+                    previously declared in the Homestead Declaration executed by{' '}
+                    <span onClick={go('affidavit', 'affidavit-priorDeclarant')} className={`font-bold uppercase ${CLICKABLE} ${dataHighlight(aff?.priorDeclarant)}`}>{factOrBlank(aff?.priorDeclarant)}</span>
+                    {' '}on <span onClick={go('affidavit', 'affidavit-declarationDate')} className={`${CLICKABLE} ${dataHighlight(aff?.declarationDate)}`}>{factOrBlank(aff?.declarationDate)}</span>
+                    {' '}and recorded on{' '}
+                    <span onClick={go('affidavit', 'affidavit-recordingDate')} className={`${CLICKABLE} ${dataHighlight(aff?.recordingDate)}`}>{factOrBlank(aff?.recordingDate)}</span>, as Instrument No.{' '}
+                    <span onClick={go('affidavit', 'affidavit-instrumentNo')} className={`${CLICKABLE} ${dataHighlight(aff?.instrumentNo)}`}>{factOrBlank(aff?.instrumentNo)}</span>
+                    {' '}in the Official Records of the County Recorder of{' '}
+                    <span onClick={go('property')} className={`font-bold ${CLICKABLE} ${placeholder(preview.county)} ${dataHighlight(preview.county)}`}>{preview.county}</span>,
+                    {' '}County, State of California, pertaining to the following real property:
+                  </p>
+                </div>
+
+                <div className={`mb-3 ${highlight('property')}`}>
+                  <span onClick={go('property')} className={`font-bold text-[10.5pt] whitespace-pre-wrap ${CLICKABLE} ${placeholder(preview.legalDescription)} ${dataHighlight(preview.legalDescription)}`}>
+                    {preview.legalDescription}
+                  </span>
+                </div>
+
+                <p className={`mb-3 text-[11pt] ${highlight('property')}`}>
+                  and commonly known as (Street address){' '}
+                  <span onClick={go('property')} className={`font-bold ${CLICKABLE} ${dataHighlight(state.property?.address)}`}>{state.property?.address || '________________________'}</span>.
+                </p>
+
+                <div className="mt-6 flex justify-between items-end gap-4">
+                  <div className="text-[11pt]">Dated: <span className="inline-block min-w-[1.6in] border-b border-black" /></div>
+                  <div className="w-[45%]">
+                    <div className="border-b border-black h-7 mb-3" />
+                    <div className="border-b border-black h-7" />
+                  </div>
+                </div>
+                {ackSketch}
+              </>
             ) : isDeclaration ? (
               <>
                 {/* Homestead declaration recital (PCT #33) — numbered
@@ -376,30 +482,8 @@ export function PreviewPanel({ state, activeSection, onRegionClick }: PreviewPan
                   </div>
                 </div>
 
-                {/* Acknowledgment sketch — CC §1189 (CCP §704.930: a homestead
-                    declaration is ACKNOWLEDGED, not sworn). All entries are
-                    the notary's; nothing pre-fills. */}
-                <div className="mt-5 text-[9.5px] border border-black p-2 leading-snug">
-                  A notary public or other officer completing this certificate verifies only the
-                  identity of the individual who signed the document to which this certificate is
-                  attached, and not the truthfulness, accuracy, or validity of that document.
-                </div>
-                <div className="mt-3 text-[10px]">
-                  <div>STATE OF CALIFORNIA&nbsp;&nbsp;)</div>
-                  <div>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;)&nbsp;&nbsp;SS.</div>
-                  <div>COUNTY OF <span className="inline-block min-w-[1.4in] border-b border-black">{preview.county.startsWith('[') ? '' : preview.county}</span>&nbsp;)</div>
-                  <p className="mt-2">
-                    On ____________ before me, ______________________________, Notary Public,
-                    personally appeared ______________________________, who proved to me on the
-                    basis of satisfactory evidence to be the person(s) whose name(s) is/are
-                    subscribed to the within instrument and acknowledged to me that he/she/they
-                    executed the same in his/her/their authorized capacity(ies)…
-                  </p>
-                  <div className="mt-4 flex justify-between items-end">
-                    <div>Signature <span className="inline-block min-w-[2in] border-b border-black" /></div>
-                    <div className="border border-black w-[1.6in] h-[1.1in] flex items-center justify-center text-center text-[8px] uppercase text-gray-500">(This area for notary stamp)</div>
-                  </div>
-                </div>
+                {/* CC §1189 sketch (CCP §704.930: ACKNOWLEDGED, not sworn) */}
+                {ackSketch}
               </>
             ) : isAffidavit ? (
               <>

--- a/frontend/src/lib/deedPayload.ts
+++ b/frontend/src/lib/deedPayload.ts
@@ -47,6 +47,9 @@ function buildFactsBlock(aff: AffidavitFacts | undefined) {
     signer_names: aff.signerNames || '',
     title_vesting: aff.titleVesting || '',
     revoking_grantor: aff.revokingGrantor || '',
+    declarant2_name: aff.declarant2Name || '',
+    prior_declarant: aff.priorDeclarant || '',
+    declaration_date: aff.declarationDate || '',
   };
   return Object.values(block).some((v) => v) ? block : null;
 }
@@ -82,7 +85,11 @@ export function buildDeedPayload(genState: DeedBuilderState) {
         ? { trustee: aff?.trustees || '' }
         : genState.deedType === 'tod-revocation'
           ? { grantor: aff?.revokingGrantor || '' }
-          : { declarant: aff?.declarantName || '' }
+          : genState.deedType === 'homestead-declaration-spouses'
+            ? { declarant: aff?.declarantName || '', second_declarant: aff?.declarant2Name || '' }
+            : genState.deedType === 'homestead-abandonment'
+              ? { declarant: aff?.priorDeclarant || '' }
+              : { declarant: aff?.declarantName || '' }
       : null,
     vesting: genState.vesting,
     requested_by: genState.requestedBy,

--- a/frontend/src/lib/deedResume.ts
+++ b/frontend/src/lib/deedResume.ts
@@ -194,6 +194,9 @@ export function hydrateStateFromDeedRow(row: Record<string, any>): ResumeResult 
           signerNames: meta.affidavit?.signer_names || '',
           titleVesting: meta.affidavit?.title_vesting || '',
           revokingGrantor: meta.affidavit?.revoking_grantor || '',
+          declarant2Name: meta.affidavit?.declarant2_name || (row.parties && row.parties.second_declarant) || '',
+          priorDeclarant: meta.affidavit?.prior_declarant || '',
+          declarationDate: meta.affidavit?.declaration_date || '',
         }
       : undefined,
     returnTo,

--- a/frontend/src/lib/deedValidation.ts
+++ b/frontend/src/lib/deedValidation.ts
@@ -87,7 +87,49 @@ export function evaluateSubstantive(state: DeedBuilderState): CheckResult[] {
         },
       ];
     }
-    // Homestead: the declarant plus the premises.
+    if (state.deedType === 'homestead-declaration-spouses') {
+      // Both declared owners, plus the premises.
+      return [
+        {
+          id: 'declarants_present',
+          label: 'Both declared owners stated',
+          ok: !!state.affidavit?.declarantName?.trim() && !!state.affidavit?.declarant2Name?.trim(),
+          sectionId: 'affidavit',
+        },
+        {
+          id: 'legal_description_present',
+          label: 'Legal description present',
+          ok: !!state.property?.legalDescription?.trim(),
+          sectionId: 'property',
+        },
+      ];
+    }
+    if (state.deedType === 'homestead-abandonment') {
+      // The prior declaration is identified by who executed it and its
+      // recording reference (the recorded-instrument class).
+      return [
+        {
+          id: 'prior_declarant_named',
+          label: 'Prior declaration executed-by stated',
+          ok: !!state.affidavit?.priorDeclarant?.trim(),
+          sectionId: 'affidavit',
+        },
+        {
+          id: 'recorded_instrument_reference',
+          label: 'Recorded declaration reference',
+          ok: !!state.affidavit?.instrumentNo?.trim() && !!state.affidavit?.recordingDate?.trim(),
+          detail: 'The recorded declaration is identified by its recording date and instrument number.',
+          sectionId: 'affidavit',
+        },
+        {
+          id: 'legal_description_present',
+          label: 'Legal description present',
+          ok: !!state.property?.legalDescription?.trim(),
+          sectionId: 'property',
+        },
+      ];
+    }
+    // Homestead (individual): the declarant plus the premises.
     return [
       {
         id: 'declarant_present',
@@ -303,10 +345,14 @@ export function deriveSectionTruth(state: DeedBuilderState): SectionTruth {
       ? !!(aff?.trustName?.trim() && aff?.trustees?.trim())
       : state.deedType === 'tod-revocation'
         ? !!aff?.revokingGrantor?.trim()
-        : isDeclarationType(state.deedType)
-          ? !!aff?.declarantName?.trim()
-          : !!(aff?.affiantName?.trim() && aff?.decedentName?.trim() &&
-            aff?.instrumentNo?.trim() && aff?.recordingDate?.trim());
+        : state.deedType === 'homestead-declaration-spouses'
+          ? !!(aff?.declarantName?.trim() && aff?.declarant2Name?.trim())
+          : state.deedType === 'homestead-abandonment'
+            ? !!(aff?.priorDeclarant?.trim() && aff?.instrumentNo?.trim() && aff?.recordingDate?.trim())
+            : isDeclarationType(state.deedType)
+              ? !!aff?.declarantName?.trim()
+              : !!(aff?.affiantName?.trim() && aff?.decedentName?.trim() &&
+                aff?.instrumentNo?.trim() && aff?.recordingDate?.trim());
     const statuses: Record<string, SectionStatus> = {
       // Property-less instruments (certification of trust) have no
       // property section — the one-truth counter must not count it.

--- a/frontend/src/lib/formRegistry.ts
+++ b/frontend/src/lib/formRegistry.ts
@@ -342,6 +342,65 @@ export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
       },
     ],
   },
+  // Wave 2 form #4 — reference: PCT blank form #34 (Homestead_Dec-Spouses).
+  // Acknowledgment verified from the reference (CCP §704.930). TWO
+  // declarants — a parties-JSONB shape, not a new class ("We are husband
+  // and wife" is Flag-3 furniture, the CP-spouse-recital class).
+  'homestead-declaration-spouses': {
+    slug: 'homestead-declaration-spouses',
+    label: 'Declaration of Homestead — Spouses',
+    title: 'DECLARATION OF HOMESTEAD',
+    subtitle: '(Spouses as Declared Owners)',
+    description: 'Spouses declare a homestead on their principal dwelling (CCP §704.930) — acknowledged and recorded',
+    popular: false,
+    family: 'declaration',
+    sections: DECLARATION_SECTIONS,
+    notarial: 'acknowledgment',
+    hasDtt: false,
+    affidavitFields: [
+      {
+        key: 'declarantName',
+        label: 'First declared owner',
+        placeholder: 'ROBERT OWNER',
+        uppercase: true,
+        hint: 'Both spouses sign before a notary.',
+      },
+      {
+        key: 'declarant2Name',
+        label: 'Second declared owner (spouse)',
+        placeholder: 'MARIA OWNER',
+        uppercase: true,
+      },
+    ],
+  },
+  // Wave 2 form #5 — reference: PCT blank form #32 (Homestead-Abandon).
+  // Acknowledgment verified from the reference; the operative
+  // "hereby abandon(s)" recital is instrument-defining furniture (the
+  // TOD-revocation operative-statement precedent), and the prior
+  // declaration's recording reference is the recorded-instrument class.
+  'homestead-abandonment': {
+    slug: 'homestead-abandonment',
+    label: 'Abandonment of Declared Homestead',
+    title: 'DECLARATION OF ABANDONMENT OF DECLARED HOMESTEAD',
+    description: 'Abandons a previously recorded homestead declaration — acknowledged; identifies the prior declaration by its recording reference',
+    popular: false,
+    family: 'declaration',
+    sections: DECLARATION_SECTIONS,
+    notarial: 'acknowledgment',
+    hasDtt: false,
+    affidavitFields: [
+      {
+        key: 'priorDeclarant',
+        label: 'Prior declaration executed by',
+        placeholder: 'ROBERT OWNER',
+        uppercase: true,
+        hint: 'As named on the recorded Homestead Declaration being abandoned. Also the abandoning owner.',
+        group: 'The recorded declaration being abandoned',
+      },
+      { key: 'declarationDate', label: 'Executed on', placeholder: 'June 1, 2015', group: 'The recorded declaration being abandoned' },
+      ...RECORDING_REF_FIELDS('The recorded declaration being abandoned'),
+    ],
+  },
   // Wave 1 form #6 — reference: PCT blank form #72 (Trust-Certification).
   // Correction-note family: an ACKNOWLEDGED penalty-of-perjury declaration
   // ("(Acknowledgement must be attached)"), not a jurat. Owner ruling:

--- a/frontend/src/types/builder.ts
+++ b/frontend/src/types/builder.ts
@@ -87,9 +87,15 @@ export interface AffidavitFacts {
   /* Trustee variant — the declaration of trust. */
   trustDate?: string;
   trustors?: string;
-  /* Declaration family (homestead): the single party. Persisted to the
+  /* Declaration family (homestead): the declarant(s). Persisted to the
      deeds.parties JSONB column, not metadata.affidavit. */
   declarantName?: string;
+  /* Homestead — Spouses variant: the second declared owner. */
+  declarant2Name?: string;
+  /* Homestead — Abandonment: the prior declaration being abandoned
+     (executed-by + dates identify the recorded instrument). */
+  priorDeclarant?: string;
+  declarationDate?: string;
   /* Certification of trust (Prob C §18100.5) — typed transcriptions of
      the trust instrument. The form's initial lines and checkboxes stay
      BLANK for the trustee's hand (owner ruling: execution acts). */

--- a/templates/homestead_abandonment_ca/index.jinja2
+++ b/templates/homestead_abandonment_ca/index.jinja2
@@ -1,0 +1,244 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Declaration of Abandonment of Declared Homestead - California</title>
+    <style>
+        /* ==========================================================================
+           ABANDONMENT OF DECLARED HOMESTEAD — wave 2 #5
+
+           First declaration-family instrument. Reference implementation:
+           Pacific Coast Title blank form #32 (Homestead-Abandon),
+           measured with pdfplumber (letter, one page, §1189 acknowledgment
+           in the lower half). The operative "hereby abandon(s)" recital is
+           instrument-defining furniture (the TOD-revocation operative-
+           statement precedent); the prior declaration is identified by its
+           executed-by + dates + recording reference (the recorded-
+           instrument class). Reference carries Order/Escrow lines.
+
+           Family facts (per the FORMS_TRIAGE correction note):
+           - ACKNOWLEDGED, not sworn — CCP §704.930 requires a homestead
+             declaration to be acknowledged. The certificate is the §1189
+             acknowledgment partial, NOT the jurat.
+           - Single-party instrument: the declarant rides in the
+             deeds.parties JSONB column (owner-ledgered migration) — no
+             grantor/grantee, no vesting.
+           - Not a conveyance: no DTT declaration, no mail-tax directive
+             ("AND WHEN RECORDED MAIL TO"). The reference carries no
+             Order/Escrow lines either (consumer instrument) — they render
+             only when the officer supplies values.
+           Chassis rules (G2/G3) carried over verbatim: §27361.6 open
+           recorder space + boundary caption; §27361.7 no chrome;
+           blank-contents doctrine (execution and notarial entries blank).
+           ========================================================================== */
+
+        @page {
+            size: letter;
+            margin: 0.5in 0.5in 0.6in 0.6in;
+        }
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        body {
+            font-family: "Times New Roman", Times, Georgia, serif;
+            font-size: 11pt;
+            line-height: 1.35;
+            color: #000;
+            background: #fff;
+        }
+
+        .header-section { display: flex; min-height: 1.85in; }
+
+        .recording-info {
+            width: 3.4in;
+            flex-shrink: 0;
+            border-right: 0.75pt solid #000;
+            padding-right: 0.15in;
+            font-size: 10pt;
+            line-height: 1.35;
+        }
+
+        .recorder-space { flex-grow: 1; }
+
+        .recording-label {
+            font-weight: bold;
+            text-transform: uppercase;
+            font-size: 9pt;
+        }
+
+        .recording-value { margin-bottom: 0.12in; min-height: 0.35in; }
+
+        .ref-line { font-size: 10pt; }
+
+        .header-boundary {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            border-bottom: 0.75pt solid #000;
+            padding-bottom: 0.03in;
+            margin-bottom: 0.12in;
+        }
+
+        .apn-ref { font-weight: bold; font-size: 10pt; }
+
+        .recorder-caption {
+            font-size: 7.5pt;
+            font-weight: bold;
+            text-transform: uppercase;
+        }
+
+        .deed-title {
+            text-align: center;
+            font-size: 14pt;
+            font-weight: bold;
+            letter-spacing: 2px;
+            text-transform: uppercase;
+            margin: 0.08in 0 0.02in 0;
+        }
+
+        .deed-subtitle {
+            text-align: center;
+            font-size: 11pt;
+            font-weight: bold;
+            margin-bottom: 0.1in;
+        }
+
+        .declaration-body {
+            font-size: 11pt;
+            line-height: 1.35;
+            text-align: justify;
+        }
+
+        .declaration-body p { margin-bottom: 0.07in; }
+
+        .fact {
+            /* Officer-supplied facts render bold; a missing fact renders as
+               the reference's blank line so an incomplete instrument LOOKS
+               incomplete. */
+            font-weight: bold;
+        }
+
+        .fact-line {
+            display: inline-block;
+            min-width: 2.2in;
+            border-bottom: 1px solid #000;
+        }
+
+        .legal-content {
+            font-weight: bold;
+            white-space: pre-wrap;
+            margin: 0.08in 0;
+            min-height: 0.5in;
+        }
+
+        .execution-section {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-end;
+            margin-top: 0.12in;
+            margin-bottom: 0.05in;
+        }
+
+        .signature-block { width: 3.2in; }
+
+        .signature-line {
+            border-bottom: 1px solid #000;
+            width: 3.2in;
+            height: 0.35in;
+        }
+
+        .print-name {
+            font-size: 10pt;
+            text-transform: uppercase;
+        }
+    </style>
+</head>
+<body>
+    <div class="deed-page">
+
+        <header class="header-section">
+            <div class="recording-info">
+                <div class="recording-label">Recording Requested By:</div>
+                <div class="recording-value">{{ requested_by or '' }}{% if requested_by_address %}<br>{{ requested_by_address }}{% endif %}</div>
+
+                <div class="recording-label">And When Recorded Mail To:</div>
+                <div class="recording-value">
+                    {% if return_to %}
+                        {% if return_to.get('name') %}{{ return_to.get('name') }}<br>{% endif %}
+                        {% if return_to.get('company') %}{{ return_to.get('company') }}<br>{% endif %}
+                        {% if return_to.get('address1') %}{{ return_to.get('address1') }}<br>{% endif %}
+                        {% if return_to.get('address2') %}{{ return_to.get('address2') }}<br>{% endif %}
+                        {% set city = return_to.get('city', '') %}
+                        {% set state = return_to.get('state', '') %}
+                        {% set zip = return_to.get('zip', '') %}
+                        {% if city or state or zip %}
+                            {{ city }}{% if city and (state or zip) %}, {% endif %}{{ state }} {{ zip }}
+                        {% endif %}
+                    {% else %}
+                        _________________________________<br>
+                        _________________________________<br>
+                        _________________________________
+                    {% endif %}
+                </div>
+
+                <div class="ref-line">Order No.: {{ title_order_no or '____________________' }}</div>
+                <div class="ref-line">Escrow No.: {{ escrow_no or '____________________' }}</div>
+            </div>
+
+            <div class="recorder-space"><!-- Gov. Code §27361.6 — recorder's use only --></div>
+        </header>
+
+        <div class="header-boundary">
+            <span class="apn-ref">APN: {{ apn or '____________________' }}</span>
+            <span class="recorder-caption">Space Above This Line Is For Recorder&rsquo;s Use</span>
+        </div>
+
+        <h1 class="deed-title">Declaration of Abandonment of Declared Homestead</h1>
+
+        {% set aff = affidavit or {} %}
+        <div class="declaration-body">
+            <p>
+                The undersigned declare(s) that he/she/they hereby abandon(s) the homestead
+                previously declared in the Homestead Declaration executed by
+                {% if aff.get('prior_declarant') %}<span class="fact">{{ aff.get('prior_declarant') }}</span>{% else %}<span class="fact-line">&nbsp;</span>{% endif %}
+                on {% if aff.get('declaration_date') %}<span class="fact">{{ aff.get('declaration_date') }}</span>{% else %}<span class="fact-line" style="min-width:1.4in">&nbsp;</span>{% endif %}
+                and recorded on
+                {% if aff.get('recording_date') %}<span class="fact">{{ aff.get('recording_date') }}</span>{% else %}<span class="fact-line" style="min-width:1.4in">&nbsp;</span>{% endif %},
+                as Instrument No. {% if aff.get('instrument_no') %}<span class="fact">{{ aff.get('instrument_no') }}</span>{% else %}<span class="fact-line" style="min-width:1.4in">&nbsp;</span>{% endif %}
+                in the Official Records of the County Recorder of
+                {% if county %}<span class="fact">{{ county }}</span>{% else %}<span class="fact-line" style="min-width:1.6in">&nbsp;</span>{% endif %},
+                County, State of California, pertaining to the following real property:
+            </p>
+        </div>
+
+        <div class="legal-content">{{ legal_description or '' }}</div>
+
+        <div class="declaration-body">
+            <p>
+                and commonly known as (Street address)
+                {% if property_address %}<span class="fact">{{ property_address }}</span>{% else %}<span class="fact-line" style="min-width:3in">&nbsp;</span>{% endif %}.
+            </p>
+        </div>
+
+        {# Execution: the declarant signs at the notarization — date and
+           signature stay blank (blank-contents doctrine). The printed name
+           identifies the signer, as the deed chassis prints signer names. #}
+        {# Reference-faithful bare signature lines (two provided);
+           the abandoning owner(s) sign at notarization. #}
+        <div class="execution-section">
+            <div>Dated: <span class="fact-line" style="min-width:1.8in">&nbsp;</span></div>
+            <div class="signature-block">
+                <div class="signature-line"></div>
+                <div class="signature-line" style="margin-top:0.12in"></div>
+            </div>
+        </div>
+
+        {# CCP §704.930: ACKNOWLEDGED, not sworn — §1189 certificate,
+           on the SAME page as the reference lays it out. #}
+        {% set document_title = 'Declaration of Abandonment of Declared Homestead' %}
+        {% set ack_inline = true %}
+        {% include '_partials/notary_acknowledgment.jinja2' %}
+
+    </div>
+</body>
+</html>

--- a/templates/homestead_declaration_spouses_ca/index.jinja2
+++ b/templates/homestead_declaration_spouses_ca/index.jinja2
@@ -1,0 +1,250 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Declaration of Homestead (Spouses) - California</title>
+    <style>
+        /* ==========================================================================
+           DECLARATION OF HOMESTEAD (SPOUSES) — wave 2 #4
+
+           First declaration-family instrument. Reference implementation:
+           Pacific Coast Title blank form #34 (Homestead_Dec-Spouses),
+           measured with pdfplumber (letter, one page, §1189 acknowledgment
+           in the lower half). TWO declared owners: "We are husband and
+           wife" is instrument-defining furniture (Flag-3, the CP-spouse-
+           recital class); both spouses sign, both names print (deed-
+           chassis signer-name precedent). Parties ride in deeds.parties
+           ({declarant, second_declarant}).
+
+           Family facts (per the FORMS_TRIAGE correction note):
+           - ACKNOWLEDGED, not sworn — CCP §704.930 requires a homestead
+             declaration to be acknowledged. The certificate is the §1189
+             acknowledgment partial, NOT the jurat.
+           - Single-party instrument: the declarant rides in the
+             deeds.parties JSONB column (owner-ledgered migration) — no
+             grantor/grantee, no vesting.
+           - Not a conveyance: no DTT declaration, no mail-tax directive
+             ("AND WHEN RECORDED MAIL TO"). The reference carries no
+             Order/Escrow lines either (consumer instrument) — they render
+             only when the officer supplies values.
+           Chassis rules (G2/G3) carried over verbatim: §27361.6 open
+           recorder space + boundary caption; §27361.7 no chrome;
+           blank-contents doctrine (execution and notarial entries blank).
+           ========================================================================== */
+
+        @page {
+            size: letter;
+            margin: 0.5in 0.5in 0.6in 0.6in;
+        }
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        body {
+            font-family: "Times New Roman", Times, Georgia, serif;
+            font-size: 11pt;
+            line-height: 1.35;
+            color: #000;
+            background: #fff;
+        }
+
+        .header-section { display: flex; min-height: 1.85in; }
+
+        .recording-info {
+            width: 3.4in;
+            flex-shrink: 0;
+            border-right: 0.75pt solid #000;
+            padding-right: 0.15in;
+            font-size: 10pt;
+            line-height: 1.35;
+        }
+
+        .recorder-space { flex-grow: 1; }
+
+        .recording-label {
+            font-weight: bold;
+            text-transform: uppercase;
+            font-size: 9pt;
+        }
+
+        .recording-value { margin-bottom: 0.12in; min-height: 0.35in; }
+
+        .ref-line { font-size: 10pt; }
+
+        .header-boundary {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            border-bottom: 0.75pt solid #000;
+            padding-bottom: 0.03in;
+            margin-bottom: 0.12in;
+        }
+
+        .apn-ref { font-weight: bold; font-size: 10pt; }
+
+        .recorder-caption {
+            font-size: 7.5pt;
+            font-weight: bold;
+            text-transform: uppercase;
+        }
+
+        .deed-title {
+            text-align: center;
+            font-size: 14pt;
+            font-weight: bold;
+            letter-spacing: 2px;
+            text-transform: uppercase;
+            margin: 0.08in 0 0.02in 0;
+        }
+
+        .deed-subtitle {
+            text-align: center;
+            font-size: 11pt;
+            font-weight: bold;
+            margin-bottom: 0.1in;
+        }
+
+        .declaration-body {
+            font-size: 11pt;
+            line-height: 1.28;
+            text-align: justify;
+        }
+
+        .declaration-body p { margin-bottom: 0.04in; }
+
+        .fact {
+            /* Officer-supplied facts render bold; a missing fact renders as
+               the reference's blank line so an incomplete instrument LOOKS
+               incomplete. */
+            font-weight: bold;
+        }
+
+        .fact-line {
+            display: inline-block;
+            min-width: 2.2in;
+            border-bottom: 1px solid #000;
+        }
+
+        .legal-content {
+            font-weight: bold;
+            white-space: pre-wrap;
+            margin: 0.04in 0;
+            min-height: 0.3in;
+        }
+
+        .execution-section {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-end;
+            margin-top: 0.05in;
+            margin-bottom: 0.03in;
+        }
+
+        .signature-block { width: 3.2in; }
+
+        .signature-line {
+            border-bottom: 1px solid #000;
+            width: 3.2in;
+            height: 0.26in;
+        }
+
+        .print-name {
+            font-size: 10pt;
+            text-transform: uppercase;
+        }
+    </style>
+</head>
+<body>
+    <div class="deed-page">
+
+        <header class="header-section">
+            <div class="recording-info">
+                <div class="recording-label">Recording Requested By:</div>
+                <div class="recording-value">{{ requested_by or '' }}{% if requested_by_address %}<br>{{ requested_by_address }}{% endif %}</div>
+
+                <div class="recording-label">And When Recorded Mail To:</div>
+                <div class="recording-value">
+                    {% if return_to %}
+                        {% if return_to.get('name') %}{{ return_to.get('name') }}<br>{% endif %}
+                        {% if return_to.get('company') %}{{ return_to.get('company') }}<br>{% endif %}
+                        {% if return_to.get('address1') %}{{ return_to.get('address1') }}<br>{% endif %}
+                        {% if return_to.get('address2') %}{{ return_to.get('address2') }}<br>{% endif %}
+                        {% set city = return_to.get('city', '') %}
+                        {% set state = return_to.get('state', '') %}
+                        {% set zip = return_to.get('zip', '') %}
+                        {% if city or state or zip %}
+                            {{ city }}{% if city and (state or zip) %}, {% endif %}{{ state }} {{ zip }}
+                        {% endif %}
+                    {% else %}
+                        _________________________________<br>
+                        _________________________________<br>
+                        _________________________________
+                    {% endif %}
+                </div>
+
+                {# The reference carries no Order/Escrow lines (consumer
+                   instrument) — render only when the officer supplied one. #}
+                {% if title_order_no %}<div class="ref-line">Order No.: {{ title_order_no }}</div>{% endif %}
+                {% if escrow_no %}<div class="ref-line">Escrow No.: {{ escrow_no }}</div>{% endif %}
+            </div>
+
+            <div class="recorder-space"><!-- Gov. Code §27361.6 — recorder's use only --></div>
+        </header>
+
+        <div class="header-boundary">
+            <span class="apn-ref">APN: {{ apn or '____________________' }}</span>
+            <span class="recorder-caption">Space Above This Line Is For Recorder&rsquo;s Use</span>
+        </div>
+
+        <h1 class="deed-title">Declaration of Homestead</h1>
+        <div class="deed-subtitle">(Spouses as Declared Owners)</div>
+
+        {% set declarant = (parties or {}).get('declarant') %}
+        {% set declarant2 = (parties or {}).get('second_declarant') %}
+        <div class="declaration-body">
+            <p>
+                We, {% if declarant %}<span class="fact">{{ declarant }}</span>{% else %}<span class="fact-line">&nbsp;</span>{% endif %}
+                and {% if declarant2 %}<span class="fact">{{ declarant2 }}</span>{% else %}<span class="fact-line">&nbsp;</span>{% endif %},
+                hereby certify and declare as follows:
+            </p>
+            <p>1. We are husband and wife.</p>
+            <p>
+                2. We hereby claim as a declared homestead the premises described as follows:
+            </p>
+        </div>
+
+        <div class="legal-content">{{ legal_description or '' }}</div>
+
+        <div class="declaration-body">
+            <p>3. We are the owners of the above described homestead.</p>
+            <p>
+                4. The above described homestead is our principal dwelling and we currently
+                reside thereon.
+            </p>
+            <p>
+                5. The facts stated in this declaration are known to be true as of our
+                personal knowledge.
+            </p>
+        </div>
+
+        {# Execution: the declarant signs at the notarization — date and
+           signature stay blank (blank-contents doctrine). The printed name
+           identifies the signer, as the deed chassis prints signer names. #}
+        <div class="execution-section">
+            <div>Dated: <span class="fact-line" style="min-width:1.8in">&nbsp;</span></div>
+            <div class="signature-block">
+                <div class="signature-line"></div>
+                <div class="print-name">Print Name: {% if declarant %}<span class="fact">{{ declarant }}</span>{% endif %}</div>
+                <div class="signature-line" style="margin-top:0.08in"></div>
+                <div class="print-name">Print Name: {% if declarant2 %}<span class="fact">{{ declarant2 }}</span>{% endif %}</div>
+            </div>
+        </div>
+
+        {# CCP §704.930: ACKNOWLEDGED, not sworn — §1189 certificate,
+           on the SAME page as the reference lays it out. #}
+        {% set document_title = 'Declaration of Homestead' %}
+        {% set ack_inline = true %}
+        {% include '_partials/notary_acknowledgment.jinja2' %}
+
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Wave 2, forms #4 and #5 — the homestead pair

### References fetched and measured
PCT #34 (`Homestead_Dec-Spouses`) and #32 (`Homestead-Abandon`) — one page each, §1189 acknowledgment in the lower half, chassis geometry.

## Drift review (all six attestations)

**1. Certificate from the reference.** Both blanks print the **§1189 acknowledgment** body — verified in the extracted text before family assignment; the canary is pinned in both directions per form. Consistent with the corrected family facts (CCP §704.930).

**2. Doctrine-pass diff against precedent.** "We are husband and wife" → Flag-3 instrument-defining recital (the CP-spouse-clause class). The operative "hereby abandon(s)" → the TOD-revocation operative-statement class (choosing/executing the instrument IS the act). Prior-declaration identification (executed-by + dates + instrument no.) → the recorded-instrument class. **Two declared owners** → a parties-JSONB shape the #86 migration was designed for (`{declarant, second_declarant}`), not a new class. **No uncovered element → no hold.** Three new `AffidavitFacts` keys: `declarant2Name`, `priorDeclarant`, `declarationDate`.

**3. Coherence pins before template.** Both entries land inside the three-family matrix (declaration ⇒ acknowledgment + no DTT + facts specs + no smuggled value); count pin 15 → 17; registry↔backend family mirror covers both slugs.

**4. Ledger consistency.** Nothing made stale; `OWNER_LEDGER.md` untouched.

**5. No silent scope absorption.** One smell **noted, not built**: the per-slug substantive-check chains in `deedValidation` are growing — a registry-driven `requiredFacts` config is the eventual cleanup, proposed for whenever the catalog next grows a family.

**6. Per-form gate attestation.**
- [x] Geometry pins vs. reference: 1 page each, caption >100pt top / >300pt x, title below caption, certificate lower half. The Spouses one-page budget was refought (extra clause + second signature block) and holds pinned; Abandonment fit first try
- [x] Statutory/furniture strings verbatim: all five We-clauses; the abandonment recital including "in the Official Records of the County Recorder of" and "commonly known as (Street address)" (context now passes `property_address` for that line)
- [x] Blank-contents occurrence pins: exactly one certificate per form; declarant names absent from the certificate; vesting sentinel cannot leak
- [x] Backend **209 passed** (was 193; +16) · six-flow ✔ unchanged · jest **284** · tsc frozen **98**

### Per-form actuals vs. 1–2 hr projection
~55 min for the pair (~28 min/form) — sibling rate holds even across a new fact shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_