### PR TITLE
FORMS wave 2 (#7): Uniform Statutory Form Power of Attorney (Prob C §4401)

### DIFF
--- a/backend/services/deed_pdf.py
+++ b/backend/services/deed_pdf.py
@@ -60,6 +60,8 @@ TEMPLATE_BY_DEED_TYPE = {
     # FORMS wave 2 #6 — entity grantors (PCT references #22 and #29).
     "grant-deed-corp": "grant_deed_corp_ca/index.jinja2",
     "grant-deed-partnership": "grant_deed_partnership_ca/index.jinja2",
+    # FORMS wave 2 #7 — statutory POA (Prob C §4401; PCT reference #55).
+    "poa-statutory": "poa_statutory_ca/index.jinja2",
 }
 DEFAULT_TEMPLATE = "grant_deed_ca/index.jinja2"
 

--- a/backend/services/form_families.py
+++ b/backend/services/form_families.py
@@ -39,6 +39,7 @@ FAMILY_BY_DEED_TYPE = {
     "tod-revocation": "declaration",
     "homestead-declaration-spouses": "declaration",
     "homestead-abandonment": "declaration",
+    "poa-statutory": "declaration",
 }
 
 SINGLE_PARTY_FAMILIES = {"declaration"}
@@ -47,7 +48,7 @@ SINGLE_PARTY_FAMILIES = {"declaration"}
 # description (the certification of trust certifies a TRUST — Prob C
 # §18100.5). Everything else still requires a legal description on the
 # generate path.
-PROPERTYLESS_TYPES = {"trust-certification"}
+PROPERTYLESS_TYPES = {"trust-certification", "poa-statutory"}
 
 
 def family_of(deed_type):

--- a/backend/tests/test_wave2_poa.py
+++ b/backend/tests/test_wave2_poa.py
@@ -1,0 +1,174 @@
+"""FORMS wave 2 #7 — Uniform Statutory Form Power of Attorney, pinned.
+
+The STATUTORY form (Prob C §4401; PCT reference #55 mirrors it). The
+wave's flagged high-risk object, resolved WITHOUT force:
+
+- TYPED OFFICER FACTS — exactly two: the principal's name/address and
+  the appointee(s). Nothing else is an input.
+- THE PRINCIPAL'S EXECUTION ACTS — blank/verbatim, always: 14 power
+  initial lines (cert-of-trust ruling, directly on point); the
+  special-instruction lines and the SEPARATELY/JOINTLY word-blank
+  (signer-completed text blanks, the "Other:"-line class — the
+  word-blank carries a jointly-by-default legal effect, so pre-writing
+  it would fabricate an election); the incapacity sentence prints
+  verbatim and is NEVER pre-struck.
+
+Certificate verified from the reference: §1189 acknowledgment, inline on
+page two. Property-less, single-party (principal), no DTT.
+"""
+import io
+import re
+
+import pdfplumber
+
+from services.deed_pdf import render_deed_html, render_deed_pdf
+from tests.test_deed_pdf import _normalized
+
+POA_META = {
+    "requested_by_address": "456 Escrow Way, Los Angeles, CA 90012",
+    "return_to": {"name": "ROBERT OWNER", "address1": "1358 5TH ST",
+                  "city": "Santa Monica", "state": "CA", "zip": "90401"},
+    "title_order_no": "TO-9921",
+    "escrow_no": "ESC-4410",
+    "affidavit": {
+        "principal_name": "ROBERT OWNER, 1358 5TH ST, SANTA MONICA, CA 90401",
+        "agent_names": "JANE B. DOE, 456 ESCROW WAY, LOS ANGELES, CA 90012",
+    },
+}
+
+
+def poa_row(**overrides):
+    row = {
+        "id": 1,
+        "deed_type": "poa-statutory",
+        "grantor_name": "",
+        "grantee_name": "",
+        "parties": {"principal": "ROBERT OWNER"},
+        "legal_description": "",
+        "county": "",
+        "apn": "",
+        "property_address": "",
+        "requested_by": "Pacific Coast Escrow",
+        "metadata": POA_META,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_statutory_furniture_verbatim():
+    html = _normalized(render_deed_html(poa_row()))
+    assert "Uniform Statutory Form Power of Attorney" in html
+    assert "(California Probate Code Section 4401)" in html
+    assert "THE POWERS GRANTED BY THIS DOCUMENT ARE BROAD AND SWEEPING" in html
+    assert "PROBATE CODE SECTIONS 4400-4465" in html
+    assert "DOES NOT AUTHORIZE ANYONE TO MAKE MEDICAL AND OTHER HEALTH-CARE" in html
+    assert "as my agent (attorney-in-fact) to act for me in any lawful way" in html
+    assert "TO WITHHOLD A POWER, DO NOT INITIAL THE LINE IN FRONT OF IT" in html
+    assert "(A) Real property transactions." in html
+    assert "(N) ALL OF THE POWERS LISTED ABOVE." in html
+    assert "YOU NEED NOT INITIAL ANY OTHER LINES IF YOU INITIAL LINE (N)." in html
+    assert "SPECIAL INSTRUCTIONS: ON THE FOLLOWING LINES" in html
+    assert "EFFECTIVE IMMEDIATELY AND WILL CONTINUE UNTIL IT IS REVOKED" in html
+    assert "I agree to indemnify the third party" in html
+    assert "THE AGENT ASSUMES THE FIDUCIARY" in html
+
+
+def test_the_two_typed_facts_render():
+    html = _normalized(render_deed_html(poa_row()))
+    assert "ROBERT OWNER, 1358 5TH ST, SANTA MONICA, CA 90401" in html
+    assert "JANE B. DOE, 456 ESCROW WAY, LOS ANGELES, CA 90012" in html
+
+
+def test_missing_facts_render_blank_never_invented():
+    html = render_deed_html(poa_row(parties=None, metadata={}))
+    assert "fact-line" in html
+    assert "ROBERT OWNER" not in html
+
+
+def test_power_initials_blank_always_occurrence_pinned():
+    """THE ruling pin: exactly 14 power initial lines, every one empty."""
+    html = render_deed_html(poa_row())
+    assert html.count('class="initial-line"') == 14
+    for m in re.finditer(r'class="initial-line"[^>]*>([^<]*)<', html):
+        assert m.group(1).strip() in ("", "&nbsp;"), m.group(0)
+
+
+def test_principal_elections_never_pre_completed():
+    """Special-instruction lines empty; the SEPARATELY/JOINTLY word-blank
+    empty (jointly-by-default is the statute's rule, not ours to write);
+    the incapacity sentence verbatim and never struck."""
+    html = render_deed_html(poa_row())
+    assert html.count('class="special-line"') == 3
+    for m in re.finditer(r'class="special-line"[^>]*>([^<]*)<', html):
+        assert m.group(1).strip() == "", m.group(0)
+    body = _normalized(html)
+    assert "the agents are to act" in body
+    assert "SEPARATELY" in body   # only inside the statute's instruction text
+    assert "will continue to be effective even though I become incapacitated" in body
+    assert "STRIKE THE PRECEDING SENTENCE" in body
+    for strike_markup in ("<s>", "<strike>", "line-through"):
+        assert strike_markup not in html, strike_markup
+
+
+def test_acknowledgment_not_jurat_and_contents_blank():
+    html = _normalized(render_deed_html(poa_row()))
+    assert "personally appeared" in html
+    assert "acknowledged to me" in html
+    assert "Subscribed and sworn to (or affirmed) before me" not in html
+    assert html.count("verifies only the identity") == 1
+    ack = html[html.index("personally appeared"):]
+    assert "ROBERT OWNER" not in ack
+    assert "JANE B. DOE" not in ack
+
+
+def test_property_less_no_dtt_no_mail_tax():
+    html = _normalized(render_deed_html(poa_row()))
+    assert "APN:" not in html
+    assert "legal-content" not in html
+    assert "DOCUMENTARY TRANSFER TAX" not in html.upper()
+    assert "Mail Tax Statements" not in html
+    assert "And When Recorded Mail To" in html
+
+
+def test_two_page_statutory_layout_and_no_chrome():
+    """Page 1: notice + appointment + powers. Page 2: instructions +
+    execution + the inline §1189 certificate (as the reference prints)."""
+    pdf = render_deed_pdf(poa_row())
+    with pdfplumber.open(io.BytesIO(pdf)) as doc:
+        assert len(doc.pages) == 2
+        p1 = doc.pages[0].extract_text()
+        p2 = doc.pages[1].extract_text()
+        assert "BROAD AND SWEEPING" in p1
+        assert "(N) ALL OF THE POWERS" in p1
+        assert "SPECIAL INSTRUCTIONS" in p2
+        assert "personally" in p2 and "personally" not in p1
+
+        words = doc.pages[0].extract_words()
+
+        def top_of(needle):
+            hits = [w for w in words if needle.upper() in w["text"].upper()]
+            assert hits, needle
+            return hits[0]["top"]
+
+        def x_of(needle):
+            hits = [w for w in words if needle.upper() in w["text"].upper()]
+            return hits[0]["x0"]
+
+        caption_top = top_of("RECORDER’S")
+        title_top = top_of("STATUTORY")
+        assert caption_top > 100
+        assert x_of("RECORDER’S") > 300
+        assert title_top > caption_top
+
+    html = render_deed_html(poa_row())
+    for leaked in ("7C4DFF", "Generated by", "deedpro.com/verify", "recorder-box", "bg-brand"):
+        assert leaked not in html, leaked
+
+
+def test_registered_in_the_type_and_family_maps():
+    from services.deed_pdf import TEMPLATE_BY_DEED_TYPE
+    from services.form_families import family_of, is_single_party, requires_legal_description
+    assert TEMPLATE_BY_DEED_TYPE["poa-statutory"] == "poa_statutory_ca/index.jinja2"
+    assert family_of("poa-statutory") == "declaration"
+    assert is_single_party("poa-statutory")
+    assert not requires_legal_description("poa-statutory")  # property-less

--- a/frontend/src/__tests__/formRegistry.test.ts
+++ b/frontend/src/__tests__/formRegistry.test.ts
@@ -23,8 +23,13 @@ const KNOWN_SECTIONS = new Set(['property', 'grantor', 'grantee', 'vesting', 'tr
 describe('FORMS registry — completeness and coherence', () => {
   const entries = Object.values(FORM_REGISTRY);
 
-  it('carries the nineteen shipped types', () => {
-    expect(entries.length).toBe(19);
+  it('carries the twenty shipped types', () => {
+    expect(entries.length).toBe(20);
+    // Wave 2 #7 — the statutory POA (acknowledged, property-less,
+    // single-party; only two typed facts by design):
+    expect(formConfig('poa-statutory')?.family).toBe('declaration');
+    expect(formConfig('poa-statutory')?.sections).not.toContain('property');
+    expect((formConfig('poa-statutory')?.affidavitFields ?? []).length).toBe(2);
     // Wave 2 #6 — entity grantors (two references, one owner-named form):
     expect(formConfig('grant-deed-corp')?.family).toBe('deed');
     expect(formConfig('grant-deed-partnership')?.family).toBe('deed');

--- a/frontend/src/components/builder/PreviewPanel.tsx
+++ b/frontend/src/components/builder/PreviewPanel.tsx
@@ -227,7 +227,70 @@ export function PreviewPanel({ state, activeSection, onRegionClick }: PreviewPan
               </div>
             )}
 
-            {isDeclaration && state.deedType === 'tod-revocation' ? (
+            {isDeclaration && state.deedType === 'poa-statutory' ? (
+              <>
+                {/* Prob C §4401 statutory form. Only TWO typed facts; every
+                    other mark is the principal's execution act — blank. */}
+                <div className="text-[9.5px] font-bold text-justify mb-3">
+                  NOTICE: THE POWERS GRANTED BY THIS DOCUMENT ARE BROAD AND SWEEPING. THEY ARE
+                  EXPLAINED IN THE UNIFORM STATUTORY FORM POWER OF ATTORNEY ACT (CALIFORNIA
+                  PROBATE CODE SECTIONS 4400-4465). IF YOU HAVE ANY QUESTIONS ABOUT THESE
+                  POWERS, OBTAIN COMPETENT LEGAL ADVICE. THIS DOCUMENT DOES NOT AUTHORIZE
+                  ANYONE TO MAKE MEDICAL AND OTHER HEALTH-CARE DECISIONS FOR YOU. YOU MAY
+                  REVOKE THIS POWER OF ATTORNEY IF YOU LATER WISH TO DO SO.
+                </div>
+                <div className={`text-[10.5pt] leading-relaxed mb-2 ${highlight('affidavit')}`}>
+                  <p className="mb-1">
+                    I, <span onClick={go('affidavit', 'affidavit-principalName')} className={`font-bold uppercase ${CLICKABLE} ${dataHighlight(aff?.principalName)}`}>{factOrBlank(aff?.principalName)}</span>
+                    {' '}<span className="italic text-[8.5px]">(your name and address)</span>
+                  </p>
+                  <p className="mb-1">
+                    appoint <span onClick={go('affidavit', 'affidavit-agentNames')} className={`font-bold uppercase ${CLICKABLE} ${dataHighlight(aff?.agentNames)}`}>{factOrBlank(aff?.agentNames)}</span>
+                    {' '}<span className="italic text-[8.5px]">(name and address of the person appointed, or of each person appointed if you want to designate more than one)</span>
+                  </p>
+                  <p>as my agent (attorney-in-fact) to act for me in any lawful way with respect to the following initialed subjects:</p>
+                </div>
+                <div className="text-[9px] font-bold mb-2">
+                  TO GRANT ALL OF THE FOLLOWING POWERS, INITIAL THE LINE IN FRONT OF (N)…
+                  TO WITHHOLD A POWER, DO NOT INITIAL THE LINE IN FRONT OF IT.
+                </div>
+                <div className="text-[10px] mb-3">
+                  {['(A) Real property transactions.', '(B) Tangible personal property transactions.', '(C) Stock and bond transactions.',
+                    '(D) Commodity and option transactions.', '(E) Banking and other financial institution transactions.',
+                    '(F) Business operating transactions.', '(G) Insurance and annuity transactions.',
+                    '(H) Estate, trust, and other beneficiary transactions.', '(I) Claims and litigation.',
+                    '(J) Personal and family maintenance.', '(K) Benefits from social security, medicare, medicaid, or other governmental programs, or civil or military service.',
+                    '(L) Retirement plan transactions.', '(M) Tax matters.', '(N) ALL OF THE POWERS LISTED ABOVE.'].map((p) => (
+                    /* The principal's initials — blank in preview as on the instrument. */
+                    <div key={p}><span className="inline-block w-10 border-b border-black mr-2" />{p}</div>
+                  ))}
+                </div>
+                <div className="text-[9px] font-bold mb-2">
+                  SPECIAL INSTRUCTIONS: ON THE FOLLOWING LINES YOU MAY GIVE SPECIAL INSTRUCTIONS
+                  LIMITING OR EXTENDING THE POWERS GRANTED TO YOUR AGENT.
+                </div>
+                <div className="border-b border-black h-4 mb-1" />
+                <div className="border-b border-black h-4 mb-3" />
+                <p className="text-[10px] mb-1">
+                  This power of attorney will continue to be effective even though I become incapacitated.
+                </p>
+                <div className="text-[9px] font-bold mb-2">
+                  STRIKE THE PRECEDING SENTENCE IF YOU DO NOT WANT THIS POWER OF ATTORNEY TO
+                  CONTINUE IF YOU BECOME INCAPACITATED.
+                </div>
+                <p className="text-[10px] mb-2">
+                  If I have designated more than one agent, the agents are to act{' '}
+                  <span className="inline-block min-w-[1.4in] border-b border-black" />.
+                  {' '}<span className="italic text-[8.5px]">(the principal writes &quot;SEPARATELY&quot; or &quot;JOINTLY&quot; — jointly by default)</span>
+                </p>
+                <div className="mt-4">
+                  <div>Signed this ____ day of ____________, ______</div>
+                  <div className="border-b border-black h-6 w-[50%] mt-2" />
+                  <div className="text-[8.5px] italic">(your signature)</div>
+                </div>
+                {ackSketch}
+              </>
+            ) : isDeclaration && state.deedType === 'tod-revocation' ? (
               <>
                 {/* Statutory revocation form (Prob C §§5600/5644) — the
                     exemption recitals and notice are the statute's own

--- a/frontend/src/lib/deedPayload.ts
+++ b/frontend/src/lib/deedPayload.ts
@@ -52,6 +52,8 @@ function buildFactsBlock(aff: AffidavitFacts | undefined) {
     declaration_date: aff.declarationDate || '',
     entity_state: aff.entityState || '',
     partnership_type: aff.partnershipType || '',
+    principal_name: aff.principalName || '',
+    agent_names: aff.agentNames || '',
   };
   return Object.values(block).some((v) => v) ? block : null;
 }
@@ -83,7 +85,9 @@ export function buildDeedPayload(genState: DeedBuilderState) {
     // The single party by role: the homestead's declarant, or the trust
     // certification's certifying trustee(s).
     parties: isSingleParty
-      ? genState.deedType === 'trust-certification'
+      ? genState.deedType === 'poa-statutory'
+        ? { principal: aff?.principalName || '' }
+        : genState.deedType === 'trust-certification'
         ? { trustee: aff?.trustees || '' }
         : genState.deedType === 'tod-revocation'
           ? { grantor: aff?.revokingGrantor || '' }

--- a/frontend/src/lib/deedResume.ts
+++ b/frontend/src/lib/deedResume.ts
@@ -199,6 +199,8 @@ export function hydrateStateFromDeedRow(row: Record<string, any>): ResumeResult 
           declarationDate: meta.affidavit?.declaration_date || '',
           entityState: meta.affidavit?.entity_state || '',
           partnershipType: meta.affidavit?.partnership_type || '',
+          principalName: meta.affidavit?.principal_name || '',
+          agentNames: meta.affidavit?.agent_names || '',
         }
       : undefined,
     returnTo,

--- a/frontend/src/lib/deedValidation.ts
+++ b/frontend/src/lib/deedValidation.ts
@@ -68,6 +68,24 @@ export function evaluateSubstantive(state: DeedBuilderState): CheckResult[] {
         },
       ];
     }
+    if (state.deedType === 'poa-statutory') {
+      // The statute's only content blanks: principal and appointee(s).
+      // Powers/instructions/elections are the principal's execution acts.
+      return [
+        {
+          id: 'principal_named',
+          label: 'Principal (name and address) stated',
+          ok: !!state.affidavit?.principalName?.trim(),
+          sectionId: 'affidavit',
+        },
+        {
+          id: 'agents_named',
+          label: 'Agent(s) stated',
+          ok: !!state.affidavit?.agentNames?.trim(),
+          sectionId: 'affidavit',
+        },
+      ];
+    }
     if (state.deedType === 'tod-revocation') {
       // The statutory form names the grantor only at signature; the typed
       // name identifies the record (and the parties column) — plus the
@@ -341,7 +359,9 @@ export function deriveSectionTruth(state: DeedBuilderState): SectionTruth {
     // The typed-facts section is complete when its family's substantive
     // facts are present: the declaration's single declarant, or the
     // affidavit's affiant/decedent/recording reference.
-    const affFilled = state.deedType === 'trust-certification'
+    const affFilled = state.deedType === 'poa-statutory'
+      ? !!(aff?.principalName?.trim() && aff?.agentNames?.trim())
+      : state.deedType === 'trust-certification'
       ? !!(aff?.trustName?.trim() && aff?.trustees?.trim())
       : state.deedType === 'tod-revocation'
         ? !!aff?.revokingGrantor?.trim()

--- a/frontend/src/lib/formRegistry.ts
+++ b/frontend/src/lib/formRegistry.ts
@@ -497,6 +497,40 @@ export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
       },
     ],
   },
+  // Wave 2 form #7 — the STATUTORY form (Prob C §4401; PCT #55 mirrors
+  // it). Acknowledgment verified from the reference (recordability).
+  // Property-less, single-party (the principal). The owner's high-risk
+  // flag resolved WITHOUT force: only two typed facts exist (principal,
+  // agent(s)); the 14 power initial lines, special-instruction lines,
+  // the separately/jointly word-blank, and the incapacity strike are all
+  // the principal's execution acts — blank/verbatim, never an input.
+  'poa-statutory': {
+    slug: 'poa-statutory',
+    label: 'Power of Attorney — Uniform Statutory Form',
+    title: 'UNIFORM STATUTORY FORM POWER OF ATTORNEY',
+    subtitle: '(California Probate Code Section 4401)',
+    description: 'The §4401 statutory power of attorney, recordable — the principal initials powers and signs before a notary',
+    popular: false,
+    family: 'declaration',
+    sections: PROPERTYLESS_DECLARATION_SECTIONS,
+    notarial: 'acknowledgment',
+    hasDtt: false,
+    affidavitFields: [
+      {
+        key: 'principalName',
+        label: 'Principal — name and address',
+        placeholder: 'ROBERT OWNER, 1358 5TH ST, SANTA MONICA, CA 90401',
+        uppercase: true,
+        hint: 'The person granting the power. Initials the powers and signs before a notary — those marks stay blank on the generated form.',
+      },
+      {
+        key: 'agentNames',
+        label: 'Agent(s) (attorney(s)-in-fact) — name and address of each',
+        placeholder: 'JANE B. DOE, 456 ESCROW WAY, LOS ANGELES, CA 90012',
+        uppercase: true,
+      },
+    ],
+  },
 };
 
 export function formConfig(slug: string | undefined | null): FormTypeConfig | undefined {

--- a/frontend/src/types/builder.ts
+++ b/frontend/src/types/builder.ts
@@ -116,6 +116,13 @@ export interface AffidavitFacts {
      (general/limited) on the partnership form. */
   entityState?: string;
   partnershipType?: string;
+  /* Statutory POA (Prob C §4401, wave 2 #7): the ONLY typed facts — the
+     statute's blanks are "(your name and address)" and the appointee(s).
+     Every other mark (power initials, special instructions, the
+     separately/jointly word, the incapacity strike) is the PRINCIPAL's
+     execution act and renders blank/verbatim, never pre-completed. */
+  principalName?: string;
+  agentNames?: string;
 }
 
 export interface DeedBuilderState {

--- a/templates/poa_statutory_ca/index.jinja2
+++ b/templates/poa_statutory_ca/index.jinja2
@@ -1,0 +1,346 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Uniform Statutory Form Power of Attorney - California</title>
+    <style>
+        /* ==========================================================================
+           UNIFORM STATUTORY FORM POWER OF ATTORNEY — Prob C §4401 — wave 2 #7
+
+           The STATUTORY form (PCT reference #55 mirrors it): two pages —
+           (1) statutory notice + appointment + the 14 initialed powers;
+           (2) special instructions + durability + multi-agent election +
+           third-party reliance + execution + the §1189 acknowledgment
+           (inline, as the reference prints it). Statutory text VERBATIM.
+
+           The owner's high-risk flag, resolved WITHOUT force — the split:
+           - TYPED OFFICER FACTS (only two): the principal's name/address
+             and the appointee(s). Nothing else is an input.
+           - THE PRINCIPAL'S EXECUTION ACTS (blank/verbatim, always): the
+             14 power initial lines (cert-of-trust ruling, directly on
+             point); the special-instruction lines and the SEPARATELY/
+             JOINTLY word-blank ("Other:"-line class — signer-completed
+             text blanks; the word-blank carries a jointly-by-default
+             legal effect, so pre-writing it would fabricate an election);
+             the incapacity sentence prints verbatim, never pre-struck
+             (striking is the principal's pen).
+
+           Chassis notes: recorder header per §27361.6 with the caption
+           KEPT (the reference omits it; format furniture in the
+           recorder's favor — stated in the drift review). Property-less,
+           no DTT, no mail-tax. No chrome (§27361.7).
+           ========================================================================== */
+
+        @page {
+            size: letter;
+            margin: 0.5in 0.5in 0.6in 0.6in;
+        }
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        body {
+            font-family: "Times New Roman", Times, Georgia, serif;
+            font-size: 10.5pt;
+            line-height: 1.35;
+            color: #000;
+            background: #fff;
+        }
+
+        .header-section { display: flex; min-height: 1.85in; }
+
+        .recording-info {
+            width: 3.4in;
+            flex-shrink: 0;
+            border-right: 0.75pt solid #000;
+            padding-right: 0.15in;
+            font-size: 10pt;
+            line-height: 1.35;
+        }
+
+        .recorder-space { flex-grow: 1; }
+
+        .recording-label {
+            font-weight: bold;
+            text-transform: uppercase;
+            font-size: 9pt;
+        }
+
+        .recording-value { margin-bottom: 0.12in; min-height: 0.35in; }
+
+        .ref-line { font-size: 10pt; }
+
+        .header-boundary {
+            display: flex;
+            justify-content: flex-end;
+            align-items: baseline;
+            border-bottom: 0.75pt solid #000;
+            padding-bottom: 0.03in;
+            margin-bottom: 0.12in;
+        }
+
+        .recorder-caption {
+            font-size: 7.5pt;
+            font-weight: bold;
+            text-transform: uppercase;
+        }
+
+        .deed-title {
+            text-align: center;
+            font-size: 13pt;
+            font-weight: bold;
+            letter-spacing: 1px;
+            text-transform: uppercase;
+            margin: 0.06in 0 0.02in 0;
+        }
+
+        .deed-subtitle {
+            text-align: center;
+            font-size: 10pt;
+            font-weight: bold;
+            margin-bottom: 0.08in;
+        }
+
+        .statutory-notice {
+            font-size: 9.5pt;
+            font-weight: bold;
+            text-align: justify;
+            margin-bottom: 0.1in;
+        }
+
+        .poa-body {
+            font-size: 10.5pt;
+            line-height: 1.4;
+            text-align: justify;
+        }
+
+        .poa-body p { margin-bottom: 0.04in; }
+
+        .fact { font-weight: bold; }
+
+        .fact-line {
+            display: inline-block;
+            min-width: 3in;
+            border-bottom: 1px solid #000;
+        }
+
+        .caption-note {
+            font-size: 8.5pt;
+            font-style: italic;
+        }
+
+        .instruction {
+            font-size: 9pt;
+            font-weight: bold;
+            margin: 0.035in 0;
+        }
+
+        /* The PRINCIPAL's initial lines — blank, always. */
+        .initial-line {
+            display: inline-block;
+            width: 0.5in;
+            border-bottom: 1px solid #000;
+            margin-right: 0.1in;
+        }
+
+        .power-item { margin-bottom: 0.03in; font-size: 10pt; }
+
+        .special-line {
+            border-bottom: 1px solid #000;
+            height: 0.2in;
+            margin-bottom: 0.04in;
+        }
+
+        .word-blank {
+            display: inline-block;
+            min-width: 1.6in;
+            border-bottom: 1px solid #000;
+        }
+
+        .execution-section { margin-top: 0.12in; }
+
+        .signature-line {
+            border-bottom: 1px solid #000;
+            width: 3in;
+            height: 0.28in;
+            margin-top: 0.05in;
+        }
+
+        .page-break { page-break-before: always; }
+
+        .page-note { text-align: center; font-size: 9pt; margin-top: 0.1in; }
+    </style>
+</head>
+<body>
+    <div class="deed-page">
+
+        <header class="header-section">
+            <div class="recording-info">
+                <div class="recording-label">Recording Requested By:</div>
+                <div class="recording-value">{{ requested_by or '' }}{% if requested_by_address %}<br>{{ requested_by_address }}{% endif %}</div>
+
+                <div class="recording-label">And When Recorded Mail To:</div>
+                <div class="recording-value">
+                    {% if return_to %}
+                        {% if return_to.get('name') %}{{ return_to.get('name') }}<br>{% endif %}
+                        {% if return_to.get('company') %}{{ return_to.get('company') }}<br>{% endif %}
+                        {% if return_to.get('address1') %}{{ return_to.get('address1') }}<br>{% endif %}
+                        {% if return_to.get('address2') %}{{ return_to.get('address2') }}<br>{% endif %}
+                        {% set city = return_to.get('city', '') %}
+                        {% set state = return_to.get('state', '') %}
+                        {% set zip = return_to.get('zip', '') %}
+                        {% if city or state or zip %}
+                            {{ city }}{% if city and (state or zip) %}, {% endif %}{{ state }} {{ zip }}
+                        {% endif %}
+                    {% else %}
+                        _________________________________<br>
+                        _________________________________<br>
+                        _________________________________
+                    {% endif %}
+                </div>
+
+                <div class="ref-line">Order No.: {{ title_order_no or '____________________' }}</div>
+                <div class="ref-line">Escrow No.: {{ escrow_no or '____________________' }}</div>
+            </div>
+
+            <div class="recorder-space"><!-- Gov. Code §27361.6 — recorder's use only --></div>
+        </header>
+
+        <div class="header-boundary">
+            <span class="recorder-caption">Space Above This Line Is For Recorder&rsquo;s Use</span>
+        </div>
+
+        <h1 class="deed-title">Uniform Statutory Form Power of Attorney</h1>
+        <div class="deed-subtitle">(California Probate Code Section 4401)</div>
+
+        <div class="statutory-notice">
+            NOTICE: THE POWERS GRANTED BY THIS DOCUMENT ARE BROAD AND SWEEPING. THEY ARE
+            EXPLAINED IN THE UNIFORM STATUTORY FORM POWER OF ATTORNEY ACT (CALIFORNIA
+            PROBATE CODE SECTIONS 4400-4465). IF YOU HAVE ANY QUESTIONS ABOUT THESE POWERS,
+            OBTAIN COMPETENT LEGAL ADVICE. THIS DOCUMENT DOES NOT AUTHORIZE ANYONE TO MAKE
+            MEDICAL AND OTHER HEALTH-CARE DECISIONS FOR YOU. YOU MAY REVOKE THIS POWER OF
+            ATTORNEY IF YOU LATER WISH TO DO SO.
+        </div>
+
+        {% set aff = affidavit or {} %}
+        <div class="poa-body">
+            <p>
+                I, {% if aff.get('principal_name') %}<span class="fact">{{ aff.get('principal_name') }}</span>{% else %}<span class="fact-line">&nbsp;</span>{% endif %}
+                <span class="caption-note">(your name and address)</span>
+            </p>
+            <p>
+                appoint {% if aff.get('agent_names') %}<span class="fact">{{ aff.get('agent_names') }}</span>{% else %}<span class="fact-line">&nbsp;</span>{% endif %}
+                <span class="caption-note">(name and address of the person appointed, or of each person appointed if you want to designate more than one)</span>
+            </p>
+            <p>as my agent (attorney-in-fact) to act for me in any lawful way with respect to the following initialed subjects:</p>
+        </div>
+
+        <div class="instruction">
+            TO GRANT ALL OF THE FOLLOWING POWERS, INITIAL THE LINE IN FRONT OF (N) AND IGNORE
+            THE LINES IN FRONT OF THE OTHER POWERS.
+        </div>
+        <div class="instruction">
+            TO GRANT ONE OR MORE, BUT FEWER THAN ALL, OF THE FOLLOWING POWERS, INITIAL THE
+            LINE IN FRONT OF EACH POWER YOU ARE GRANTING.
+        </div>
+        <div class="instruction">
+            TO WITHHOLD A POWER, DO NOT INITIAL THE LINE IN FRONT OF IT. YOU MAY, BUT NEED
+            NOT, CROSS OUT EACH POWER WITHHELD.
+        </div>
+
+        <div class="instruction">INITIAL</div>
+        {# The PRINCIPAL initials at execution — 14 lines, blank ALWAYS
+           (cert-of-trust ruling: a pre-marked power is a fabricated
+           assertion). #}
+        <div class="power-item"><span class="initial-line">&nbsp;</span>(A) Real property transactions.</div>
+        <div class="power-item"><span class="initial-line">&nbsp;</span>(B) Tangible personal property transactions.</div>
+        <div class="power-item"><span class="initial-line">&nbsp;</span>(C) Stock and bond transactions.</div>
+        <div class="power-item"><span class="initial-line">&nbsp;</span>(D) Commodity and option transactions.</div>
+        <div class="power-item"><span class="initial-line">&nbsp;</span>(E) Banking and other financial institution transactions.</div>
+        <div class="power-item"><span class="initial-line">&nbsp;</span>(F) Business operating transactions.</div>
+        <div class="power-item"><span class="initial-line">&nbsp;</span>(G) Insurance and annuity transactions.</div>
+        <div class="power-item"><span class="initial-line">&nbsp;</span>(H) Estate, trust, and other beneficiary transactions.</div>
+        <div class="power-item"><span class="initial-line">&nbsp;</span>(I) Claims and litigation.</div>
+        <div class="power-item"><span class="initial-line">&nbsp;</span>(J) Personal and family maintenance.</div>
+        <div class="power-item"><span class="initial-line">&nbsp;</span>(K) Benefits from social security, medicare, medicaid, or other governmental programs, or civil or military service.</div>
+        <div class="power-item"><span class="initial-line">&nbsp;</span>(L) Retirement plan transactions.</div>
+        <div class="power-item"><span class="initial-line">&nbsp;</span>(M) Tax matters.</div>
+        <div class="power-item"><span class="initial-line">&nbsp;</span>(N) ALL OF THE POWERS LISTED ABOVE.</div>
+        <div class="instruction">YOU NEED NOT INITIAL ANY OTHER LINES IF YOU INITIAL LINE (N).</div>
+
+        <div class="page-note">Page 1 of 2</div>
+
+    </div>
+
+    <div class="page-break"></div>
+    <div class="deed-page">
+
+        <div class="instruction">
+            SPECIAL INSTRUCTIONS: ON THE FOLLOWING LINES YOU MAY GIVE SPECIAL INSTRUCTIONS
+            LIMITING OR EXTENDING THE POWERS GRANTED TO YOUR AGENT.
+        </div>
+        {# The principal's hand — free-form legal content stays blank
+           (the "Other:"-line class). #}
+        <div class="special-line"></div>
+        <div class="special-line"></div>
+        <div class="special-line"></div>
+
+        <div class="instruction">
+            UNLESS YOU DIRECT OTHERWISE ABOVE, THIS POWER OF ATTORNEY IS EFFECTIVE
+            IMMEDIATELY AND WILL CONTINUE UNTIL IT IS REVOKED.
+        </div>
+
+        <div class="poa-body">
+            <p>This power of attorney will continue to be effective even though I become incapacitated.</p>
+        </div>
+        <div class="instruction">
+            STRIKE THE PRECEDING SENTENCE IF YOU DO NOT WANT THIS POWER OF ATTORNEY TO
+            CONTINUE IF YOU BECOME INCAPACITATED.
+        </div>
+
+        <div class="instruction" style="text-align:center">
+            EXERCISE OF POWER OF ATTORNEY WHERE MORE THAN ONE AGENT DESIGNATED
+        </div>
+        <div class="poa-body">
+            {# The word-blank is the PRINCIPAL's election (jointly by
+               default per the statute's own text) — blank, always. #}
+            <p>If I have designated more than one agent, the agents are to act <span class="word-blank">&nbsp;</span>.</p>
+        </div>
+        <div class="instruction">
+            IF YOU APPOINTED MORE THAN ONE AGENT AND YOU WANT EACH AGENT TO BE ABLE TO ACT
+            ALONE WITHOUT THE OTHER AGENT JOINING, WRITE THE WORD &quot;SEPARATELY&quot; IN THE BLANK
+            SPACE ABOVE. IF YOU DO NOT INSERT ANY WORD IN THE BLANK SPACE, OR IF YOU INSERT
+            THE WORD &quot;JOINTLY&quot;, THEN ALL OF YOUR AGENTS MUST ACT OR SIGN TOGETHER.
+        </div>
+
+        <div class="poa-body">
+            <p>
+                I agree that any third party who receives a copy of this document may act under it.
+                A third party may seek identification. Revocation of the power of attorney is not
+                effective as to a third party until the third party has actual knowledge of the
+                revocation. I agree to indemnify the third party for any claims that arise against
+                the third party because of reliance on this power of attorney.
+            </p>
+        </div>
+
+        <div class="execution-section">
+            <div>Signed this <span class="word-blank" style="min-width:0.7in">&nbsp;</span> day of
+                <span class="word-blank">&nbsp;</span>, <span class="word-blank" style="min-width:0.7in">&nbsp;</span></div>
+            <div class="signature-line"></div>
+            <div class="caption-note">(your signature)</div>
+            <div style="margin-top:0.06in">State of <span class="word-blank">&nbsp;</span>&nbsp;&nbsp;County of <span class="word-blank">&nbsp;</span></div>
+        </div>
+
+        <div class="instruction" style="margin-top:0.08in">
+            BY ACCEPTING OR ACTING UNDER THE APPOINTMENT, THE AGENT ASSUMES THE FIDUCIARY
+            AND OTHER LEGAL RESPONSIBILITIES OF AN AGENT.
+        </div>
+
+        {# The §1189 acknowledgment, inline on page two as the reference
+           prints it. #}
+        {% set document_title = 'Uniform Statutory Form Power of Attorney' %}
+        {% set ack_inline = true %}
+        {% include '_partials/notary_acknowledgment.jinja2' %}
+
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Wave 2, form #7 — the flagged high-risk object, resolved without force

### Reference fetched and measured
PCT #55 (`PofA-Statutory.pdf`) — the Prob C §4401 statutory form: two pages, §1189 acknowledgment **inline on page 2** (verified from the reference). PCT's other POA blanks (Special, Revocation, Confirm-Authority) are not the ordered form — noted, not built.

## Drift review (all six attestations)

**1. Certificate from the reference.** §1189 acknowledgment — the recordability certificate — verified before family assignment; canary pinned both directions. Family: declaration (property-less, single-party, no DTT).

**2. Doctrine-pass diff against precedent.** The owner-directed cert-of-trust split holds with no forcing:
- **Typed officer facts: exactly two** — the principal's name/address and the appointee(s), the statute's only content blanks. Nothing else is an input, by design.
- **14 power initial lines** → the cert-of-trust ruling *directly on point*: blank always, occurrence-pinned at exactly 14, every span verified empty.
- **Special-instruction lines + the SEPARATELY/JOINTLY word-blank** → signer-completed text blanks (the "Other:"-line class). The word-blank carries a **jointly-by-default legal effect** under the statute's own text — pre-writing it would fabricate an election, and offering an officer input for it (or for free-form special instructions) is legal-choice-shaped. **Neither input exists**; if escrow practice wants them typed, that's a future ruling, flagged here — not built.
- **The incapacity sentence** prints verbatim with its STRIKE instruction and is never pre-struck (striking is the principal's pen) — pinned against strike markup.
- All statutory notices verbatim: the §§4400–4465 NOTICE, the grant/withhold instructions, third-party reliance, the agent-fiduciary notice.

**3. Coherence pins before template.** Registry entry in the declaration branch; count 19 → 20; a pin asserts the form has **exactly two** fact fields; property-less set + backend family mirror updated.

**4. Ledger consistency.** Nothing made stale.

**5. No silent scope absorption.** Three unbuilt POA variants noted above.

**6. Per-form gate attestation.**
- [x] Geometry pins vs. reference: 2 pages (notice + powers p1; instructions + execution + inline certificate p2), chassis caption/title geometry on p1. One stated deviation: the blank omits the recorder caption; the chassis keeps it (format furniture in the recorder's favor)
- [x] Statutory strings verbatim (notice, instructions, reliance, fiduciary)
- [x] Blank-contents occurrence pins: 14/14 initial lines empty · 3/3 special lines empty · word-blank empty · no strike markup · certificate contents blank
- [x] Backend **234 passed** (was 225; +9) · six-flow ✔ unchanged · jest **292** · tsc frozen **98**

### Per-form actuals vs. 1–2 hr projection
~1.25 hr — inside projection for the wave's hardest object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_