### PR TITLE
A3: an admin tab for the API, and a request form that actually submits

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -223,6 +223,32 @@ def create_tables():
                 created_at TIMESTAMPTZ DEFAULT now()
             )""",
             "CREATE INDEX IF NOT EXISTS idx_api_usage_log_key ON api_usage_log(api_key_id, created_at)",
+            # A3: the API-access inquiry funnel. The request form used to
+            # fake its own submission (setTimeout, then a success screen
+            # promising a 24-hour review nobody could perform, because
+            # nothing was ever sent or stored). Requests land here, the
+            # owner is emailed through the one honest transport, and the
+            # admin API tab lists them — key issuance stays manual per
+            # ruling, so this table IS the queue.
+            """CREATE TABLE IF NOT EXISTS api_key_requests (
+                id SERIAL PRIMARY KEY,
+                user_id INTEGER REFERENCES users(id),
+                company_name TEXT NOT NULL,
+                business_type TEXT,
+                contact_name TEXT,
+                email TEXT NOT NULL,
+                phone TEXT,
+                use_case TEXT,
+                expected_volume TEXT,
+                integration_timeline TEXT,
+                current_software TEXT,
+                additional_info TEXT,
+                status VARCHAR(20) DEFAULT 'new',
+                notified_at TIMESTAMPTZ,
+                notify_error TEXT,
+                created_at TIMESTAMPTZ DEFAULT now()
+            )""",
+            "CREATE INDEX IF NOT EXISTS idx_api_key_requests_status ON api_key_requests(status, created_at)",
             """CREATE TABLE IF NOT EXISTS api_rate_limits (
                 id SERIAL PRIMARY KEY,
                 api_key_id UUID,

--- a/backend/main.py
+++ b/backend/main.py
@@ -174,6 +174,10 @@ print("✅ QR Verification System loaded (/api/verify/{code} - public, /admin/ve
 # Public API v1 (Partner API for deed generation)
 from routers.api_v1.router import router as api_v1_router
 app.include_router(api_v1_router, tags=["Public API v1"])
+
+# A3: API-access inquiry funnel (the form that used to fake its submit).
+from routers.api_key_requests import router as api_key_requests_router
+app.include_router(api_key_requests_router)
 print("✅ Public API v1 loaded (/api/v1/deeds - partner deed generation)")
 
 # T8: routers extracted from main.py's former inline sections, mounted in the

--- a/backend/routers/api_key_requests.py
+++ b/backend/routers/api_key_requests.py
@@ -1,0 +1,199 @@
+"""A3 — the honest API-access inquiry funnel.
+
+What this replaces: a form whose submit handler was
+`await new Promise(r => setTimeout(r, 2000))` followed by a success
+screen promising a review within 24 hours. Nothing was sent, nothing was
+stored, and nobody could perform the review — the fabricated-success
+class (invariant #4), aimed at the exact people we would want to sell to.
+
+The loop now: the request is STORED first, the owner is emailed through
+the one honest transport, and the admin API tab lists what is waiting.
+Key issuance stays manual by ruling, so this table is the queue — which
+is why the store must survive a failed email, and why the failure reason
+is recorded on the row rather than swallowed.
+"""
+import os
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, EmailStr, Field
+
+from auth import get_current_admin, get_current_user_id
+# NOTE: two get_db_connection helpers exist in this codebase and they
+# differ in ROW TYPE — database.get_db_connection hands out
+# RealDictCursor connections (dict rows), db.get_db_connection returns
+# the shared connection with tuple rows. Reading one as the other is
+# exactly the defect that made every partner API key 401 for months
+# (A1). This module reads rows as dicts, so it uses database's, which
+# also gives a fresh per-request connection rather than the shared one.
+from database import clean_profile_text, get_db_connection
+from utils.notifications import notify_api_key_request
+
+router = APIRouter(tags=["API Access Requests"])
+
+
+class ApiKeyRequestIn(BaseModel):
+    company_name: str = Field(..., min_length=1)
+    business_type: Optional[str] = None
+    contact_name: Optional[str] = None
+    email: EmailStr
+    phone: Optional[str] = None
+    use_case: Optional[str] = None
+    expected_volume: Optional[str] = None
+    integration_timeline: Optional[str] = None
+    current_software: Optional[str] = None
+    additional_info: Optional[str] = None
+
+
+@router.post("/api-key-requests")
+def create_api_key_request(payload: ApiKeyRequestIn,
+                           user_id: int = Depends(get_current_user_id)):
+    """Record an API-access inquiry and ping the owner.
+
+    Returns whether the notification email went out AND why not when it
+    did not (the S1 contract) — but the request itself is saved either
+    way, and the response says so plainly. The user is told what actually
+    happens next: a conversation, not an automatic provisioning.
+    """
+    conn = get_db_connection()
+    if not conn:
+        raise HTTPException(status_code=503,
+                            detail="Unable to record the request right now — please try again.")
+
+    company = clean_profile_text(payload.company_name)
+    if not company:
+        raise HTTPException(status_code=400, detail="Company name is required")
+
+    try:
+        with conn.cursor() as cur:
+            cur.execute("""
+                INSERT INTO api_key_requests (
+                    user_id, company_name, business_type, contact_name, email, phone,
+                    use_case, expected_volume, integration_timeline, current_software,
+                    additional_info, status
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, 'new')
+                RETURNING id, created_at
+            """, (
+                user_id, company, payload.business_type,
+                clean_profile_text(payload.contact_name), payload.email.lower(),
+                clean_profile_text(payload.phone), payload.use_case,
+                payload.expected_volume, payload.integration_timeline,
+                payload.current_software, payload.additional_info,
+            ))
+            row = cur.fetchone()
+            conn.commit()
+    except Exception as e:
+        try:
+            conn.rollback()
+        except Exception:
+            pass
+        print(f"[api-key-request] store failed: {e}")
+        raise HTTPException(status_code=500,
+                            detail="Could not record the request — please try again.")
+
+    request_id = row["id"] if isinstance(row, dict) else row[0]
+    # The connection stays open only long enough to record the send
+    # result below; closed in the finally that follows.
+
+    admin_email = os.getenv("ADMIN_EMAIL", "admin@deedpro.com")
+    notified, notify_error = notify_api_key_request(
+        admin_email=admin_email,
+        company_name=company,
+        contact_email=payload.email.lower(),
+        business_type=payload.business_type or "—",
+        expected_volume=payload.expected_volume or "—",
+        use_case=payload.use_case or "",
+        request_id=request_id,
+    )
+
+    # The row carries whether its own ping landed. A failed email must
+    # not lose a sales lead — the admin queue still shows it, flagged.
+    try:
+        with conn.cursor() as cur:
+            cur.execute("""
+                UPDATE api_key_requests
+                SET notified_at = CASE WHEN %s THEN NOW() ELSE NULL END,
+                    notify_error = %s
+                WHERE id = %s
+            """, (notified, None if notified else (notify_error or "unknown")[:500], request_id))
+            conn.commit()
+    except Exception as e:
+        try:
+            conn.rollback()
+        except Exception:
+            pass
+        print(f"[api-key-request] could not record notification state: {e}")
+    finally:
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+    if not notified:
+        print(f"[api-key-request] request #{request_id} stored but not emailed: {notify_error}")
+
+    return {
+        "success": True,
+        "request_id": request_id,
+        "email_sent": notified,
+        "email_error": notify_error,
+        "message": "Your request is recorded. We'll reach out to discuss your integration.",
+    }
+
+
+@router.get("/admin/api-key-requests")
+def list_api_key_requests(status: Optional[str] = None,
+                          admin=Depends(get_current_admin)):
+    """The queue behind the manual-issuance ruling."""
+    conn = get_db_connection()
+    if not conn:
+        raise HTTPException(status_code=503, detail="Database unavailable")
+    with conn.cursor() as cur:
+        if status:
+            cur.execute("""
+                SELECT id, company_name, business_type, contact_name, email, phone,
+                       use_case, expected_volume, integration_timeline, current_software,
+                       additional_info, status, notified_at, notify_error, created_at
+                FROM api_key_requests WHERE status = %s
+                ORDER BY created_at DESC LIMIT 100
+            """, (status,))
+        else:
+            cur.execute("""
+                SELECT id, company_name, business_type, contact_name, email, phone,
+                       use_case, expected_volume, integration_timeline, current_software,
+                       additional_info, status, notified_at, notify_error, created_at
+                FROM api_key_requests
+                ORDER BY created_at DESC LIMIT 100
+            """)
+        items = [dict(r) for r in cur.fetchall()]
+    conn.close()
+    return {"items": items, "total": len(items)}
+
+
+class RequestStatusIn(BaseModel):
+    status: str = Field(..., description="new | contacted | approved | declined")
+
+
+@router.patch("/admin/api-key-requests/{request_id}")
+def update_api_key_request(request_id: int, payload: RequestStatusIn,
+                           admin=Depends(get_current_admin)):
+    allowed = {"new", "contacted", "approved", "declined"}
+    if payload.status not in allowed:
+        raise HTTPException(status_code=400,
+                            detail=f"status must be one of {sorted(allowed)}")
+    conn = get_db_connection()
+    if not conn:
+        raise HTTPException(status_code=503, detail="Database unavailable")
+    with conn.cursor() as cur:
+        cur.execute("""
+            UPDATE api_key_requests SET status = %s WHERE id = %s
+            RETURNING id, company_name, status
+        """, (payload.status, request_id))
+        row = cur.fetchone()
+        if not row:
+            conn.close()
+            raise HTTPException(status_code=404, detail="Request not found")
+        conn.commit()
+    result = dict(row)
+    conn.close()
+    return {"success": True, "request": result}

--- a/backend/tests/snapshots/openapi_routes.json
+++ b/backend/tests/snapshots/openapi_routes.json
@@ -25,6 +25,10 @@
  ],
  [
   "GET",
+  "/admin/api-key-requests"
+ ],
+ [
+  "GET",
   "/admin/api-keys"
  ],
  [
@@ -281,6 +285,10 @@
  ],
  [
   "PATCH",
+  "/admin/api-key-requests/{request_id}"
+ ],
+ [
+  "PATCH",
   "/admin/api-keys/{key_id}"
  ],
  [
@@ -314,6 +322,10 @@
  [
   "POST",
   "/ai/deed-suggestions"
+ ],
+ [
+  "POST",
+  "/api-key-requests"
  ],
  [
   "POST",

--- a/backend/tests/test_api_key_requests.py
+++ b/backend/tests/test_api_key_requests.py
@@ -1,0 +1,180 @@
+"""A3 — the API-access inquiry funnel is real.
+
+What it replaces: a form whose submit was a two-second timeout followed by
+a success screen promising a review within 24 hours. Nothing was sent,
+nothing was stored, nobody could perform the review — the
+fabricated-success class aimed at prospective customers.
+
+The invariant that matters here: the request is STORED before the email
+is attempted, and a failed email is recorded on the row rather than
+swallowed. A lost notification must never lose a sales lead.
+"""
+import inspect
+import os
+from unittest.mock import patch
+
+import pytest
+
+LIVE_DB = os.getenv("DATABASE_URL")
+
+REQUEST_BODY = {
+    "company_name": "  Pacific Coast Escrow  ",
+    "business_type": "title_company",
+    "contact_name": "Dana Reyes",
+    "email": "Dana@PacificCoastEscrow.example",
+    "phone": "555-0100",
+    "use_case": "Generating grant deeds at closing from our escrow platform.",
+    "expected_volume": "100-500/mo",
+    "integration_timeline": "this quarter",
+    "current_software": "Qualia",
+    "additional_info": "",
+}
+
+
+# ── Structural (CI-safe) ─────────────────────────────────────────────
+
+def test_store_happens_before_notify():
+    """Order is the guarantee: a request that cannot be emailed is still
+    a request we have."""
+    from routers import api_key_requests
+    src = inspect.getsource(api_key_requests.create_api_key_request)
+    assert src.index("INSERT INTO api_key_requests") < src.index("notify_api_key_request"), \
+        "the email must not be attempted before the row exists"
+
+
+def test_notification_failure_is_recorded_not_swallowed():
+    from routers import api_key_requests
+    src = inspect.getsource(api_key_requests.create_api_key_request)
+    assert "notify_error" in src
+    assert "email_error" in src, "the S1 reason must reach the response too"
+
+
+def test_admin_queue_requires_admin():
+    from routers.api_key_requests import list_api_key_requests, update_api_key_request
+    for fn in (list_api_key_requests, update_api_key_request):
+        src = inspect.getsource(fn)
+        assert "get_current_admin" in src or "admin=Depends(get_current_admin)" in src
+
+
+def test_request_table_is_in_the_schema_authority():
+    from pathlib import Path
+    schema = (Path(__file__).resolve().parents[1] / "database.py").read_text(encoding="utf-8")
+    assert "CREATE TABLE IF NOT EXISTS api_key_requests" in schema
+
+
+def test_the_ops_email_uses_the_one_transport():
+    from utils import notifications
+    src = inspect.getsource(notifications.notify_api_key_request)
+    assert "send_email_with_reason" in src
+
+
+# ── End to end (live DB) ─────────────────────────────────────────────
+
+@pytest.fixture
+def client_and_token():
+    from fastapi.testclient import TestClient
+    from main import app
+    client = TestClient(app)
+    email = "funnel@apirequest.test"
+    password = "Funnel!Passw0rd"
+    import psycopg2
+    conn = psycopg2.connect(LIVE_DB)
+    conn.autocommit = True
+    with conn.cursor() as cur:
+        cur.execute("DELETE FROM api_key_requests WHERE email = %s", ("dana@pacificcoastescrow.example",))
+        cur.execute("""DELETE FROM api_key_requests WHERE user_id IN
+                       (SELECT id FROM users WHERE email = %s)""", (email,))
+        cur.execute("""DELETE FROM user_profiles WHERE user_id IN
+                       (SELECT id FROM users WHERE email = %s)""", (email,))
+        cur.execute("DELETE FROM users WHERE email = %s", (email,))
+    conn.close()
+    client.post("/users/register", json={
+        "email": email, "password": password, "confirm_password": password,
+        "full_name": "Funnel Tester", "role": "escrow_officer", "state": "CA",
+        "agree_terms": True,
+    })
+    token = client.post("/users/login", json={
+        "email": email, "password": password}).json()["access_token"]
+    return client, token
+
+
+@pytest.mark.skipif(not LIVE_DB, reason="live test DB required")
+def test_request_is_stored_and_owner_is_notified(client_and_token):
+    client, token = client_and_token
+    with patch("routers.api_key_requests.notify_api_key_request",
+               return_value=(True, None)) as notify:
+        res = client.post("/api-key-requests", json=REQUEST_BODY,
+                          headers={"Authorization": f"Bearer {token}"})
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["email_sent"] is True
+    assert body["request_id"] > 0
+    # The user is told what actually happens — not a 24-hour promise.
+    assert "reach out" in body["message"].lower()
+    assert notify.called
+
+    import psycopg2
+    conn = psycopg2.connect(LIVE_DB)
+    with conn.cursor() as cur:
+        cur.execute("""SELECT company_name, email, status, notified_at, notify_error
+                       FROM api_key_requests WHERE id = %s""", (body["request_id"],))
+        row = cur.fetchone()
+    conn.close()
+    assert row is not None
+    assert row[0] == "Pacific Coast Escrow"   # whitespace normalized
+    assert row[1] == "dana@pacificcoastescrow.example"  # lowercased
+    assert row[2] == "new"
+    assert row[3] is not None
+    assert row[4] is None
+
+
+@pytest.mark.skipif(not LIVE_DB, reason="live test DB required")
+def test_a_failed_email_still_keeps_the_request(client_and_token):
+    """The whole point of storing first."""
+    client, token = client_and_token
+    with patch("routers.api_key_requests.notify_api_key_request",
+               return_value=(False, "SENDGRID_API_KEY is not set in the environment")):
+        res = client.post("/api-key-requests", json=REQUEST_BODY,
+                          headers={"Authorization": f"Bearer {token}"})
+    assert res.status_code == 200
+    body = res.json()
+    assert body["success"] is True
+    assert body["email_sent"] is False
+    assert "SENDGRID_API_KEY" in body["email_error"]
+
+    import psycopg2
+    conn = psycopg2.connect(LIVE_DB)
+    with conn.cursor() as cur:
+        cur.execute("SELECT notified_at, notify_error FROM api_key_requests WHERE id = %s",
+                    (body["request_id"],))
+        notified_at, notify_error = cur.fetchone()
+    conn.close()
+    assert notified_at is None
+    assert "SENDGRID_API_KEY" in notify_error
+
+
+@pytest.mark.skipif(not LIVE_DB, reason="live test DB required")
+def test_the_queue_lists_it_for_an_admin_only(client_and_token):
+    client, token = client_and_token
+    with patch("routers.api_key_requests.notify_api_key_request", return_value=(True, None)):
+        client.post("/api-key-requests", json=REQUEST_BODY,
+                    headers={"Authorization": f"Bearer {token}"})
+
+    # A non-admin cannot read the queue.
+    assert client.get("/admin/api-key-requests",
+                      headers={"Authorization": f"Bearer {token}"}).status_code == 403
+
+    import psycopg2
+    conn = psycopg2.connect(LIVE_DB)
+    conn.autocommit = True
+    with conn.cursor() as cur:
+        cur.execute("UPDATE users SET role = 'admin' WHERE email = %s", ("funnel@apirequest.test",))
+    conn.close()
+    admin_token = client.post("/users/login", json={
+        "email": "funnel@apirequest.test", "password": "Funnel!Passw0rd"}).json()["access_token"]
+
+    listed = client.get("/admin/api-key-requests",
+                        headers={"Authorization": f"Bearer {admin_token}"})
+    assert listed.status_code == 200
+    companies = [i["company_name"] for i in listed.json()["items"]]
+    assert "Pacific Coast Escrow" in companies

--- a/backend/utils/email_templates.py
+++ b/backend/utils/email_templates.py
@@ -296,6 +296,34 @@ def welcome(full_name) -> Rendered:
     return subject, _base("Your account is ready", content, False), text
 
 
+def admin_api_key_request(company_name, contact_email, business_type,
+                          expected_volume, use_case, request_id,
+                          requested_at: Optional[str] = None) -> Rendered:
+    """A3 ops ping: someone asked for API access. Key issuance is manual
+    by ruling, so this email is the start of a conversation, not a
+    provisioning trigger — it carries what the owner needs to decide
+    whether to have that conversation."""
+    ts = requested_at or datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")
+    subject = f"API access request: {company_name}"
+    content = (
+        _p("A platform asked about integrating with the DeedPro API.")
+        + _facts([("Company", company_name), ("Contact", contact_email),
+                  ("Business type", business_type), ("Expected volume", expected_volume),
+                  ("Request", f"#{request_id}"), ("At", ts)])
+        + (_p(f'<span style="color:#8a94a0;font-size:13px;">What they described:</span><br>{_esc(use_case)}')
+           if use_case else "")
+        + _button(f"{_frontend_url()}/admin?tab=api", "Open the API admin")
+    )
+    text = (
+        f"API access request from {company_name}.\n\n"
+        f"Contact: {contact_email}\nBusiness type: {business_type}\n"
+        f"Expected volume: {expected_volume}\nRequest: #{request_id}\nAt: {ts}\n"
+        + (f"\nWhat they described:\n{use_case}\n" if use_case else "")
+        + f"\nAdmin: {_frontend_url()}/admin?tab=api"
+    )
+    return subject, _base(f"API access request from {company_name}", content, False), text
+
+
 def admin_new_user(user_email, user_id, registered_at: Optional[str] = None) -> Rendered:
     """Ops ping (owner ruling): registrant email + timestamp — no more."""
     ts = registered_at or datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")

--- a/backend/utils/notifications.py
+++ b/backend/utils/notifications.py
@@ -95,6 +95,17 @@ def send_welcome_with_reason(user_email: str, full_name: str) -> SendResult:
     return send_email_with_reason(user_email, subject, html, text)
 
 
+def notify_api_key_request(admin_email: str, company_name: str, contact_email: str,
+                           business_type: str, expected_volume: str, use_case: str,
+                           request_id: int) -> SendResult:
+    """A3: an API-access inquiry reached us. The row is already stored —
+    this is the ping, and its reason is recorded on the row when it
+    fails, so a lost email cannot lose the request."""
+    subject, html, text = email_templates.admin_api_key_request(
+        company_name, contact_email, business_type, expected_volume, use_case, request_id)
+    return send_email_with_reason(admin_email, subject, html, text)
+
+
 def notify_new_user_registration(admin_email: str, user_email: str, user_name: str,
                                  user_id: int) -> SendResult:
     """E1 fix (owner-ruled): this function was imported on every signup

--- a/frontend/src/__tests__/apiAccessFunnel.test.ts
+++ b/frontend/src/__tests__/apiAccessFunnel.test.ts
@@ -1,0 +1,120 @@
+/**
+ * A3 — the API access funnel tells the truth, and the admin can reach it.
+ *
+ * Two things were wrong on this surface:
+ *
+ * 1. The request form's submit handler was a two-second timeout followed
+ *    by a success screen promising a review within 24 hours. Nothing was
+ *    sent, nothing stored, and nobody could perform that review — a
+ *    fabricated success (invariant #4) aimed at prospective customers.
+ * 2. The page claimed "SOC2 compliant" security. That is a compliance
+ *    certification, not a feature description, and it was not earned.
+ *    Stating it to enterprise buyers is the most consequential untrue
+ *    sentence that was on the site.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+
+function readSource(...segments: string[]) {
+  return fs.readFileSync(path.join(__dirname, '..', ...segments), 'utf8');
+}
+
+/**
+ * Copy pins must read what a VISITOR sees, not what the file contains —
+ * the comments explaining why a claim was removed necessarily quote it,
+ * and a naive source match then fails on its own explanation.
+ */
+function withoutComments(src: string) {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, '')   // block and JSX comments
+    .replace(/^\s*\/\/.*$/gm, '');       // line comments
+}
+
+const requestPage = readSource('app', 'api-key-request', 'page.tsx');
+const adminPage = readSource('app', 'admin', 'page.tsx');
+const adminLayout = readSource('app', 'admin', 'layout.tsx');
+const apiTab = readSource('app', 'admin', 'components', 'ApiTab.tsx');
+const adminApi = readSource('lib', 'adminApi.ts');
+
+describe('API access request — the submit is real', () => {
+  it('posts to the backend instead of faking a delay', () => {
+    expect(requestPage).toContain("apiFetch('/api-key-requests'");
+    expect(requestPage).toContain("method: 'POST'");
+  });
+
+  it('has no simulated submission left', () => {
+    // The exact shape of the old lie: a timeout standing in for a request.
+    expect(requestPage).not.toMatch(/setTimeout\(resolve/);
+    expect(requestPage).not.toContain('Simulate API call');
+    expect(requestPage).not.toMatch(/In production, send to backend/);
+  });
+
+  it('surfaces a failed submit instead of showing success anyway', () => {
+    expect(requestPage).toContain('setError');
+    expect(requestPage).toContain('role="alert"');
+    // Success is set only on a successful response.
+    const successSets = requestPage.match(/setSubmitted\(true\)/g) || [];
+    expect(successSets).toHaveLength(1);
+  });
+});
+
+describe('API access request — the copy is true', () => {
+  const copy = withoutComments(requestPage);
+
+  it('makes no compliance certification claim', () => {
+    expect(copy).not.toMatch(/SOC\s?2/i);
+    expect(copy).not.toMatch(/HIPAA|ISO 27001|PCI[- ]DSS/i);
+  });
+
+  it('promises no turnaround time it cannot keep', () => {
+    expect(copy).not.toMatch(/within 24 hours/i);
+    expect(copy).not.toMatch(/within 4 hours/i);
+    expect(copy).not.toMatch(/delivered within/i);
+  });
+
+  it('describes the manual issuance process honestly', () => {
+    expect(copy).toMatch(/reach out/i);
+    expect(copy).toMatch(/conversation/i);
+  });
+
+  it('does not advertise staff it does not have', () => {
+    expect(copy).not.toMatch(/Dedicated Support/i);
+    expect(copy).not.toMatch(/Personal onboarding/i);
+  });
+});
+
+describe('admin API tab', () => {
+  it('is registered as a tab and linked in the nav', () => {
+    // The key-admin screens existed before but nothing linked to them —
+    // they could only be found by typing a URL.
+    expect(adminPage).toContain('ApiTab');
+    expect(adminPage).toMatch(/api:\s*\{/);
+    expect(adminLayout).toContain("id: 'api'");
+    expect(adminLayout).toContain('/admin?tab=api');
+  });
+
+  it('talks to the main API through the authenticated admin client', () => {
+    expect(apiTab).toContain("from '@/lib/adminApi'");
+    // The previous key UI used a shared setup secret against a separate
+    // service and dropped the admin's own JWT.
+    expect(apiTab).not.toMatch(/X-Admin-Setup-Secret/i);
+    expect(apiTab).not.toMatch(/EXTERNAL_API/i);
+    expect(adminApi).toContain("'/admin/api-keys");
+  });
+
+  it('warns that a minted key is shown once', () => {
+    expect(apiTab).toMatch(/cannot be shown again/i);
+  });
+
+  it('shows an inquiry whose notification email failed', () => {
+    // Storing before sending is pointless if the UI hides the ones that
+    // did not send.
+    expect(apiTab).toContain('notify_error');
+  });
+
+  it('reports load failures instead of rendering an empty state', () => {
+    expect(apiTab).toContain('setError');
+    expect(apiTab).toMatch(/Failed to load API data/);
+  });
+});

--- a/frontend/src/app/admin/components/ApiTab.tsx
+++ b/frontend/src/app/admin/components/ApiTab.tsx
@@ -1,0 +1,295 @@
+'use client';
+/**
+ * A3 — partner API administration.
+ *
+ * The backend key CRUD has existed since the public-API work and no
+ * frontend had ever called it. The only key UI in the app talked to a
+ * separate dormant service through a shared setup secret, dropping the
+ * admin's own JWT, and it was unreachable from the admin nav anyway.
+ * This tab uses the same authenticated client as every other admin
+ * screen.
+ *
+ * Key issuance is manual by ruling — every partner is a conversation at
+ * this stage — so the inquiry queue sits beside the keys, and the mint
+ * button lives here rather than at the end of a self-serve funnel.
+ */
+import { useCallback, useEffect, useState } from 'react';
+import {
+  AdminApi,
+  type ApiKeyRequestRow,
+  type ApiKeyRow,
+  type CreatedApiKey,
+} from '@/lib/adminApi';
+import Badge from './Badge';
+import StatCard from './StatCard';
+
+function fmtDate(value?: string | null) {
+  if (!value) return '—';
+  const d = new Date(value);
+  return isNaN(d.getTime()) ? '—' : d.toLocaleDateString();
+}
+
+export default function ApiTab() {
+  const [keys, setKeys] = useState<ApiKeyRow[]>([]);
+  const [requests, setRequests] = useState<ApiKeyRequestRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  const [showMint, setShowMint] = useState(false);
+  const [mintName, setMintName] = useState('');
+  const [mintTest, setMintTest] = useState(false);
+  const [minting, setMinting] = useState(false);
+  const [minted, setMinted] = useState<CreatedApiKey['api_key'] | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const [keyRes, reqRes] = await Promise.all([
+        AdminApi.listApiKeys(),
+        AdminApi.listApiKeyRequests().catch(() => ({ items: [], total: 0 })),
+      ]);
+      setKeys(keyRes.api_keys || []);
+      setRequests(reqRes.items || []);
+    } catch (e) {
+      // Loud, not an empty state pretending to be "no keys yet".
+      setError(e instanceof Error ? e.message : 'Failed to load API data');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function handleMint() {
+    if (!mintName.trim()) return;
+    setMinting(true);
+    setError('');
+    try {
+      const res = await AdminApi.createApiKey({
+        name: mintName.trim(),
+        is_test: mintTest,
+      });
+      setMinted(res.api_key);
+      setMintName('');
+      setMintTest(false);
+      setShowMint(false);
+      load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to create key');
+    } finally {
+      setMinting(false);
+    }
+  }
+
+  async function handleDeactivate(key: ApiKeyRow) {
+    if (!confirm(`Deactivate "${key.name}" (${key.key_prefix})? Calls using it will stop working immediately.`)) return;
+    try {
+      await AdminApi.deactivateApiKey(key.id);
+      load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to deactivate key');
+    }
+  }
+
+  async function handleRequestStatus(row: ApiKeyRequestRow, status: ApiKeyRequestRow['status']) {
+    try {
+      await AdminApi.updateApiKeyRequest(row.id, status);
+      load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to update request');
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="vstack">
+        <div className="grid stats">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="card skeleton" style={{ height: 92 }} />
+          ))}
+        </div>
+        <div className="card skeleton" style={{ height: 280 }} />
+      </div>
+    );
+  }
+
+  const active = keys.filter((k) => k.is_active);
+  const totalRequests = keys.reduce((sum, k) => sum + (k.request_count || 0), 0);
+  const totalDeeds = keys.reduce((sum, k) => sum + (k.deed_count || 0), 0);
+  const newRequests = requests.filter((r) => r.status === 'new');
+
+  return (
+    <div className="vstack">
+      <div className="grid stats">
+        <StatCard title="Active Keys" value={active.length} />
+        <StatCard title="Deeds via API" value={totalDeeds} />
+        <StatCard title="API Requests" value={totalRequests} />
+        <StatCard title="Open Inquiries" value={newRequests.length} />
+      </div>
+
+      {error && (
+        <div className="card" style={{ borderColor: 'var(--dp-danger)', color: 'var(--dp-danger)' }}>
+          {error}
+        </div>
+      )}
+
+      {/* The full key is displayed exactly once — it is bcrypt-hashed at
+          rest and cannot be recovered afterward. */}
+      {minted && (
+        <div className="card" style={{ borderColor: 'var(--dp-brand, #7C4DFF)' }}>
+          <div style={{ fontWeight: 700, marginBottom: 8 }}>
+            Copy this key now — it cannot be shown again
+          </div>
+          <code
+            style={{
+              display: 'block', padding: '12px 14px', background: 'var(--dp-surface-2, #f7f8fa)',
+              borderRadius: 8, wordBreak: 'break-all', fontSize: 14, marginBottom: 12,
+            }}
+          >
+            {minted.key}
+          </code>
+          <div className="hstack" style={{ gap: 8 }}>
+            <button className="btn" onClick={() => navigator.clipboard?.writeText(minted.key)}>
+              Copy
+            </button>
+            <button className="btn" onClick={() => setMinted(null)}>
+              I&apos;ve saved it
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Keys */}
+      <div className="card">
+        <div className="hstack" style={{ justifyContent: 'space-between', marginBottom: 16 }}>
+          <div style={{ fontWeight: 700, fontSize: 16 }}>Partner API keys</div>
+          <button className="btn" onClick={() => setShowMint((v) => !v)}>
+            {showMint ? 'Cancel' : 'Create key'}
+          </button>
+        </div>
+
+        {showMint && (
+          <div className="vstack" style={{ gap: 10, marginBottom: 16 }}>
+            <input
+              className="input"
+              placeholder="Who is this key for? (e.g. Pacific Coast Escrow)"
+              value={mintName}
+              onChange={(e) => setMintName(e.target.value)}
+            />
+            <label className="hstack" style={{ gap: 8, alignItems: 'center' }}>
+              <input type="checkbox" checked={mintTest} onChange={(e) => setMintTest(e.target.checked)} />
+              <span>Test key (dp_test_ prefix)</span>
+            </label>
+            <button className="btn" onClick={handleMint} disabled={minting || !mintName.trim()}>
+              {minting ? 'Creating…' : 'Create key'}
+            </button>
+          </div>
+        )}
+
+        {keys.length === 0 ? (
+          <div style={{ color: 'var(--dp-muted, #8a94a0)' }}>
+            No API keys yet. Keys are issued manually — create one after you&apos;ve
+            talked with the partner.
+          </div>
+        ) : (
+          <div style={{ overflowX: 'auto' }}>
+            <table className="table">
+              <thead>
+                <tr>
+                  <th>Name</th><th>Prefix</th><th>Status</th><th>Limits</th>
+                  <th>Deeds</th><th>Requests</th><th>Last used</th><th></th>
+                </tr>
+              </thead>
+              <tbody>
+                {keys.map((k) => (
+                  <tr key={k.id}>
+                    <td>{k.name}</td>
+                    <td><code style={{ fontSize: 13 }}>{k.key_prefix}…</code></td>
+                    <td>
+                      <Badge kind={k.is_active ? 'success' : 'neutral'}>
+                        {k.is_active ? 'Active' : 'Deactivated'}
+                      </Badge>
+                      {k.is_test && <Badge kind="neutral">Test</Badge>}
+                    </td>
+                    <td>{k.rate_limit_hour}/hr · {k.rate_limit_day}/day</td>
+                    <td>{k.deed_count ?? 0}</td>
+                    <td>{k.request_count ?? 0}</td>
+                    <td>{fmtDate(k.last_used_at)}</td>
+                    <td>
+                      {k.is_active && (
+                        <button className="btn" onClick={() => handleDeactivate(k)}>
+                          Deactivate
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* Inquiries */}
+      <div className="card">
+        <div className="hstack" style={{ justifyContent: 'space-between', marginBottom: 16 }}>
+          <div style={{ fontWeight: 700, fontSize: 16 }}>API access inquiries</div>
+          <Badge kind="neutral">{requests.length} total</Badge>
+        </div>
+
+        {requests.length === 0 ? (
+          <div style={{ color: 'var(--dp-muted, #8a94a0)' }}>
+            No inquiries yet. Submissions from the API access form land here.
+          </div>
+        ) : (
+          <div style={{ overflowX: 'auto' }}>
+            <table className="table">
+              <thead>
+                <tr>
+                  <th>Company</th><th>Contact</th><th>Type</th><th>Volume</th>
+                  <th>Received</th><th>Status</th><th></th>
+                </tr>
+              </thead>
+              <tbody>
+                {requests.map((r) => (
+                  <tr key={r.id}>
+                    <td>
+                      {r.company_name}
+                      {r.notify_error && (
+                        // The request survived an email failure — say so,
+                        // rather than letting it look like it never came.
+                        <div style={{ fontSize: 12, color: 'var(--dp-warn, #b26a00)' }}>
+                          notification email failed — {r.notify_error}
+                        </div>
+                      )}
+                    </td>
+                    <td>{r.email}</td>
+                    <td>{r.business_type || '—'}</td>
+                    <td>{r.expected_volume || '—'}</td>
+                    <td>{fmtDate(r.created_at)}</td>
+                    <td><Badge kind={r.status === 'new' ? 'warn' : 'neutral'}>{r.status}</Badge></td>
+                    <td>
+                      <select
+                        className="input"
+                        value={r.status}
+                        onChange={(e) => handleRequestStatus(r, e.target.value as ApiKeyRequestRow['status'])}
+                      >
+                        <option value="new">new</option>
+                        <option value="contacted">contacted</option>
+                        <option value="approved">approved</option>
+                        <option value="declined">declined</option>
+                      </select>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -8,6 +8,13 @@ import './styles/admin-layout.css';
 
 // Icons as simple SVG components
 const Icons = {
+  Plug: () => (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <path d="M9 2v6"/><path d="M15 2v6"/>
+      <path d="M6 8h12v3a6 6 0 0 1-6 6 6 6 0 0 1-6-6z"/>
+      <path d="M12 17v5"/>
+    </svg>
+  ),
   Dashboard: () => (
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
       <rect x="3" y="3" width="7" height="7" rx="1"/>
@@ -71,6 +78,9 @@ const NAV_ITEMS = [
   { id: 'verification', label: 'Verification', icon: Icons.Shield, href: '/admin?tab=verification' },
   { id: 'revenue', label: 'Revenue', icon: Icons.DollarSign, href: '/admin?tab=revenue' },
   { id: 'system', label: 'System', icon: Icons.Settings, href: '/admin?tab=system' },
+  // A3: reachable at last — the key admin screens existed but nothing
+  // linked to them, so they could only be found by typing a URL.
+  { id: 'api', label: 'API', icon: Icons.Plug, href: '/admin?tab=api' },
 ];
 
 export default function AdminLayout({ children }: { children: React.ReactNode }) {

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -7,6 +7,7 @@ import DeedsTab from './components/DeedsTab';
 import VerificationTab from './components/VerificationTab';
 import RevenueTab from './components/RevenueTab';
 import SystemTab from './components/SystemTab';
+import ApiTab from './components/ApiTab';
 import { FEATURE_FLAGS } from '@/config/featureFlags';
 import './styles/tokens.css';
 import './styles/admin-honest.css';
@@ -38,10 +39,17 @@ const TABS: Record<string, { title: string; description: string; component: () =
     description: 'Stripe revenue analytics',
     component: () => <RevenueTab/> 
   },
-  system: { 
-    title: 'System', 
+  system: {
+    title: 'System',
     description: 'Health and PDF statistics',
-    component: () => <SystemTab/> 
+    component: () => <SystemTab/>
+  },
+  // A3: partner API administration. The backend key CRUD existed since
+  // the public-API work with no frontend calling it.
+  api: {
+    title: 'API',
+    description: 'Partner API keys, usage, and access inquiries',
+    component: () => <ApiTab/>
   },
 };
 

--- a/frontend/src/app/api-key-request/page.tsx
+++ b/frontend/src/app/api-key-request/page.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { apiFetch } from '@/lib/apiClient';
 
 export default function ApiKeyRequest() {
   const [formData, setFormData] = useState({
@@ -19,6 +20,7 @@ export default function ApiKeyRequest() {
   });
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
+  const [error, setError] = useState('');
   const router = useRouter();
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
@@ -29,22 +31,54 @@ export default function ApiKeyRequest() {
     }));
   };
 
+  /**
+   * A3: this handler used to be `await new Promise(r => setTimeout(r, 2000))`
+   * followed by a success screen promising a review within 24 hours.
+   * Nothing was sent, nothing was stored, and nobody could perform that
+   * review — a fabricated success (invariant #4) aimed at exactly the
+   * people we would want to sell to. It reaches the backend now, and the
+   * screen it leads to describes what actually happens.
+   */
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setIsSubmitting(true);
+    setError('');
 
-    // Simulate API call
-    await new Promise(resolve => setTimeout(resolve, 2000));
+    try {
+      const res = await apiFetch('/api-key-requests', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          company_name: formData.company_name,
+          business_type: formData.business_type,
+          contact_name: formData.contact_name,
+          email: formData.email,
+          phone: formData.phone,
+          use_case: formData.use_case,
+          expected_volume: formData.expected_volume,
+          integration_timeline: formData.integration_timeline,
+          current_software: formData.has_current_software === 'yes'
+            ? formData.current_software
+            : null,
+          additional_info: formData.additional_info,
+        }),
+      }, { label: 'API access request', silent: true });
 
-    // In production, send to backend:
-    // const response = await fetch('/api/request-api-key', {
-    //   method: 'POST',
-    //   headers: { 'Content-Type': 'application/json' },
-    //   body: JSON.stringify(formData)
-    // });
-
-    setSubmitted(true);
-    setIsSubmitting(false);
+      if (!res.ok) {
+        const detail = await res.json().catch(() => ({}));
+        throw new Error(detail.detail || 'We could not record your request.');
+      }
+      setSubmitted(true);
+    } catch (err) {
+      // No pretending. If it did not land, say so and keep their input.
+      setError(
+        err instanceof Error
+          ? `${err.message} Please try again, or email us directly.`
+          : 'We could not record your request. Please try again.'
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   if (submitted) {
@@ -52,54 +86,40 @@ export default function ApiKeyRequest() {
       <div className="min-h-screen bg-light-seafoam flex items-center justify-center px-6">
         <div className="max-w-2xl mx-auto text-center">
           <div className="bg-white rounded-2xl border border-gray-200 p-8 shadow-lg">
-            <div className="text-6xl mb-6">🎉</div>
             <h1 className="text-3xl font-bold text-dark-slate mb-6">
-              Request Submitted Successfully!
+              Your request is recorded
             </h1>
             <p className="text-dark-slate/80 text-lg mb-8">
-              Thank you for your interest in DeedPro&#39;s API. Our team will review your request and get back to you within 24 hours.
+              Thanks for your interest in the DeedPro API. We&#39;ll reach out to
+              discuss your integration — API keys are issued after a conversation,
+              not automatically, so we can make sure the API fits what you&#39;re
+              building.
             </p>
-            
+
             <div className="bg-blue-50 border border-blue-200 rounded-xl p-6 mb-8">
-              <h3 className="font-bold text-dark-slate mb-4">📧 What happens next?</h3>
+              <h3 className="font-bold text-dark-slate mb-4">What happens next</h3>
               <div className="text-left space-y-2 text-dark-slate/80">
-                <div className="flex items-center gap-3">
-                  <span className="w-6 h-6 bg-blue-500 text-white rounded-full flex items-center justify-center text-sm font-bold">1</span>
-                  <span>Technical review of your use case (within 4 hours)</span>
+                <div className="flex items-start gap-3">
+                  <span className="w-6 h-6 bg-blue-500 text-white rounded-full flex items-center justify-center text-sm font-bold shrink-0">1</span>
+                  <span>We read what you sent and get in touch at the email address above.</span>
                 </div>
-                <div className="flex items-center gap-3">
-                  <span className="w-6 h-6 bg-blue-500 text-white rounded-full flex items-center justify-center text-sm font-bold">2</span>
-                  <span>API key generation and documentation package</span>
+                <div className="flex items-start gap-3">
+                  <span className="w-6 h-6 bg-blue-500 text-white rounded-full flex items-center justify-center text-sm font-bold shrink-0">2</span>
+                  <span>We talk through your use case — volume, deed types, and how you&#39;d integrate.</span>
                 </div>
-                <div className="flex items-center gap-3">
-                  <span className="w-6 h-6 bg-blue-500 text-white rounded-full flex items-center justify-center text-sm font-bold">3</span>
-                  <span>Onboarding call to discuss integration strategy</span>
-                </div>
-                <div className="flex items-center gap-3">
-                  <span className="w-6 h-6 bg-blue-500 text-white rounded-full flex items-center justify-center text-sm font-bold">4</span>
-                  <span>Dedicated support during implementation</span>
+                <div className="flex items-start gap-3">
+                  <span className="w-6 h-6 bg-blue-500 text-white rounded-full flex items-center justify-center text-sm font-bold shrink-0">3</span>
+                  <span>If it&#39;s a fit, we issue a test key so you can build against the API, then a live key.</span>
                 </div>
               </div>
             </div>
 
             <div className="flex flex-col sm:flex-row gap-4">
               <button
-                onClick={() => router.push('/docs')}
-                className="bg-primary text-white px-6 py-3 rounded-lg font-semibold hover:bg-blue-600 transition-colors"
-              >
-                📚 Browse Documentation
-              </button>
-              <button
-                onClick={() => router.push('/team')}
-                className="bg-tertiary text-white px-6 py-3 rounded-lg font-semibold hover:bg-blue-600 transition-colors"
-              >
-                👥 Explore Team Features
-              </button>
-              <button
                 onClick={() => router.push('/')}
                 className="border-2 border-gray-300 text-dark-slate px-6 py-3 rounded-lg font-semibold hover:border-tertiary hover:text-tertiary transition-colors"
               >
-                🏠 Back to Home
+                Back to home
               </button>
             </div>
           </div>
@@ -117,27 +137,33 @@ export default function ApiKeyRequest() {
             🔑 Request API Access
           </h1>
           <p className="text-xl text-dark-slate/80 max-w-3xl mx-auto">
-            Get started with DeedPro&#39;s enterprise API platform. We&#39;ll set you up with everything you need for seamless integration.
+            Tell us what you&#39;re building. We issue API keys after a conversation,
+            so start here and we&#39;ll get in touch.
           </p>
         </div>
 
         {/* Benefits */}
         <div className="grid md:grid-cols-3 gap-6 mb-12">
+          {/* A3: these cards previously promised a key "within 24 hours",
+              "SOC2 compliant" security, and dedicated support staff. The
+              SOC2 claim was the serious one — an unearned compliance
+              certification stated to prospective enterprise customers.
+              What replaces them is what the API actually does today. */}
           {[
             {
-              icon: '⚡',
-              title: 'Fast Setup',
-              description: 'API key delivered within 24 hours with complete documentation'
+              icon: '📄',
+              title: 'Recorder-formatted output',
+              description: 'The same California deed templates and page geometry the app itself renders'
             },
             {
-              icon: '🔒',
-              title: 'Enterprise Security',
-              description: 'SOC2 compliant with role-based permissions and audit logging'
+              icon: '🔑',
+              title: 'Test keys before live keys',
+              description: 'Build against a test key first; keys are scoped, rate-limited, and revocable'
             },
             {
-              icon: '🎯',
-              title: 'Dedicated Support',
-              description: 'Personal onboarding and ongoing technical assistance'
+              icon: '💬',
+              title: 'A conversation first',
+              description: 'We talk through your use case before issuing a key, so the fit is clear on both sides'
             }
           ].map((benefit, index) => (
             <div key={index} className="bg-white rounded-xl border border-gray-200 p-6 text-center">
@@ -364,6 +390,16 @@ export default function ApiKeyRequest() {
 
             {/* Submit */}
             <div className="pt-6 border-t border-gray-200">
+              {error && (
+                // A failed submit says so and keeps their input — the old
+                // handler could not fail, because it never tried.
+                <div
+                  role="alert"
+                  className="mb-4 rounded-lg border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-800"
+                >
+                  {error}
+                </div>
+              )}
               <div className="flex flex-col sm:flex-row gap-4">
                 <button
                   type="submit"

--- a/frontend/src/lib/adminApi.ts
+++ b/frontend/src/lib/adminApi.ts
@@ -16,6 +16,72 @@ export type Paged<T> = {
   total: number 
 };
 
+export type ApiKeyRow = {
+  id: string;
+  key_prefix: string;
+  name: string;
+  is_active: boolean;
+  is_test: boolean;
+  rate_limit_hour: number;
+  rate_limit_day: number;
+  created_at?: string;
+  last_used_at?: string | null;
+  deed_count?: number;
+  request_count?: number;
+};
+
+export type ApiKeyListResponse = {
+  api_keys: ApiKeyRow[];
+  total: number;
+  page: number;
+  pages: number;
+};
+
+export type ApiKeyDetail = {
+  api_key: ApiKeyRow & { created_by_email?: string };
+  stats: {
+    total_deeds?: number;
+    completed_deeds?: number;
+    total_requests?: number;
+    error_requests?: number;
+    avg_response_ms?: number | null;
+  };
+  recent_requests: Array<{
+    endpoint: string;
+    method: string;
+    status_code: number;
+    response_time_ms: number;
+    created_at: string;
+  }>;
+};
+
+/** The full key is returned exactly once, at creation. */
+export type CreatedApiKey = {
+  success: boolean;
+  api_key: ApiKeyRow & { key: string };
+  warning: string;
+};
+
+export type ApiKeyRequestRow = {
+  id: number;
+  company_name: string;
+  business_type?: string | null;
+  contact_name?: string | null;
+  email: string;
+  phone?: string | null;
+  use_case?: string | null;
+  expected_volume?: string | null;
+  integration_timeline?: string | null;
+  current_software?: string | null;
+  additional_info?: string | null;
+  status: 'new' | 'contacted' | 'approved' | 'declined';
+  notified_at?: string | null;
+  /** Set when the owner's notification email failed — the request is
+   *  still here, which is the point of storing before sending. */
+  notify_error?: string | null;
+  created_at: string;
+};
+
 export type StatSummary = {
   total_users: number;
   active_users: number;
@@ -184,7 +250,36 @@ export const AdminApi = {
     http<{success: boolean; message: string}>(`/admin/users/${id}`, {
       method: 'DELETE'
     }),
-  
+
+  // A3: partner API keys. These endpoints existed on the main API since
+  // the public-API work and no frontend had ever called them — the only
+  // key UI talked to a separate, dormant service through a shared setup
+  // secret, dropping the admin's own JWT. This goes through the same
+  // authenticated client as every other admin call.
+  listApiKeys: (page = 1, limit = 25) =>
+    http<ApiKeyListResponse>(`/admin/api-keys?page=${page}&limit=${limit}`),
+
+  getApiKey: (id: string) => http<ApiKeyDetail>(`/admin/api-keys/${id}`),
+
+  createApiKey: (body: { name: string; is_test?: boolean; rate_limit_hour?: number; rate_limit_day?: number }) =>
+    http<CreatedApiKey>('/admin/api-keys', { method: 'POST', body: JSON.stringify(body) }),
+
+  updateApiKey: (id: string, updates: { name?: string; is_active?: boolean; rate_limit_hour?: number; rate_limit_day?: number }) =>
+    http<{ success: boolean; api_key: ApiKeyRow }>(`/admin/api-keys/${id}`, {
+      method: 'PATCH', body: JSON.stringify(updates)
+    }),
+
+  deactivateApiKey: (id: string) =>
+    http<{ success: boolean; message: string }>(`/admin/api-keys/${id}`, { method: 'DELETE' }),
+
+  // The inquiry queue behind manual key issuance.
+  listApiKeyRequests: () =>
+    http<{ items: ApiKeyRequestRow[]; total: number }>('/admin/api-key-requests'),
+
+  updateApiKeyRequest: (id: number, status: ApiKeyRequestRow['status']) =>
+    http<{ success: boolean }>(`/admin/api-key-requests/${id}`, {
+      method: 'PATCH', body: JSON.stringify({ status })
+    }),
 };
 
 /**


### PR DESCRIPTION
## The form

Its submit handler was `await new Promise(r => setTimeout(r, 2000))` followed by a success screen promising a review within 24 hours. Nothing was sent, nothing was stored, and nobody could perform that review. Every platform that ever asked for API access got a green checkmark and silence — the fabricated-success class, pointed at exactly the people we'd want to sell to.

It reaches the backend now, and the ordering is the guarantee: the request is **stored first**, then the owner is emailed through the one honest transport, and the send result is written back to the row. A failed notification *marks* the row rather than vanishing — a lost email must never lose a sales lead. The response carries `email_sent`/`email_error` per the S1 contract, and a failed submit shows the visitor an error and keeps their input instead of showing success anyway.

## The copy — three claims came off the page

- **"SOC2 compliant"** — a compliance certification, not a feature description, and not earned. Stating it to enterprise buyers was the most consequential untrue sentence on the site. Flagging this one specifically: if any pitch deck, email template, or contract draft carries the same claim, it should come out of those too.
- **"API key delivered within 24 hours"**, plus a four-step timeline with 4-hour SLAs — no such process exists; issuance is manual by ruling.
- **"Dedicated Support" / "Personal onboarding"** — staff we don't have.

What replaces them describes what the API actually does: recorder-formatted output from the same templates the app renders, test keys before live keys, and a conversation before issuance. The success screen now says what genuinely happens next.

## The admin tab

The backend key CRUD — list with usage, mint-once, rate limits, deactivate — has existed since the public-API work and **no frontend had ever called it**. The only key UI in the app talked to a separate dormant service through a shared setup secret (dropping the admin's own JWT) and was unreachable from the nav anyway.

There's now an **API tab**, linked in the admin nav, going through the same authenticated client as every other admin screen:
- keys with their deed and request counts, last-used, and limits
- a mint flow that states plainly the key cannot be shown again
- deactivation with a confirmation naming the consequence
- the inquiry queue beside them, with failed-notification rows flagged — storing before sending is pointless if the UI hides them

## One defect found while building

This codebase has **two `get_db_connection` helpers with different row types**: `database`'s returns dict rows, `db`'s returns tuples. Reading one as the other is precisely what made every partner API key 401 for months (the A1 auth defect). The new router's first draft repeated it, caught by the live-DB test. The trap is now named in a comment where the next person will hit it — and it's worth considering a follow-up that removes the ambiguity rather than documenting it.

## Gates

| Gate | Result |
|---|---|
| Backend (live DB) | 312 passed |
| Six-flow baseline | ✔ unchanged |
| API baseline | ✔ unchanged |
| OpenAPI snapshot | re-recorded — **purely additive** (3 new funnel routes, nothing removed) |
| Jest | 324 passed (29 suites) |
| tsc | 94, flat |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_