### PR TITLE
security: registration could mint an admin account

### DIFF
--- a/backend/routers/users_auth.py
+++ b/backend/routers/users_auth.py
@@ -16,7 +16,7 @@ from typing import Optional
 import db
 from auth import (
     get_password_hash, verify_password, create_access_token,
-    get_current_user_id, AuthUtils
+    get_current_user_id, is_admin_role, AuthUtils
 )
 from database import clean_profile_text, get_user_profile, update_user_profile, get_recent_properties
 
@@ -75,6 +75,21 @@ async def register_user(user: UserRegister = Body(...)):
         # value prints on deed faces and emails.
         if not clean_profile_text(user.full_name):
             raise HTTPException(status_code=400, detail="Full name is required")
+
+        # SECURITY: registration must never grant privilege. users.role is
+        # the professional role that prints on the profile (Escrow Officer,
+        # Title Agent, ...) AND the value is_admin_role() reads to gate the
+        # admin console — one column, two meanings. The field was accepted
+        # verbatim from the request body, so registering with
+        # {"role": "admin"} minted a working admin account: the login token
+        # carried role=admin and /admin/* answered it, including API-key
+        # minting. Privilege is granted by an operator, never claimed by a
+        # registrant.
+        if is_admin_role(user.role):
+            raise HTTPException(
+                status_code=400,
+                detail="That role cannot be selected at registration.",
+            )
 
         # Hash password
         hashed_password = get_password_hash(user.password)
@@ -173,6 +188,13 @@ async def register_user(user: UserRegister = Body(...)):
         except Exception as rollback_error:
             print(f"[REGISTER ROLLBACK ERROR] {rollback_error}")
         raise HTTPException(status_code=400, detail="Email already exists")
+    except HTTPException:
+        # Deliberate validation failures (weak password, bad email, bad
+        # state, missing name, privileged role) are already the right
+        # answer — the blanket handler below used to re-wrap them as
+        # "Registration failed: 400: ..." with a 500 status, so every
+        # validation message reached the user as a server error.
+        raise
     except Exception as e:
         # PHASE 24-G FIX: Safe rollback that handles closed connections
         try:

--- a/backend/tests/test_registration_privilege.py
+++ b/backend/tests/test_registration_privilege.py
@@ -1,0 +1,103 @@
+"""Registration must never grant privilege.
+
+`users.role` carries two meanings at once: the professional role that
+prints on a profile (Escrow Officer, Title Agent, ...) and the value
+`is_admin_role()` reads to open the admin console. Registration accepted
+that field verbatim from the request body, so:
+
+    POST /users/register {"role": "admin", ...}
+
+minted a working admin account — the token returned by the very same call
+carried role=admin, and /admin/* answered it, including POST
+/admin/api-keys (mint a live partner key) and the user/deed search
+consoles. Found while building the A1 partner-API harness, which needed
+an admin token and got one far too easily.
+
+The structural pin runs everywhere; the end-to-end proof needs a database.
+"""
+import inspect
+import os
+
+import pytest
+
+LIVE_DB = os.getenv("DATABASE_URL")
+
+ADMIN_ROLE_SPELLINGS = ["admin", "Admin", "ADMIN", " administrator ",
+                        "superadmin", "super_admin"]
+
+
+def test_registration_rejects_privileged_roles_structurally():
+    """The guard lives in the handler and must stay there."""
+    from routers import users_auth
+    src = inspect.getsource(users_auth.register_user)
+    assert "is_admin_role(user.role)" in src, "registration no longer checks the role"
+
+
+def test_is_admin_role_still_covers_every_spelling():
+    """The guard is only as wide as the predicate it shares with the
+    admin gate — they must not drift apart."""
+    from auth import is_admin_role
+    for spelling in ADMIN_ROLE_SPELLINGS:
+        assert is_admin_role(spelling), spelling
+    for ordinary in ["escrow_officer", "Title Agent", "attorney", "user", ""]:
+        assert not is_admin_role(ordinary), ordinary
+
+
+@pytest.mark.skipif(not LIVE_DB, reason="live test DB required")
+@pytest.mark.parametrize("spelling", ADMIN_ROLE_SPELLINGS)
+def test_cannot_self_register_as_admin(spelling):
+    # No create_tables() here: calling it mid-suite issues ALTER TABLE
+    # users, which queues behind any connection sitting idle-in-
+    # transaction and then blocks every later reader of that table. The
+    # schema is already converged by the time tests run.
+    from fastapi.testclient import TestClient
+    from main import app
+
+    client = TestClient(app)
+    email = f"escalate-{spelling.strip().lower()}@privilege.test"
+    resp = client.post("/users/register", json={
+        "email": email, "password": "Escalate!Passw0rd",
+        "confirm_password": "Escalate!Passw0rd", "full_name": "Escalation Probe",
+        "role": spelling, "state": "CA", "agree_terms": True,
+    })
+    assert resp.status_code == 400, f"{spelling!r} was accepted: {resp.text}"
+
+    # And no account exists to be promoted by a later login.
+    import psycopg2
+    conn = psycopg2.connect(LIVE_DB)
+    with conn.cursor() as cur:
+        cur.execute("SELECT COUNT(*) FROM users WHERE email = %s", (email,))
+        assert cur.fetchone()[0] == 0
+    conn.close()
+
+
+@pytest.mark.skipif(not LIVE_DB, reason="live test DB required")
+def test_ordinary_registration_still_works_and_is_not_admin():
+    """The guard must not cost an honest signup."""
+    from fastapi.testclient import TestClient
+    from main import app
+    import base64
+    import json
+    import psycopg2
+
+    client = TestClient(app)
+    email = "ordinary@privilege.test"
+    conn = psycopg2.connect(LIVE_DB)
+    conn.autocommit = True
+    with conn.cursor() as cur:
+        cur.execute("""DELETE FROM user_profiles WHERE user_id IN
+                       (SELECT id FROM users WHERE email = %s)""", (email,))
+        cur.execute("DELETE FROM users WHERE email = %s", (email,))
+    conn.close()
+
+    resp = client.post("/users/register", json={
+        "email": email, "password": "Ordinary!Passw0rd",
+        "confirm_password": "Ordinary!Passw0rd", "full_name": "Ordinary User",
+        "role": "Escrow Officer", "state": "CA", "agree_terms": True,
+    })
+    assert resp.status_code == 200, resp.text
+    token = resp.json()["access_token"]
+    claims = json.loads(base64.urlsafe_b64decode(token.split(".")[1] + "=="))
+    assert claims["role"] == "Escrow Officer"
+    assert client.get("/admin/api-keys",
+                      headers={"Authorization": f"Bearer {token}"}).status_code == 403


### PR DESCRIPTION
## What was wrong

`POST /users/register` accepted the `role` field verbatim from the request body and wrote it to `users.role`. That column carries two meanings at once: the professional role shown on a profile (Escrow Officer, Title Agent, …) **and** the value `is_admin_role()` reads to open the admin console.

So this worked, against production code:

```
POST /users/register  {"email": "...", "role": "admin", ...}
→ 200, and the access_token returned by that same call carries role=admin
```

**Verified end to end against a live database before fixing.** The token opened `GET /admin/api-keys` (200). The same guard fronts `POST /admin/api-keys` — minting a live partner API key — plus the user and deed search consoles and the revenue reports. `is_admin_role()` accepts `admin`, `administrator`, `superadmin`, `super_admin`, case-insensitively and whitespace-trimmed, so several spellings worked.

No credentials, no invite, no approval step. Register, and you are an administrator.

Found while building the A1 partner-API integration harness, which needed an admin token to mint a test key — and got one far too easily.

## The fix

Registration rejects any role that `is_admin_role()` would accept, with a 400. Privilege is granted by an operator, never claimed by a registrant. The guard deliberately shares the predicate with the admin gate so the two cannot drift apart, and a test pins every spelling.

**Also fixed, same handler:** a blanket `except Exception` re-wrapped every deliberate `HTTPException` as `"Registration failed: 400: ..."` with a **500** status. That masked the new guard — and, before it, every existing validation message: weak password, bad email format, bad state code, missing name all reached users as server errors. `HTTPException` now re-raises unchanged.

## Scope of exposure

The profile-update path writes `user_profiles.role`, a different column that no auth gate reads, so registration was the only way in. Two things for the owner, both outside what code can decide:

1. **Audit existing accounts.** Anyone who registered with an admin-ish role still has it — the fix closes the door but does not change rows already written:
   ```sql
   SELECT id, email, role, created_at FROM users
   WHERE lower(trim(role)) IN ('admin','administrator','superadmin','super_admin')
   ORDER BY created_at;
   ```
   Expected result is your own account and nothing else. Anything unfamiliar is an intruder with API-key minting rights, and its keys should be revoked alongside the account.
2. **Deploy timing.** This is a live hole; it merges independently of the A1 API work, which stays held for the production schema check.

## Tests

`backend/tests/test_registration_privilege.py` — structural pin that the guard stays in the handler, a pin that the shared predicate keeps covering every spelling, a live-DB parametrized proof that each spelling is rejected *and leaves no account behind*, and a proof that an ordinary signup still succeeds and is **not** admin (403 against `/admin/api-keys`).

| Gate | Result |
|---|---|
| Backend (live DB) | 270 passed |
| Backend (CI mode) | 262 passed, 8 skipped |
| Six-flow baseline | ✔ unchanged |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_