### PR TITLE
A2: derive the API's deed catalog from the registry, and kill the rate fork

### DIFF
--- a/backend/routers/api_v1/router.py
+++ b/backend/routers/api_v1/router.py
@@ -19,6 +19,8 @@ from schemas.api_v1.deeds import (
     VerificationResponse, VerificationDocumentModel, VerificationPropertyModel, VerificationPartiesModel,
     APIErrorResponse, ErrorResponse
 )
+from services.api_catalog import chassis_type
+from services.dtt_rates import compute_dtt
 from utils.api_keys import extract_key_prefix, validate_api_key, generate_deed_id, generate_document_id
 from utils.short_code import generate_content_hash
 from pdf_engine import render_pdf_async
@@ -39,8 +41,18 @@ def build_render_row(deed_request) -> dict:
         "exemption_reason": tt.exempt_code or "",
     }
     ret = deed_request.recording.return_to
+    # A2: entity recitals ride in metadata.affidavit, the same slot the
+    # wizard's entity deeds read (templates bind `aff = affidavit`).
+    entity = getattr(deed_request.grantor, "entity", None)
+    affidavit = None
+    if entity is not None:
+        facts = {k: v for k, v in {
+            "entity_state": entity.entity_state,
+            "partnership_type": entity.partnership_type,
+        }.items() if v}
+        affidavit = facts or None
     return {
-        "deed_type": deed_request.deed_type.value.replace("_", "-"),
+        "deed_type": chassis_type(deed_request.deed_type.value),
         "grantor_name": deed_request.grantor.name,
         "grantee_name": deed_request.grantee.name,
         "legal_description": deed_request.property.legal_description,
@@ -49,6 +61,7 @@ def build_render_row(deed_request) -> dict:
         "vesting": deed_request.grantee.vesting,
         "requested_by": deed_request.recording.requested_by,
         "metadata": {
+            "affidavit": affidavit,
             "title_order_no": deed_request.recording.title_order_no,
             "escrow_no": deed_request.recording.escrow_no,
             "return_to": {
@@ -718,58 +731,58 @@ async def calculate_transfer_tax(
     request: TransferTaxCalculateRequest,
     api_key: dict = Depends(get_api_key)
 ):
-    """Calculate documentary transfer tax for a given value and location."""
-    
-    # California county rate: $1.10 per $1,000
+    """Calculate documentary transfer tax for a given value and location.
+
+    A2: this endpoint used to carry its OWN city-rate table, and it
+    disagreed with the officer-facing calculator (San Francisco $3.75 vs
+    $7.50, Santa Monica and Berkeley priced here and not there). Whichever
+    surface a caller happened to use decided what their deed declared.
+    One source now: services/dtt_rates, mirrored to dttCalc.ts and pinned.
+    """
     taxable_value = request.value - request.less_liens
-    county_rate = 1.10
-    county_tax = (taxable_value / 1000) * county_rate
-    
-    # City tax varies - common ones
-    city_rates = {
-        "los angeles": 4.50,
-        "oakland": 15.00,  # Measure W
-        "san francisco": 3.75,  # Base rate
-        "berkeley": 15.00,
-        "culver city": 4.50,
-        "santa monica": 3.00,
-        "pasadena": 2.20,
-        "pomona": 2.20,
-        "riverside": 1.10,
-    }
-    
-    city_tax = 0
+    dtt = compute_dtt(taxable_value, request.city)
+    city_rate = dtt["city_rate_per_1000"]
+
     city_breakdown = None
-    
     if request.city:
-        city_lower = request.city.lower()
-        if city_lower in city_rates:
-            city_rate = city_rates[city_lower]
-            city_tax = (taxable_value / 1000) * city_rate
+        if city_rate is None:
+            # Honest silence beats an invented number: cities absent from
+            # the own-DTT list levy no municipal transfer tax.
+            city_breakdown = {
+                "name": request.city,
+                "rate": None,
+                "amount": 0.0,
+                "notes": "This city levies no documentary transfer tax of its own.",
+            }
+        else:
             city_breakdown = {
                 "name": request.city,
                 "rate": f"${city_rate:.2f} per $1,000",
-                "amount": round(city_tax, 2),
-                "notes": "Additional city transfer tax applies" if city_rate > 2.20 else None
+                "amount": dtt["city_tax"],
+                "notes": None,
             }
-    
-    total_tax = county_tax + city_tax
-    
+
     return {
         "success": True,
         "data": {
             "taxable_value": taxable_value,
-            "county_tax": round(county_tax, 2),
-            "city_tax": round(city_tax, 2),
-            "total_tax": round(total_tax, 2),
+            "county_tax": dtt["county_tax"],
+            "city_tax": dtt["city_tax"],
+            "total_tax": dtt["total_tax"],
             "breakdown": {
                 "county": {
                     "name": f"{request.county} County",
-                    "rate": "$1.10 per $1,000",
-                    "amount": round(county_tax, 2)
+                    "rate": f"${dtt['county_rate_per_1000']:.2f} per $1,000",
+                    "amount": dtt["county_tax"]
                 },
                 "city": city_breakdown
-            }
+            },
+            # Rate provenance travels with the number — these are
+            # approximations of tiered municipal schedules, and a caller
+            # declaring tax on a recorded instrument should know that.
+            "disclaimer": "County rate per R&T §11911. City rates are approximations "
+                          "of tiered municipal schedules; verify against the current "
+                          "schedule for the recording jurisdiction."
         }
     }
 

--- a/backend/schemas/api_v1/deeds.py
+++ b/backend/schemas/api_v1/deeds.py
@@ -7,12 +7,12 @@ from datetime import datetime
 from enum import Enum
 
 
-class DeedType(str, Enum):
-    GRANT_DEED = "grant_deed"
-    QUITCLAIM_DEED = "quitclaim_deed"
-    INTERSPOUSAL_TRANSFER = "interspousal_transfer"
-    WARRANTY_DEED = "warranty_deed"
-    TAX_DEED = "tax_deed"
+from services.api_catalog import API_DEED_TYPES, rules_for
+
+# A2: derived from the FORMS registry (via services/form_families), deed
+# family only per the Flag-4 doctrine ruling. The old hardcoded five-value
+# list silently omitted four deed-family instruments the chassis renders.
+DeedType = Enum("DeedType", {t.upper(): t for t in API_DEED_TYPES}, type=str)
 
 
 class TaxBasis(str, Enum):
@@ -45,14 +45,33 @@ class PropertyModel(BaseModel):
         return v.upper()
 
 
+class EntityModel(BaseModel):
+    """Recitals an entity grantor's deed prints about itself. Required for
+    the entity deed types (see api_catalog.TYPE_REQUIREMENTS) — the deed
+    recites them mid-sentence, so an absent value prints a blank line
+    inside a granting clause."""
+    entity_state: Optional[str] = Field(
+        None, description="State under whose laws the entity is organized (e.g. 'California')")
+    partnership_type: Optional[str] = Field(
+        None, description="Partnership type recited on the deed (e.g. 'general partnership')")
+
+
 class GrantorModel(BaseModel):
     name: str = Field(..., description="Grantor name(s), uppercase recommended")
     address: Optional[AddressModel] = None
+    entity: Optional[EntityModel] = Field(
+        None, description="Required for entity deed types (grant_deed_corp, grant_deed_partnership)")
 
 
 class GranteeModel(BaseModel):
     name: str = Field(..., description="Grantee name(s), uppercase recommended")
-    vesting: str = Field(..., description="Vesting clause (e.g., 'a married couple as joint tenants')")
+    # A2: optional at the schema level because two instruments FIX their
+    # own vesting and refuse a supplied value; per-type enforcement lives
+    # in CreateDeedRequest.check_type_rules so the message can say why.
+    vesting: Optional[str] = Field(
+        None, description="Vesting clause (e.g., 'a married couple as joint tenants'). "
+                          "Required for most deed types; refused for the fixed-vesting "
+                          "instruments, whose title is itself the vesting decision.")
 
 
 class TransferTaxModel(BaseModel):
@@ -94,7 +113,52 @@ class CreateDeedRequest(BaseModel):
     transfer_tax: TransferTaxModel
     recording: RecordingModel
     options: Optional[DeedOptionsModel] = DeedOptionsModel()
-    
+
+    @validator("recording")
+    def check_type_rules(cls, v, values):
+        """A2 — per-instrument facts and refusals, matching what the
+        wizard's backend enforces for the same instruments. Runs on the
+        last field so the earlier ones are present in `values`.
+
+        Two refusals matter doctrinally:
+        - A fixed-vesting instrument (joint tenancy, CP with right of
+          survivorship) states its vesting on its face and its template
+          never reads a supplied value. Accepting one and dropping it
+          would silently discard a caller's legal input, so we refuse it
+          and say which instrument decided.
+        - An entity deed recites the entity's organizing state mid
+          granting-clause. Missing, it prints a blank line inside the
+          recital — a defective instrument, not a partial one.
+        """
+        deed_type = values.get("deed_type")
+        grantee = values.get("grantee")
+        grantor = values.get("grantor")
+        if deed_type is None:
+            return v
+        rules = rules_for(deed_type.value if hasattr(deed_type, "value") else str(deed_type))
+        supplied_vesting = (getattr(grantee, "vesting", None) or "").strip() if grantee else ""
+
+        if rules.fixed_vesting and supplied_vesting:
+            raise ValueError(
+                f"This instrument fixes its own vesting — {rules.note} "
+                "Remove grantee.vesting, or choose a deed type whose vesting you set."
+            )
+        if rules.requires_vesting and not supplied_vesting:
+            raise ValueError("grantee.vesting is required for this deed type")
+
+        if rules.required_entity_facts:
+            entity = getattr(grantor, "entity", None)
+            missing = [f for f in rules.required_entity_facts
+                       if not (getattr(entity, f, None) or "").strip()]
+            if missing:
+                raise ValueError(
+                    "This instrument recites facts about the grantor entity that are "
+                    f"missing: {', '.join('grantor.entity.' + f for f in missing)}. "
+                    + rules.note
+                )
+        return v
+
+
     class Config:
         json_schema_extra = {
             "example": {

--- a/backend/services/api_catalog.py
+++ b/backend/services/api_catalog.py
@@ -1,0 +1,100 @@
+"""What the partner API exposes, derived — not a second hand-kept list.
+
+The API's deed types used to be a hardcoded five-value enum that drifted
+from the catalog the wizard serves: four deed-family instruments the
+chassis renders (the fixed-vesting pair and the two entity grant deeds)
+were simply invisible to partners, and nothing would have told us.
+
+The exposed set is now derived from services/form_families.py — itself
+the mirror of the frontend FORMS registry — filtered to the DEED FAMILY
+ONLY per the Flag-4 doctrine ruling (DOCTRINE_CONFORMANCE.md §8):
+affidavits and declarations carry execution-act machinery whose premise
+is a human hand at the moment of execution, and each family needs its own
+doctrine pass before any machine-to-machine exposure.
+
+Deriving the SET is automatic. Deciding an instrument's FACTS is not:
+every exposed type must have an explicit TYPE_REQUIREMENTS entry, and a
+test fails if one is missing. So adding a deed type to the registry
+surfaces it to partners, but only after someone answers "what does this
+instrument need, and what must it refuse?" — which is the question the
+entity deeds would have failed silently (they need the grantor entity's
+state of organization; without it the deed prints a blank line where a
+recital belongs).
+"""
+from typing import Dict, List, NamedTuple
+
+from services.form_families import FAMILY_BY_DEED_TYPE
+
+# Chassis slugs are hyphenated; the API's JSON contract is underscored.
+_LEGACY_ALIASES = {"grant_deed", "quitclaim"}
+
+
+def _chassis_slugs() -> List[str]:
+    return sorted(
+        slug for slug, family in FAMILY_BY_DEED_TYPE.items()
+        if family == "deed" and slug not in _LEGACY_ALIASES and "_" not in slug
+    )
+
+
+def api_type(chassis_slug: str) -> str:
+    return chassis_slug.replace("-", "_")
+
+
+def chassis_type(api_slug: str) -> str:
+    return api_slug.replace("_", "-")
+
+
+API_DEED_TYPES: List[str] = [api_type(s) for s in _chassis_slugs()]
+
+
+class TypeRules(NamedTuple):
+    """Per-instrument facts and refusals.
+
+    fixed_vesting — the instrument's own title IS the vesting decision
+      (Flag-3 precedent). Its template deliberately never reads a stored
+      vesting value, so accepting one from a caller and dropping it would
+      be silently discarding a legal input. We refuse it instead.
+    required_entity_facts — recitals the instrument prints about the
+      grantor entity. Absent, the deed renders a blank line inside a
+      recital, which is a defective instrument, not a partial one.
+    """
+    fixed_vesting: bool = False
+    requires_vesting: bool = True
+    required_entity_facts: tuple = ()
+    note: str = ""
+
+
+TYPE_REQUIREMENTS: Dict[str, TypeRules] = {
+    "grant_deed": TypeRules(),
+    "quitclaim_deed": TypeRules(
+        requires_vesting=False,
+        note="Quitclaim conveys whatever interest the grantor holds; vesting is optional.",
+    ),
+    "interspousal_transfer": TypeRules(),
+    "warranty_deed": TypeRules(),
+    "tax_deed": TypeRules(),
+    "grant_deed_jt": TypeRules(
+        fixed_vesting=True, requires_vesting=False,
+        note="Vesting is fixed by the instrument: joint tenancy. Choosing this "
+             "form IS the vesting decision, so no vesting value is accepted.",
+    ),
+    "grant_deed_cp_ros": TypeRules(
+        fixed_vesting=True, requires_vesting=False,
+        note="Vesting is fixed by the instrument: community property with right "
+             "of survivorship. No vesting value is accepted.",
+    ),
+    "grant_deed_corp": TypeRules(
+        required_entity_facts=("entity_state",),
+        note="Corporate grantor. The deed recites the state under whose laws the "
+             "corporation is organized.",
+    ),
+    "grant_deed_partnership": TypeRules(
+        required_entity_facts=("entity_state", "partnership_type"),
+        note="Partnership grantor. The deed recites the partnership type and the "
+             "state under whose laws it is organized.",
+    ),
+}
+
+
+def rules_for(api_slug: str) -> TypeRules:
+    return TYPE_REQUIREMENTS.get(api_slug, TypeRules())

--- a/backend/services/dtt_rates.py
+++ b/backend/services/dtt_rates.py
@@ -1,0 +1,96 @@
+"""Documentary transfer tax rates — the ONE source on the backend.
+
+Mirror of the officer-facing calculator (frontend/src/lib/dttCalc.ts). A
+jest pin in dttCalc.test.ts reads this file and holds the two in sync, the
+same arrangement form_families.py has with formRegistry.ts — because a
+rate that differs between the wizard and the API is a number headed for a
+legal declaration under two different values.
+
+A2 killed the fork: the partner API carried its OWN city table with
+different rates than the wizard (San Francisco $3.75 vs $7.50, Santa
+Monica $3.00, Berkeley $15.00 — cities the wizard priced differently or
+not at all). Whichever table a partner hit decided what their deed
+declared. There is one table now, and it is this one.
+
+RATE PROVENANCE — unchanged from dttCalc.ts, and still the owner's
+escrow review to confirm against current schedules:
+  county $1.10 per $1,000 (R&T §11911)
+  city rates are APPROXIMATIONS of tiered municipal schedules:
+    Los Angeles $4.50, San Francisco $7.50, Oakland $15.00,
+    every other city with its own DTT $2.20 per $1,000
+Cities absent from CITIES_WITH_OWN_DTT levy no municipal transfer tax and
+must be charged nothing — the pre-X2.3 code applied a generic $2.20 to
+any city at all, which invented tax for cities that levy none.
+"""
+from typing import Optional, TypedDict
+
+COUNTY_RATE_PER_1000 = 1.10
+
+# Cities with their own documentary transfer tax (order mirrors dttCalc.ts).
+CITIES_WITH_OWN_DTT = [
+    "los angeles",
+    "san francisco",
+    "oakland",
+    "berkeley",
+    "san jose",
+    "sacramento",
+    "riverside",
+    "pomona",
+    "culver city",
+    "santa monica",
+    "redondo beach",
+    "inglewood",
+    "long beach",
+    "pasadena",
+]
+
+# Cities whose rate differs from the $2.20 default.
+CITY_RATES_PER_1000 = {
+    "los angeles": 4.50,
+    "san francisco": 7.50,
+    "oakland": 15.00,
+}
+DEFAULT_CITY_RATE_PER_1000 = 2.20
+
+
+class DttBreakdown(TypedDict):
+    county_tax: float
+    city_tax: float
+    total_tax: float
+    county_rate_per_1000: float
+    city_rate_per_1000: Optional[float]
+    city_levies_own_dtt: bool
+
+
+def city_rate_per_1000(city: Optional[str]) -> Optional[float]:
+    """None when the city levies no transfer tax of its own — distinct
+    from 0.0, which would read as 'levies one, and it is zero'."""
+    if not city:
+        return None
+    lowered = city.strip().lower()
+    if not any(known in lowered for known in CITIES_WITH_OWN_DTT):
+        return None
+    for known, rate in CITY_RATES_PER_1000.items():
+        if known in lowered:
+            return rate
+    return DEFAULT_CITY_RATE_PER_1000
+
+
+def compute_dtt(taxable_value: float, city: Optional[str] = None,
+                apply_city_tax: bool = True) -> DttBreakdown:
+    """County portion always; city portion only when the property sits in
+    a city that levies its own DTT."""
+    value = max(0.0, float(taxable_value or 0))
+    county_tax = (value / 1000.0) * COUNTY_RATE_PER_1000
+
+    rate = city_rate_per_1000(city) if apply_city_tax else None
+    city_tax = (value / 1000.0) * rate if rate else 0.0
+
+    return {
+        "county_tax": round(county_tax, 2),
+        "city_tax": round(city_tax, 2),
+        "total_tax": round(county_tax + city_tax, 2),
+        "county_rate_per_1000": COUNTY_RATE_PER_1000,
+        "city_rate_per_1000": rate,
+        "city_levies_own_dtt": rate is not None,
+    }

--- a/backend/tests/test_api_catalog_and_rates.py
+++ b/backend/tests/test_api_catalog_and_rates.py
@@ -1,0 +1,205 @@
+"""A2 — the derived catalog and the single rates source (CI-safe).
+
+Two forks died here:
+
+1. The API's deed types were a hardcoded five-value enum while the
+   chassis rendered nine deed-family instruments. Four were invisible to
+   partners and nothing would have reported it. The set is now derived
+   from the FORMS registry mirror.
+2. The transfer-tax endpoint carried its own city-rate table that
+   disagreed with the officer-facing calculator — same city, two rates,
+   and whichever surface a caller hit decided what their deed declared.
+"""
+import re
+from pathlib import Path
+
+import pytest
+
+from schemas.api_v1.deeds import (
+    CreateDeedRequest, DeedType, EntityModel, GranteeModel, GrantorModel,
+    PropertyModel, RecordingModel, ReturnToModel, TaxBasis, TransferTaxModel,
+)
+from services.api_catalog import (
+    API_DEED_TYPES, TYPE_REQUIREMENTS, chassis_type, rules_for,
+)
+from services.deed_pdf import TEMPLATE_BY_DEED_TYPE
+from services.dtt_rates import (
+    CITIES_WITH_OWN_DTT, CITY_RATES_PER_1000, COUNTY_RATE_PER_1000,
+    DEFAULT_CITY_RATE_PER_1000, city_rate_per_1000, compute_dtt,
+)
+from services.form_families import FAMILY_BY_DEED_TYPE
+
+BACKEND = Path(__file__).resolve().parents[1]
+DTT_CALC_TS = BACKEND.parent / "frontend/src/lib/dttCalc.ts"
+
+
+# ── The catalog is derived, not hand-kept ────────────────────────────
+
+def test_exposed_types_match_the_registry_deed_family():
+    # Spelled out rather than imported: these are the registry's legacy
+    # slug aliases (deed_pdf accepts both spellings), and listing them
+    # here means adding another alias cannot quietly change the API's
+    # public type set.
+    legacy_aliases = {"quitclaim"}
+    from_registry = {
+        slug.replace("-", "_") for slug, fam in FAMILY_BY_DEED_TYPE.items()
+        if fam == "deed" and "_" not in slug and slug not in legacy_aliases
+    }
+    assert set(API_DEED_TYPES) == from_registry
+    assert set(t.value for t in DeedType) == from_registry
+
+
+def test_the_four_previously_invisible_instruments_are_exposed():
+    """These render on the chassis and the wizard offers them; the API's
+    hardcoded list simply omitted them."""
+    for slug in ["grant_deed_jt", "grant_deed_cp_ros",
+                 "grant_deed_corp", "grant_deed_partnership"]:
+        assert slug in API_DEED_TYPES
+
+
+def test_every_exposed_type_has_an_explicit_requirements_entry():
+    """Deriving the SET is automatic; deciding an instrument's FACTS is
+    not. A new deed type must not reach partners until someone answers
+    what it needs and what it refuses — the entity deeds would have
+    shipped silently printing a blank line inside a granting clause."""
+    missing = [t for t in API_DEED_TYPES if t not in TYPE_REQUIREMENTS]
+    assert missing == [], f"exposed without a requirements decision: {missing}"
+    stale = [t for t in TYPE_REQUIREMENTS if t not in API_DEED_TYPES]
+    assert stale == [], f"requirements for types no longer exposed: {stale}"
+
+
+def test_every_exposed_type_has_a_chassis_template():
+    for api_slug in API_DEED_TYPES:
+        assert chassis_type(api_slug) in TEMPLATE_BY_DEED_TYPE, api_slug
+
+
+# ── Per-instrument facts and refusals ────────────────────────────────
+
+def _payload(deed_type, vesting="a single man", entity=None):
+    return dict(
+        deed_type=deed_type,
+        property=PropertyModel(
+            address="1 Test St", city="Los Angeles", state="CA", zip="90001",
+            county="Los Angeles", apn="1-2-3",
+            legal_description="LOT 1, TRACT 1"),
+        grantor=GrantorModel(name="GRANTOR", entity=entity),
+        grantee=GranteeModel(name="GRANTEE", vesting=vesting),
+        transfer_tax=TransferTaxModel(exempt=False, value=1000.0,
+                                      basis=TaxBasis.FULL_VALUE),
+        recording=RecordingModel(
+            requested_by="Escrow",
+            return_to=ReturnToModel(name="GRANTEE", address="1 Test St",
+                                    city="Los Angeles", state="CA", zip="90001")),
+    )
+
+
+@pytest.mark.parametrize("deed_type", ["grant_deed_jt", "grant_deed_cp_ros"])
+def test_fixed_vesting_instruments_refuse_a_supplied_vesting(deed_type):
+    """Their templates never read a stored vesting value, so accepting one
+    and dropping it would silently discard a caller's legal input."""
+    with pytest.raises(Exception) as exc:
+        CreateDeedRequest(**_payload(deed_type, vesting="as tenants in common"))
+    assert "fixes its own vesting" in str(exc.value)
+
+    # And they build fine without one.
+    CreateDeedRequest(**_payload(deed_type, vesting=None))
+
+
+@pytest.mark.parametrize("deed_type", ["grant_deed", "interspousal_transfer",
+                                       "warranty_deed", "tax_deed"])
+def test_ordinary_deeds_still_require_vesting(deed_type):
+    with pytest.raises(Exception) as exc:
+        CreateDeedRequest(**_payload(deed_type, vesting=None))
+    assert "vesting is required" in str(exc.value)
+
+
+def test_quitclaim_vesting_is_optional():
+    CreateDeedRequest(**_payload("quitclaim_deed", vesting=None))
+
+
+def test_entity_deeds_require_their_recited_facts():
+    with pytest.raises(Exception) as exc:
+        CreateDeedRequest(**_payload("grant_deed_corp"))
+    assert "grantor.entity.entity_state" in str(exc.value)
+
+    with pytest.raises(Exception) as exc:
+        CreateDeedRequest(**_payload(
+            "grant_deed_partnership", entity=EntityModel(entity_state="California")))
+    assert "grantor.entity.partnership_type" in str(exc.value)
+
+    CreateDeedRequest(**_payload(
+        "grant_deed_corp", entity=EntityModel(entity_state="Delaware")))
+
+
+def test_entity_facts_reach_the_template_slot():
+    """Entity recitals must land where the templates read them
+    (metadata.affidavit), or the deed prints blanks mid-clause."""
+    from routers.api_v1.router import build_render_row
+    req = CreateDeedRequest(**_payload(
+        "grant_deed_partnership",
+        entity=EntityModel(entity_state="Nevada", partnership_type="limited partnership")))
+    meta = build_render_row(req)["metadata"]
+    assert meta["affidavit"] == {"entity_state": "Nevada",
+                                 "partnership_type": "limited partnership"}
+
+
+def test_entity_slot_is_absent_for_ordinary_deeds():
+    from routers.api_v1.router import build_render_row
+    req = CreateDeedRequest(**_payload("grant_deed"))
+    assert build_render_row(req)["metadata"]["affidavit"] is None
+
+
+# ── One rates source ─────────────────────────────────────────────────
+
+def _ts_rates():
+    """Parse the officer-facing calculator's rates out of dttCalc.ts."""
+    src = DTT_CALC_TS.read_text(encoding="utf-8")
+    cities = re.search(r"CITIES_WITH_OWN_DTT\s*=\s*\[(.*?)\]", src, re.S).group(1)
+    city_list = re.findall(r"'([^']+)'", cities)
+    county = float(re.search(r"\(amount / 1000\) \* ([\d.]+)", src).group(1))
+    specials = {}
+    for city, rate in re.findall(
+            r"cityLower\.includes\('([^']+)'\)\)\s*\{\s*cityTax = \(amount / 1000\) \* ([\d.]+)", src):
+        specials[city] = float(rate)
+    default = float(re.findall(r"else \{\s*cityTax = \(amount / 1000\) \* ([\d.]+)", src)[0])
+    return city_list, county, specials, default
+
+
+def test_backend_rates_mirror_the_officer_facing_calculator():
+    """Same arrangement form_families.py has with formRegistry.ts: a rate
+    that differs between the wizard and the API is a number headed for a
+    legal declaration under two different values."""
+    city_list, county, specials, default = _ts_rates()
+    assert CITIES_WITH_OWN_DTT == city_list
+    assert COUNTY_RATE_PER_1000 == county
+    assert CITY_RATES_PER_1000 == specials
+    assert DEFAULT_CITY_RATE_PER_1000 == default
+
+
+def test_the_api_no_longer_carries_its_own_rate_table():
+    src = (BACKEND / "routers/api_v1/router.py").read_text(encoding="utf-8")
+    assert "city_rates = {" not in src, "the forked table came back"
+    assert "from services.dtt_rates import compute_dtt" in src
+    # No literal rate arithmetic left in the router — rates live in one
+    # module. (Comments may name the old rates; code may not compute
+    # with them.)
+    code = "\n".join(line for line in src.splitlines()
+                     if not line.strip().startswith("#"))
+    assert not re.search(r"/ 1000\)?\s*\*\s*[\d.]+", code), "rate math back in the router"
+
+
+def test_cities_without_their_own_dtt_are_charged_nothing():
+    """The pre-X2.3 disease: applying a generic city rate to any city at
+    all invented tax for cities that levy none."""
+    assert city_rate_per_1000("Fresno") is None
+    assert compute_dtt(500_000, "Fresno")["city_tax"] == 0.0
+    assert compute_dtt(500_000, "Fresno")["city_levies_own_dtt"] is False
+
+
+def test_known_city_rates():
+    assert city_rate_per_1000("Los Angeles") == 4.50
+    assert city_rate_per_1000("San Francisco") == 7.50
+    assert city_rate_per_1000("Oakland") == 15.00
+    assert city_rate_per_1000("Pasadena") == DEFAULT_CITY_RATE_PER_1000
+    # County portion alone on a $500k transfer.
+    assert compute_dtt(500_000, None)["total_tax"] == 550.0

--- a/backend/tests/test_api_v1_render.py
+++ b/backend/tests/test_api_v1_render.py
@@ -11,17 +11,37 @@ import re
 
 from routers.api_v1.router import build_render_row
 from schemas.api_v1.deeds import (
-    CreateDeedRequest, DeedType, PropertyModel, GrantorModel, GranteeModel,
-    TransferTaxModel, RecordingModel, ReturnToModel, TaxBasis,
+    CreateDeedRequest, DeedType, EntityModel, PropertyModel, GrantorModel,
+    GranteeModel, TransferTaxModel, RecordingModel, ReturnToModel, TaxBasis,
 )
 from services.deed_pdf import TEMPLATE_BY_DEED_TYPE, render_deed_html
 
 
 def _request(deed_type=DeedType.GRANT_DEED, **tt_overrides):
+    """A2: the sample is now type-aware. A fixed-vesting instrument
+    REFUSES a supplied vesting (its title is the vesting decision) and an
+    entity deed REQUIRES its organizing-state recital, so one fixed
+    payload can no longer stand in for every type — which is the point of
+    the per-type rules."""
+    from services.api_catalog import rules_for
+
     tt = dict(exempt=False, exempt_code=None, value=500000.0,
               computed_amount="550.00", basis=TaxBasis.FULL_VALUE,
               city_tax=True, city_name="Los Angeles")
     tt.update(tt_overrides)
+
+    rules = rules_for(deed_type.value)
+    grantee = GranteeModel(
+        name="ROBERT C. ROE",
+        vesting=None if rules.fixed_vesting else "a single man",
+    )
+    entity = None
+    if rules.required_entity_facts:
+        entity = EntityModel(
+            entity_state="California" if "entity_state" in rules.required_entity_facts else None,
+            partnership_type="general partnership" if "partnership_type" in rules.required_entity_facts else None,
+        )
+
     return CreateDeedRequest(
         deed_type=deed_type,
         property=PropertyModel(
@@ -29,8 +49,8 @@ def _request(deed_type=DeedType.GRANT_DEED, **tt_overrides):
             zip="90001", county="Los Angeles", apn="1234-567-890",
             legal_description="LOT 15, BLOCK 3, TRACT 12345",
         ),
-        grantor=GrantorModel(name="JOHN A. DOE"),
-        grantee=GranteeModel(name="ROBERT C. ROE", vesting="a single man"),
+        grantor=GrantorModel(name="JOHN A. DOE", entity=entity),
+        grantee=grantee,
         transfer_tax=TransferTaxModel(**tt),
         recording=RecordingModel(
             requested_by="Pacific Coast Escrow",

--- a/frontend/src/__tests__/dttRatesMirror.test.ts
+++ b/frontend/src/__tests__/dttRatesMirror.test.ts
@@ -1,0 +1,65 @@
+/**
+ * A2 — the DTT rate tables must agree across the wire.
+ *
+ * The partner API carried its own city-rate table that disagreed with
+ * this calculator: San Francisco $3.75 there vs $7.50 here, plus cities
+ * priced on one side and absent from the other. Whichever surface a
+ * caller happened to use decided what their deed declared — and these
+ * numbers go onto a recorded instrument as a tax declaration.
+ *
+ * Same arrangement formRegistry.test.ts has with form_families.py: the
+ * Python mirror is read here and pinned against this file's values.
+ */
+import { describe, expect, it } from '@jest/globals';
+import fs from 'fs';
+import path from 'path';
+
+import { CITIES_WITH_OWN_DTT, computeDttBreakdown } from '@/lib/dttCalc';
+
+const py = fs.readFileSync(
+  path.join(__dirname, '..', '..', '..', 'backend', 'services', 'dtt_rates.py'),
+  'utf8'
+);
+
+describe('DTT rates — one source across the wire', () => {
+  it('every city with its own DTT appears in the backend mirror', () => {
+    for (const city of CITIES_WITH_OWN_DTT) {
+      expect(py).toContain(`"${city}"`);
+    }
+  });
+
+  it('the backend list has no cities this one lacks', () => {
+    const block = py.match(/CITIES_WITH_OWN_DTT = \[([\s\S]*?)\]/);
+    expect(block).not.toBeNull();
+    const backendCities = [...block![1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+    expect(backendCities).toEqual(CITIES_WITH_OWN_DTT);
+  });
+
+  it('the county rate matches', () => {
+    expect(py).toContain('COUNTY_RATE_PER_1000 = 1.10');
+    // ...and this file still computes with it.
+    const breakdown = computeDttBreakdown({
+      transferValue: '500000', isExempt: false, areaType: 'unincorporated',
+      cityName: '', basis: 'full_value', exemptionReason: '', calculatedAmount: '',
+    } as never);
+    expect(breakdown?.county).toBe('550.00');
+  });
+
+  it('the city rates that differ from the default match', () => {
+    expect(py).toContain('"los angeles": 4.50');
+    expect(py).toContain('"san francisco": 7.50');
+    expect(py).toContain('"oakland": 15.00');
+    expect(py).toContain('DEFAULT_CITY_RATE_PER_1000 = 2.20');
+  });
+
+  it('a city with no DTT of its own is charged nothing on both sides', () => {
+    const breakdown = computeDttBreakdown({
+      transferValue: '500000', isExempt: false, areaType: 'city',
+      cityName: 'Fresno', basis: 'full_value', exemptionReason: '', calculatedAmount: '',
+    } as never);
+    expect(breakdown?.city).toBeNull();
+    // The backend returns None for the same reason, not 0.0 — "levies
+    // none" and "levies one, and it is zero" are different claims.
+    expect(py).toContain('None when the city levies no transfer tax of its own');
+  });
+});


### PR DESCRIPTION
Two lists were being kept by hand, and both had drifted.

## The catalog

The API's deed types were a hardcoded five-value enum while the chassis renders **nine** deed-family instruments. The fixed-vesting pair (joint tenancy, CP with right of survivorship) and both entity grant deeds (corporation, partnership) were invisible to partners — the wizard offered them, the templates existed, the API simply didn't list them, and nothing would have reported it.

The exposed set now derives from `services/form_families.py` — the mirror of the FORMS registry — filtered to the deed family per the Flag-4 doctrine ruling.

**Deriving the set is automatic; deciding an instrument's facts is not.** Every exposed type must carry an explicit entry in `api_catalog.TYPE_REQUIREMENTS`, and a test fails when one is missing. Adding a deed type to the registry surfaces it to partners only after someone answers *what does this instrument need, and what must it refuse?* — which is exactly the question the entity deeds would have failed silently: they recite the grantor entity's organizing state mid-granting-clause, and without it the deed prints a blank line inside a recital. That's a defective instrument, not a partial one, so it's a 422.

### Two refusals that matter doctrinally

- **Fixed-vesting instruments refuse a supplied vesting.** Their templates deliberately never read a stored vesting value (Flag-3 precedent: choosing the form *is* the vesting decision). Accepting a caller's vesting and silently dropping it would discard a legal input without saying so. The API refuses it and names the instrument that decided.
- **Entity deeds require their recited facts** — `grantor.entity.entity_state`, plus `partnership_type` for partnerships — routed to `metadata.affidavit`, the same slot the wizard's entity deeds read.

Quitclaim vesting is optional (it conveys whatever interest the grantor holds); every other type still requires it.

## The rates

The transfer-tax endpoint carried its own city table that disagreed with the officer-facing calculator — **San Francisco $3.75 there against $7.50 in `dttCalc.ts`**, plus cities priced on one side and absent from the other. Whichever surface a caller happened to hit decided what their deed declared, and these numbers go onto a recorded instrument as a tax declaration.

One source now: `services/dtt_rates.py`, mirrored to `dttCalc.ts` and pinned **from both directions** — a Python test reads the TypeScript, a jest test reads the Python, the arrangement `form_families.py` already has with `formRegistry.ts`.

The rates remain the ones awaiting the owner's escrow review. Consolidating them does not bless them, so the endpoint now returns their provenance alongside the number. It also stops inventing tax: a city absent from the own-DTT list is reported as levying **none**, rather than charged a generic rate — the X2.3 lesson, which the API had never received.

## Gates

| Gate | Result |
|---|---|
| Backend (live DB) | 304 passed |
| Six-flow baseline | ✔ unchanged |
| API baseline | ✔ unchanged |
| OpenAPI contract snapshot | ✔ unchanged |
| Jest | 312 passed (28 suites) |
| tsc | 94, flat |

Both baselines holding is the useful signal here: the partner contract **widened** without shifting — existing request shapes behave identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_