### PR TITLE
hotfix: heal the poisoned shared DB connection (login 500 outage)

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -31,28 +31,58 @@ if conn:
         print(f"Warning: could not ensure deed_pdfs table: {_pdf_table_error}")
 
 def get_db_connection():
-    """Get database connection, reconnecting if necessary"""
+    """Get database connection — healing a POISONED one, reconnecting a
+    dead one.
+
+    Production outage 2026-08-01: one failed query on this shared
+    connection, never rolled back, left the transaction aborted — and
+    Postgres then refuses EVERY later query on it ("current transaction
+    is aborted, commands ignored until end of transaction block"), which
+    surfaced as login 500s. The old liveness probe made it worse: it
+    caught only Operational/Interface errors, so the aborted-transaction
+    error (a different psycopg2 class) escaped to callers instead of
+    triggering recovery, and it never tried rollback() — the one call
+    that instantly cures that state.
+
+    Recovery ladder, in order:
+      1. closed/None      → reconnect
+      2. probe SELECT 1   → healthy, return
+      3. probe failed     → rollback() and re-probe (heals the poisoned
+                            case without dropping the connection)
+      4. still failing    → reconnect
+      5. reconnect failed → 500
+    """
     global conn
     if not DB_URL:
         raise HTTPException(status_code=500, detail="Database connection not available")
 
-    try:
-        # Test if connection is alive
-        if conn is None or conn.closed:
-            print("⚠️ Database connection closed, reconnecting...")
-            conn = psycopg2.connect(DB_URL, connect_timeout=10)
-            print("✅ Database reconnected successfully")
-        else:
-            # Test with a simple query
-            with conn.cursor() as cur:
-                cur.execute("SELECT 1")
-    except (psycopg2.OperationalError, psycopg2.InterfaceError, AttributeError) as e:
-        print(f"⚠️ Database connection lost ({e}), reconnecting...")
+    def _reconnect(reason):
+        global conn
+        print(f"⚠️ Database connection lost ({reason}), reconnecting...")
         try:
             conn = psycopg2.connect(DB_URL, connect_timeout=10)
             print("✅ Database reconnected successfully")
         except Exception as reconnect_error:
             print(f"❌ Failed to reconnect to database: {reconnect_error}")
             raise HTTPException(status_code=500, detail="Database connection failed")
+
+    try:
+        if conn is None or conn.closed:
+            print("⚠️ Database connection closed, reconnecting...")
+            conn = psycopg2.connect(DB_URL, connect_timeout=10)
+            print("✅ Database reconnected successfully")
+        else:
+            # Liveness probe. ANY psycopg2 error here means the shared
+            # connection is unusable for callers — recover, never raise.
+            with conn.cursor() as cur:
+                cur.execute("SELECT 1")
+    except (psycopg2.Error, AttributeError) as e:
+        try:
+            conn.rollback()
+            with conn.cursor() as cur:
+                cur.execute("SELECT 1")
+            print(f"♻️ Healed poisoned connection via rollback ({e})")
+        except Exception:
+            _reconnect(e)
 
     return conn

--- a/backend/routers/users_auth.py
+++ b/backend/routers/users_auth.py
@@ -170,8 +170,12 @@ async def register_user(user: UserRegister = Body(...)):
 @router.post("/users/login")
 async def login_user(credentials: UserLogin = Body(...)):
     """Authenticate user and return JWT token"""
+    # Poisoned-conn hotfix: bind before try — if get_db_connection raises,
+    # the except block's rollback used to hit an UnboundLocalError.
+    conn = None
     try:
         # PHASE 24-G FIX: Use resilient connection that auto-reconnects
+        # (and, since the 2026-08-01 outage, heals aborted transactions).
         conn = db.get_db_connection()
 
         with conn.cursor() as cur:

--- a/backend/tests/test_poisoned_connection.py
+++ b/backend/tests/test_poisoned_connection.py
@@ -1,0 +1,139 @@
+"""Production outage 2026-08-01 — the poisoned shared connection, pinned.
+
+One failed query on the module-level psycopg2 connection, never rolled
+back, aborted the transaction — and Postgres then refused EVERY later
+query on it, surfacing as login 500s ("current transaction is aborted,
+commands ignored until end of transaction block"). Three stacked defects
+let it stick: the liveness probe caught only Operational/Interface
+errors (the aborted-transaction class escaped to callers), it never
+tried rollback() (the instant cure), and the login handler's rollback
+fallback referenced an unbound local when get_db_connection raised.
+
+Pins: get_db_connection HEALS a poisoned connection via rollback (fake
+connection, CI-safe), the recovery ladder falls through to reconnect,
+and — against the live test DB — a genuinely poisoned psycopg2
+connection comes back usable and the login route answers 401, not 500.
+"""
+import os
+
+import psycopg2
+import pytest
+
+import db
+
+
+class FakePoisonedConn:
+    """Mimics psycopg2's aborted-transaction state: every query raises
+    until rollback() is called."""
+
+    closed = 0
+
+    def __init__(self):
+        self.poisoned = True
+        self.rollbacks = 0
+
+    def cursor(self):
+        conn = self
+
+        class _Cur:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def execute(self, sql, params=None):
+                if conn.poisoned:
+                    raise psycopg2.errors.InFailedSqlTransaction(
+                        "current transaction is aborted, commands ignored "
+                        "until end of transaction block\n"
+                    )
+
+        return _Cur()
+
+    def rollback(self):
+        self.rollbacks += 1
+        self.poisoned = False
+
+
+class FakeDeadConn(FakePoisonedConn):
+    """Rollback does NOT help — forces the reconnect rung."""
+
+    def rollback(self):
+        self.rollbacks += 1  # still poisoned
+
+
+def test_poisoned_connection_heals_via_rollback(monkeypatch):
+    fake = FakePoisonedConn()
+    monkeypatch.setattr(db, "conn", fake)
+    monkeypatch.setattr(db, "DB_URL", "postgresql://unused/healed-before-reconnect")
+
+    healed = db.get_db_connection()
+
+    assert healed is fake            # same connection, not a reconnect
+    assert fake.rollbacks == 1       # the cure was rollback
+    assert not fake.poisoned
+
+
+def test_unhealable_connection_falls_through_to_reconnect(monkeypatch):
+    fake = FakeDeadConn()
+    fresh = FakePoisonedConn()
+    fresh.poisoned = False
+    monkeypatch.setattr(db, "conn", fake)
+    monkeypatch.setattr(db, "DB_URL", "postgresql://unused/reconnect-rung")
+    monkeypatch.setattr(db.psycopg2, "connect", lambda *a, **k: fresh)
+
+    healed = db.get_db_connection()
+
+    assert healed is fresh           # rollback failed → reconnected
+    assert fake.rollbacks == 1       # ... but rollback WAS attempted first
+
+
+LIVE_DB = os.getenv("DATABASE_URL")
+
+
+@pytest.mark.skipif(not LIVE_DB, reason="live test DB required")
+def test_real_poisoned_connection_recovers_and_login_returns_401():
+    """The production failure, reproduced end to end: poison a REAL
+    psycopg2 connection with a failing statement, install it as the
+    shared conn, and prove (a) the helper heals it and (b) the login
+    route answers 401 for bad credentials — never the outage's 500."""
+    from fastapi.testclient import TestClient
+    from main import app
+
+    poisoned = psycopg2.connect(LIVE_DB, connect_timeout=10)
+    try:
+        with poisoned.cursor() as cur:
+            cur.execute("SELECT 1")   # open a transaction
+        try:
+            with poisoned.cursor() as cur:
+                cur.execute("SELECT * FROM table_that_does_not_exist_xyz")
+        except psycopg2.Error:
+            pass                      # transaction now aborted — poisoned
+
+        # Confirm the poisoned state is real before installing it:
+        with pytest.raises(psycopg2.Error):
+            with poisoned.cursor() as cur:
+                cur.execute("SELECT 1")
+
+        original = db.conn
+        db.conn = poisoned
+        try:
+            healed = db.get_db_connection()
+            with healed.cursor() as cur:
+                cur.execute("SELECT 1")   # usable again
+
+            db.conn = poisoned if healed is poisoned else healed
+            client = TestClient(app)
+            resp = client.post("/users/login", json={
+                "email": "poisoned-conn-probe@example.com",
+                "password": "wrong-password",
+            })
+            assert resp.status_code == 401, resp.text
+        finally:
+            db.conn = original
+    finally:
+        try:
+            poisoned.close()
+        except Exception:
+            pass


### PR DESCRIPTION
## Production outage — diagnosed live, fixed, reproduced in tests

**Symptom:** every login shows "Server error. Please try again later or contact support."
**Live diagnosis** (probed the production API directly): `GET /health` → 200; `POST /users/login` → **500** with `current transaction is aborted, commands ignored until end of transaction block`. That is a **poisoned shared connection**: one failed query on the module-level psycopg2 connection, never rolled back, and Postgres then refuses every later query on it — logins included — until rollback or restart. Not related to BRAND1/2 (frontend-only).

### Three stacked defects, all fixed
1. **The liveness probe couldn't see the poison.** `get_db_connection()` caught only `OperationalError`/`InterfaceError`; `InFailedSqlTransaction` escaped to callers instead of triggering recovery. It now catches all `psycopg2.Error`.
2. **It never tried the cure.** `rollback()` instantly clears an aborted transaction. New recovery ladder: probe → **rollback + re-probe** (heals in place, same connection) → reconnect → loud 500.
3. **Login's fallback was unreachable.** Its rollback referenced a local `conn` that was never bound when `get_db_connection` raised; it now binds before the `try`.

### Pins (+3)
- CI-safe fake-connection tests: heal-via-rollback returns the **same** connection; an unhealable one falls through to reconnect *with rollback attempted first*.
- Live-DB reproduction of the outage end to end: a **real** psycopg2 connection poisoned by a failing statement, installed as the shared conn, healed by the helper — and the login route answering **401** for bad credentials, never the outage's 500. (Skips cleanly in CI, which has no database.)

### Recovery
The deploy restarts the service, clearing the currently-stuck connection immediately. With the fix, any future poisoning self-heals on the next request instead of wedging login until a restart. The original poisoning query isn't identifiable without Render logs — if the owner grabs the log lines just before the first failure we can name it, but with self-healing the failure class is extinct either way.

### Gates
Backend **244** (was 241; +3) · six-flow ✔ unchanged · jest **312** · tsc frozen **98**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_