### PR TITLE
FORMS wave 2 (#6): Corporation + Partnership Grant Deeds — entity grantors

### DIFF
--- a/backend/services/deed_pdf.py
+++ b/backend/services/deed_pdf.py
@@ -57,6 +57,9 @@ TEMPLATE_BY_DEED_TYPE = {
     # FORMS wave 2 — homestead pair (PCT references #34 and #32).
     "homestead-declaration-spouses": "homestead_declaration_spouses_ca/index.jinja2",
     "homestead-abandonment": "homestead_abandonment_ca/index.jinja2",
+    # FORMS wave 2 #6 — entity grantors (PCT references #22 and #29).
+    "grant-deed-corp": "grant_deed_corp_ca/index.jinja2",
+    "grant-deed-partnership": "grant_deed_partnership_ca/index.jinja2",
 }
 DEFAULT_TEMPLATE = "grant_deed_ca/index.jinja2"
 

--- a/backend/services/form_families.py
+++ b/backend/services/form_families.py
@@ -27,6 +27,8 @@ FAMILY_BY_DEED_TYPE = {
     "tax-deed": "deed",
     "grant-deed-jt": "deed",
     "grant-deed-cp-ros": "deed",
+    "grant-deed-corp": "deed",
+    "grant-deed-partnership": "deed",
     "affidavit-death-jt": "affidavit",
     "affidavit-death-cp-spouse": "affidavit",
     "affidavit-death-trustee": "affidavit",

--- a/backend/tests/test_wave2_entity_deeds.py
+++ b/backend/tests/test_wave2_entity_deeds.py
@@ -1,0 +1,178 @@
+"""FORMS wave 2 #6 — entity-grantor grant deeds, pinned.
+
+TWO references implement the one owner-named form ("Corporation/
+Partnership as Grantor"): PCT #22 (Deed-Corporation) and #29
+(Deed-Partnership). Drift review: acknowledgment verified from both
+references (§1189 body printed); the entity recitals are Flag-3
+instrument-defining furniture (choosing the form IS declaring the
+grantor's kind); state-of-organization / partnership-type are typed
+officer facts (transcription class, blanks tolerated); the capacity
+signature lines ("By/And", "General Partner") are furniture VERIFIED
+from the references — corp signs bare By/And, partnership adds the
+General Partner captions. No entity-type selection shapes legal content
+within either form. Full deed chassis preserved: R&T §11932–11933 DTT
+declaration and decision gate, officer vesting, mail-tax directives.
+"""
+import io
+
+import pdfplumber
+import pytest
+
+from services.deed_pdf import render_deed_html, render_deed_pdf
+from tests.test_deed_pdf import _normalized
+
+DEED_META = {
+    "requested_by_address": "456 Escrow Way, Los Angeles, CA 90012",
+    "return_to": {"name": "JOHN A. DOE", "address1": "1358 5TH ST",
+                  "city": "Santa Monica", "state": "CA", "zip": "90401"},
+    "dtt": {
+        "transfer_value": "500000",
+        "calculated_amount": "550.00",
+        "basis": "full_value",
+        "area_type": "city",
+        "city_name": "Santa Monica",
+        "is_exempt": False,
+        "exemption_reason": "",
+    },
+}
+
+FORMS = {
+    "grant-deed-corp": {
+        "template": "grant_deed_corp_ca/index.jinja2",
+        "title": "Corporation Grant Deed",
+        "aff": {"entity_state": "Delaware"},
+        "recital": "a corporation organized under the laws of the State of",
+        "capacity_caption": None,
+    },
+    "grant-deed-partnership": {
+        "template": "grant_deed_partnership_ca/index.jinja2",
+        "title": "Partnership Grant Deed",
+        "aff": {"entity_state": "California", "partnership_type": "general"},
+        "recital": "partnership organized under the laws of the State of",
+        "capacity_caption": "General Partner",
+    },
+}
+
+
+def deed_row(deed_type, **overrides):
+    row = {
+        "id": 1,
+        "deed_type": deed_type,
+        "grantor_name": "ACME HOLDINGS, INC." if deed_type == "grant-deed-corp" else "DOE FAMILY PARTNERS",
+        "grantee_name": "JOHN A. DOE AND JANE B. DOE",
+        "vesting": "as joint tenants",
+        "legal_description": "LOT 7, BLOCK B, TRACT 12345",
+        "county": "Los Angeles",
+        "apn": "4290-012-034",
+        "property_address": "1358 5TH ST, Santa Monica, CA 90401",
+        "requested_by": "Pacific Coast Escrow",
+        "metadata": {**DEED_META, "affidavit": FORMS[deed_type]["aff"]},
+    }
+    row.update(overrides)
+    return row
+
+
+@pytest.fixture(params=sorted(FORMS))
+def deed_type(request):
+    return request.param
+
+
+def test_title_and_entity_recital_furniture(deed_type):
+    html = _normalized(render_deed_html(deed_row(deed_type)))
+    assert FORMS[deed_type]["title"] in html
+    assert "For valuable consideration, receipt of which is hereby acknowledged," in html
+    assert FORMS[deed_type]["recital"] in html
+    assert "hereby GRANTS to" in html
+    assert "State of California, more particularly" in html
+
+
+def test_officer_facts_render(deed_type):
+    html = _normalized(render_deed_html(deed_row(deed_type)))
+    grantor = "ACME HOLDINGS, INC." if deed_type == "grant-deed-corp" else "DOE FAMILY PARTNERS"
+    for fact in (grantor, "JOHN A. DOE AND JANE B. DOE", "as joint tenants",
+                 "LOT 7, BLOCK B, TRACT 12345", "4290-012-034"):
+        assert fact in html, fact
+    # Entity facts (typed transcription):
+    for v in FORMS[deed_type]["aff"].values():
+        assert v in html, v
+
+
+def test_missing_entity_facts_tolerated_as_blanks(deed_type):
+    """Gate-strictness ruling: the reference tolerates a blank state /
+    partnership-type line; nothing is invented."""
+    html = render_deed_html(deed_row(deed_type, metadata=dict(DEED_META)))
+    assert "Delaware" not in html
+    assert "____" in html  # the reference's blank lines
+
+
+def test_capacity_signature_furniture(deed_type):
+    """Verified from the references: the entity is NAMED; the signature
+    lines carry By/And capacity furniture — blank for the officers'/
+    partners' hands. Partnership adds the General Partner captions;
+    the corporation reference signs bare By/And."""
+    html = _normalized(render_deed_html(deed_row(deed_type)))
+    assert ">By" in html.replace(" ", "").replace("\n", "") or "By<" in html or ">By<" in html.replace(" ", "")
+    assert "And" in html
+    # Count in the execution region only — the template's doc comment
+    # also names the caption (the stripComments lesson, template edition).
+    execution = html[html.index("Dated:"):]
+    caption = FORMS[deed_type]["capacity_caption"]
+    if caption:
+        assert execution.count(caption) == 2   # once per signature line
+    else:
+        assert "General Partner" not in execution
+
+
+def test_full_dtt_declaration_preserved(deed_type):
+    """Entity variants ARE conveyances: the complete DTT declaration and
+    the officer's recorded decision render exactly as on the grant deed."""
+    html = _normalized(render_deed_html(deed_row(deed_type)))
+    assert "THE UNDERSIGNED GRANTOR(S) DECLARE(S):" in html
+    assert "DOCUMENTARY TRANSFER TAX IS" in html
+    assert "550.00" in html
+    assert "Mail Tax Statements" in html
+
+
+def test_acknowledgment_not_jurat(deed_type):
+    html = _normalized(render_deed_html(deed_row(deed_type)))
+    assert "personally appeared" in html
+    assert "acknowledged to me" in html
+    assert "Subscribed and sworn to (or affirmed) before me" not in html
+    assert html.count("verifies only the identity") == 1
+    ack = html[html.index("personally appeared"):]
+    assert "ACME HOLDINGS" not in ack
+    assert "DOE FAMILY PARTNERS" not in ack
+
+
+def test_chassis_geometry_and_no_chrome(deed_type):
+    pdf = render_deed_pdf(deed_row(deed_type))
+    with pdfplumber.open(io.BytesIO(pdf)) as doc:
+        assert len(doc.pages) <= 2   # page one + acknowledgment page
+        page = doc.pages[0]
+        words = page.extract_words()
+
+        def top_of(needle):
+            hits = [w for w in words if needle.upper() in w["text"].upper()]
+            assert hits, needle
+            return hits[0]["top"]
+
+        def x_of(needle):
+            hits = [w for w in words if needle.upper() in w["text"].upper()]
+            return hits[0]["x0"]
+
+        caption_top = top_of("RECORDER’S")
+        title_top = top_of("GRANT")
+        assert caption_top > 100
+        assert x_of("RECORDER’S") > 300
+        assert title_top > caption_top
+
+    html = render_deed_html(deed_row(deed_type))
+    for leaked in ("7C4DFF", "Generated by", "deedpro.com/verify", "recorder-box", "bg-brand"):
+        assert leaked not in html, leaked
+
+
+def test_registered_in_the_type_and_family_maps(deed_type):
+    from services.deed_pdf import TEMPLATE_BY_DEED_TYPE
+    from services.form_families import family_of
+    assert TEMPLATE_BY_DEED_TYPE[deed_type] == FORMS[deed_type]["template"]
+    assert family_of(deed_type) == "deed"

--- a/frontend/src/__tests__/formRegistry.test.ts
+++ b/frontend/src/__tests__/formRegistry.test.ts
@@ -23,8 +23,11 @@ const KNOWN_SECTIONS = new Set(['property', 'grantor', 'grantee', 'vesting', 'tr
 describe('FORMS registry — completeness and coherence', () => {
   const entries = Object.values(FORM_REGISTRY);
 
-  it('carries the seventeen shipped types', () => {
-    expect(entries.length).toBe(17);
+  it('carries the nineteen shipped types', () => {
+    expect(entries.length).toBe(19);
+    // Wave 2 #6 — entity grantors (two references, one owner-named form):
+    expect(formConfig('grant-deed-corp')?.family).toBe('deed');
+    expect(formConfig('grant-deed-partnership')?.family).toBe('deed');
     // Wave 2 #4/#5 — homestead pair (acknowledgment verified from the
     // references; spouses = two declarants in parties JSONB):
     expect(formConfig('homestead-declaration-spouses')?.family).toBe('declaration');

--- a/frontend/src/__tests__/previewChassisConformance.test.ts
+++ b/frontend/src/__tests__/previewChassisConformance.test.ts
@@ -27,6 +27,7 @@ import {
   OPERATIVE_WORDS,
   EXEMPTION_RECITALS,
   FIXED_VESTING_PHRASES,
+  ENTITY_GRANTOR_RECITALS,
   TOD_NOTICE_HEAD,
   TOD_REVOCATION_STATEMENT,
   TOD_WITNESS_INSTRUCTION,
@@ -54,6 +55,8 @@ const TEMPLATE_DIRS: Record<string, string> = {
   'tax-deed': 'tax_deed_ca',
   'grant-deed-jt': 'grant_deed_jt_ca',
   'grant-deed-cp-ros': 'grant_deed_cp_ros_ca',
+  'grant-deed-corp': 'grant_deed_corp_ca',
+  'grant-deed-partnership': 'grant_deed_partnership_ca',
 };
 
 /** Normalize Jinja/HTML source for wording comparison. */
@@ -113,7 +116,7 @@ describe('preview carries no dead pre-G2 furniture', () => {
 
 describe('the same wording lives in the backend chassis templates', () => {
   const allTypes = Object.keys(TEMPLATE_DIRS);
-  const dttTypes = ['grant-deed', 'quitclaim-deed', 'warranty-deed', 'grant-deed-jt', 'grant-deed-cp-ros'];
+  const dttTypes = ['grant-deed', 'quitclaim-deed', 'warranty-deed', 'grant-deed-jt', 'grant-deed-cp-ros', 'grant-deed-corp', 'grant-deed-partnership'];
 
   it.each(allTypes)('%s: recorder caption and mail-tax directive', (dt) => {
     const t = template(dt);
@@ -146,6 +149,13 @@ describe('the same wording lives in the backend chassis templates', () => {
     expect(t).toContain(`${FIXED_VESTING_PHRASES[dt]} the real property situated in the County of`);
     expect(t).not.toContain('{{ vesting }}');
     expect(t).not.toContain('{% if vesting %}');
+  });
+
+  // Wave 2 #6: the entity-grantor recital renders verbatim in preview
+  // (by identifier) and templates (by value).
+  it.each(Object.keys(ENTITY_GRANTOR_RECITALS))('%s: entity-grantor recital furniture', (dt) => {
+    expect(template(dt)).toContain(ENTITY_GRANTOR_RECITALS[dt]);
+    expect(PANEL).toContain('ENTITY_GRANTOR_RECITALS');
   });
 
   // Wave 1 #7: the statutory revocation text renders verbatim in both the

--- a/frontend/src/components/builder/InputPanel.tsx
+++ b/frontend/src/components/builder/InputPanel.tsx
@@ -145,6 +145,41 @@ export function InputPanel({
             provenance={state.grantorProvenance}
             onComplete={() => onSectionChange('grantee')}
           />
+          {/* Wave 2 #6 — entity grantors: typed facts completing the
+              entity recital (Flag-3 furniture prints the recital; these
+              blanks are the officer's transcription, tolerated blank). */}
+          {['grant-deed-corp', 'grant-deed-partnership'].includes(state.deedType) && (
+            <div className="mt-4 space-y-4">
+              {state.deedType === 'grant-deed-partnership' && (
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Partnership type (as stated in the partnership agreement)
+                  </label>
+                  <input
+                    type="text"
+                    data-builder-field="affidavit-partnershipType"
+                    value={state.affidavit?.partnershipType ?? ''}
+                    onChange={(e) => onChange({ affidavit: { ...(state.affidavit ?? { affiantName: '', decedentName: '', recordingDate: '', instrumentNo: '' }), partnershipType: e.target.value } })}
+                    placeholder="general"
+                    className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+                  />
+                </div>
+              )}
+              <div>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  State of organization
+                </label>
+                <input
+                  type="text"
+                  data-builder-field="affidavit-entityState"
+                  value={state.affidavit?.entityState ?? ''}
+                  onChange={(e) => onChange({ affidavit: { ...(state.affidavit ?? { affiantName: '', decedentName: '', recordingDate: '', instrumentNo: '' }), entityState: e.target.value } })}
+                  placeholder="California"
+                  className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+                />
+              </div>
+            </div>
+          )}
         </InputSection>
 
         <InputSection

--- a/frontend/src/components/builder/PreviewPanel.tsx
+++ b/frontend/src/components/builder/PreviewPanel.tsx
@@ -20,6 +20,7 @@ import {
   OPERATIVE_WORDS,
   EXEMPTION_RECITALS,
   FIXED_VESTING_PHRASES,
+  ENTITY_GRANTOR_RECITALS,
   TOD_DTT_EXEMPTION,
   TOD_PCOR_EXEMPTION,
   TOD_NOTICE_HEAD,
@@ -674,7 +675,24 @@ export function PreviewPanel({ state, activeSection, onRegionClick }: PreviewPan
               <span onClick={go('grantor')} className={`font-bold uppercase text-[11pt] ${CLICKABLE} ${placeholder(preview.grantor)} ${dataHighlight(preview.grantor)}`}>{preview.grantor}</span>
             </div>
 
-            <p className="mb-2 text-[11pt]">{operative}</p>
+            {ENTITY_GRANTOR_RECITALS[state.deedType] ? (
+              /* Entity-grantor recital (Flag-3 furniture) + the officer's
+                 typed state-of-organization / partnership-type facts. */
+              <p className="mb-2 text-[11pt]">
+                {state.deedType === 'grant-deed-partnership' ? (
+                  <>
+                    a <span onClick={go('grantor')} className={`${CLICKABLE} ${dataHighlight(aff?.partnershipType)}`}>{aff?.partnershipType || '___________'}</span>
+                    {' '}{ENTITY_GRANTOR_RECITALS[state.deedType]}{' '}
+                  </>
+                ) : (
+                  <>{ENTITY_GRANTOR_RECITALS[state.deedType]}{' '}</>
+                )}
+                <span onClick={go('grantor')} className={`${CLICKABLE} ${dataHighlight(aff?.entityState)}`}>{aff?.entityState || '____________________'}</span>
+                {' '}{operative}
+              </p>
+            ) : (
+              <p className="mb-2 text-[11pt]">{operative}</p>
+            )}
 
             <div className={`mb-2 ${highlight('grantee')}`}>
               <span onClick={go('grantee', 'grantee')} className={`font-bold uppercase text-[11pt] ${CLICKABLE} ${placeholder(preview.grantee)} ${dataHighlight(preview.grantee)}`}>{preview.grantee}</span>

--- a/frontend/src/lib/deedFurniture.ts
+++ b/frontend/src/lib/deedFurniture.ts
@@ -37,6 +37,17 @@ export const OPERATIVE_WORDS: Record<string, string> = {
   'tax-deed': 'does hereby grant, bargain, sell and convey to',
   'grant-deed-jt': 'hereby GRANT(S) to',
   'grant-deed-cp-ros': 'hereby GRANT(S) to',
+  'grant-deed-corp': 'hereby GRANTS to',
+  'grant-deed-partnership': 'hereby GRANTS to',
+};
+
+/** Entity-grantor recitals (wave 2 #6) — instrument-defining furniture:
+ * choosing "Corporation Grant Deed" IS declaring the grantor's kind
+ * (Flag-3). The blanks (state of organization; partnership type) are
+ * typed officer facts. Drift-pinned in preview and templates. */
+export const ENTITY_GRANTOR_RECITALS: Record<string, string> = {
+  'grant-deed-corp': 'a corporation organized under the laws of the State of',
+  'grant-deed-partnership': 'partnership organized under the laws of the State of',
 };
 
 /** Fixed-vesting phrases printed on the instrument's face (wave 1 #3/#4).

--- a/frontend/src/lib/deedPayload.ts
+++ b/frontend/src/lib/deedPayload.ts
@@ -50,6 +50,8 @@ function buildFactsBlock(aff: AffidavitFacts | undefined) {
     declarant2_name: aff.declarant2Name || '',
     prior_declarant: aff.priorDeclarant || '',
     declaration_date: aff.declarationDate || '',
+    entity_state: aff.entityState || '',
+    partnership_type: aff.partnershipType || '',
   };
   return Object.values(block).some((v) => v) ? block : null;
 }
@@ -110,7 +112,9 @@ export function buildDeedPayload(genState: DeedBuilderState) {
       : genState.requestedBy,
     title_order_no: genState.titleOrderNo || '',
     escrow_no: genState.escrowNo || '',
-    affidavit: buildFactsBlock(isAffidavit || isSingleParty ? aff : undefined),
+    // The typed-facts bucket now serves all three families (deed-family
+    // entity facts included); buildFactsBlock nulls it when empty.
+    affidavit: buildFactsBlock(aff),
     dtt: {
       transfer_value: genState.dtt?.transferValue?.replace(/[^0-9]/g, '') || '',
       is_exempt: genState.dtt?.isExempt || false,

--- a/frontend/src/lib/deedResume.ts
+++ b/frontend/src/lib/deedResume.ts
@@ -197,6 +197,8 @@ export function hydrateStateFromDeedRow(row: Record<string, any>): ResumeResult 
           declarant2Name: meta.affidavit?.declarant2_name || (row.parties && row.parties.second_declarant) || '',
           priorDeclarant: meta.affidavit?.prior_declarant || '',
           declarationDate: meta.affidavit?.declaration_date || '',
+          entityState: meta.affidavit?.entity_state || '',
+          partnershipType: meta.affidavit?.partnership_type || '',
         }
       : undefined,
     returnTo,

--- a/frontend/src/lib/formRegistry.ts
+++ b/frontend/src/lib/formRegistry.ts
@@ -206,6 +206,34 @@ export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
     notarial: 'acknowledgment',
     hasDtt: true,
   },
+  // Wave 2 form #6 — TWO references implement the one owner-named form
+  // ("Corporation/Partnership as Grantor"): PCT #22 (Deed-Corporation)
+  // and #29 (Deed-Partnership). Entity recitals are Flag-3 furniture;
+  // state-of-organization / partnership-type are typed officer facts;
+  // signature capacity lines ("By/And", "General Partner") are furniture
+  // verified from the references. Full deed chassis incl. the DTT gate.
+  'grant-deed-corp': {
+    slug: 'grant-deed-corp',
+    label: 'Corporation Grant Deed',
+    title: 'CORPORATION GRANT DEED',
+    description: 'Grant deed with a corporation as grantor — officers sign in capacity; full transfer-tax declaration',
+    popular: false,
+    family: 'deed',
+    sections: DEED_SECTIONS,
+    notarial: 'acknowledgment',
+    hasDtt: true,
+  },
+  'grant-deed-partnership': {
+    slug: 'grant-deed-partnership',
+    label: 'Partnership Grant Deed',
+    title: 'PARTNERSHIP GRANT DEED',
+    description: 'Grant deed with a partnership as grantor — general partners sign in capacity; full transfer-tax declaration',
+    popular: false,
+    family: 'deed',
+    sections: DEED_SECTIONS,
+    notarial: 'acknowledgment',
+    hasDtt: true,
+  },
   'affidavit-death-jt': {
     slug: 'affidavit-death-jt',
     label: 'Affidavit — Death of Joint Tenant',

--- a/frontend/src/types/builder.ts
+++ b/frontend/src/types/builder.ts
@@ -111,6 +111,11 @@ export interface AffidavitFacts {
      identification only; the statutory form is signed AND printed by the
      grantor at notarization (execution act; nothing pre-prints). */
   revokingGrantor?: string;
+  /* Entity grant deeds (wave 2 #6): typed facts completing the entity-
+     grantor recital — state of organization, and the partnership's kind
+     (general/limited) on the partnership form. */
+  entityState?: string;
+  partnershipType?: string;
 }
 
 export interface DeedBuilderState {

--- a/templates/grant_deed_corp_ca/index.jinja2
+++ b/templates/grant_deed_corp_ca/index.jinja2
@@ -1,0 +1,496 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Corporation Grant Deed - California</title>
+    <style>
+        /* ==========================================================================
+           CORPORATION GRANT DEED — CALIFORNIA (wave 2 #6)
+
+           Entity-grantor variant of the grant-deed chassis (PCT reference
+           blank form #22, Deed-Corporation). The entity recital ("a
+           corporation organized under the laws of the State of ___") is
+           instrument-defining furniture — Flag-3: choosing this form IS
+           declaring the grantor's kind; the state of organization is a
+           typed officer fact, blank tolerated. Officers sign in capacity:
+           the "By/And" lines are furniture verified from the reference.
+           Every other chassis behavior — full R&T §11932–11933 DTT
+           declaration, officer vesting, §1189 acknowledgment — is the
+           grant deed's. Chassis notes below are the grant deed's.
+
+           Geometry mirrors the owner's reference sample of a standard recorded
+           CA Grant Deed plus statute:
+           - Gov. Code §27361.6: recorder's space top-right of page one
+             (open space — no drawn box; a border invites rejection), caption
+             "SPACE ABOVE THIS LINE IS FOR RECORDER'S USE" at its bottom
+             boundary (~2.66" from the page top in the reference).
+           - R&T §11932–11933: DTT declaration opens with
+             "THE UNDERSIGNED GRANTOR(S) DECLARE(S):" and shows the
+             computed-on and unincorporated/City checklines.
+           - Gov. Code §27361.7 reproducibility: recorded pages carry no
+             color, no backgrounds, no branding. The QR/verification block
+             was REMOVED from recorded pages — the capability survives as
+             data (deed_pdfs.sha256 + metadata + the /api/verify portal).
+           ========================================================================== */
+
+        @page {
+            size: letter;
+            margin: 0.5in 0.5in 0.6in 0.6in;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: "Times New Roman", Times, Georgia, serif;
+            font-size: 11pt;
+            line-height: 1.35;
+            color: #000;
+            background: #fff;
+        }
+
+        /* --------------------------------------------------------------------------
+           PAGE-ONE HEADER — left info column beside the open recorder's space.
+           The vertical rule at 3.4in marks the left boundary of the recorder's
+           space, exactly as on the reference form. The space itself is empty.
+           -------------------------------------------------------------------------- */
+
+        .header-section {
+            display: flex;
+            min-height: 1.85in;
+        }
+
+        .recording-info {
+            width: 3.4in;
+            flex-shrink: 0;
+            border-right: 0.75pt solid #000;
+            padding-right: 0.15in;
+            font-size: 10pt;
+            line-height: 1.35;
+        }
+
+        .recorder-space {
+            /* Open space for the recorder — nothing renders here. */
+            flex-grow: 1;
+        }
+
+        .recording-label {
+            font-weight: bold;
+            text-transform: uppercase;
+            font-size: 9pt;
+        }
+
+        .recording-value {
+            margin-bottom: 0.12in;
+            min-height: 0.35in;
+        }
+
+        .ref-line {
+            font-size: 10pt;
+        }
+
+        /* Boundary row: APN left, recorder caption right, rule underneath. */
+        .header-boundary {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            border-bottom: 0.75pt solid #000;
+            padding-bottom: 0.03in;
+            margin-bottom: 0.12in;
+        }
+
+        .apn-ref {
+            /* D2: the parcel id carries the same weight as the parties. */
+            font-weight: bold;
+            font-size: 10pt;
+        }
+
+        .recorder-caption {
+            font-size: 7.5pt;
+            font-weight: bold;
+            text-transform: uppercase;
+        }
+
+        /* --------------------------------------------------------------------------
+           TITLE
+           -------------------------------------------------------------------------- */
+
+        .deed-title {
+            text-align: center;
+            font-size: 14pt;
+            font-weight: bold;
+            letter-spacing: 2px;
+            text-transform: uppercase;
+            margin: 0.08in 0 0.12in 0;
+        }
+
+        /* --------------------------------------------------------------------------
+           DOCUMENTARY TRANSFER TAX DECLARATION — statutory wording, no chrome.
+           -------------------------------------------------------------------------- */
+
+        .dtt-section {
+            font-size: 10pt;
+            line-height: 1.5;
+            margin-bottom: 0.15in;
+        }
+
+        .dtt-lead {
+            display: flex;
+            justify-content: space-between;
+            gap: 0.2in;
+        }
+
+        .dtt-amount {
+            border-bottom: 0.75pt solid #000;
+            min-width: 1.6in;
+            display: inline-block;
+            text-align: center;
+        }
+
+        .checkline {
+            display: inline-block;
+            width: 0.35in;
+            border-bottom: 0.75pt solid #000;
+            text-align: center;
+            font-weight: bold;
+            margin-right: 0.06in;
+        }
+
+        .dtt-option {
+            margin-left: 0.15in;
+        }
+
+        .city-field {
+            border-bottom: 0.75pt solid #000;
+            min-width: 1.8in;
+            display: inline-block;
+            text-align: center;
+        }
+
+        .dtt-exempt {
+            margin-left: 0.15in;
+        }
+
+        /* --------------------------------------------------------------------------
+           DEED BODY
+           -------------------------------------------------------------------------- */
+
+        .deed-body {
+            font-size: 11pt;
+            line-height: 1.45;
+        }
+
+        .deed-body p {
+            margin-bottom: 0.08in;
+        }
+
+        .party-name {
+            font-weight: bold;
+            text-transform: uppercase;
+        }
+
+        .legal-content {
+            /* D1: the property description carries the same weight as the
+               parties — the three data blocks an examiner scans first. */
+            font-weight: bold;
+            white-space: pre-wrap;
+            margin: 0.08in 0 0.08in 0;
+        }
+
+        .legal-exhibit-ref {
+            font-weight: bold;
+            margin: 0.08in 0;
+        }
+
+        .apn-line { font-weight: bold;
+            margin-top: 0.08in;
+        }
+
+        /* --------------------------------------------------------------------------
+           EXECUTION — date left, signature lines right (reference layout).
+           -------------------------------------------------------------------------- */
+
+        .execution-section {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            margin-top: 0.25in;
+            page-break-inside: avoid;
+        }
+
+        .execution-date {
+            padding-top: 0.25in;
+        }
+
+        .date-value {
+            border-bottom: 0.75pt solid #000;
+            min-width: 1.8in;
+            display: inline-block;
+            text-align: center;
+        }
+
+        .signatures {
+            width: 3.4in;
+        }
+
+        .signature-entry {
+            margin-bottom: 0.35in;
+        }
+
+        .signature-line {
+            border-bottom: 0.75pt solid #000;
+            width: 3.4in;
+            height: 0.35in;
+        }
+
+        .signature-name {
+            font-size: 10pt;
+            text-transform: uppercase;
+        }
+
+        /* --------------------------------------------------------------------------
+           PAGE-ONE FOOTER — statutory mail-tax directive, nothing else.
+           -------------------------------------------------------------------------- */
+
+        .mail-tax-directive {
+            text-align: center;
+            font-size: 9pt;
+            font-weight: bold;
+            text-transform: uppercase;
+            margin-top: 0.3in;
+        }
+
+        /* --------------------------------------------------------------------------
+           EXHIBIT A (legal-description overflow) — plain page.
+           -------------------------------------------------------------------------- */
+
+        .page-break {
+            page-break-before: always;
+        }
+
+        .exhibit-page {
+            padding-top: 0.5in;
+        }
+
+        .exhibit-header {
+            text-align: center;
+            margin-bottom: 0.4in;
+        }
+
+        .exhibit-title {
+            font-size: 14pt;
+            font-weight: bold;
+            text-transform: uppercase;
+            letter-spacing: 2px;
+        }
+
+        .exhibit-subtitle {
+            font-size: 11pt;
+            margin-top: 0.08in;
+        }
+
+        .exhibit-reference {
+            font-size: 10pt;
+            margin-top: 0.12in;
+        }
+
+        .exhibit-content {
+            font-size: 11pt;
+            line-height: 1.5;
+            text-align: justify;
+            white-space: pre-wrap;
+        }
+
+        .exhibit-apn {
+            margin-top: 0.3in;
+            font-size: 10pt;
+        }
+
+        /* G3: the acknowledgment partial now carries its own single-page
+           spacing — the G2-era local overrides are retired. */
+    </style>
+</head>
+<body>
+    <div class="deed-page">
+
+        <!-- ================================================================
+             PAGE-ONE HEADER — info column + open recorder's space
+             ================================================================ -->
+
+        <header class="header-section">
+            <div class="recording-info">
+                <div class="recording-label">Recording Requested By:</div>
+                <div class="recording-value">{{ requested_by or title_company or '' }}{% if requested_by_address %}<br>{{ requested_by_address }}{% endif %}</div>
+
+                <div class="recording-label">Mail Tax Statements and<br>When Recorded Mail To:</div>
+                <div class="recording-value">
+                    {% if return_to %}
+                        {% if return_to.get('name') %}{{ return_to.get('name') }}<br>{% endif %}
+                        {% if return_to.get('company') %}{{ return_to.get('company') }}<br>{% endif %}
+                        {% if return_to.get('address1') %}{{ return_to.get('address1') }}<br>{% endif %}
+                        {% if return_to.get('address2') %}{{ return_to.get('address2') }}<br>{% endif %}
+                        {% set city = return_to.get('city', '') %}
+                        {% set state = return_to.get('state', '') %}
+                        {% set zip = return_to.get('zip', '') %}
+                        {% if city or state or zip %}
+                            {{ city }}{% if city and (state or zip) %}, {% endif %}{{ state }} {{ zip }}
+                        {% endif %}
+                    {% else %}
+                        _________________________________<br>
+                        _________________________________<br>
+                        _________________________________
+                    {% endif %}
+                </div>
+
+                <div class="ref-line">Order No.: {{ title_order_no or '____________________' }}</div>
+                <div class="ref-line">Escrow No.: {{ escrow_no or '____________________' }}</div>
+            </div>
+
+            <div class="recorder-space"><!-- Gov. Code §27361.6 — recorder's use only --></div>
+        </header>
+
+        <div class="header-boundary">
+            <span class="apn-ref">APN: {{ apn or '____________________' }}</span>
+            <span class="recorder-caption">Space Above This Line Is For Recorder&rsquo;s Use</span>
+        </div>
+
+        <!-- ================================================================
+             TITLE
+             ================================================================ -->
+
+        <h1 class="deed-title">Corporation Grant Deed</h1>
+
+        <!-- ================================================================
+             DOCUMENTARY TRANSFER TAX — R&T §11932–11933 declaration
+             ================================================================ -->
+
+        <div class="dtt-section">
+            <div class="dtt-lead">
+                <span>THE UNDERSIGNED GRANTOR(S) DECLARE(S):</span>
+                <span>DOCUMENTARY TRANSFER TAX IS
+                    <span class="dtt-amount">${{ dtt.get('amount', '') if dtt else '' }}</span>
+                </span>
+            </div>
+            <div class="dtt-option">
+                <span class="checkline">{% if dtt and dtt.get('basis') == 'full' %}X{% endif %}</span>
+                Computed on full value of property conveyed, or
+            </div>
+            <div class="dtt-option">
+                <span class="checkline">{% if dtt and dtt.get('basis') == 'less_liens' %}X{% endif %}</span>
+                Computed on full value less liens and encumbrances remaining at time of sale.
+            </div>
+            <div class="dtt-option">
+                <span class="checkline">{% if dtt and dtt.get('area_type') == 'unincorporated' %}X{% endif %}</span>
+                Unincorporated area&nbsp;&nbsp;&nbsp;
+                <span class="checkline">{% if dtt and dtt.get('area_type') == 'city' %}X{% endif %}</span>
+                City of <span class="city-field">{{ dtt.get('city_name', '') if dtt else '' }}</span>
+            </div>
+            {% if dtt and dtt.get('is_exempt') and dtt.get('exemption_reason') %}
+            <div class="dtt-exempt">Exempt from transfer tax: {{ dtt.get('exemption_reason') }}</div>
+            {% endif %}
+        </div>
+
+        <!-- ================================================================
+             GRANTING CLAUSE — standard deed wording, no defined-term labels
+             ================================================================ -->
+
+        <div class="deed-body">
+            <p>For valuable consideration, receipt of which is hereby acknowledged,</p>
+
+            <p class="party-name">{{ grantors_text or '_________________________________________________' }}</p>
+
+            <p>
+                {% set aff = affidavit or {} %}
+                a corporation organized under the laws of the State of
+                {% if aff.get('entity_state') %}<strong>{{ aff.get('entity_state') }}</strong>{% else %}____________________{% endif %}
+                hereby GRANTS to
+            </p>
+
+            <p><span class="party-name">{{ grantees_text or '_________________________________________________' }}</span>{% if vesting %}, {{ vesting }}{% endif %}</p>
+
+            <p>
+                the real property situated in the County of
+                <strong>{{ county or '___________________________' }}</strong>,
+                State of California, more particularly described as follows:
+            </p>
+
+            {% if legal_description and legal_description|length > (exhibit_threshold or 600) %}
+                <p class="legal-exhibit-ref">
+                    See Exhibit &ldquo;A&rdquo; attached hereto and incorporated herein by this reference.
+                </p>
+            {% else %}
+                <div class="legal-content">{{ legal_description or 'LEGAL DESCRIPTION TO BE INSERTED' }}</div>
+            {% endif %}
+
+            {% if apn %}
+            <div class="apn-line">Assessor&rsquo;s Parcel Number: {{ apn }}</div>
+            {% endif %}
+        </div>
+
+        <!-- ================================================================
+             EXECUTION — date left, signatures right
+             ================================================================ -->
+
+        <div class="execution-section">
+            <div class="execution-date">
+                Dated: <span class="date-value">{{ execution_date or now().strftime('%B %d, %Y') }}</span>
+            </div>
+
+            <div class="signatures">
+                {# Entity execution: the entity is named; the officers/
+                   partners sign in capacity — "By/And" lines are furniture
+                   verified from the reference; signatures stay blank. #}
+                <div class="signature-entry">
+                    <div class="signature-name">{{ grantors_text or '' }}</div>
+                </div>
+                <div class="signature-entry">
+                    <div class="signature-line"></div>
+                    <div class="signature-name">By</div>
+                </div>
+                <div class="signature-entry">
+                    <div class="signature-line"></div>
+                    <div class="signature-name">And</div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Statutory footer directive (pairs with the combined mail-to block) -->
+        <div class="mail-tax-directive">Mail Tax Statements As Directed Above</div>
+
+    </div>
+
+    <!-- ====================================================================
+         EXHIBIT A — Legal Description (if too long for page one)
+         ==================================================================== -->
+
+    {% if legal_description and legal_description|length > (exhibit_threshold or 600) %}
+    <div class="page-break"></div>
+    <div class="exhibit-page">
+        <div class="exhibit-header">
+            <div class="exhibit-title">Exhibit &ldquo;A&rdquo;</div>
+            <div class="exhibit-subtitle">Legal Description</div>
+            <div class="exhibit-reference">
+                Attached to and made a part of Corporation Grant Deed dated {{ execution_date or now().strftime('%B %d, %Y') }}
+            </div>
+        </div>
+
+        <div class="exhibit-content">{{ legal_description }}</div>
+
+        {% if apn %}
+        <div class="exhibit-apn">Assessor&rsquo;s Parcel Number: {{ apn }}</div>
+        {% endif %}
+    </div>
+    {% endif %}
+
+    <!-- ====================================================================
+         CALIFORNIA ALL-PURPOSE ACKNOWLEDGMENT — Civil Code §1189
+         (shared partial; the notary completes its contents, never us)
+         ==================================================================== -->
+    {% set document_title = 'Corporation Grant Deed' %}
+    {% include '_partials/notary_acknowledgment.jinja2' %}
+
+</body>
+</html>

--- a/templates/grant_deed_partnership_ca/index.jinja2
+++ b/templates/grant_deed_partnership_ca/index.jinja2
@@ -1,0 +1,499 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Partnership Grant Deed - California</title>
+    <style>
+        /* ==========================================================================
+           PARTNERSHIP GRANT DEED — CALIFORNIA (wave 2 #6)
+
+           Entity-grantor variant of the grant-deed chassis (PCT reference
+           blank form #29, Deed-Partnership). The entity recital ("a ___
+           partnership organized under the laws of the State of ___") is
+           instrument-defining furniture (Flag-3); the partnership type
+           and state of organization are typed officer facts, blanks
+           tolerated. General partners sign in capacity: the "By/And ...
+           General Partner" lines are furniture verified from the
+           reference. Every other chassis behavior — full R&T §11932–11933
+           DTT declaration, officer vesting, §1189 acknowledgment — is the
+           grant deed's. Chassis notes below are the grant deed's.
+
+           Geometry mirrors the owner's reference sample of a standard recorded
+           CA Grant Deed plus statute:
+           - Gov. Code §27361.6: recorder's space top-right of page one
+             (open space — no drawn box; a border invites rejection), caption
+             "SPACE ABOVE THIS LINE IS FOR RECORDER'S USE" at its bottom
+             boundary (~2.66" from the page top in the reference).
+           - R&T §11932–11933: DTT declaration opens with
+             "THE UNDERSIGNED GRANTOR(S) DECLARE(S):" and shows the
+             computed-on and unincorporated/City checklines.
+           - Gov. Code §27361.7 reproducibility: recorded pages carry no
+             color, no backgrounds, no branding. The QR/verification block
+             was REMOVED from recorded pages — the capability survives as
+             data (deed_pdfs.sha256 + metadata + the /api/verify portal).
+           ========================================================================== */
+
+        @page {
+            size: letter;
+            margin: 0.5in 0.5in 0.6in 0.6in;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: "Times New Roman", Times, Georgia, serif;
+            font-size: 11pt;
+            line-height: 1.35;
+            color: #000;
+            background: #fff;
+        }
+
+        /* --------------------------------------------------------------------------
+           PAGE-ONE HEADER — left info column beside the open recorder's space.
+           The vertical rule at 3.4in marks the left boundary of the recorder's
+           space, exactly as on the reference form. The space itself is empty.
+           -------------------------------------------------------------------------- */
+
+        .header-section {
+            display: flex;
+            min-height: 1.85in;
+        }
+
+        .recording-info {
+            width: 3.4in;
+            flex-shrink: 0;
+            border-right: 0.75pt solid #000;
+            padding-right: 0.15in;
+            font-size: 10pt;
+            line-height: 1.35;
+        }
+
+        .recorder-space {
+            /* Open space for the recorder — nothing renders here. */
+            flex-grow: 1;
+        }
+
+        .recording-label {
+            font-weight: bold;
+            text-transform: uppercase;
+            font-size: 9pt;
+        }
+
+        .recording-value {
+            margin-bottom: 0.12in;
+            min-height: 0.35in;
+        }
+
+        .ref-line {
+            font-size: 10pt;
+        }
+
+        /* Boundary row: APN left, recorder caption right, rule underneath. */
+        .header-boundary {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            border-bottom: 0.75pt solid #000;
+            padding-bottom: 0.03in;
+            margin-bottom: 0.12in;
+        }
+
+        .apn-ref {
+            /* D2: the parcel id carries the same weight as the parties. */
+            font-weight: bold;
+            font-size: 10pt;
+        }
+
+        .recorder-caption {
+            font-size: 7.5pt;
+            font-weight: bold;
+            text-transform: uppercase;
+        }
+
+        /* --------------------------------------------------------------------------
+           TITLE
+           -------------------------------------------------------------------------- */
+
+        .deed-title {
+            text-align: center;
+            font-size: 14pt;
+            font-weight: bold;
+            letter-spacing: 2px;
+            text-transform: uppercase;
+            margin: 0.08in 0 0.12in 0;
+        }
+
+        /* --------------------------------------------------------------------------
+           DOCUMENTARY TRANSFER TAX DECLARATION — statutory wording, no chrome.
+           -------------------------------------------------------------------------- */
+
+        .dtt-section {
+            font-size: 10pt;
+            line-height: 1.5;
+            margin-bottom: 0.15in;
+        }
+
+        .dtt-lead {
+            display: flex;
+            justify-content: space-between;
+            gap: 0.2in;
+        }
+
+        .dtt-amount {
+            border-bottom: 0.75pt solid #000;
+            min-width: 1.6in;
+            display: inline-block;
+            text-align: center;
+        }
+
+        .checkline {
+            display: inline-block;
+            width: 0.35in;
+            border-bottom: 0.75pt solid #000;
+            text-align: center;
+            font-weight: bold;
+            margin-right: 0.06in;
+        }
+
+        .dtt-option {
+            margin-left: 0.15in;
+        }
+
+        .city-field {
+            border-bottom: 0.75pt solid #000;
+            min-width: 1.8in;
+            display: inline-block;
+            text-align: center;
+        }
+
+        .dtt-exempt {
+            margin-left: 0.15in;
+        }
+
+        /* --------------------------------------------------------------------------
+           DEED BODY
+           -------------------------------------------------------------------------- */
+
+        .deed-body {
+            font-size: 11pt;
+            line-height: 1.45;
+        }
+
+        .deed-body p {
+            margin-bottom: 0.08in;
+        }
+
+        .party-name {
+            font-weight: bold;
+            text-transform: uppercase;
+        }
+
+        .legal-content {
+            /* D1: the property description carries the same weight as the
+               parties — the three data blocks an examiner scans first. */
+            font-weight: bold;
+            white-space: pre-wrap;
+            margin: 0.08in 0 0.08in 0;
+        }
+
+        .legal-exhibit-ref {
+            font-weight: bold;
+            margin: 0.08in 0;
+        }
+
+        .apn-line { font-weight: bold;
+            margin-top: 0.08in;
+        }
+
+        /* --------------------------------------------------------------------------
+           EXECUTION — date left, signature lines right (reference layout).
+           -------------------------------------------------------------------------- */
+
+        .execution-section {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-start;
+            margin-top: 0.25in;
+            page-break-inside: avoid;
+        }
+
+        .execution-date {
+            padding-top: 0.25in;
+        }
+
+        .date-value {
+            border-bottom: 0.75pt solid #000;
+            min-width: 1.8in;
+            display: inline-block;
+            text-align: center;
+        }
+
+        .signatures {
+            width: 3.4in;
+        }
+
+        .signature-entry {
+            margin-bottom: 0.35in;
+        }
+
+        .signature-line {
+            border-bottom: 0.75pt solid #000;
+            width: 3.4in;
+            height: 0.35in;
+        }
+
+        .signature-name {
+            font-size: 10pt;
+            text-transform: uppercase;
+        }
+
+        /* --------------------------------------------------------------------------
+           PAGE-ONE FOOTER — statutory mail-tax directive, nothing else.
+           -------------------------------------------------------------------------- */
+
+        .mail-tax-directive {
+            text-align: center;
+            font-size: 9pt;
+            font-weight: bold;
+            text-transform: uppercase;
+            margin-top: 0.3in;
+        }
+
+        /* --------------------------------------------------------------------------
+           EXHIBIT A (legal-description overflow) — plain page.
+           -------------------------------------------------------------------------- */
+
+        .page-break {
+            page-break-before: always;
+        }
+
+        .exhibit-page {
+            padding-top: 0.5in;
+        }
+
+        .exhibit-header {
+            text-align: center;
+            margin-bottom: 0.4in;
+        }
+
+        .exhibit-title {
+            font-size: 14pt;
+            font-weight: bold;
+            text-transform: uppercase;
+            letter-spacing: 2px;
+        }
+
+        .exhibit-subtitle {
+            font-size: 11pt;
+            margin-top: 0.08in;
+        }
+
+        .exhibit-reference {
+            font-size: 10pt;
+            margin-top: 0.12in;
+        }
+
+        .exhibit-content {
+            font-size: 11pt;
+            line-height: 1.5;
+            text-align: justify;
+            white-space: pre-wrap;
+        }
+
+        .exhibit-apn {
+            margin-top: 0.3in;
+            font-size: 10pt;
+        }
+
+        /* G3: the acknowledgment partial now carries its own single-page
+           spacing — the G2-era local overrides are retired. */
+    </style>
+</head>
+<body>
+    <div class="deed-page">
+
+        <!-- ================================================================
+             PAGE-ONE HEADER — info column + open recorder's space
+             ================================================================ -->
+
+        <header class="header-section">
+            <div class="recording-info">
+                <div class="recording-label">Recording Requested By:</div>
+                <div class="recording-value">{{ requested_by or title_company or '' }}{% if requested_by_address %}<br>{{ requested_by_address }}{% endif %}</div>
+
+                <div class="recording-label">Mail Tax Statements and<br>When Recorded Mail To:</div>
+                <div class="recording-value">
+                    {% if return_to %}
+                        {% if return_to.get('name') %}{{ return_to.get('name') }}<br>{% endif %}
+                        {% if return_to.get('company') %}{{ return_to.get('company') }}<br>{% endif %}
+                        {% if return_to.get('address1') %}{{ return_to.get('address1') }}<br>{% endif %}
+                        {% if return_to.get('address2') %}{{ return_to.get('address2') }}<br>{% endif %}
+                        {% set city = return_to.get('city', '') %}
+                        {% set state = return_to.get('state', '') %}
+                        {% set zip = return_to.get('zip', '') %}
+                        {% if city or state or zip %}
+                            {{ city }}{% if city and (state or zip) %}, {% endif %}{{ state }} {{ zip }}
+                        {% endif %}
+                    {% else %}
+                        _________________________________<br>
+                        _________________________________<br>
+                        _________________________________
+                    {% endif %}
+                </div>
+
+                <div class="ref-line">Order No.: {{ title_order_no or '____________________' }}</div>
+                <div class="ref-line">Escrow No.: {{ escrow_no or '____________________' }}</div>
+            </div>
+
+            <div class="recorder-space"><!-- Gov. Code §27361.6 — recorder's use only --></div>
+        </header>
+
+        <div class="header-boundary">
+            <span class="apn-ref">APN: {{ apn or '____________________' }}</span>
+            <span class="recorder-caption">Space Above This Line Is For Recorder&rsquo;s Use</span>
+        </div>
+
+        <!-- ================================================================
+             TITLE
+             ================================================================ -->
+
+        <h1 class="deed-title">Partnership Grant Deed</h1>
+
+        <!-- ================================================================
+             DOCUMENTARY TRANSFER TAX — R&T §11932–11933 declaration
+             ================================================================ -->
+
+        <div class="dtt-section">
+            <div class="dtt-lead">
+                <span>THE UNDERSIGNED GRANTOR(S) DECLARE(S):</span>
+                <span>DOCUMENTARY TRANSFER TAX IS
+                    <span class="dtt-amount">${{ dtt.get('amount', '') if dtt else '' }}</span>
+                </span>
+            </div>
+            <div class="dtt-option">
+                <span class="checkline">{% if dtt and dtt.get('basis') == 'full' %}X{% endif %}</span>
+                Computed on full value of property conveyed, or
+            </div>
+            <div class="dtt-option">
+                <span class="checkline">{% if dtt and dtt.get('basis') == 'less_liens' %}X{% endif %}</span>
+                Computed on full value less liens and encumbrances remaining at time of sale.
+            </div>
+            <div class="dtt-option">
+                <span class="checkline">{% if dtt and dtt.get('area_type') == 'unincorporated' %}X{% endif %}</span>
+                Unincorporated area&nbsp;&nbsp;&nbsp;
+                <span class="checkline">{% if dtt and dtt.get('area_type') == 'city' %}X{% endif %}</span>
+                City of <span class="city-field">{{ dtt.get('city_name', '') if dtt else '' }}</span>
+            </div>
+            {% if dtt and dtt.get('is_exempt') and dtt.get('exemption_reason') %}
+            <div class="dtt-exempt">Exempt from transfer tax: {{ dtt.get('exemption_reason') }}</div>
+            {% endif %}
+        </div>
+
+        <!-- ================================================================
+             GRANTING CLAUSE — standard deed wording, no defined-term labels
+             ================================================================ -->
+
+        <div class="deed-body">
+            <p>For valuable consideration, receipt of which is hereby acknowledged,</p>
+
+            <p class="party-name">{{ grantors_text or '_________________________________________________' }}</p>
+
+            <p>
+                {% set aff = affidavit or {} %}
+                a {% if aff.get('partnership_type') %}<strong>{{ aff.get('partnership_type') }}</strong>{% else %}___________{% endif %}
+                partnership organized under the laws of the State of
+                {% if aff.get('entity_state') %}<strong>{{ aff.get('entity_state') }}</strong>{% else %}______________{% endif %}
+                hereby GRANTS to
+            </p>
+
+            <p><span class="party-name">{{ grantees_text or '_________________________________________________' }}</span>{% if vesting %}, {{ vesting }}{% endif %}</p>
+
+            <p>
+                the real property situated in the County of
+                <strong>{{ county or '___________________________' }}</strong>,
+                State of California, more particularly described as follows:
+            </p>
+
+            {% if legal_description and legal_description|length > (exhibit_threshold or 600) %}
+                <p class="legal-exhibit-ref">
+                    See Exhibit &ldquo;A&rdquo; attached hereto and incorporated herein by this reference.
+                </p>
+            {% else %}
+                <div class="legal-content">{{ legal_description or 'LEGAL DESCRIPTION TO BE INSERTED' }}</div>
+            {% endif %}
+
+            {% if apn %}
+            <div class="apn-line">Assessor&rsquo;s Parcel Number: {{ apn }}</div>
+            {% endif %}
+        </div>
+
+        <!-- ================================================================
+             EXECUTION — date left, signatures right
+             ================================================================ -->
+
+        <div class="execution-section">
+            <div class="execution-date">
+                Dated: <span class="date-value">{{ execution_date or now().strftime('%B %d, %Y') }}</span>
+            </div>
+
+            <div class="signatures">
+                {# Entity execution: the entity is named; the officers/
+                   partners sign in capacity — "By/And" lines are furniture
+                   verified from the reference; signatures stay blank. #}
+                <div class="signature-entry">
+                    <div class="signature-name">{{ grantors_text or '' }}</div>
+                </div>
+                <div class="signature-entry">
+                    <div class="signature-line"></div>
+                    <div class="signature-name">By
+                    <div class="signature-name">General Partner</div></div>
+                </div>
+                <div class="signature-entry">
+                    <div class="signature-line"></div>
+                    <div class="signature-name">And
+                    <div class="signature-name">General Partner</div></div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Statutory footer directive (pairs with the combined mail-to block) -->
+        <div class="mail-tax-directive">Mail Tax Statements As Directed Above</div>
+
+    </div>
+
+    <!-- ====================================================================
+         EXHIBIT A — Legal Description (if too long for page one)
+         ==================================================================== -->
+
+    {% if legal_description and legal_description|length > (exhibit_threshold or 600) %}
+    <div class="page-break"></div>
+    <div class="exhibit-page">
+        <div class="exhibit-header">
+            <div class="exhibit-title">Exhibit &ldquo;A&rdquo;</div>
+            <div class="exhibit-subtitle">Legal Description</div>
+            <div class="exhibit-reference">
+                Attached to and made a part of Partnership Grant Deed dated {{ execution_date or now().strftime('%B %d, %Y') }}
+            </div>
+        </div>
+
+        <div class="exhibit-content">{{ legal_description }}</div>
+
+        {% if apn %}
+        <div class="exhibit-apn">Assessor&rsquo;s Parcel Number: {{ apn }}</div>
+        {% endif %}
+    </div>
+    {% endif %}
+
+    <!-- ====================================================================
+         CALIFORNIA ALL-PURPOSE ACKNOWLEDGMENT — Civil Code §1189
+         (shared partial; the notary completes its contents, never us)
+         ==================================================================== -->
+    {% set document_title = 'Partnership Grant Deed' %}
+    {% include '_partials/notary_acknowledgment.jinja2' %}
+
+</body>
+</html>


### PR DESCRIPTION
## Wave 2, form #6 — the first entity grantors

### Two references, one owner-named form
"Grant Deed — Corporation/Partnership as Grantor" spans both entity kinds by its own label; PCT implements it as two blanks — #22 (`Deed-Corporation`) and #29 (`Deed-Partnership`). Both fetched and measured (one page + acknowledgment, full DTT block, standard chassis). Building both siblings IS the ordered form — stated here per check #5 rather than silently assumed.

## Drift review (all six attestations)

**1. Certificate from the reference.** Both blanks print the **§1189 acknowledgment** — verified before family assignment, canary pinned both directions.

**2. Doctrine-pass diff against precedent.** Entity recitals ("a corporation organized under the laws of the State of ___" / "a ___ partnership organized…") → **Flag-3 instrument-defining furniture** (choosing the form IS declaring the grantor's kind — the fixed-vesting-phrase class). State-of-organization and partnership-type blanks → typed officer facts (the trust-particulars transcription class, blanks tolerated per the gate-strictness ruling). Capacity signature lines → furniture **verified from the references** per the special-attention flag: the corporation signs bare "By ___ / And ___" (no Title line); the partnership adds "General Partner" captions, occurrence-pinned at exactly two in the execution region. **No entity-type selection shapes legal content within either form → no hold.** The entity is *named* in the signature block; the By/And lines stay blank for the officers'/partners' hands (blank-contents).

**3. Coherence pins before template.** Both entries in the deed-family branch (acknowledgment + `hasDtt: true` + transferTax section); count pin 17 → 19; backend family mirror updated; `ENTITY_GRANTOR_RECITALS` and `hereby GRANTS to` drift-pinned preview↔template — the conformance sweep now covers **nine** deed templates.

**4. Ledger consistency.** Nothing made stale.

**5. No silent scope absorption.** The two-references-one-form reading is stated above; nothing else touched.

**6. Per-form gate attestation.**
- [x] Geometry pins vs. reference: ≤2 pages (page one + certificate), caption >100pt/>300pt, title below caption — both forms
- [x] Statutory/furniture strings verbatim: full R&T §11932–11933 DTT declaration with the officer's recorded decision; entity recitals; capacity captions
- [x] Blank-contents occurrence pins: one certificate each; entity names absent from the certificate; entity facts tolerated blank (nothing invented); signature lines blank
- [x] Backend **225 passed** (was 209; +16) · six-flow ✔ unchanged · jest **292** (+8) · tsc frozen **98**

### Per-form actuals vs. 1–2 hr projection
~1 hr for the pair (~30 min/form) — the deed chassis again needed zero rework; the cost was the entity-facts plumbing and pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_