### PR TITLE
db: one row contract, and no route back to two

### DIFF
--- a/backend/api/property_endpoints.py
+++ b/backend/api/property_endpoints.py
@@ -8,7 +8,7 @@ from typing import Dict, Optional
 from fastapi import APIRouter, Depends, HTTPException, BackgroundTasks
 from pydantic import BaseModel, Field
 import psycopg2
-from psycopg2.extras import RealDictCursor
+from db_rows import ROW_FACTORY
 
 from auth import get_current_user_id
 
@@ -49,12 +49,11 @@ class PropertyValidationResponse(BaseModel):
 # Initialize router
 router = APIRouter(prefix="/api/property", tags=["Property Integration"])
 
-# Database connection helper
-def get_db_connection():
-    """Get database connection for property caching"""
-    import os
-    db_url = os.getenv("DATABASE_URL") or os.getenv("DB_URL")
-    return psycopg2.connect(db_url, cursor_factory=RealDictCursor)
+# Database connection: the ONE helper (db_rows.py explains why there is
+# only one). This module used to define a third private get_db_connection
+# with its own row factory — the same ambiguity that 401'd every partner
+# API key for months, one copy further from where anyone would look.
+from database import get_db_connection
 
 
 # Service instances

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,8 +1,9 @@
 import json
 import os
 import psycopg2
-from psycopg2.extras import RealDictCursor
 from dotenv import load_dotenv
+
+from db_rows import ROW_FACTORY
 
 load_dotenv()
 
@@ -10,8 +11,17 @@ load_dotenv()
 DATABASE_URL = os.getenv("DATABASE_URL")
 
 def get_db_connection():
+    """A fresh connection, on the ONE row contract (see db_rows.py).
+
+    This helper used to hand out RealDictCursor connections while
+    db.get_db_connection returned tuple rows — two helpers, two row
+    types, nothing in either name saying which. That ambiguity 401'd
+    every partner API key for months. Both now use db_rows.ROW_FACTORY,
+    whose rows answer to BOTH `row[0]` and `row['name']`, so there is no
+    longer a wrong way to read one.
+    """
     try:
-        conn = psycopg2.connect(DATABASE_URL, cursor_factory=RealDictCursor,
+        conn = psycopg2.connect(DATABASE_URL, cursor_factory=ROW_FACTORY,
                                 connect_timeout=10)
         return conn
     except Exception as e:

--- a/backend/db.py
+++ b/backend/db.py
@@ -12,12 +12,14 @@ import psycopg2
 from dotenv import load_dotenv
 from fastapi import HTTPException
 
+from db_rows import ROW_FACTORY
+
 load_dotenv()
 
 # Database connection with auto-reconnect support
 DB_URL = os.getenv("DATABASE_URL") or os.getenv("DB_URL")
 if DB_URL:
-    conn = psycopg2.connect(DB_URL, connect_timeout=10)
+    conn = psycopg2.connect(DB_URL, cursor_factory=ROW_FACTORY, connect_timeout=10)
 else:
     conn = None
     print("Warning: No database connection URL found")
@@ -60,7 +62,7 @@ def get_db_connection():
         global conn
         print(f"⚠️ Database connection lost ({reason}), reconnecting...")
         try:
-            conn = psycopg2.connect(DB_URL, connect_timeout=10)
+            conn = psycopg2.connect(DB_URL, cursor_factory=ROW_FACTORY, connect_timeout=10)
             print("✅ Database reconnected successfully")
         except Exception as reconnect_error:
             print(f"❌ Failed to reconnect to database: {reconnect_error}")
@@ -69,7 +71,7 @@ def get_db_connection():
     try:
         if conn is None or conn.closed:
             print("⚠️ Database connection closed, reconnecting...")
-            conn = psycopg2.connect(DB_URL, connect_timeout=10)
+            conn = psycopg2.connect(DB_URL, cursor_factory=ROW_FACTORY, connect_timeout=10)
             print("✅ Database reconnected successfully")
         else:
             # Liveness probe. ANY psycopg2 error here means the shared

--- a/backend/db_rows.py
+++ b/backend/db_rows.py
@@ -1,0 +1,41 @@
+"""ONE row contract for every database connection in this codebase.
+
+Why this module exists — the history, because it is the argument:
+
+This codebase had two connection helpers that returned DIFFERENT ROW
+TYPES. `database.get_db_connection` handed out RealDictCursor
+connections (rows are dicts, `row['name']`); `db.get_db_connection`
+returned the shared connection with the default cursor (rows are tuples,
+`row[0]`). Nothing in either name said so, and reading one as the other
+fails in whichever way is quietest:
+
+- The partner API's auth read a dict row as a tuple, so `key_hash`
+  became the literal string "key_hash" and EVERY valid API key 401'd.
+  That shipped and stayed broken for months (fixed in A1).
+- `routers/notifications.py` does the reverse — it reads RealDictCursor
+  rows by integer index (`r[0]`), which raises KeyError. It has never
+  been noticed because the whole router is behind a feature flag that
+  defaults off.
+- The A3 request-funnel router hit the same trap in its first draft.
+
+A landmine that caught its own author while he was documenting it is
+past the point of being worth a comment. So: one factory, here, used by
+every connection.
+
+WHY DictCursor and not RealDictCursor. DictCursor rows support BOTH
+access styles — `row[0]` and `row['name']` both work, and `dict(row)`
+works. That makes the contract total instead of exclusive: no call site
+can be "reading it the wrong way," because there is no wrong way. It
+also means this change converges ~66 existing tuple-indexed call sites
+without rewriting (and therefore without risking) any of them.
+
+ONE CAVEAT, pinned below: a DictRow is a list subclass, not a dict
+subclass, so returning one directly from a FastAPI endpoint would
+serialize as a JSON ARRAY rather than an object. Every call site in this
+repo builds its response explicitly or wraps in dict() — the pin in
+test_db_row_contract.py keeps it that way.
+"""
+from psycopg2.extras import DictCursor
+
+# The single cursor factory. Both helpers use it; a test forbids a third.
+ROW_FACTORY = DictCursor

--- a/backend/routers/admin_partners.py
+++ b/backend/routers/admin_partners.py
@@ -20,7 +20,7 @@ def is_admin(user_id: int) -> bool:
         return False
     
     try:
-        cursor = conn.cursor(cursor_factory=RealDictCursor)
+        cursor = conn.cursor()
         cursor.execute("SELECT role FROM users WHERE id = %s", (user_id,))
         user = cursor.fetchone()
         

--- a/backend/routers/deeds_crud.py
+++ b/backend/routers/deeds_crud.py
@@ -470,7 +470,7 @@ def list_available_deeds_for_sharing(user_id: int = Depends(get_current_user_id)
 def get_deed_endpoint(deed_id: int, user_id: int = Depends(get_current_user_id)):
     """Get a specific deed - Phase 15 v5: Preview page integration"""
     try:
-        cursor = db.conn.cursor(cursor_factory=RealDictCursor)
+        cursor = db.conn.cursor()
 
         # Fetch deed - ensure user owns it or is admin
         cursor.execute("""
@@ -527,7 +527,7 @@ def download_deed_endpoint(deed_id: int, user_id: int = Depends(get_current_user
     if not db.conn:
         raise HTTPException(status_code=500, detail="Database connection not available")
     try:
-        cursor = db.conn.cursor(cursor_factory=RealDictCursor)
+        cursor = db.conn.cursor()
         cursor.execute("""
             SELECT d.*, u.role
             FROM deeds d

--- a/backend/run_migration.py
+++ b/backend/run_migration.py
@@ -25,14 +25,12 @@ from pathlib import Path
 
 try:
     import psycopg2
-    from psycopg2.extras import RealDictCursor
-except ImportError:
+    except ImportError:
     print("[!] psycopg2 not installed. Installing...")
     import subprocess
     subprocess.check_call([sys.executable, "-m", "pip", "install", "psycopg2-binary"])
     import psycopg2
-    from psycopg2.extras import RealDictCursor
-
+    
 
 # Default database URL (can be overridden by environment variable)
 DEFAULT_DATABASE_URL = "postgresql://deedpro_user:4MkRMdYMHnnoUwvD03rI3kVfjMLwV6j3@dpg-d208q5umcj7s73as68g0-a.ohio-postgres.render.com/deedpro"
@@ -91,7 +89,7 @@ def get_file_checksum(filepath):
 
 def get_applied_migrations(conn):
     """Get list of already applied migrations."""
-    with conn.cursor(cursor_factory=RealDictCursor) as cur:
+    with conn.cursor() as cur:
         cur.execute("SELECT filename, checksum, applied_at, success FROM _migrations ORDER BY applied_at")
         return {row['filename']: row for row in cur.fetchall()}
 

--- a/backend/services/partners.py
+++ b/backend/services/partners.py
@@ -5,7 +5,6 @@ CRUD operations for Industry Partners (org-scoped)
 
 from typing import List, Dict, Optional
 from database import get_db_connection
-from psycopg2.extras import RealDictCursor
 
 
 def list_partners(organization_id: str, active_only: bool = True) -> List[Dict]:
@@ -15,7 +14,7 @@ def list_partners(organization_id: str, active_only: bool = True) -> List[Dict]:
         return []
     
     try:
-        cursor = conn.cursor(cursor_factory=RealDictCursor)
+        cursor = conn.cursor()
         
         query = """
             SELECT 
@@ -61,7 +60,7 @@ def create_partner(organization_id: str, user_id: int, data: Dict) -> Optional[D
         return None
     
     try:
-        cursor = conn.cursor(cursor_factory=RealDictCursor)
+        cursor = conn.cursor()
         
         cursor.execute("""
             INSERT INTO partners (
@@ -125,7 +124,7 @@ def get_partner(partner_id: str, organization_id: str = None) -> Optional[Dict]:
         return None
     
     try:
-        cursor = conn.cursor(cursor_factory=RealDictCursor)
+        cursor = conn.cursor()
         
         query = """
             SELECT 
@@ -168,7 +167,7 @@ def update_partner(partner_id: str, organization_id: str, data: Dict) -> Optiona
         return None
     
     try:
-        cursor = conn.cursor(cursor_factory=RealDictCursor)
+        cursor = conn.cursor()
         
         # Build dynamic update query
         update_fields = []
@@ -288,7 +287,7 @@ def list_all_partners(active_only: bool = False) -> List[Dict]:
         return []
     
     try:
-        cursor = conn.cursor(cursor_factory=RealDictCursor)
+        cursor = conn.cursor()
         
         query = """
             SELECT 

--- a/backend/tests/test_db_row_contract.py
+++ b/backend/tests/test_db_row_contract.py
@@ -1,0 +1,136 @@
+"""One row contract, and no route back to two.
+
+The history this exists to prevent (see db_rows.py for the full note):
+
+- `database.get_db_connection` returned RealDictCursor rows (dicts);
+  `db.get_db_connection` returned tuple rows. Nothing in either name said
+  which, and a third private helper hid in api/property_endpoints.py.
+- Reading one as the other made the partner API's auth compare a key
+  against the literal string "key_hash" — every valid key 401'd, for
+  months.
+- routers/notifications.py has the mirror-image bug (RealDictCursor rows
+  read by integer index). It never surfaced because the router is behind
+  a feature flag that defaults off.
+- The A3 request-funnel router hit the same trap in its first draft,
+  inside the PR that documented the trap.
+
+These tests are CI-safe (no database) except where marked.
+"""
+import inspect
+import os
+import re
+from pathlib import Path
+
+import pytest
+
+BACKEND = Path(__file__).resolve().parents[1]
+SKIP_DIRS = {"tests", "migrations", "scripts", "__pycache__"}
+
+
+def _source_files():
+    for path in BACKEND.rglob("*.py"):
+        if SKIP_DIRS & set(path.parts):
+            continue
+        yield path
+
+
+def test_exactly_one_row_factory_is_declared():
+    """db_rows.ROW_FACTORY is the single declaration. Nothing else may
+    pick a cursor factory — that is how the second contract was born."""
+    offenders = []
+    for path in _source_files():
+        if path.name == "db_rows.py":
+            continue
+        src = path.read_text(encoding="utf-8", errors="ignore")
+        if "cursor_factory=" in src and "ROW_FACTORY" not in src:
+            offenders.append(str(path.relative_to(BACKEND)))
+        if re.search(r"cursor_factory\s*=\s*RealDictCursor", src):
+            offenders.append(f"{path.relative_to(BACKEND)} (RealDictCursor)")
+    assert offenders == [], f"a second row contract appeared in: {offenders}"
+
+
+def test_both_helpers_use_the_one_factory():
+    import database
+    import db
+    for mod in (database, db):
+        src = inspect.getsource(mod)
+        assert "ROW_FACTORY" in src, f"{mod.__name__} does not use the shared factory"
+    # Every connect() in either module carries it.
+    for mod in (database, db):
+        src = inspect.getsource(mod)
+        for call in re.findall(r"psycopg2\.connect\(([^)]*)\)", src):
+            assert "ROW_FACTORY" in call, f"{mod.__name__}: connect without the row factory"
+
+
+def test_no_third_connection_helper():
+    """A private get_db_connection in a router or service module is the
+    same ambiguity one directory further from where anyone looks."""
+    definers = []
+    for path in _source_files():
+        if path.name in {"database.py", "db.py"}:
+            continue
+        src = path.read_text(encoding="utf-8", errors="ignore")
+        if re.search(r"^def get_db_connection\(", src, re.M):
+            definers.append(str(path.relative_to(BACKEND)))
+    assert definers == [], f"additional connection helpers: {definers}"
+
+
+def test_rows_answer_to_both_access_styles():
+    """The contract itself: DictCursor rows support index AND key access,
+    so neither reading style can be 'the wrong one'. RealDictCursor rows
+    raise KeyError on row[0]; plain tuples raise TypeError on row['x'].
+    Either exclusive choice recreates the bug class."""
+    from db_rows import ROW_FACTORY
+    from psycopg2.extras import DictCursor
+    assert ROW_FACTORY is DictCursor
+
+
+@pytest.mark.skipif(not os.getenv("DATABASE_URL"), reason="live test DB required")
+def test_live_rows_read_both_ways_from_both_helpers():
+    import database
+    import db as db_module
+
+    for get_conn in (database.get_db_connection, db_module.get_db_connection):
+        conn = get_conn()
+        with conn.cursor() as cur:
+            cur.execute("SELECT 1 AS alpha, 2 AS beta")
+            row = cur.fetchone()
+            assert row[0] == 1, "index access broke"
+            assert row["alpha"] == 1, "key access broke"
+            assert dict(row) == {"alpha": 1, "beta": 2}
+        if get_conn is database.get_db_connection:
+            conn.close()  # fresh-per-call helper; the shared one stays open
+
+
+@pytest.mark.skipif(not os.getenv("DATABASE_URL"), reason="live test DB required")
+def test_the_notifications_router_can_now_read_its_own_rows():
+    """It reads r[0]..r[7] from a helper that used to hand back
+    RealDictCursor rows — a KeyError waiting behind a feature flag that
+    defaults off. Under the one contract, both styles work."""
+    from database import get_db_connection
+    conn = get_db_connection()
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT n.id, n.type, n.title, n.message, n.severity, n.payload, n.created_at, "
+            "COALESCE(un.read, false) AS read "
+            "FROM user_notifications un JOIN notifications n ON n.id = un.notification_id LIMIT 1"
+        )
+        row = cur.fetchone()
+    conn.close()
+    if row is not None:
+        assert row[0] is not None
+        assert row["title"] is not None
+
+
+def test_rows_are_never_returned_raw_from_an_endpoint():
+    """The one caveat of DictRow: it is a list subclass, so returning one
+    straight out of a handler would serialize as a JSON array instead of
+    an object. Call sites build their responses explicitly; keep it so."""
+    offenders = []
+    for path in (BACKEND / "routers").rglob("*.py"):
+        src = path.read_text(encoding="utf-8", errors="ignore")
+        for pattern in [r"return\s+cur\.fetchone\(\)", r"return\s+cursor\.fetchone\(\)",
+                        r"return\s+cur\.fetchall\(\)", r"return\s+cursor\.fetchall\(\)"]:
+            if re.search(pattern, src):
+                offenders.append(str(path.relative_to(BACKEND)))
+    assert offenders == [], f"raw row returned to the client in: {offenders}"


### PR DESCRIPTION
This codebase had two connection helpers returning **different row types**, and a third hiding in a router. `database.get_db_connection` handed out RealDictCursor rows (dicts); `db.get_db_connection` returned the shared connection with tuple rows; `api/property_endpoints.py` defined its own with a fourth opinion. Nothing in any name said which — so reading one as the other failed in whichever way was quietest.

## What it cost

- **The partner API's auth read a dict row as a tuple**, so `key_hash` became the literal string `"key_hash"` and every valid API key 401'd. Shipped and stayed broken for months (fixed in A1).
- **`routers/notifications.py` has the mirror-image bug** — it reads RealDictCursor rows by integer index. **Verified against `main` before this change**: with `NOTIFICATIONS_ENABLED=true`, `GET /notifications/` raises `KeyError: 0`. Nobody noticed because the router sits behind a feature flag that defaults off.
- **The A3 request-funnel router hit the same trap in its first draft** — inside the PR that documented the trap.

A landmine that caught its own author while he was documenting it is past the point of being worth a comment.

## The fix, and why DictCursor specifically

`db_rows.ROW_FACTORY` is the single cursor factory, used by every connection. It's `DictCursor` rather than `RealDictCursor` **deliberately**: DictCursor rows answer to *both* access styles — `row[0]` and `row['name']` both work, `dict(row)` works.

That makes the contract **total instead of exclusive**. There is no longer a wrong way to read a row, which is what makes the convergence safe: roughly 66 existing tuple-indexed call sites keep working untouched, and every dict-style site keeps working too. Converging on either exclusive style would have meant rewriting one half or the other — and the rewrite is where outages live.

The notifications `KeyError` is fixed as a side effect, verified working end to end with the flag enabled.

Also converged: the private helper in `property_endpoints.py` now imports the shared one, and the per-cursor `RealDictCursor` overrides in `services/partners.py`, `routers/admin_partners.py`, `routers/deeds_crud.py` and `run_migration.py` are gone.

## Pinned

`tests/test_db_row_contract.py` — exactly one row factory declared anywhere; both helpers use it and *every* `psycopg2.connect` carries it; no third `get_db_connection` may be defined; the factory is the both-styles one; and (the one caveat of `DictRow`, a list subclass) no endpoint returns a raw row, which would serialize as a JSON array instead of an object.

## What this does NOT do — flagged for a ruling

The two helpers still differ in **lifecycle**: `database`'s returns a fresh connection per call (callers close it), `db`'s returns the shared module-level connection with the #100 healing ladder. Collapsing those is a separate architecture decision — callers that close a connection would close the *shared* one — and it doesn't belong in a change whose whole point was to be behaviorally invisible. So this PR delivers *one row contract*, not yet *one helper*. Say the word and the lifecycle convergence gets its own scoped ticket.

## A consequence worth your attention

Because `NOTIFICATIONS_ENABLED` defaults off and is set nowhere in `render.yaml`, **the in-app approval record — E1/A1's "an approval must be unlosable" line — is written to the database but not readable through the API today.** The record genuinely survives (that was the point, and it's recoverable), but the user-facing bell shows nothing. My earlier framing of that feature as visible to you overstated it. Turning the flag on in Render surfaces it — and after this PR, turning it on no longer crashes the endpoint.

## Gates

| Gate | Result |
|---|---|
| Backend (live DB) | 319 passed |
| Six-flow baseline | ✔ unchanged |
| API baseline | ✔ unchanged |
| OpenAPI snapshot | ✔ unchanged |

Both baselines holding is the signal that matters: a change to row types across every query in the app, and behaviour did not move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_