### PR TITLE
CAT1: catalog-scale type selection — search, situation groups, recents

### DIFF
--- a/frontend/src/__tests__/formRegistry.test.ts
+++ b/frontend/src/__tests__/formRegistry.test.ts
@@ -10,7 +10,7 @@
 import { describe, expect, it } from '@jest/globals';
 import * as fs from 'fs';
 import * as path from 'path';
-import { FORM_REGISTRY, formConfig, formFamily, hasVestingInput } from '../lib/formRegistry';
+import { FORM_REGISTRY, SITUATION_GROUP_ORDER, formConfig, formFamily, hasVestingInput } from '../lib/formRegistry';
 import { DEED_LABELS, deedTypeLabel } from '../lib/deedTypes';
 import { isAffidavitType } from '../lib/deedValidation';
 
@@ -69,6 +69,14 @@ describe('FORMS registry — completeness and coherence', () => {
       expect(f.title.length).toBeGreaterThan(3);
       for (const section of f.sections) {
         expect(KNOWN_SECTIONS.has(section)).toBe(true);
+      }
+      // CAT1: every entry carries picker metadata — a valid situation
+      // group and non-empty lowercase keywords (UI metadata only).
+      expect(SITUATION_GROUP_ORDER).toContain(f.situationGroup);
+      expect(f.keywords.length).toBeGreaterThan(0);
+      for (const k of f.keywords) {
+        expect(k).toBe(k.toLowerCase());
+        expect(k.trim().length).toBeGreaterThan(0);
       }
       // Doctrine coupling, all three families enforced structurally:
       //   affidavit   → jurat, no DTT (sworn statement)
@@ -152,7 +160,10 @@ describe('FORMS registry — the consumers derive from it', () => {
   });
 
   it('the selection page and preview read the registry', () => {
-    expect(readSource('app', 'deed-builder', 'page.tsx')).toContain('FORM_REGISTRY');
+    // CAT1: the picker reads the registry through the formSearch layer.
+    const picker = readSource('app', 'deed-builder', 'page.tsx');
+    expect(picker).toContain('formSearch');
+    expect(readSource('lib', 'formSearch.ts')).toContain('FORM_REGISTRY');
     const preview = readSource('components', 'builder', 'PreviewPanel.tsx');
     expect(preview).toContain("formConfig(state.deedType)?.title");
     expect(preview).toContain("formFamily(state.deedType)");

--- a/frontend/src/__tests__/formSearch.test.ts
+++ b/frontend/src/__tests__/formSearch.test.ts
@@ -1,0 +1,103 @@
+/**
+ * CAT1 — the catalog's front door, pinned.
+ *
+ * Three registry-driven layers: search (situation words), grouped browse
+ * (desk taxonomy), recents. Constraint pinned throughout: ORGANIZATION,
+ * never recommendation — no wizard, no ranking-by-guess; choosing the
+ * instrument is the officer's legal decision (Flag-3 doctrine).
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+import { FORM_REGISTRY } from '../lib/formRegistry';
+import { groupedForms, matchesForm, searchForms } from '../lib/formSearch';
+
+function readSource(...segments: string[]): string {
+  return fs.readFileSync(path.join(__dirname, '..', ...segments), 'utf8');
+}
+
+const PICKER = readSource('app', 'deed-builder', 'page.tsx');
+
+describe('CAT1 — search translates situations into instruments', () => {
+  it('"death" surfaces all five death affidavits', () => {
+    const slugs = searchForms('death').map((f) => f.slug);
+    for (const s of ['affidavit-death-jt', 'affidavit-death-cp-spouse', 'affidavit-death-trustee',
+                     'affidavit-death-jt-dp', 'affidavit-death-cp-dp']) {
+      expect(slugs).toContain(s);
+    }
+  });
+
+  it('"corporation" and "llc" surface the entity deed', () => {
+    expect(searchForms('corporation').map((f) => f.slug)).toContain('grant-deed-corp');
+    expect(searchForms('llc').map((f) => f.slug)).toContain('grant-deed-corp');
+  });
+
+  it('"trust" surfaces the trust instruments', () => {
+    const slugs = searchForms('trust').map((f) => f.slug);
+    for (const s of ['trust-certification', 'trustee-substitution', 'affidavit-death-trustee']) {
+      expect(slugs).toContain(s);
+    }
+  });
+
+  it('"homestead" surfaces the homestead family', () => {
+    const slugs = searchForms('homestead').map((f) => f.slug);
+    for (const s of ['homestead-declaration', 'homestead-declaration-spouses', 'homestead-abandonment']) {
+      expect(slugs).toContain(s);
+    }
+  });
+
+  it('prefix tokens match ("corp" → corporation) but arbitrary fuzz does not', () => {
+    expect(searchForms('corp').map((f) => f.slug)).toContain('grant-deed-corp');
+    // Character-subsequence fuzz is deliberately absent: a near-miss on a
+    // legal instrument must read as a miss.
+    expect(searchForms('crprtn')).toHaveLength(0);
+  });
+
+  it('empty query matches everything; results keep registry order (no ranking)', () => {
+    const all = searchForms('');
+    expect(all.map((f) => f.slug)).toEqual(Object.keys(FORM_REGISTRY));
+  });
+
+  it('multi-word queries require every token', () => {
+    const slugs = searchForms('death partner').map((f) => f.slug);
+    expect(slugs).toContain('affidavit-death-jt-dp');
+    expect(slugs).not.toContain('grant-deed');
+  });
+});
+
+describe('CAT1 — grouped browse covers the whole catalog', () => {
+  it('every type appears in exactly one group; groups are desk taxonomy', () => {
+    const groups = groupedForms();
+    const seen = groups.flatMap((g) => g.forms.map((f) => f.slug));
+    expect(seen.sort()).toEqual(Object.keys(FORM_REGISTRY).sort());
+    expect(new Set(seen).size).toBe(seen.length);
+  });
+
+  it('all 21 types remain reachable through search with their own label', () => {
+    for (const f of Object.values(FORM_REGISTRY)) {
+      expect(matchesForm(f, f.label)).toBe(true);
+    }
+  });
+});
+
+describe('CAT1 — the picker organizes; the officer chooses', () => {
+  it('the picker carries the Flag-3 doctrine comment and no wizard logic', () => {
+    expect(PICKER).toMatch(/officer'?s legal decision/i);
+    expect(PICKER).toContain('Flag-3');
+    // No recommendation machinery: nothing scores, ranks, or auto-picks.
+    for (const smell of ['recommend', 'suggest', 'bestMatch', 'autoSelect', 'score(']) {
+      expect(PICKER.toLowerCase()).not.toContain(smell.toLowerCase());
+    }
+  });
+
+  it('Enter selects the visible top hit, not a hidden guess', () => {
+    expect(PICKER).toContain("e.key === 'Enter'");
+    expect(PICKER).toContain('results[0].slug');
+  });
+
+  it('recents come from the existing deeds list, silently', () => {
+    expect(PICKER).toContain("apiFetch('/deeds'");
+    expect(PICKER).toContain('silent: true');
+    expect(PICKER).toContain('Recently used');
+  });
+});

--- a/frontend/src/app/deed-builder/page.tsx
+++ b/frontend/src/app/deed-builder/page.tsx
@@ -1,82 +1,189 @@
 'use client';
 
+import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { FileText, ArrowRight } from 'lucide-react';
+import { ArrowRight, ChevronDown, ChevronRight, FileText, Search } from 'lucide-react';
 import Sidebar from '@/components/Sidebar';
 import { useRequireAuth } from '@/hooks/useRequireAuth';
-import { FORM_REGISTRY } from '@/lib/formRegistry';
+import { FormTypeConfig, SITUATION_GROUP_ORDER, formConfig } from '@/lib/formRegistry';
+import { groupedForms, searchForms } from '@/lib/formSearch';
+import { apiFetch } from '@/lib/apiClient';
 
-// FORMS registry: the selectable catalog IS the registry — adding a
-// type there adds its card here.
-const DEED_TYPES = Object.values(FORM_REGISTRY).map((f) => ({
-  id: f.slug,
-  title: f.label,
-  description: f.description,
-  popular: f.popular,
-}));
+// CAT1 — the catalog's front door, three registry-driven layers:
+// search (situation words), grouped browse (desk taxonomy), recents.
+// ORGANIZATION ONLY, deliberately: no wizard, no "we picked for you" —
+// choosing the instrument is the OFFICER'S legal decision (Flag-3
+// doctrine: the instrument choice is the decision its recitals assert).
+// The picker translates situations into a scannable catalog; the officer
+// selects.
 
 export default function DeedBuilderSelectPage() {
   // HX0: internal tool — no session, no shell.
   const { checked } = useRequireAuth();
   const router = useRouter();
 
-  const handleSelectDeedType = (deedType: string) => {
-    router.push(`/deed-builder/${deedType}`);
-  };
+  const [query, setQuery] = useState('');
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({
+    [SITUATION_GROUP_ORDER[0]]: true,
+  });
+  const [recentSlugs, setRecentSlugs] = useState<string[]>([]);
 
+  // Recents: this account's most-generated types, from the existing
+  // deeds list (no new backend route). Silent — a picker without a
+  // recents strip is fine; a toast about it is noise.
+  useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const resp = await apiFetch('/deeds', {}, { label: 'Loading recent types', silent: true });
+        if (!resp.ok) return;
+        const body = await resp.json();
+        const counts = new Map<string, number>();
+        for (const d of body.deeds ?? []) {
+          if (d.deed_type && formConfig(d.deed_type)) {
+            counts.set(d.deed_type, (counts.get(d.deed_type) ?? 0) + 1);
+          }
+        }
+        const top = [...counts.entries()]
+          .sort((a, b) => b[1] - a[1])
+          .slice(0, 4)
+          .map(([slug]) => slug);
+        if (alive) setRecentSlugs(top);
+      } catch {
+        /* silent: recents are a convenience, never a blocker */
+      }
+    })();
+    return () => { alive = false; };
+  }, []);
+
+  const results = useMemo(() => (query.trim() ? searchForms(query) : null), [query]);
+  const groups = useMemo(() => groupedForms(), []);
+
+  const select = (slug: string) => router.push(`/deed-builder/${slug}`);
 
   if (!checked) return null;
+
+  const card = (f: FormTypeConfig) => (
+    <button
+      key={f.slug}
+      onClick={() => select(f.slug)}
+      className="group relative flex items-center gap-4 p-4 bg-white rounded-xl border-2 border-gray-200 hover:border-brand-500 hover:shadow-lg transition-all duration-200 text-left w-full"
+    >
+      <div className="flex-shrink-0">
+        <div className="w-10 h-10 bg-brand-50 rounded-xl flex items-center justify-center group-hover:bg-brand-100 transition-colors">
+          <FileText className="w-5 h-5 text-brand-500" />
+        </div>
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <h3 className="font-semibold text-gray-900">{f.label}</h3>
+          {f.popular && (
+            <span className="px-2 py-0.5 text-xs font-medium bg-brand-100 text-brand-700 rounded-full">
+              Popular
+            </span>
+          )}
+        </div>
+        <p className="text-gray-600 text-sm mt-0.5">{f.description}</p>
+      </div>
+      <ArrowRight className="w-5 h-5 text-gray-400 group-hover:text-brand-500 group-hover:translate-x-1 transition-all" />
+    </button>
+  );
 
   return (
     <div className="flex min-h-screen bg-gray-50">
       <Sidebar />
-      
+
       <main className="flex-1 p-8">
         <div className="max-w-4xl mx-auto">
-          {/* Header */}
-          <div className="mb-8">
-            <h1 className="text-3xl font-bold text-gray-900 mb-2">Create a Deed</h1>
+          <div className="mb-6">
+            <h1 className="text-3xl font-bold text-gray-900 mb-2">Create a Document</h1>
             <p className="text-gray-600">
-              Select the type of deed you want to create. Each deed type serves a different purpose.
+              Search by situation or browse the catalog. You choose the instrument.
             </p>
           </div>
 
-          {/* Deed Types Grid */}
-          <div className="grid gap-4">
-            {DEED_TYPES.map((deedType) => (
-              <button
-                key={deedType.id}
-                onClick={() => handleSelectDeedType(deedType.id)}
-                className="group relative flex items-center gap-4 p-6 bg-white rounded-xl border-2 border-gray-200 hover:border-brand-500 hover:shadow-lg transition-all duration-200 text-left"
-              >
-                <div className="flex-shrink-0">
-                  <div className="w-12 h-12 bg-brand-50 rounded-xl flex items-center justify-center group-hover:bg-brand-100 transition-colors">
-                    <FileText className="w-6 h-6 text-brand-500" />
-                  </div>
-                </div>
-
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2">
-                    <h3 className="font-semibold text-gray-900 text-lg">{deedType.title}</h3>
-                    {deedType.popular && (
-                      <span className="px-2 py-0.5 text-xs font-medium bg-brand-100 text-brand-700 rounded-full">
-                        Popular
-                      </span>
-                    )}
-                  </div>
-                  <p className="text-gray-600 mt-1">{deedType.description}</p>
-                </div>
-
-                <ArrowRight className="w-5 h-5 text-gray-400 group-hover:text-brand-500 group-hover:translate-x-1 transition-all" />
-              </button>
-            ))}
+          {/* Layer 1 — search first */}
+          <div className="relative mb-6">
+            <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400" />
+            <input
+              type="text"
+              autoFocus
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              onKeyDown={(e) => {
+                // Enter selects the top hit — the catalog's first match,
+                // shown on screen; never a hidden "best guess".
+                if (e.key === 'Enter' && results && results.length > 0) {
+                  select(results[0].slug);
+                }
+              }}
+              placeholder='Try "death", "corporation", "trust", "homestead"…'
+              className="w-full pl-12 pr-4 py-3 bg-white border-2 border-gray-200 rounded-xl focus:border-brand-500 focus:ring-2 focus:ring-brand-100 outline-none text-gray-900"
+            />
           </div>
 
-          {/* Info Box */}
+          {results ? (
+            /* Search results — flat, registry order */
+            <div className="grid gap-3">
+              {results.length === 0 ? (
+                <p className="text-gray-500 text-sm px-1">
+                  No matching document types. Try a different word, or browse by clearing the search.
+                </p>
+              ) : (
+                results.map(card)
+              )}
+            </div>
+          ) : (
+            <>
+              {/* Layer 3 — recents on top */}
+              {recentSlugs.length > 0 && (
+                <div className="mb-6">
+                  <h2 className="text-xs font-semibold uppercase tracking-wide text-gray-500 mb-2">
+                    Recently used
+                  </h2>
+                  <div className="grid gap-2">
+                    {recentSlugs.map((slug) => {
+                      const f = formConfig(slug);
+                      return f ? card(f) : null;
+                    })}
+                  </div>
+                </div>
+              )}
+
+              {/* Layer 2 — grouped browse, desk taxonomy */}
+              <div className="space-y-3">
+                {groups.map(({ group, forms }) => {
+                  const open = !!expanded[group];
+                  return (
+                    <div key={group} className="bg-white rounded-xl border border-gray-200">
+                      <button
+                        onClick={() => setExpanded((e) => ({ ...e, [group]: !open }))}
+                        className="w-full flex items-center justify-between px-5 py-3.5 text-left"
+                      >
+                        <span className="font-semibold text-gray-900">
+                          {group}
+                          <span className="ml-2 text-sm font-normal text-gray-400">
+                            {forms.length}
+                          </span>
+                        </span>
+                        {open ? (
+                          <ChevronDown className="w-5 h-5 text-gray-400" />
+                        ) : (
+                          <ChevronRight className="w-5 h-5 text-gray-400" />
+                        )}
+                      </button>
+                      {open && <div className="px-4 pb-4 grid gap-2">{forms.map(card)}</div>}
+                    </div>
+                  );
+                })}
+              </div>
+            </>
+          )}
+
           <div className="mt-8 p-4 bg-brand-50 border border-brand-200 rounded-xl">
             <p className="text-sm text-brand-800">
-              <strong>New!</strong> The Document Builder shows a live preview of your deed as you fill in the details. 
-              All information is auto-filled from county records when possible.
+              The Document Builder shows a live preview as you fill in the details.
+              Property information is auto-filled from county records when possible.
             </p>
           </div>
         </div>
@@ -84,4 +191,3 @@ export default function DeedBuilderSelectPage() {
     </div>
   );
 }
-

--- a/frontend/src/lib/formRegistry.ts
+++ b/frontend/src/lib/formRegistry.ts
@@ -13,6 +13,30 @@
  */
 
 export type NotarialCertificate = 'acknowledgment' | 'jurat';
+
+/**
+ * CAT1 — the picker's browse groups. DESK taxonomy, not engineering
+ * taxonomy: officers think in situations ("the husband died", "seller is
+ * an LLC"), so the groups read like escrow work — the coherence families
+ * (deed/affidavit/declaration) stay internal.
+ */
+export type SituationGroup =
+  | 'Transfer Property'
+  | 'Clear Title After a Death'
+  | 'Homestead'
+  | 'Trusts'
+  | 'Power of Attorney'
+  | 'Other Recorded Documents';
+
+/** Browse order — by desk frequency. */
+export const SITUATION_GROUP_ORDER: SituationGroup[] = [
+  'Transfer Property',
+  'Clear Title After a Death',
+  'Homestead',
+  'Trusts',
+  'Power of Attorney',
+  'Other Recorded Documents',
+];
 /**
  * deed        — two-party conveyance: acknowledgment + DTT declaration.
  * affidavit   — sworn statement: jurat, no DTT; parties aliased onto the
@@ -72,6 +96,12 @@ export interface FormTypeConfig {
   /** Officer-typed fact inputs (affidavit family only) — drives the shared
       AffidavitSection so a sibling form is registry data + a template. */
   affidavitFields?: AffidavitFieldSpec[];
+  /** CAT1 — UI METADATA ONLY: situation words + aliases for the picker's
+      type-ahead ("death", "llc", "successor"). Never structural; the
+      registry's no-legal-choice pin is untouched by these. */
+  keywords: string[];
+  /** CAT1 — the picker's browse group (desk taxonomy). */
+  situationGroup: SituationGroup;
 }
 
 const DEED_SECTIONS = ['property', 'grantor', 'grantee', 'vesting', 'transferTax', 'recording'];
@@ -132,6 +162,8 @@ export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
     title: 'GRANT DEED',
     description: 'Standard transfer of property ownership with implied warranties',
     popular: true,
+    keywords: ['transfer', 'sale', 'sell', 'convey', 'buyer', 'seller', 'purchase'],
+    situationGroup: 'Transfer Property',
     family: 'deed',
     sections: DEED_SECTIONS,
     notarial: 'acknowledgment',
@@ -143,6 +175,8 @@ export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
     title: 'QUITCLAIM DEED',
     description: 'Transfer ownership without warranties — commonly used between family members',
     popular: true,
+    keywords: ['transfer', 'quit', 'claim', 'family', 'divorce', 'remove name', 'add name'],
+    situationGroup: 'Transfer Property',
     family: 'deed',
     sections: DEED_SECTIONS,
     notarial: 'acknowledgment',
@@ -154,6 +188,8 @@ export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
     title: 'INTERSPOUSAL TRANSFER DEED',
     description: 'Transfer between spouses — exempt from documentary transfer tax',
     popular: true,
+    keywords: ['transfer', 'spouse', 'husband', 'wife', 'marriage', 'divorce', 'interspousal'],
+    situationGroup: 'Transfer Property',
     family: 'deed',
     sections: DEED_SECTIONS,
     notarial: 'acknowledgment',
@@ -165,6 +201,8 @@ export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
     title: 'WARRANTY DEED',
     description: 'Provides the strongest buyer protections with full title guarantees',
     popular: false,
+    keywords: ['transfer', 'warranty', 'guarantee', 'sale'],
+    situationGroup: 'Transfer Property',
     family: 'deed',
     sections: DEED_SECTIONS,
     notarial: 'acknowledgment',
@@ -176,6 +214,8 @@ export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
     title: 'TAX DEED',
     description: 'Transfer resulting from tax sale — typically used by government entities',
     popular: false,
+    keywords: ['transfer', 'tax sale', 'government', 'auction'],
+    situationGroup: 'Transfer Property',
     family: 'deed',
     sections: DEED_SECTIONS,
     notarial: 'acknowledgment',
@@ -188,6 +228,8 @@ export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
     title: 'JOINT TENANCY GRANT DEED',
     description: 'Grant deed conveying to two or more grantees as joint tenants — vesting printed on the face of the form',
     popular: false,
+    keywords: ['transfer', 'joint tenants', 'joint tenancy', 'survivorship', 'couple'],
+    situationGroup: 'Transfer Property',
     family: 'deed',
     sections: FIXED_VESTING_DEED_SECTIONS,
     notarial: 'acknowledgment',
@@ -201,6 +243,8 @@ export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
     subtitle: 'Community Property with Right of Survivorship',
     description: 'Grant deed conveying to spouses as community property with right of survivorship — vesting printed on the face of the form',
     popular: false,
+    keywords: ['transfer', 'community property', 'survivorship', 'spouses', 'married couple'],
+    situationGroup: 'Transfer Property',
     family: 'deed',
     sections: FIXED_VESTING_DEED_SECTIONS,
     notarial: 'acknowledgment',
@@ -218,6 +262,8 @@ export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
     title: 'CORPORATION GRANT DEED',
     description: 'Grant deed with a corporation as grantor — officers sign in capacity; full transfer-tax declaration',
     popular: false,
+    keywords: ['transfer', 'corporation', 'company', 'inc', 'entity', 'llc', 'business seller'],
+    situationGroup: 'Transfer Property',
     family: 'deed',
     sections: DEED_SECTIONS,
     notarial: 'acknowledgment',
@@ -229,6 +275,8 @@ export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
     title: 'PARTNERSHIP GRANT DEED',
     description: 'Grant deed with a partnership as grantor — general partners sign in capacity; full transfer-tax declaration',
     popular: false,
+    keywords: ['transfer', 'partnership', 'partners', 'company', 'entity', 'business seller'],
+    situationGroup: 'Transfer Property',
     family: 'deed',
     sections: DEED_SECTIONS,
     notarial: 'acknowledgment',
@@ -240,6 +288,8 @@ export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
     title: 'AFFIDAVIT — DEATH OF JOINT TENANT',
     description: 'Clears a deceased joint tenant from title — sworn statement with jurat, death certificate attached',
     popular: false,
+    keywords: ['death', 'died', 'deceased', 'survivor', 'joint tenant', 'clear title', 'death certificate'],
+    situationGroup: 'Clear Title After a Death',
     family: 'affidavit',
     sections: AFFIDAVIT_SECTIONS,
     notarial: 'jurat',
@@ -262,6 +312,8 @@ export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
     subtitle: 'Community Property with Right of Survivorship — Spouse',
     description: 'Clears a deceased spouse from community-property-with-survivorship title — sworn statement with jurat, death certificate attached',
     popular: false,
+    keywords: ['death', 'died', 'deceased', 'survivor', 'spouse', 'husband', 'wife', 'community property', 'clear title'],
+    situationGroup: 'Clear Title After a Death',
     family: 'affidavit',
     sections: AFFIDAVIT_SECTIONS,
     notarial: 'jurat',
@@ -284,6 +336,8 @@ export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
     title: 'AFFIDAVIT — DEATH OF TRUSTEE',
     description: 'Clears a deceased trustee from title held in trust — sworn by the surviving or successor trustee, death certificate attached',
     popular: false,
+    keywords: ['death', 'died', 'deceased', 'trustee', 'trust', 'successor trustee', 'clear title'],
+    situationGroup: 'Clear Title After a Death',
     family: 'affidavit',
     sections: AFFIDAVIT_SECTIONS,
     notarial: 'jurat',
@@ -308,6 +362,8 @@ export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
     subtitle: 'By Surviving Domestic Partner',
     description: 'Clears a deceased joint tenant from title, sworn by the surviving registered domestic partner (Fam C §297) — jurat, death certificate attached',
     popular: false,
+    keywords: ['death', 'died', 'deceased', 'survivor', 'domestic partner', 'joint tenant', 'clear title'],
+    situationGroup: 'Clear Title After a Death',
     family: 'affidavit',
     sections: AFFIDAVIT_SECTIONS,
     notarial: 'jurat',
@@ -332,6 +388,8 @@ export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
     subtitle: 'Community Property with Right of Survivorship — Domestic Partner',
     description: 'Clears a deceased registered domestic partner from community-property-with-survivorship title (Fam C §297) — jurat, death certificate attached',
     popular: false,
+    keywords: ['death', 'died', 'deceased', 'survivor', 'domestic partner', 'community property', 'clear title'],
+    situationGroup: 'Clear Title After a Death',
     family: 'affidavit',
     sections: AFFIDAVIT_SECTIONS,
     notarial: 'jurat',
@@ -356,6 +414,8 @@ export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
     subtitle: '(Individual)',
     description: 'Declares a homestead on the owner’s principal dwelling (CCP §704.930) — acknowledged and recorded',
     popular: false,
+    keywords: ['homestead', 'protect home', 'equity', 'declaration', 'individual owner'],
+    situationGroup: 'Homestead',
     family: 'declaration',
     sections: DECLARATION_SECTIONS,
     notarial: 'acknowledgment',
@@ -381,6 +441,8 @@ export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
     subtitle: '(Spouses as Declared Owners)',
     description: 'Spouses declare a homestead on their principal dwelling (CCP §704.930) — acknowledged and recorded',
     popular: false,
+    keywords: ['homestead', 'protect home', 'equity', 'spouses', 'married couple'],
+    situationGroup: 'Homestead',
     family: 'declaration',
     sections: DECLARATION_SECTIONS,
     notarial: 'acknowledgment',
@@ -412,6 +474,8 @@ export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
     title: 'DECLARATION OF ABANDONMENT OF DECLARED HOMESTEAD',
     description: 'Abandons a previously recorded homestead declaration — acknowledged; identifies the prior declaration by its recording reference',
     popular: false,
+    keywords: ['homestead', 'abandon', 'abandonment', 'remove homestead', 'cancel homestead'],
+    situationGroup: 'Homestead',
     family: 'declaration',
     sections: DECLARATION_SECTIONS,
     notarial: 'acknowledgment',
@@ -441,6 +505,8 @@ export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
     subtitle: 'California Probate Code Section 18100.5',
     description: 'Certifies a trust’s existence and the trustees’ authority (Prob C §18100.5) — acknowledged; no property description',
     popular: false,
+    keywords: ['trust', 'certification', 'trustee', 'settlor', 'probate 18100.5', 'title company'],
+    situationGroup: 'Trusts',
     family: 'declaration',
     sections: PROPERTYLESS_DECLARATION_SECTIONS,
     notarial: 'acknowledgment',
@@ -483,6 +549,8 @@ export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
     subtitle: '(California Probate Code § 5600)',
     description: 'Revokes a recorded transfer on death deed — statutory form; must be recorded within 60 days of notarization',
     popular: false,
+    keywords: ['revoke', 'revocation', 'transfer on death', 'tod', 'beneficiary deed', 'cancel'],
+    situationGroup: 'Other Recorded Documents',
     family: 'declaration',
     sections: DECLARATION_SECTIONS,
     notarial: 'acknowledgment',
@@ -511,6 +579,8 @@ export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
     subtitle: '(California Probate Code Section 4401)',
     description: 'The §4401 statutory power of attorney, recordable — the principal initials powers and signs before a notary',
     popular: false,
+    keywords: ['power of attorney', 'poa', 'agent', 'attorney-in-fact', 'authority', 'principal', 'statutory'],
+    situationGroup: 'Power of Attorney',
     family: 'declaration',
     sections: PROPERTYLESS_DECLARATION_SECTIONS,
     notarial: 'acknowledgment',
@@ -544,6 +614,8 @@ export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
     title: 'SUBSTITUTION OF TRUSTEE',
     description: 'The beneficiary under a recorded deed of trust substitutes a new trustee — acknowledged and recorded',
     popular: false,
+    keywords: ['trust', 'trustee', 'substitute', 'substitution', 'deed of trust', 'beneficiary', 'lender'],
+    situationGroup: 'Trusts',
     family: 'declaration',
     sections: DECLARATION_SECTIONS,
     notarial: 'acknowledgment',

--- a/frontend/src/lib/formSearch.ts
+++ b/frontend/src/lib/formSearch.ts
@@ -1,0 +1,57 @@
+/**
+ * CAT1 — the picker's translation layer: situation → instrument.
+ *
+ * Escrow officers think in situations ("the husband died", "seller is an
+ * LLC"), not form names. Search matches the registry's labels,
+ * descriptions, and per-type keyword aliases; browse groups by desk
+ * taxonomy. ORGANIZATION ONLY — nothing here ranks by "what you probably
+ * want" or recommends an instrument: choosing the instrument is the
+ * officer's legal decision (Flag-3 doctrine).
+ */
+import {
+  FORM_REGISTRY,
+  FormTypeConfig,
+  SITUATION_GROUP_ORDER,
+  SituationGroup,
+} from '@/lib/formRegistry';
+
+const norm = (s: string) => s.toLowerCase().trim();
+
+/** One haystack per type: label + description + keywords. */
+function haystack(f: FormTypeConfig): string {
+  return norm([f.label, f.description, ...f.keywords].join(' '));
+}
+
+/**
+ * Substring + simple fuzzy: every whitespace-separated query token must
+ * appear as a substring of the type's haystack, OR prefix some word in
+ * it ("corp" → "corporation"). Order-preserving char-subsequence fuzz is
+ * deliberately NOT used — near-miss matches on legal instruments invite
+ * wrong picks; a miss should read as a miss.
+ */
+export function matchesForm(f: FormTypeConfig, query: string): boolean {
+  const q = norm(query);
+  if (!q) return true;
+  const hay = haystack(f);
+  const words = hay.split(/[^a-z0-9§.-]+/);
+  return q.split(/\s+/).every(
+    (token) => hay.includes(token) || words.some((w) => w.startsWith(token))
+  );
+}
+
+/**
+ * All matching types, registry order (stable, no relevance ranking —
+ * organization, not recommendation). Enter in the picker selects the
+ * first, which is simply the catalog's first match.
+ */
+export function searchForms(query: string): FormTypeConfig[] {
+  return Object.values(FORM_REGISTRY).filter((f) => matchesForm(f, query));
+}
+
+/** Browse groups in desk-frequency order; every type appears exactly once. */
+export function groupedForms(): Array<{ group: SituationGroup; forms: FormTypeConfig[] }> {
+  return SITUATION_GROUP_ORDER.map((group) => ({
+    group,
+    forms: Object.values(FORM_REGISTRY).filter((f) => f.situationGroup === group),
+  })).filter((g) => g.forms.length > 0);
+}


### PR DESCRIPTION
## The 21-instrument catalog gets a front door

The flat list is replaced by three registry-driven layers, exactly per the ticket:

**1. Search first.** Type-ahead over label + description + a new per-type `keywords` array (situation words: the affidavits carry "death"/"deceased"/"survivor"; the entity deeds carry "corporation"/"llc"/"partnership"). Matching lives in `lib/formSearch.ts`: substring + word-prefix ("corp" → corporation). Enter selects the **visible** top hit — registry order, no relevance ranking. Character-subsequence fuzz is deliberately absent and canary-pinned (`"crprtn"` matches nothing): a near-miss on a legal instrument must read as a miss.

**2. Grouped browse, desk taxonomy.** New `situationGroup` per entry; groups in desk-frequency order — Transfer Property (9) · Clear Title After a Death (5) · Homestead (3) · Trusts (2) · Power of Attorney (1) · Other Recorded Documents (1). Collapsible; first group open by default; cards keep their existing one-line "use when" copy. The engineering families (deed/affidavit/declaration) stay internal.

**3. Recents.** Top-4 types by this account's `deed_type` frequency, computed client-side from the existing `GET /deeds` response — **no new backend route**. Silent fetch: a missing strip never toasts.

## The doctrine constraint, pinned

Organization, never recommendation. No wizard, no scoring, no auto-pick — choosing the instrument is the officer's legal decision (Flag-3), stated in the picker's own code comment and enforced by pins (no `recommend`/`suggest`/`bestMatch`/`autoSelect` machinery; Enter's target is the on-screen first result). `keywords`/`situationGroup` are UI metadata only — both are compile-time required *and* coherence-pinned (valid group, non-empty lowercase keywords), and the registry's no-legal-choice pin passes untouched.

## Pins
- Search suite: "death" → all five affidavits · "corporation"/"llc" → entity deed · "trust" → certification + substitution + trustee affidavit · "homestead" → all three · multi-token AND ("death partner") · no-fuzz canary · empty query = whole catalog in registry order
- Browse completeness: every type in exactly one group; **all 21 reachable** by their own label
- Picker: Flag-3 comment present, visible-top-hit Enter, silent recents from `/deeds`

## Gates
- Jest: **304 passed** (was 292; +12)
- tsc: frozen baseline **98** (unchanged)
- Backend **241** + six-flow ✔ (frontend-only change; attested by full runs)

## Out of scope, untouched per ticket
Related-instrument hints at selection time (the registry already carries `family`/companion data — candidate follow-up) · registry structural fields · mobile-specific redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_