### PR TITLE
docs: record the ADMIN0 rulings before the wave builds

### DIFF
--- a/docs/DOCTRINE_CONFORMANCE.md
+++ b/docs/DOCTRINE_CONFORMANCE.md
@@ -276,10 +276,54 @@ disclosure to a title company's counsel, not an apology.
 
 ---
 
+## 9. A stored instrument is never overwritten (2026-08-03, owner-ruled)
+
+**Statement.** Once a deed's PDF is stored, those bytes and their sha256
+are the artifact. A regeneration may not silently replace them.
+
+**Finding (ADMIN0).** `services/deed_pdf.py:166-173` stores via
+`INSERT ... ON CONFLICT (deed_id) DO UPDATE SET pdf_data = EXCLUDED.pdf_data`.
+`deed_pdfs` is keyed by `deed_id`, one row per deed, so a re-store
+overwrites the prior bytes **and the prior hash** in place. Nothing
+records that a previous artifact existed. The draft path is properly
+guarded — a resume against a completed deed returns 409
+(`routers/deeds_crud.py:184-193`) — so this is not reachable through
+the ordinary builder today. It is a *latent* violation: the guard lives
+one layer above the destructive statement, and any future path that
+reaches the store directly inherits the overwrite.
+
+This matters more than an ordinary data bug because the hash is the
+verification substrate. Doctrine §3 removed QR codes from recorded pages
+on the reasoning that "verification survives as data" — that data is
+`deed_pdfs.sha256`. A silent overwrite invalidates every prior
+verification of that document without leaving a trace that anything
+changed.
+
+**Ruling.** Two parts, deliberately separated by size:
+
+1. **Insert-or-refuse (minimal, ADMIN1).** A store against an existing
+   row whose hash differs is a **loud refusal**, surfaced to the
+   operator — never an overwrite. Re-storing identical bytes is a
+   no-op. This closes the destructive path without designing anything.
+2. **Supersession (its own designed ticket).** A corrected deed is a
+   NEW record that supersedes the old one, with both retained and the
+   relationship recorded — the pattern `document_authenticity` already
+   models with `status='superseded'` + `superseded_by`
+   (`database.py:296-298`) and which `deeds` has no equivalent of.
+   Designing that is not cleanup, and it is ledgered as such.
+
+**Consequence for the admin console.** No admin deed-edit capability
+ships until the supersession model exists. An "edit" affordance over a
+last-write-wins store is how an operator destroys an instrument while
+believing they corrected one.
+
+---
+
 ## Change log
 
 | Date | Change |
 |---|---|
+| 2026-08-03 | §9 added — stored instruments are never overwritten. ADMIN0 found `deed_pdfs` stored via `ON CONFLICT DO UPDATE SET pdf_data`, replacing prior bytes AND their sha256 in place; the draft-resume 409 guard sits a layer above it, making this latent rather than live. Ruled in two parts: insert-or-refuse in ADMIN1 (differing hash = loud refusal, identical = no-op), full supersession as its own designed ticket. No admin deed-edit until supersession exists. |
 | 2026-08-03 | §8 added — API doctrine boundary ruled: v1 = deed family only; affidavit/declaration families held pending per-family passes (execution-act instruments require human flows by design). A1 also recorded three never-run defects in the mounted `/api/v1` (tuple-read auth, unassigned `full_address`, metering aborting the deed transaction) — all three survived because the only tests bypassed the HTTP and database layers, the test-vs-production asymmetry lesson under invariant #4. |
 | 2026-07-28 | Initial sweep: partner-API chassis fix, AI-chat proxy honesty fix, proxy source-scan test, partner-render tests. Draft pending owner decisions on §7. |
 | 2026-07-28 | Owner rulings executed: /api/generate-deed excised (snapshot re-recorded), /api/ai/chat logged-in-only + guard test + no-key 503, recitals ruling recorded. Report finalized. |

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -4,8 +4,8 @@
 (not only in chat) so the list survives context windows. No credential
 values ever appear in this file — item names and status only.
 
-_Last corrected: 2026-08-03 (owner board sync — four environment items
-closed; privileged-account audit executed)._
+_Last corrected: 2026-08-03 (ADMIN0 rulings recorded: wave order,
+audit-log shape, supersession + VERIFY1 parked)._
 
 ## Open — owner's card
 
@@ -95,7 +95,68 @@ closed; privileged-account audit executed)._
   furniture; blank execution marks; parties-JSONB migration; declaration
   family; FORMS_TRIAGE correction note).
 
+## Approved wave — ADMIN (ADMIN0 audit, 2026-08-03)
+
+Order approved: **ADMIN1 → 2 → 3 → 4 → 5 → 6.**
+
+- **ADMIN1 — truth pass + operator home.** Kills the fabricated System
+  values (`pdf_engine` hardcoded `"up"`, `avg_time_ms` never assigned,
+  `weasyprint_count` asserted equal to a deed count) — each gets a real
+  probe or an honest absence, and the System tab fails loudly instead of
+  rendering zeros that read as measurements. Also: the Revenue
+  silent-zero dies (a missing table must not render as `$0`); the
+  Overview QR silent-zero dies; the 7-day activity feed that
+  `/admin/dashboard` already computes and discards gets rendered; and
+  the §9 insert-or-refuse fix is absorbed here. **H1 adoption rides
+  along:** the billing tables and `partners` are outside
+  `create_tables()` and adopt into it — adopt-vs-create branch decided
+  by the owner's production table check. **GATED on that paste.**
+- **ADMIN2 — share lifecycle console.** The largest visibility hole:
+  `deed_shares` records sent → viewed → approved/rejected/revoked/
+  expired plus rejection feedback, and no admin surface reads any of it.
+- **ADMIN3 — email outcome persistence.** Generalize the one working
+  pattern (`api_key_requests.notify_error`) to the other ten templates;
+  10 of 11 send outcomes are currently printed and discarded.
+- **ADMIN4 — admin audit log.** UNBLOCKED by the ruling below.
+- **ADMIN5 — orphan wiring.** ~18 admin endpoints have no caller; the
+  cheap wins are per-key error rates, deed PDF open, a partners tab,
+  payments detail, and API-key reactivation (deactivation is currently
+  one-way in the UI only).
+- **ADMIN6 — trends.** **Derives from existing tables** by ruling; no
+  rollup emission unless queries prove slow.
+
+### ADMIN4 audit-log ruling (owner, 2026-08-03) — build to this
+
+- **Scope:** privileged mutations only — not every read, not every write.
+- **Prior values:** captured. Role, status, and limit changes record the
+  old → new values **verbatim**; personal fields (email, name, phone)
+  are **masked** rather than stored in the clear.
+- **Retention:** indefinite.
+- **Surface:** admin-visible, **read-only, append-only, no delete path**,
+  and that absence is **pinned** by test — a log with a delete path is a
+  log that can be edited by whoever is being logged.
+- Note for the builder: nothing exists today. `get_current_admin`
+  already returns the actor's email and every handler discards it, so
+  actor threading is the first task, not the last.
+
 ## Parked tickets (scoped, not scheduled)
+
+- **Deed supersession model** (doctrine §9, 2026-08-03) — a corrected
+  deed is a NEW record superseding the old, both retained, relationship
+  recorded. `document_authenticity` already models this shape
+  (`status='superseded'` + `superseded_by`); `deeds` has no equivalent.
+  This is design work, not cleanup, and is explicitly NOT to be absorbed
+  into an admin ticket. **Blocks:** any admin deed-edit capability.
+- **VERIFY1 — wizard-deed public verification** (ADMIN0 finding, queued
+  AFTER the admin wave; roadmap, not admin). `create_document_authenticity`
+  (`routers/verification.py:227`) has zero callers — the only live writer
+  of `document_authenticity` is the partner-API lane
+  (`routers/api_v1/router.py:438`). So wizard deeds carry a stored
+  `deed_pdfs.sha256` but no verifiable short code, and the admin
+  Verification tab shows API-lane documents only. Whether public
+  verifiability was ever intended for wizard deeds is a product
+  question — doctrine §3 removed QR codes from recorded pages on the
+  reasoning that "verification survives as data."
 
 - **Connection-helper LIFECYCLE collapse** — parked 2026-08-03 by owner
   ruling; explicitly NOT to be absorbed into another ticket. PR #107


### PR DESCRIPTION
Docs-only. The ADMIN0 audit produced four rulings and two new parked tickets; they land in the canonical files **now**, not only in chat. The W0 §3 lesson was that a ruling living only in a conversation gets inverted by the next context window.

**ADMIN1 is not started** — it's gated on the production table-check paste, which decides the adopt-vs-create branch for the billing tables and `partners` under H1.

## Doctrine §9 — a stored instrument is never overwritten

`deed_pdfs` is stored via `ON CONFLICT DO UPDATE SET pdf_data`, replacing prior bytes **and their sha256** in place. The draft-resume 409 guard sits one layer above that statement, so this is *latent* rather than live — but it's worth being precise about why it still matters: the hash is the verification substrate doctrine §3 relied on when it removed QR codes from recorded pages ("verification survives as data"). A silent overwrite invalidates every prior verification of that document without leaving a trace that anything changed.

Ruled in two parts, separated by size: **insert-or-refuse** in ADMIN1 (differing hash → loud refusal surfaced to the operator; identical bytes → no-op), and **full supersession** as its own designed ticket. No admin deed-edit ships until supersession exists — an "edit" affordance over a last-write-wins store is how an operator destroys an instrument while believing they corrected one.

## Ledger — the approved wave

ADMIN1→6 with each ticket's scope, plus the **ADMIN4 audit-log ruling written as build-to spec**: privileged mutations only; prior values captured with role/status/limits verbatim old→new and personal fields masked; indefinite retention; admin-visible, read-only, append-only, **no delete path, pinned**.

One note recorded for whoever builds ADMIN4: `get_current_admin` already returns the actor's email and every single handler discards it. Actor threading is the first task, not the last.

## Parked

- **Deed supersession** — design work, explicitly not absorbable into an admin ticket. Blocks any admin deed-edit.
- **VERIFY1** — wizard-deed public verification, queued after the admin wave as roadmap. `create_document_authenticity` has zero callers; only the partner-API lane writes verification records, so the Verification tab shows API-lane documents only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_