### PR TITLE
FORMS wave 2 (#8): Substitution of Trustee + wave-end ledger sweep

### DIFF
--- a/backend/services/deed_pdf.py
+++ b/backend/services/deed_pdf.py
@@ -62,6 +62,8 @@ TEMPLATE_BY_DEED_TYPE = {
     "grant-deed-partnership": "grant_deed_partnership_ca/index.jinja2",
     # FORMS wave 2 #7 — statutory POA (Prob C §4401; PCT reference #55).
     "poa-statutory": "poa_statutory_ca/index.jinja2",
+    # FORMS wave 2 #8 — substitution of trustee (PCT reference #20).
+    "trustee-substitution": "trustee_substitution_ca/index.jinja2",
 }
 DEFAULT_TEMPLATE = "grant_deed_ca/index.jinja2"
 

--- a/backend/services/form_families.py
+++ b/backend/services/form_families.py
@@ -40,15 +40,16 @@ FAMILY_BY_DEED_TYPE = {
     "homestead-declaration-spouses": "declaration",
     "homestead-abandonment": "declaration",
     "poa-statutory": "declaration",
+    "trustee-substitution": "declaration",
 }
 
 SINGLE_PARTY_FAMILIES = {"declaration"}
 
-# Property-less instruments describe no parcel: no APN, no legal
-# description (the certification of trust certifies a TRUST — Prob C
-# §18100.5). Everything else still requires a legal description on the
-# generate path.
-PROPERTYLESS_TYPES = {"trust-certification", "poa-statutory"}
+# Types whose generate path does NOT require a legal description. Most
+# describe no parcel at all (certification of trust, POA); the trustee
+# substitution carries an APN but identifies the property via the deed of
+# trust's recording reference — its reference prints no legal description.
+PROPERTYLESS_TYPES = {"trust-certification", "poa-statutory", "trustee-substitution"}
 
 
 def family_of(deed_type):

--- a/backend/tests/test_wave2_sub_trustee.py
+++ b/backend/tests/test_wave2_sub_trustee.py
@@ -1,0 +1,139 @@
+"""FORMS wave 2 #8 — Substitution of Trustee, pinned. The wave closer.
+
+Built against Pacific Coast Title blank form #20 (Trust_Deed-Sub_Trustee).
+Drift review: ACKNOWLEDGMENT VERIFIED FROM THE REFERENCE; every element
+maps onto covered precedent exactly as the wave order predicted —
+WHEREAS/NOW-THEREFORE recitals → the TOD-revocation operative class;
+deed-of-trust identification → the recorded-instrument class; the new
+trustee → the grantee-name typed-fact class; bare signature lines → the
+bare-signature ruling. Carries an APN but NO legal description (the DOT
+reference identifies the property).
+"""
+import io
+
+import pdfplumber
+
+from services.deed_pdf import render_deed_html, render_deed_pdf
+from tests.test_deed_pdf import _normalized
+
+SUB_META = {
+    "requested_by_address": "456 Escrow Way, Los Angeles, CA 90012",
+    "return_to": {"name": "ACME LENDING, INC.", "address1": "789 LENDER BLVD",
+                  "city": "Los Angeles", "state": "CA", "zip": "90012"},
+    "title_order_no": "TO-9921",
+    "escrow_no": "ESC-4410",
+    "affidavit": {
+        "original_trustor": "JOHN A. DOE",
+        "original_trustee": "FIRST TITLE COMPANY",
+        "original_beneficiary": "ACME LENDING, INC.",
+        "deed_date": "June 1, 2015",
+        "recording_date": "June 15, 2015",
+        "instrument_no": "2015-0654321",
+        "new_trustee": "PACIFIC COAST TITLE COMPANY",
+    },
+}
+
+
+def sub_row(**overrides):
+    row = {
+        "id": 1,
+        "deed_type": "trustee-substitution",
+        "grantor_name": "",
+        "grantee_name": "",
+        "parties": {"beneficiary": "ACME LENDING, INC."},
+        "legal_description": "",   # the reference prints none
+        "county": "Los Angeles",
+        "apn": "4290-012-034",
+        "property_address": "1358 5TH ST, Santa Monica, CA 90401",
+        "requested_by": "Pacific Coast Escrow",
+        "metadata": SUB_META,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_recital_furniture_present():
+    html = _normalized(render_deed_html(sub_row()))
+    assert "Substitution of Trustee" in html
+    assert "was the original Trustor," in html
+    assert "was the original Trustee, and" in html
+    assert "was the original beneficiary under that" in html
+    assert "WHEREAS, the undersigned Beneficiary desires to substitute a new Trustee under said deed of trust." in html
+    assert "NOW THEREFORE, the undersigned hereby substitute(s)" in html
+    assert "as Trustee under said Deed of Trust." in html
+
+
+def test_officer_facts_render():
+    html = _normalized(render_deed_html(sub_row()))
+    for fact in ("JOHN A. DOE", "FIRST TITLE COMPANY", "ACME LENDING, INC.",
+                 "June 1, 2015", "June 15, 2015", "2015-0654321",
+                 "PACIFIC COAST TITLE COMPANY", "Los Angeles",
+                 "4290-012-034", "TO-9921", "ESC-4410"):
+        assert fact in html, fact
+
+
+def test_missing_facts_render_blank_never_invented():
+    html = render_deed_html(sub_row(parties=None, metadata={}))
+    assert "fact-line" in html
+    assert "PACIFIC COAST TITLE COMPANY" not in html
+    assert "2015-0654321" not in html
+
+
+def test_acknowledgment_not_jurat_and_contents_blank():
+    html = _normalized(render_deed_html(sub_row()))
+    assert "personally appeared" in html
+    assert "acknowledged to me" in html
+    assert "Subscribed and sworn to (or affirmed) before me" not in html
+    assert html.count("verifies only the identity") == 1
+    ack = html[html.index("personally appeared"):]
+    assert "ACME LENDING" not in ack
+
+
+def test_apn_but_no_legal_description_no_dtt():
+    """The reference's shape: APN prints; no legal-description block; not
+    a conveyance (no DTT, no mail-tax); vesting cannot leak."""
+    html = _normalized(render_deed_html(sub_row(vesting="SENTINEL VESTING TEXT")))
+    assert "APN: 4290-012-034" in html
+    assert "legal-content" not in html
+    assert "DOCUMENTARY TRANSFER TAX" not in html.upper()
+    assert "Mail Tax Statements" not in html
+    assert "And When Recorded Mail To" in html
+    assert "SENTINEL VESTING TEXT" not in html
+
+
+def test_one_page_with_inline_acknowledgment():
+    pdf = render_deed_pdf(sub_row())
+    with pdfplumber.open(io.BytesIO(pdf)) as doc:
+        assert len(doc.pages) == 1
+        page = doc.pages[0]
+        words = page.extract_words()
+
+        def top_of(needle):
+            hits = [w for w in words if needle.upper() in w["text"].upper()]
+            assert hits, needle
+            return hits[0]["top"]
+
+        def x_of(needle):
+            hits = [w for w in words if needle.upper() in w["text"].upper()]
+            return hits[0]["x0"]
+
+        caption_top = top_of("RECORDER’S")
+        title_top = top_of("SUBSTITUTION")
+        ack_top = top_of("personally")
+        assert caption_top > 100
+        assert x_of("RECORDER’S") > 300
+        assert title_top > caption_top
+        assert ack_top > page.height / 2
+
+    html = render_deed_html(sub_row())
+    for leaked in ("7C4DFF", "Generated by", "deedpro.com/verify", "recorder-box", "bg-brand"):
+        assert leaked not in html, leaked
+
+
+def test_registered_in_the_type_and_family_maps():
+    from services.deed_pdf import TEMPLATE_BY_DEED_TYPE
+    from services.form_families import family_of, is_single_party, requires_legal_description
+    assert TEMPLATE_BY_DEED_TYPE["trustee-substitution"] == "trustee_substitution_ca/index.jinja2"
+    assert family_of("trustee-substitution") == "declaration"
+    assert is_single_party("trustee-substitution")
+    assert not requires_legal_description("trustee-substitution")

--- a/docs/FORMS_TRIAGE.md
+++ b/docs/FORMS_TRIAGE.md
@@ -14,10 +14,12 @@ Tenant (SHIPPED, the spike) · – Surviving Spouse/CP w/ROS · – Trustee ·
 deltas each; highest non-deed volume in escrow.
 
 *Other single recordables:* Declaration of Homestead (+ Abandonment) ·
-Certification of Trust (Prob C §18100.5 — sworn, jurat) · Revocation of
-Revocable TOD Deed · Power of Attorney (recordable, acknowledgment) ·
-Substitution of Trustee · Full/Partial Reconveyance. *Rationale:* one
-instrument, one signer-set, recorder-formatted — chassis-shaped.
+Certification of Trust (Prob C §18100.5 — ~~sworn, jurat~~ ACKNOWLEDGED;
+see correction note below) · Revocation of Revocable TOD Deed · Power of
+Attorney (recordable, acknowledgment) · Substitution of Trustee ·
+Full/Partial Reconveyance (HOLD — owner ruling, wave 2: lender-side
+paper needing a separate decision). *Rationale:* one instrument, one
+signer-set, recorder-formatted — chassis-shaped.
 
 **Tier B — fillable government forms; need a form-fill pipeline (LAST, owner directive)**
 
@@ -42,7 +44,8 @@ territory the doctrine deliberately avoids.
 2. Affidavit of Death – Trustee — sibling, ~1–2 hrs
 3. Grant Deed – Joint Tenancy — deed variant, escrow staple
 4. Grant Deed – CP w/Right of Survivorship — deed variant, pairs with #1
-5. Declaration of Homestead — new family, high consumer demand, jurat reuse
+5. Declaration of Homestead — new family, high consumer demand, ~~jurat
+   reuse~~ (ACKNOWLEDGED per CCP §704.930 — see correction note below)
 6. Certification of Trust — sworn instrument, title-company request magnet
 7. Revocation of Revocable TOD Deed — small, completes a common workflow
 

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -21,6 +21,11 @@ _Last corrected: 2026-07-30 (owner corrections relayed post-wave-1)._
 - **Full/Partial Reconveyance — HOLD** (wave-2 ruling): lender-side
   paper adjacent to Tier C; needs a separate owner decision before any
   build. Not part of wave 2.
+- **Affidavit of Death — TOD Beneficiary — HOLD** (wave-2 form #1): NO
+  PCT reference exists (the Succeed-* blanks are a different
+  instrument). Sourcing it — drafting from the Prob C §5680-series
+  procedure or adopting a county-published form — is a doctrine-shaped
+  decision awaiting the owner. The other seven wave-2 forms shipped.
 
 ## Closed — do not re-report
 

--- a/frontend/src/__tests__/formRegistry.test.ts
+++ b/frontend/src/__tests__/formRegistry.test.ts
@@ -23,8 +23,12 @@ const KNOWN_SECTIONS = new Set(['property', 'grantor', 'grantee', 'vesting', 'tr
 describe('FORMS registry — completeness and coherence', () => {
   const entries = Object.values(FORM_REGISTRY);
 
-  it('carries the twenty shipped types', () => {
-    expect(entries.length).toBe(20);
+  it('carries the twenty-one shipped types', () => {
+    expect(entries.length).toBe(21);
+    // Wave 2 #8 — substitution of trustee (acknowledged; APN but no
+    // legal description — the DOT reference identifies the property):
+    expect(formConfig('trustee-substitution')?.family).toBe('declaration');
+    expect(formConfig('trustee-substitution')?.sections).toContain('property');
     // Wave 2 #7 — the statutory POA (acknowledged, property-less,
     // single-party; only two typed facts by design):
     expect(formConfig('poa-statutory')?.family).toBe('declaration');

--- a/frontend/src/components/builder/PreviewPanel.tsx
+++ b/frontend/src/components/builder/PreviewPanel.tsx
@@ -227,7 +227,47 @@ export function PreviewPanel({ state, activeSection, onRegionClick }: PreviewPan
               </div>
             )}
 
-            {isDeclaration && state.deedType === 'poa-statutory' ? (
+            {isDeclaration && state.deedType === 'trustee-substitution' ? (
+              <>
+                {/* PCT #20 — WHEREAS/NOW-THEREFORE recitals are furniture;
+                    the DOT identification and new trustee are typed facts. */}
+                <div className={`text-[11pt] leading-relaxed mb-3 ${highlight('affidavit')}`}>
+                  <p className="mb-2">
+                    WHEREAS, <span onClick={go('affidavit', 'affidavit-originalTrustor')} className={`font-bold uppercase ${CLICKABLE} ${dataHighlight(aff?.originalTrustor)}`}>{factOrBlank(aff?.originalTrustor)}</span>
+                    {' '}was the original Trustor,{' '}
+                    <span onClick={go('affidavit', 'affidavit-originalTrustee')} className={`font-bold uppercase ${CLICKABLE} ${dataHighlight(aff?.originalTrustee)}`}>{factOrBlank(aff?.originalTrustee)}</span>
+                    {' '}was the original Trustee, and{' '}
+                    <span onClick={go('affidavit', 'affidavit-originalBeneficiary')} className={`font-bold uppercase ${CLICKABLE} ${dataHighlight(aff?.originalBeneficiary)}`}>{factOrBlank(aff?.originalBeneficiary)}</span>
+                    {' '}was the original beneficiary under that certain Deed of Trust dated{' '}
+                    <span onClick={go('affidavit', 'affidavit-deedDate')} className={`${CLICKABLE} ${dataHighlight(aff?.deedDate)}`}>{factOrBlank(aff?.deedDate)}</span>
+                    {' '}and recorded on{' '}
+                    <span onClick={go('affidavit', 'affidavit-recordingDate')} className={`${CLICKABLE} ${dataHighlight(aff?.recordingDate)}`}>{factOrBlank(aff?.recordingDate)}</span>
+                    {' '}as Instrument No.{' '}
+                    <span onClick={go('affidavit', 'affidavit-instrumentNo')} className={`${CLICKABLE} ${dataHighlight(aff?.instrumentNo)}`}>{factOrBlank(aff?.instrumentNo)}</span>
+                    {' '}of Official Records of{' '}
+                    <span onClick={go('property')} className={`font-bold ${CLICKABLE} ${placeholder(preview.county)} ${dataHighlight(preview.county)}`}>{preview.county}</span>
+                    {' '}County, California;
+                  </p>
+                  <p className="mb-2">
+                    WHEREAS, the undersigned Beneficiary desires to substitute a new Trustee under said deed of trust.
+                  </p>
+                  <p className="mb-2">
+                    NOW THEREFORE, the undersigned hereby substitute(s){' '}
+                    <span onClick={go('affidavit', 'affidavit-newTrustee')} className={`font-bold uppercase ${CLICKABLE} ${dataHighlight(aff?.newTrustee)}`}>{factOrBlank(aff?.newTrustee)}</span>
+                    {' '}as Trustee under said Deed of Trust.
+                  </p>
+                </div>
+
+                <div className="mt-6 flex justify-between items-end gap-4">
+                  <div className="text-[11pt]">Dated: <span className="inline-block min-w-[1.6in] border-b border-black" /></div>
+                  <div className="w-[45%]">
+                    <div className="border-b border-black h-7 mb-3" />
+                    <div className="border-b border-black h-7" />
+                  </div>
+                </div>
+                {ackSketch}
+              </>
+            ) : isDeclaration && state.deedType === 'poa-statutory' ? (
               <>
                 {/* Prob C §4401 statutory form. Only TWO typed facts; every
                     other mark is the principal's execution act — blank. */}

--- a/frontend/src/lib/deedPayload.ts
+++ b/frontend/src/lib/deedPayload.ts
@@ -54,6 +54,10 @@ function buildFactsBlock(aff: AffidavitFacts | undefined) {
     partnership_type: aff.partnershipType || '',
     principal_name: aff.principalName || '',
     agent_names: aff.agentNames || '',
+    original_trustor: aff.originalTrustor || '',
+    original_trustee: aff.originalTrustee || '',
+    original_beneficiary: aff.originalBeneficiary || '',
+    new_trustee: aff.newTrustee || '',
   };
   return Object.values(block).some((v) => v) ? block : null;
 }
@@ -85,7 +89,9 @@ export function buildDeedPayload(genState: DeedBuilderState) {
     // The single party by role: the homestead's declarant, or the trust
     // certification's certifying trustee(s).
     parties: isSingleParty
-      ? genState.deedType === 'poa-statutory'
+      ? genState.deedType === 'trustee-substitution'
+        ? { beneficiary: aff?.originalBeneficiary || '' }
+        : genState.deedType === 'poa-statutory'
         ? { principal: aff?.principalName || '' }
         : genState.deedType === 'trust-certification'
         ? { trustee: aff?.trustees || '' }

--- a/frontend/src/lib/deedResume.ts
+++ b/frontend/src/lib/deedResume.ts
@@ -201,6 +201,10 @@ export function hydrateStateFromDeedRow(row: Record<string, any>): ResumeResult 
           partnershipType: meta.affidavit?.partnership_type || '',
           principalName: meta.affidavit?.principal_name || '',
           agentNames: meta.affidavit?.agent_names || '',
+          originalTrustor: meta.affidavit?.original_trustor || '',
+          originalTrustee: meta.affidavit?.original_trustee || '',
+          originalBeneficiary: meta.affidavit?.original_beneficiary || '',
+          newTrustee: meta.affidavit?.new_trustee || '',
         }
       : undefined,
     returnTo,

--- a/frontend/src/lib/deedValidation.ts
+++ b/frontend/src/lib/deedValidation.ts
@@ -68,6 +68,33 @@ export function evaluateSubstantive(state: DeedBuilderState): CheckResult[] {
         },
       ];
     }
+    if (state.deedType === 'trustee-substitution') {
+      // The deed of trust is identified by its recording reference; the
+      // undersigned beneficiary and the new trustee are the substance.
+      // No legal description on the reference (the DOT reference
+      // identifies the property).
+      return [
+        {
+          id: 'beneficiary_named',
+          label: 'Beneficiary (the undersigned) stated',
+          ok: !!state.affidavit?.originalBeneficiary?.trim(),
+          sectionId: 'affidavit',
+        },
+        {
+          id: 'new_trustee_named',
+          label: 'New trustee stated',
+          ok: !!state.affidavit?.newTrustee?.trim(),
+          sectionId: 'affidavit',
+        },
+        {
+          id: 'recorded_instrument_reference',
+          label: 'Recorded deed-of-trust reference',
+          ok: !!state.affidavit?.instrumentNo?.trim() && !!state.affidavit?.recordingDate?.trim(),
+          detail: 'The deed of trust is identified by its recording date and instrument number.',
+          sectionId: 'affidavit',
+        },
+      ];
+    }
     if (state.deedType === 'poa-statutory') {
       // The statute's only content blanks: principal and appointee(s).
       // Powers/instructions/elections are the principal's execution acts.
@@ -359,7 +386,10 @@ export function deriveSectionTruth(state: DeedBuilderState): SectionTruth {
     // The typed-facts section is complete when its family's substantive
     // facts are present: the declaration's single declarant, or the
     // affidavit's affiant/decedent/recording reference.
-    const affFilled = state.deedType === 'poa-statutory'
+    const affFilled = state.deedType === 'trustee-substitution'
+      ? !!(aff?.originalBeneficiary?.trim() && aff?.newTrustee?.trim() &&
+        aff?.instrumentNo?.trim() && aff?.recordingDate?.trim())
+      : state.deedType === 'poa-statutory'
       ? !!(aff?.principalName?.trim() && aff?.agentNames?.trim())
       : state.deedType === 'trust-certification'
       ? !!(aff?.trustName?.trim() && aff?.trustees?.trim())

--- a/frontend/src/lib/formRegistry.ts
+++ b/frontend/src/lib/formRegistry.ts
@@ -531,6 +531,38 @@ export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
       },
     ],
   },
+  // Wave 2 form #8 — reference: PCT blank form #20 (Trust_Deed-
+  // Sub_Trustee). Acknowledgment verified from the reference. The
+  // WHEREAS/NOW-THEREFORE recitals are instrument-defining furniture
+  // (TOD-revocation operative class); the deed of trust is identified by
+  // its recording reference (recorded-instrument class); the new trustee
+  // is a typed party fact (grantee-name class). Carries an APN but NO
+  // legal description — the DOT reference identifies the property.
+  'trustee-substitution': {
+    slug: 'trustee-substitution',
+    label: 'Substitution of Trustee',
+    title: 'SUBSTITUTION OF TRUSTEE',
+    description: 'The beneficiary under a recorded deed of trust substitutes a new trustee — acknowledged and recorded',
+    popular: false,
+    family: 'declaration',
+    sections: DECLARATION_SECTIONS,
+    notarial: 'acknowledgment',
+    hasDtt: false,
+    affidavitFields: [
+      { key: 'originalTrustor', label: 'Original trustor', placeholder: 'JOHN A. DOE', uppercase: true, group: 'The recorded deed of trust' },
+      { key: 'originalTrustee', label: 'Original trustee', placeholder: 'FIRST TITLE COMPANY', uppercase: true, group: 'The recorded deed of trust' },
+      { key: 'originalBeneficiary', label: 'Original beneficiary (the undersigned)', placeholder: 'ACME LENDING, INC.', uppercase: true, group: 'The recorded deed of trust', hint: 'Signs before a notary.' },
+      { key: 'deedDate', label: 'Deed of Trust dated', placeholder: 'June 1, 2015', group: 'The recorded deed of trust' },
+      ...RECORDING_REF_FIELDS('The recorded deed of trust'),
+      {
+        key: 'newTrustee',
+        label: 'New trustee substituted',
+        placeholder: 'PACIFIC COAST TITLE COMPANY',
+        uppercase: true,
+        group: 'The substitution',
+      },
+    ],
+  },
 };
 
 export function formConfig(slug: string | undefined | null): FormTypeConfig | undefined {

--- a/frontend/src/types/builder.ts
+++ b/frontend/src/types/builder.ts
@@ -123,6 +123,13 @@ export interface AffidavitFacts {
      execution act and renders blank/verbatim, never pre-completed. */
   principalName?: string;
   agentNames?: string;
+  /* Substitution of Trustee (wave 2 #8): the deed of trust is identified
+     by its original parties + recording reference; the undersigned
+     beneficiary substitutes the new trustee. */
+  originalTrustor?: string;
+  originalTrustee?: string;
+  originalBeneficiary?: string;
+  newTrustee?: string;
 }
 
 export interface DeedBuilderState {

--- a/templates/trustee_substitution_ca/index.jinja2
+++ b/templates/trustee_substitution_ca/index.jinja2
@@ -1,0 +1,229 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Substitution of Trustee - California</title>
+    <style>
+        /* ==========================================================================
+           SUBSTITUTION OF TRUSTEE — wave 2 #8
+
+           Reference implementation: Pacific Coast Title blank form #20
+           (Trust_Deed-Sub_Trustee), measured with pdfplumber (letter, one
+           page, §1189 acknowledgment lower half). Acknowledgment verified
+           from the reference.
+
+           Doctrine (all covered precedent): the WHEREAS / NOW THEREFORE
+           recitals are instrument-defining furniture (the TOD-revocation
+           operative class); the deed of trust is identified by its
+           original parties + recording reference (recorded-instrument
+           class); the NEW trustee is a typed party fact (grantee-name
+           class); bare signature lines per the bare-signature ruling —
+           the undersigned beneficiary signs at notarization.
+           Carries an APN but NO legal description: the reference
+           identifies the property through the deed of trust. Not a
+           conveyance — no DTT, no mail-tax ("AND WHEN RECORDED MAIL TO").
+           Chassis rules (G2/G3) verbatim; parties ride deeds.parties
+           ({beneficiary}).
+           ========================================================================== */
+
+        @page {
+            size: letter;
+            margin: 0.5in 0.5in 0.6in 0.6in;
+        }
+
+        * { margin: 0; padding: 0; box-sizing: border-box; }
+
+        body {
+            font-family: "Times New Roman", Times, Georgia, serif;
+            font-size: 11pt;
+            line-height: 1.35;
+            color: #000;
+            background: #fff;
+        }
+
+        .header-section { display: flex; min-height: 1.85in; }
+
+        .recording-info {
+            width: 3.4in;
+            flex-shrink: 0;
+            border-right: 0.75pt solid #000;
+            padding-right: 0.15in;
+            font-size: 10pt;
+            line-height: 1.35;
+        }
+
+        .recorder-space { flex-grow: 1; }
+
+        .recording-label {
+            font-weight: bold;
+            text-transform: uppercase;
+            font-size: 9pt;
+        }
+
+        .recording-value { margin-bottom: 0.12in; min-height: 0.35in; }
+
+        .ref-line { font-size: 10pt; }
+
+        .header-boundary {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            border-bottom: 0.75pt solid #000;
+            padding-bottom: 0.03in;
+            margin-bottom: 0.12in;
+        }
+
+        .apn-ref { font-weight: bold; font-size: 10pt; }
+
+        .recorder-caption {
+            font-size: 7.5pt;
+            font-weight: bold;
+            text-transform: uppercase;
+        }
+
+        .deed-title {
+            text-align: center;
+            font-size: 14pt;
+            font-weight: bold;
+            letter-spacing: 2px;
+            text-transform: uppercase;
+            margin: 0.08in 0 0.02in 0;
+        }
+
+        .deed-subtitle {
+            text-align: center;
+            font-size: 11pt;
+            font-weight: bold;
+            margin-bottom: 0.1in;
+        }
+
+        .declaration-body {
+            font-size: 11pt;
+            line-height: 1.35;
+            text-align: justify;
+        }
+
+        .declaration-body p { margin-bottom: 0.07in; }
+
+        .fact {
+            /* Officer-supplied facts render bold; a missing fact renders as
+               the reference's blank line so an incomplete instrument LOOKS
+               incomplete. */
+            font-weight: bold;
+        }
+
+        .fact-line {
+            display: inline-block;
+            min-width: 2.2in;
+            border-bottom: 1px solid #000;
+        }
+
+        .execution-section {
+            display: flex;
+            justify-content: space-between;
+            align-items: flex-end;
+            margin-top: 0.12in;
+            margin-bottom: 0.05in;
+        }
+
+        .signature-block { width: 3.2in; }
+
+        .signature-line {
+            border-bottom: 1px solid #000;
+            width: 3.2in;
+            height: 0.35in;
+        }
+
+        .print-name {
+            font-size: 10pt;
+            text-transform: uppercase;
+        }
+    </style>
+</head>
+<body>
+    <div class="deed-page">
+
+        <header class="header-section">
+            <div class="recording-info">
+                <div class="recording-label">Recording Requested By:</div>
+                <div class="recording-value">{{ requested_by or '' }}{% if requested_by_address %}<br>{{ requested_by_address }}{% endif %}</div>
+
+                <div class="recording-label">And When Recorded Mail To:</div>
+                <div class="recording-value">
+                    {% if return_to %}
+                        {% if return_to.get('name') %}{{ return_to.get('name') }}<br>{% endif %}
+                        {% if return_to.get('company') %}{{ return_to.get('company') }}<br>{% endif %}
+                        {% if return_to.get('address1') %}{{ return_to.get('address1') }}<br>{% endif %}
+                        {% if return_to.get('address2') %}{{ return_to.get('address2') }}<br>{% endif %}
+                        {% set city = return_to.get('city', '') %}
+                        {% set state = return_to.get('state', '') %}
+                        {% set zip = return_to.get('zip', '') %}
+                        {% if city or state or zip %}
+                            {{ city }}{% if city and (state or zip) %}, {% endif %}{{ state }} {{ zip }}
+                        {% endif %}
+                    {% else %}
+                        _________________________________<br>
+                        _________________________________<br>
+                        _________________________________
+                    {% endif %}
+                </div>
+
+                <div class="ref-line">Order No.: {{ title_order_no or '____________________' }}</div>
+                <div class="ref-line">Escrow No.: {{ escrow_no or '____________________' }}</div>
+            </div>
+
+            <div class="recorder-space"><!-- Gov. Code §27361.6 — recorder's use only --></div>
+        </header>
+
+        <div class="header-boundary">
+            <span class="apn-ref">APN: {{ apn or '____________________' }}</span>
+            <span class="recorder-caption">Space Above This Line Is For Recorder&rsquo;s Use</span>
+        </div>
+
+        <h1 class="deed-title">Substitution of Trustee</h1>
+
+        {% set aff = affidavit or {} %}
+        <div class="declaration-body">
+            <p>
+                WHEREAS, {% if aff.get('original_trustor') %}<span class="fact">{{ aff.get('original_trustor') }}</span>{% else %}<span class="fact-line">&nbsp;</span>{% endif %} was the original Trustor,
+                {% if aff.get('original_trustee') %}<span class="fact">{{ aff.get('original_trustee') }}</span>{% else %}<span class="fact-line">&nbsp;</span>{% endif %} was the original Trustee, and
+                {% if aff.get('original_beneficiary') %}<span class="fact">{{ aff.get('original_beneficiary') }}</span>{% else %}<span class="fact-line">&nbsp;</span>{% endif %} was the original beneficiary under that
+                certain Deed of Trust dated {% if aff.get('deed_date') %}<span class="fact">{{ aff.get('deed_date') }}</span>{% else %}<span class="fact-line" style="min-width:1.4in">&nbsp;</span>{% endif %}
+                and recorded on {% if aff.get('recording_date') %}<span class="fact">{{ aff.get('recording_date') }}</span>{% else %}<span class="fact-line" style="min-width:1.4in">&nbsp;</span>{% endif %}
+                as Instrument No. {% if aff.get('instrument_no') %}<span class="fact">{{ aff.get('instrument_no') }}</span>{% else %}<span class="fact-line" style="min-width:1.4in">&nbsp;</span>{% endif %}
+                of Official Records of {% if county %}<span class="fact">{{ county }}</span>{% else %}<span class="fact-line" style="min-width:1.6in">&nbsp;</span>{% endif %} County, California;
+            </p>
+            <p>
+                WHEREAS, the undersigned Beneficiary desires to substitute a new Trustee under said deed of trust.
+            </p>
+            <p>
+                NOW THEREFORE, the undersigned hereby substitute(s)
+                {% if aff.get('new_trustee') %}<span class="fact">{{ aff.get('new_trustee') }}</span>{% else %}<span class="fact-line" style="min-width:3in">&nbsp;</span>{% endif %}
+                as Trustee under said Deed of Trust.
+            </p>
+        </div>
+
+
+
+        {# Execution: the declarant signs at the notarization — date and
+           signature stay blank (blank-contents doctrine). The printed name
+           identifies the signer, as the deed chassis prints signer names. #}
+        {# Reference-faithful bare signature lines (two provided); the
+           undersigned beneficiary signs at notarization. #}
+        <div class="execution-section">
+            <div>Dated: <span class="fact-line" style="min-width:1.8in">&nbsp;</span></div>
+            <div class="signature-block">
+                <div class="signature-line"></div>
+                <div class="signature-line" style="margin-top:0.12in"></div>
+            </div>
+        </div>
+
+        {# CCP §704.930: ACKNOWLEDGED, not sworn — §1189 certificate,
+           on the SAME page as the reference lays it out. #}
+        {% set document_title = 'Substitution of Trustee' %}
+        {% set ack_inline = true %}
+        {% include '_partials/notary_acknowledgment.jinja2' %}
+
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Wave 2, form #8 — the wave closer, with the mandated wave-end ledger sweep

### Reference fetched and measured
PCT #20 (`Trust_Deed-Sub_Trustee.pdf`) — one page, §1189 acknowledgment inline in the lower half.

## Drift review (all six attestations)

**1. Certificate from the reference.** §1189 acknowledgment, verified before family assignment; canary pinned both directions.

**2. Doctrine-pass diff against precedent.** Every element covered, exactly as the wave order predicted: WHEREAS/NOW-THEREFORE recitals → the TOD-revocation operative class; the deed-of-trust identification (original trustor/trustee/beneficiary + date + recording reference) → the recorded-instrument class; the **new trustee** → the grantee-name typed-fact class; two bare signature lines → the bare-signature ruling. **No uncovered element → no hold.**

**3. Coherence pins before template.** Registry entry in the declaration branch; count 20 → 21; family mirror updated. Shape note: the reference carries an **APN but no legal description** (the DOT reference identifies the property) — the property section stays, the legal-description requirement relaxes for this slug only, pinned in both directions.

**4. Ledger consistency — the wave-end sweep.** `FORMS_TRIAGE.md` body text corrected *in place* where wave 1's note had only footnoted it (the cert-of-trust "sworn, jurat" and homestead "jurat reuse" predictions now struck inline, pointing at the correction note; the reconveyance HOLD annotated in the Tier-A list). `OWNER_LEDGER.md` gains the **wave-2 form #1 HOLD**: Affidavit of Death — TOD Beneficiary has no PCT reference (the Succeed-* blanks are a different instrument); sourcing it is a doctrine-shaped owner decision.

**5. No silent scope absorption.** PCT's combined `#63 SubAndRecon` form touches the HELD reconveyance — not built.

**6. Per-form gate attestation.**
- [x] Geometry pins vs. reference: 1 page, caption/title geometry, certificate lower half (inline mode)
- [x] Recital strings verbatim (both WHEREAS clauses, the NOW-THEREFORE operative)
- [x] Blank-contents occurrence pins: one certificate; beneficiary absent from the certificate; blanks never invented; vesting sentinel cannot leak
- [x] Backend **241 passed** (was 234; +7) · six-flow ✔ unchanged · jest **292** · tsc frozen **98**

### Per-form actuals vs. 1–2 hr projection
~40 min — sibling rate on the declaration chassis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_