### PR TITLE
ADMIN1: the console's numbers are measurements or absences, never both

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -268,6 +268,116 @@ def create_tables():
                 created_at TIMESTAMPTZ DEFAULT now(),
                 UNIQUE(api_key_id, window_type, window_key)
             )""",
+            # ── ADMIN1: the last tables outside the one authority ────────
+            # ADMIN0 found live code depending on tables create_tables()
+            # never made. Production check (2026-08-03): invoices,
+            # payment_history and partners EXIST (hand-run migrations);
+            # subscriptions was MISSING ENTIRELY — which is why the
+            # Revenue tab's $0 was never a real zero, it was the
+            # no-table branch of a try/except (see services/revenue.py,
+            # fixed in this same pass to fail loudly instead).
+            #
+            # Shapes below match migrations/phase23/*.sql and
+            # migrations/add_partners_table_v2.py exactly, so the CREATEs
+            # no-op against the existing production tables; the ALTER
+            # ladders converge any column the code needs.
+            """CREATE TABLE IF NOT EXISTS partners (
+                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                organization_id VARCHAR(255) NOT NULL DEFAULT 'default-org',
+                created_by_user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                category VARCHAR(50) NOT NULL DEFAULT 'other',
+                role VARCHAR(50) NOT NULL DEFAULT 'other',
+                company_name VARCHAR(255) NOT NULL,
+                contact_name VARCHAR(255),
+                email VARCHAR(255),
+                phone VARCHAR(50),
+                address_line1 VARCHAR(255),
+                address_line2 VARCHAR(255),
+                city VARCHAR(100),
+                state VARCHAR(50),
+                postal_code VARCHAR(20),
+                notes TEXT,
+                is_active BOOLEAN NOT NULL DEFAULT TRUE,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )""",
+            "CREATE INDEX IF NOT EXISTS idx_partners_org ON partners(organization_id)",
+            "CREATE INDEX IF NOT EXISTS idx_partners_active ON partners(is_active)",
+            """CREATE TABLE IF NOT EXISTS invoices (
+                id SERIAL PRIMARY KEY,
+                user_id INT,
+                api_key_prefix TEXT,
+                invoice_number VARCHAR(50) UNIQUE NOT NULL,
+                stripe_invoice_id VARCHAR(255) UNIQUE,
+                subtotal_cents INT NOT NULL,
+                tax_cents INT DEFAULT 0,
+                discount_cents INT DEFAULT 0,
+                total_cents INT NOT NULL,
+                amount_paid_cents INT DEFAULT 0,
+                amount_due_cents INT NOT NULL,
+                currency VARCHAR(3) DEFAULT 'USD',
+                status VARCHAR(20) NOT NULL,
+                billing_period_start TIMESTAMPTZ NOT NULL,
+                billing_period_end TIMESTAMPTZ NOT NULL,
+                due_date TIMESTAMP NOT NULL,
+                paid_at TIMESTAMP,
+                voided_at TIMESTAMP,
+                line_items JSONB NOT NULL,
+                notes TEXT,
+                invoice_pdf_url TEXT,
+                created_at TIMESTAMPTZ DEFAULT now(),
+                updated_at TIMESTAMPTZ DEFAULT now()
+            )""",
+            """CREATE TABLE IF NOT EXISTS payment_history (
+                id SERIAL PRIMARY KEY,
+                invoice_id INT REFERENCES invoices(id),
+                user_id INT,
+                stripe_payment_intent_id VARCHAR(255) UNIQUE,
+                stripe_charge_id VARCHAR(255),
+                amount_cents INT NOT NULL,
+                currency VARCHAR(3) DEFAULT 'USD',
+                status VARCHAR(20) NOT NULL,
+                payment_method VARCHAR(50),
+                stripe_fee_cents INT DEFAULT 0,
+                net_amount_cents INT NOT NULL,
+                failure_code VARCHAR(50),
+                failure_message TEXT,
+                refunded_at TIMESTAMP,
+                refund_reason TEXT,
+                refund_amount_cents INT,
+                created_at TIMESTAMPTZ DEFAULT now()
+            )""",
+            "CREATE INDEX IF NOT EXISTS idx_payment_history_status ON payment_history(status, created_at)",
+            # CREATED FRESH — this one did not exist in production at all.
+            # Base shape from scripts/init_db.py (the only prior CREATE)
+            # plus the columns phase23_006's ALTER-IF-EXISTS ladder adds,
+            # since that migration could never have applied to a table
+            # that was never created.
+            """CREATE TABLE IF NOT EXISTS subscriptions (
+                id SERIAL PRIMARY KEY,
+                user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+                stripe_subscription_id VARCHAR(255) UNIQUE,
+                status VARCHAR(50) NOT NULL,
+                current_period_start TIMESTAMP,
+                current_period_end TIMESTAMP,
+                plan_name VARCHAR(50) NOT NULL,
+                current_plan_price_cents INT,
+                billing_cycle VARCHAR(20),
+                auto_renew BOOLEAN DEFAULT TRUE,
+                cancel_at_period_end BOOLEAN DEFAULT FALSE,
+                cancellation_reason TEXT,
+                mrr_cents INT,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )""",
+            "ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS current_plan_price_cents INT",
+            "ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS billing_cycle VARCHAR(20)",
+            "ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS auto_renew BOOLEAN DEFAULT TRUE",
+            "ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS cancel_at_period_end BOOLEAN DEFAULT FALSE",
+            "ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS cancellation_reason TEXT",
+            "ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS mrr_cents INT",
+            "ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS stripe_subscription_id VARCHAR(255)",
+            "CREATE INDEX IF NOT EXISTS idx_subscriptions_stripe ON subscriptions(stripe_subscription_id)",
             # Same-invariant gap, declared (not silently absorbed — named
             # in the A1 report): the LIVE verification system and the E1
             # in-app notification writes also depended on hand-run

--- a/backend/phase23_billing/router_admin.py
+++ b/backend/phase23_billing/router_admin.py
@@ -15,10 +15,24 @@ router = APIRouter(prefix="/admin", tags=["admin-billing"],
 
 @router.get("/revenue")
 def revenue(db: Session = Depends(get_db)):
+    """ADMIN1: read failures travel to the operator.
+
+    Every read here used to collapse to 0 on any exception, so a missing
+    table rendered as a confident $0 on the money screen. The reads now
+    return UNKNOWN (null) plus a reason, and this endpoint aggregates
+    those reasons into `errors` — the tab shows a banner rather than a
+    number nobody can trust.
+    """
+    overview = get_revenue_overview(db)
+    breakdown, breakdown_errors = monthly_breakdown(db)
+    mrr = mrr_arr(db)
+
+    errors = overview.pop("errors", []) + breakdown_errors + mrr.pop("errors", [])
     return {
-        "overview": get_revenue_overview(db),
-        "monthly_breakdown": monthly_breakdown(db),
-        "mrr_arr": mrr_arr(db)
+        "overview": overview,
+        "monthly_breakdown": breakdown,
+        "mrr_arr": mrr,
+        "errors": errors,
     }
 
 @router.get("/invoices")

--- a/backend/phase23_billing/services/revenue.py
+++ b/backend/phase23_billing/services/revenue.py
@@ -1,48 +1,77 @@
+"""Revenue reads — a zero here must mean zero, not "the query failed".
+
+ADMIN1: every function in this module used to wrap its query in a bare
+`try/except: return 0`, one of them with the comment "subscriptions table
+doesn't exist yet, return zeros". The production check on 2026-08-03
+found that table missing entirely — so the Revenue tab's $0 MRR was
+never a real zero, it was the except branch, and no operator could tell
+the two apart. That is invariant #4 (errors are never swallowed into
+empty states) sitting on the money screen.
+
+The tables are now in the one schema authority (`database.create_tables`),
+so a missing table is no longer an expected condition — it is a real
+failure, and it says so. Each read returns its value plus an `errors`
+list; the router surfaces those, and the tab shows a banner instead of a
+confident $0.
+"""
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
+# Zero and unknown are different claims. `None` means "we could not
+# read this", and every consumer must render it as such.
+UNKNOWN = None
+
+
+def _scalar(db: Session, sql: str, errors: list, label: str):
+    """Run a scalar read. On failure, record WHY and return UNKNOWN —
+    never a number the caller cannot distinguish from real data."""
+    try:
+        return int(db.execute(text(sql)).scalar() or 0)
+    except Exception as e:
+        db.rollback()  # a failed read leaves the session unusable otherwise
+        errors.append(f"{label}: {type(e).__name__}: {str(e)[:200]}")
+        return UNKNOWN
+
+
 def get_revenue_overview(db: Session):
-    try:
-        total = db.execute(text("""
-            SELECT COALESCE(SUM(amount_cents),0)::bigint FROM payment_history WHERE status='succeeded'
-        """)).scalar() or 0
-    except Exception:
-        total = 0
-    
-    try:
-        monthly = db.execute(text("""
-            SELECT COALESCE(SUM(amount_cents),0)::bigint FROM payment_history 
-            WHERE status='succeeded' AND created_at >= DATE_TRUNC('month', CURRENT_DATE)
-        """)).scalar() or 0
-    except Exception:
-        monthly = 0
-    
-    try:
-        fees = db.execute(text("""
-            SELECT COALESCE(SUM(stripe_fee_cents),0)::bigint FROM payment_history 
-            WHERE status='succeeded' AND created_at >= DATE_TRUNC('month', CURRENT_DATE)
-        """)).scalar() or 0
-    except Exception:
-        fees = 0
-    
-    try:
-        refunded = db.execute(text("""
-            SELECT COALESCE(SUM(refund_amount_cents),0)::bigint FROM payment_history 
-            WHERE status='refunded' AND refunded_at >= DATE_TRUNC('month', CURRENT_DATE)
-        """)).scalar() or 0
-    except Exception:
-        refunded = 0
-    
-    net = monthly - fees - refunded
+    errors: list = []
+
+    total = _scalar(db, """
+        SELECT COALESCE(SUM(amount_cents),0)::bigint FROM payment_history WHERE status='succeeded'
+    """, errors, "total_revenue")
+
+    monthly = _scalar(db, """
+        SELECT COALESCE(SUM(amount_cents),0)::bigint FROM payment_history
+        WHERE status='succeeded' AND created_at >= DATE_TRUNC('month', CURRENT_DATE)
+    """, errors, "monthly_revenue")
+
+    fees = _scalar(db, """
+        SELECT COALESCE(SUM(stripe_fee_cents),0)::bigint FROM payment_history
+        WHERE status='succeeded' AND created_at >= DATE_TRUNC('month', CURRENT_DATE)
+    """, errors, "stripe_fees")
+
+    refunded = _scalar(db, """
+        SELECT COALESCE(SUM(refund_amount_cents),0)::bigint FROM payment_history
+        WHERE status='refunded' AND refunded_at >= DATE_TRUNC('month', CURRENT_DATE)
+    """, errors, "refunds")
+
+    # Net is only meaningful if all three inputs are real.
+    net = (monthly - fees - refunded
+           if UNKNOWN not in (monthly, fees, refunded) else UNKNOWN)
+
     return {
-        "total_revenue_cents": int(total),
-        "monthly_revenue_cents": int(monthly),
-        "stripe_fees_cents": int(fees),
-        "refunds_cents": int(refunded),
-        "net_monthly_revenue_cents": int(net)
+        "total_revenue_cents": total,
+        "monthly_revenue_cents": monthly,
+        "stripe_fees_cents": fees,
+        "refunds_cents": refunded,
+        "net_monthly_revenue_cents": net,
+        "errors": errors,
     }
 
+
 def monthly_breakdown(db: Session):
+    """Returns (rows, errors). An empty list from a FAILED query and an
+    empty list from a business with no revenue yet are different facts."""
     try:
         rows = db.execute(text("""
             SELECT TO_CHAR(DATE_TRUNC('month', created_at), 'YYYY-MM') AS month,
@@ -52,23 +81,22 @@ def monthly_breakdown(db: Session):
               AND created_at >= DATE_TRUNC('month', CURRENT_DATE) - INTERVAL '12 months'
             GROUP BY 1 ORDER BY 1 DESC
         """)).fetchall()
-        return [{"month": r.month, "revenue_cents": int(r.revenue), "revenue_dollars": int(r.revenue)/100} for r in rows]
-    except Exception:
-        return []
+        return [{"month": r.month, "revenue_cents": int(r.revenue),
+                 "revenue_dollars": int(r.revenue) / 100} for r in rows], []
+    except Exception as e:
+        db.rollback()
+        return [], [f"monthly_breakdown: {type(e).__name__}: {str(e)[:200]}"]
+
 
 def mrr_arr(db: Session):
-    # assumes subscriptions table exists and contains mrr_cents + status
-    try:
-        row = db.execute(text("""
-            SELECT COALESCE(SUM(mrr_cents),0)::bigint FROM subscriptions WHERE status='active'
-        """)).fetchone()
-        mrr = int(row[0] or 0) if row else 0
-    except Exception:
-        # subscriptions table doesn't exist yet, return zeros
-        mrr = 0
+    errors: list = []
+    mrr = _scalar(db, """
+        SELECT COALESCE(SUM(mrr_cents),0)::bigint FROM subscriptions WHERE status='active'
+    """, errors, "mrr")
     return {
         "mrr_cents": mrr,
-        "mrr_dollars": mrr/100,
-        "arr_cents": mrr*12,
-        "arr_dollars": (mrr*12)/100
+        "mrr_dollars": mrr / 100 if mrr is not UNKNOWN else UNKNOWN,
+        "arr_cents": mrr * 12 if mrr is not UNKNOWN else UNKNOWN,
+        "arr_dollars": (mrr * 12) / 100 if mrr is not UNKNOWN else UNKNOWN,
+        "errors": errors,
     }

--- a/backend/routers/admin_inline.py
+++ b/backend/routers/admin_inline.py
@@ -345,43 +345,92 @@ def admin_system_overview():
     except Exception as e:
         print(f"Stripe health check failed: {e}")
 
-    # PDF engine status — WeasyPrint is THE engine (PS2; PDFShift removed).
+    # PDF engine — WeasyPrint is THE engine (PS2; PDFShift removed).
+    #
+    # ADMIN1 kill-list item 1: this used to be the literal
+    # `{"status": "up"}` with no probe of any kind, so the engine
+    # rendered green on the one screen an operator opens during an
+    # incident — even if WeasyPrint could not render a page. It is a
+    # real probe now: render a minimal document and see if bytes come
+    # back. Cheap (a few ms, no network) and it fails the way the real
+    # thing fails, because it IS the real thing.
     pdf_primary = "WeasyPrint"
+    pdf_status = "down"
+    pdf_probe_error = None
+    try:
+        from pdf_engine import render_pdf
+        probe = render_pdf("<html><body>ok</body></html>")
+        pdf_status = "up" if probe[:5] == b"%PDF-" else "down"
+        if pdf_status == "down":
+            pdf_probe_error = "renderer returned non-PDF bytes"
+    except Exception as e:
+        pdf_probe_error = f"{type(e).__name__}: {str(e)[:200]}"
+        print(f"PDF engine health check failed: {pdf_probe_error}")
 
-    # Get PDF generation stats from deeds table
+    # ADMIN1 kill-list items 2 and 3.
+    #
+    # `weasyprint_count` was assigned `= total_generated` — an assertion
+    # dressed as a measurement — and `total_generated` itself counted
+    # deeds in status 'completed', which is deed STATE, not evidence a
+    # PDF exists. `deed_pdfs` is the table that knows: one row per deed
+    # whose bytes we actually stored. Counting there also makes the
+    # stuck-deed gap visible (completed deeds with no stored artifact),
+    # which is one of the recurring shell pastes ADMIN0 catalogued.
+    #
+    # `avg_time_ms` was initialised to 0 and never assigned. Nothing in
+    # the platform times a render, so there is no honest number to show:
+    # it is reported as null and the UI renders an em-dash. An absence
+    # stated is worth more than a zero that reads as a measurement.
     pdf_stats = {
-        "total_generated": 0,
-        "weasyprint_count": 0,
-        "avg_time_ms": 0,
+        "stored_pdfs": 0,
+        "completed_deeds": 0,
+        "completed_without_pdf": 0,
+        "avg_time_ms": None,  # not measured anywhere — see above
+        "engine": pdf_primary,
         "by_type": {}
     }
 
     try:
         with db.conn.cursor() as cur:
-            # Total deeds with PDFs (completed deeds)
-            cur.execute("SELECT COUNT(*) FROM deeds WHERE status = 'completed'")
-            pdf_stats["total_generated"] = cur.fetchone()[0] or 0
-            pdf_stats["weasyprint_count"] = pdf_stats["total_generated"]
+            cur.execute("SELECT COUNT(*) FROM deed_pdfs")
+            pdf_stats["stored_pdfs"] = cur.fetchone()[0] or 0
 
-            # By deed type
+            cur.execute("SELECT COUNT(*) FROM deeds WHERE status = 'completed'")
+            pdf_stats["completed_deeds"] = cur.fetchone()[0] or 0
+
+            # The H1 silent-store class, finally countable from the console.
             cur.execute("""
-                SELECT deed_type, COUNT(*) as count
-                FROM deeds
-                WHERE status = 'completed'
-                GROUP BY deed_type
+                SELECT COUNT(*) FROM deeds d
+                LEFT JOIN deed_pdfs p ON p.deed_id = d.id
+                WHERE d.status = 'completed' AND p.deed_id IS NULL
+            """)
+            pdf_stats["completed_without_pdf"] = cur.fetchone()[0] or 0
+
+            cur.execute("""
+                SELECT d.deed_type, COUNT(*) as count
+                FROM deed_pdfs p JOIN deeds d ON d.id = p.deed_id
+                GROUP BY d.deed_type
                 ORDER BY count DESC
             """)
             for row in cur.fetchall():
                 pdf_stats["by_type"][row[0]] = row[1]
 
     except Exception as e:
+        # Not swallowed into zeros: the caller is told the numbers are
+        # unavailable rather than shown a confident 0.
         print(f"PDF stats error: {e}")
+        pdf_stats = {**pdf_stats, "error": f"{type(e).__name__}: {str(e)[:200]}"}
 
     return {
         "health": {
             "database": {"status": db_status, "latency_ms": db_latency},
-            "pdf_engine": {"status": "up", "primary": pdf_primary},
-            "sitex": {"status": "unknown", "last_call": None},
+            "pdf_engine": {"status": pdf_status, "primary": pdf_primary,
+                           "error": pdf_probe_error},
+            # SiteX has no health probe. Rather than reporting a
+            # hardcoded "unknown" that looks like a checked result, say
+            # plainly that nothing checks it.
+            "sitex": {"status": "not_monitored",
+                      "note": "no health probe exists for this integration"},
             "stripe": {"status": stripe_status}
         },
         "pdf_stats": pdf_stats

--- a/backend/services/deed_pdf.py
+++ b/backend/services/deed_pdf.py
@@ -155,22 +155,75 @@ def ensure_deed_pdfs_table(conn):
         conn.commit()
 
 
+class StoredPdfConflict(Exception):
+    """A different artifact is already stored for this deed.
+
+    Raised instead of overwriting. Carries both hashes so the operator
+    sees what would have been destroyed.
+    """
+
+    def __init__(self, deed_id: int, stored_sha256: str, incoming_sha256: str):
+        self.deed_id = deed_id
+        self.stored_sha256 = stored_sha256
+        self.incoming_sha256 = incoming_sha256
+        super().__init__(
+            f"Deed {deed_id} already has a stored PDF with a different hash "
+            f"(stored {stored_sha256[:12]}…, incoming {incoming_sha256[:12]}…). "
+            "Refusing to overwrite a recorded instrument — a correction must "
+            "supersede the original, not replace it."
+        )
+
+
 def store_deed_pdf(conn, deed_id: int, pdf_bytes: bytes) -> str:
-    """Persist the PDF bytes and stamp pdf_url + sha256 on the deed row."""
+    """Persist the PDF bytes and stamp pdf_url + sha256 on the deed row.
+
+    INSERT-OR-REFUSE (doctrine §9, ADMIN1). This was
+    `ON CONFLICT DO UPDATE SET pdf_data = EXCLUDED.pdf_data`, which
+    replaced the stored bytes AND their sha256 in place. `deed_pdfs` is
+    keyed by deed_id — one row per deed — so the prior artifact was
+    simply gone, with nothing recording that it had existed.
+
+    That hash is the verification substrate: doctrine §3 removed QR
+    codes from recorded pages on the reasoning that "verification
+    survives as data," and the data is this column. A silent overwrite
+    invalidates every prior verification of the document and leaves no
+    trace that anything changed.
+
+    So: re-storing identical bytes is a no-op (idempotent regeneration
+    is legitimate — the H1 self-heal path relies on it), and re-storing
+    DIFFERENT bytes raises StoredPdfConflict for the caller to surface.
+    Replacing an instrument is a supersession decision, not a storage
+    detail; the supersession model is a separate ledgered ticket, and
+    until it exists the honest answer is to refuse.
+    """
     digest = hashlib.sha256(pdf_bytes).hexdigest()
     stamp = json.dumps({
         "pdf_sha256": digest,
         "pdf_generated_at": datetime.now(timezone.utc).isoformat(),
     })
     with conn.cursor() as cur:
+        # DO NOTHING, not DO UPDATE: the insert is attempted atomically
+        # and simply declines if a row already exists. Deliberately not a
+        # SELECT-then-INSERT — two concurrent self-heal downloads would
+        # both see "no row" and the second would hit a primary-key
+        # violation. This way the loser of that race falls through to the
+        # hash comparison below and, for identical bytes, succeeds.
         cur.execute("""
             INSERT INTO deed_pdfs (deed_id, pdf_data, sha256, generated_at)
             VALUES (%s, %s, %s, CURRENT_TIMESTAMP)
-            ON CONFLICT (deed_id) DO UPDATE
-                SET pdf_data = EXCLUDED.pdf_data,
-                    sha256 = EXCLUDED.sha256,
-                    generated_at = CURRENT_TIMESTAMP
+            ON CONFLICT (deed_id) DO NOTHING
+            RETURNING deed_id
         """, (deed_id, psycopg2.Binary(pdf_bytes), digest))
+
+        if cur.fetchone() is None:
+            # Something is already stored. Identical bytes → no-op (the
+            # deed row's stamp still refreshes below, so the H1 self-heal
+            # path keeps working). Different bytes → refuse.
+            cur.execute("SELECT sha256 FROM deed_pdfs WHERE deed_id = %s", (deed_id,))
+            row = cur.fetchone()
+            stored_sha = row[0] if row else None
+            if stored_sha != digest:
+                raise StoredPdfConflict(deed_id, stored_sha or "unknown", digest)
         cur.execute("""
             UPDATE deeds
             SET pdf_url = %s,

--- a/backend/tests/test_admin1_truth_pass.py
+++ b/backend/tests/test_admin1_truth_pass.py
@@ -1,0 +1,251 @@
+"""ADMIN1 — the console's numbers are measurements or absences, never both.
+
+ADMIN0's audit found the System tab partly hardcoded to look healthy and
+two screens rendering zeros that were really failures. The rule these
+tests hold: **a number shown to an operator must be measured; anything
+unmeasured is reported as absent, and anything unreadable says so.**
+
+The three named fabrications:
+  1. `pdf_engine: {"status": "up"}` — a literal, no probe ever run.
+  2. `avg_time_ms: 0` — initialised and never assigned.
+  3. `weasyprint_count = total_generated` — an assertion, and
+     `total_generated` counted deed STATUS rather than stored PDFs.
+
+Plus doctrine §9's insert-or-refuse, which lives in the same pass.
+"""
+import inspect
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+BACKEND = Path(__file__).resolve().parents[1]
+LIVE_DB = os.getenv("DATABASE_URL")
+
+
+def code_only(src: str) -> str:
+    """Source with docstrings and comments removed.
+
+    Pins that forbid a pattern must read CODE, not prose: the comment
+    explaining why a pattern was removed necessarily contains it, and a
+    naive substring check then fails on its own explanation. (This has
+    now bitten four separate pins in this codebase — see the same helper
+    in the frontend's developerDocs and apiAccessFunnel suites.)
+    """
+    import ast
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef,
+                             ast.AsyncFunctionDef)):
+            doc = ast.get_docstring(node, clean=False)
+            if doc:
+                src = src.replace(doc, "")
+    return "\n".join(
+        line for line in src.splitlines() if not line.strip().startswith("#")
+    )
+
+
+# ── The fabricated-health kill list ──────────────────────────────────
+
+def test_pdf_engine_status_is_probed_not_asserted():
+    from routers import admin_inline
+    src = inspect.getsource(admin_inline.admin_system_overview)
+    assert '"pdf_engine": {"status": "up"' not in src, "the hardcoded literal came back"
+    assert "render_pdf(" in src, "the engine must actually be exercised"
+    assert 'b"%PDF-"' in src, "the probe must check it got a PDF back"
+
+
+def test_avg_render_time_is_absent_not_zero():
+    """Nothing in the platform times a render, so there is no honest
+    number. Absence is reported; a 0 would read as a measurement."""
+    from routers import admin_inline
+    src = inspect.getsource(admin_inline.admin_system_overview)
+    assert '"avg_time_ms": None' in src
+    assert '"avg_time_ms": 0' not in src
+
+
+def test_stored_pdf_count_is_counted_not_asserted():
+    from routers import admin_inline
+    src = inspect.getsource(admin_inline.admin_system_overview)
+    assert "COUNT(*) FROM deed_pdfs" in src, "count stored artifacts, not deed status"
+    assert 'pdf_stats["weasyprint_count"] = pdf_stats["total_generated"]' not in src
+
+
+def test_unmonitored_services_say_so():
+    """SiteX has no probe. Reporting a hardcoded 'unknown' looks like a
+    checked result that came back inconclusive; it wasn't checked."""
+    from routers import admin_inline
+    src = inspect.getsource(admin_inline.admin_system_overview)
+    assert "not_monitored" in src
+
+
+@pytest.mark.skipif(not LIVE_DB, reason="live test DB required")
+def test_probe_reports_down_when_the_engine_is_broken():
+    """The point of a probe: it fails when the thing fails."""
+    from fastapi.testclient import TestClient
+    from main import app
+    import psycopg2
+
+    client = TestClient(app)
+    email, password = "admin1probe@t.example", "Probe!Passw0rd"
+    conn = psycopg2.connect(LIVE_DB)
+    conn.autocommit = True
+    with conn.cursor() as cur:
+        cur.execute("""DELETE FROM user_profiles WHERE user_id IN
+                       (SELECT id FROM users WHERE email = %s)""", (email,))
+        cur.execute("DELETE FROM users WHERE email = %s", (email,))
+    conn.close()
+    client.post("/users/register", json={
+        "email": email, "password": password, "confirm_password": password,
+        "full_name": "Probe", "role": "escrow_officer", "state": "CA", "agree_terms": True})
+    conn = psycopg2.connect(LIVE_DB)
+    conn.autocommit = True
+    with conn.cursor() as cur:
+        cur.execute("UPDATE users SET role = 'admin' WHERE email = %s", (email,))
+    conn.close()
+    token = client.post("/users/login", json={
+        "email": email, "password": password}).json()["access_token"]
+    auth = {"Authorization": f"Bearer {token}"}
+
+    healthy = client.get("/admin/system/overview", headers=auth).json()
+    assert healthy["health"]["pdf_engine"]["status"] == "up"
+
+    with patch("pdf_engine.render_pdf", side_effect=RuntimeError("libpango missing")):
+        broken = client.get("/admin/system/overview", headers=auth).json()
+    assert broken["health"]["pdf_engine"]["status"] == "down"
+    assert "libpango missing" in broken["health"]["pdf_engine"]["error"]
+
+
+# ── Revenue: a zero must mean zero ───────────────────────────────────
+
+def test_revenue_reads_return_unknown_not_zero_on_failure():
+    from phase23_billing.services import revenue
+    src = code_only(inspect.getsource(revenue))
+    assert "return 0" not in src, "the silent-zero came back"
+    assert "subscriptions table doesn't exist yet, return zeros" not in src
+    assert "UNKNOWN = None" in src
+
+
+def test_revenue_endpoint_surfaces_errors():
+    from phase23_billing import router_admin
+    src = inspect.getsource(router_admin.revenue)
+    assert '"errors"' in src
+
+
+def test_revenue_failure_yields_null_and_a_reason():
+    """A broken session must produce nulls plus reasons — never a
+    confident $0 on the money screen."""
+    from phase23_billing.services.revenue import get_revenue_overview, mrr_arr
+
+    class BrokenSession:
+        def execute(self, *a, **k):
+            raise RuntimeError('relation "payment_history" does not exist')
+
+        def rollback(self):
+            pass
+
+    overview = get_revenue_overview(BrokenSession())
+    assert overview["total_revenue_cents"] is None
+    assert overview["net_monthly_revenue_cents"] is None
+    assert any("does not exist" in e for e in overview["errors"])
+
+    mrr = mrr_arr(BrokenSession())
+    assert mrr["mrr_cents"] is None
+    assert mrr["errors"]
+
+
+# ── Schema authority (H1) ────────────────────────────────────────────
+
+def test_billing_and_partner_tables_are_in_the_schema_authority():
+    """Production check 2026-08-03: invoices/payment_history/partners
+    existed via hand-run migrations; subscriptions did not exist at all,
+    which is why Revenue's $0 was the no-table branch."""
+    schema = (BACKEND / "database.py").read_text(encoding="utf-8")
+    for table in ["partners", "invoices", "payment_history", "subscriptions"]:
+        assert f"CREATE TABLE IF NOT EXISTS {table}" in schema, table
+
+
+@pytest.mark.skipif(not LIVE_DB, reason="live test DB required")
+def test_the_four_tables_exist_after_convergence():
+    # No create_tables() here: calling it mid-suite issues ALTER TABLE
+    # users, which queues behind any open transaction and then blocks
+    # every later reader. Schema is already converged when tests run.
+    import psycopg2
+    conn = psycopg2.connect(LIVE_DB)
+    with conn.cursor() as cur:
+        cur.execute("""SELECT table_name FROM information_schema.tables
+                       WHERE table_name IN ('partners','invoices','payment_history','subscriptions')""")
+        found = {r[0] for r in cur.fetchall()}
+    conn.close()
+    assert found == {"partners", "invoices", "payment_history", "subscriptions"}
+
+
+@pytest.mark.skipif(not LIVE_DB, reason="live test DB required")
+def test_subscriptions_carries_every_column_the_webhook_writes():
+    """The webhook UPDATEs status, cancel_at_period_end, mrr_cents and
+    matches on stripe_subscription_id. The table was created fresh here,
+    so phase23_006's ALTER-IF-EXISTS ladder never applied to it."""
+    import psycopg2
+    conn = psycopg2.connect(LIVE_DB)
+    with conn.cursor() as cur:
+        cur.execute("""SELECT column_name FROM information_schema.columns
+                       WHERE table_name = 'subscriptions'""")
+        cols = {r[0] for r in cur.fetchall()}
+    conn.close()
+    for needed in ["status", "cancel_at_period_end", "mrr_cents",
+                   "stripe_subscription_id", "updated_at"]:
+        assert needed in cols, needed
+
+
+# ── Doctrine §9: insert-or-refuse ────────────────────────────────────
+
+def test_the_overwriting_upsert_is_gone():
+    src = code_only((BACKEND / "services/deed_pdf.py").read_text(encoding="utf-8"))
+    assert "SET pdf_data = EXCLUDED.pdf_data" not in src, \
+        "the overwrite came back — a stored instrument is never replaced"
+    assert "ON CONFLICT (deed_id) DO NOTHING" in src
+
+
+@pytest.mark.skipif(not LIVE_DB, reason="live test DB required")
+def test_identical_restore_is_a_noop_and_different_bytes_are_refused():
+    """Idempotent regeneration must keep working (the H1 self-heal path
+    depends on it); a genuinely different artifact must be refused."""
+    import psycopg2
+    from services.deed_pdf import StoredPdfConflict, store_deed_pdf
+
+    conn = psycopg2.connect(LIVE_DB)
+    conn.autocommit = False
+    with conn.cursor() as cur:
+        cur.execute("""INSERT INTO users (email, password_hash, full_name, role, state)
+                       VALUES ('pdfconflict@t.example', 'x', 'PDF Conflict', 'escrow_officer', 'CA')
+                       ON CONFLICT (email) DO UPDATE SET full_name = EXCLUDED.full_name
+                       RETURNING id""")
+        user_id = cur.fetchone()[0]
+        cur.execute("""INSERT INTO deeds (user_id, deed_type, property_address, status)
+                       VALUES (%s, 'grant-deed', '1 Conflict St', 'draft') RETURNING id""",
+                    (user_id,))
+        deed_id = cur.fetchone()[0]
+        cur.execute("DELETE FROM deed_pdfs WHERE deed_id = %s", (deed_id,))
+        conn.commit()
+
+    first = store_deed_pdf(conn, deed_id, b"%PDF-1.4 original")
+    # Same bytes again: allowed, and the stored hash is unchanged.
+    again = store_deed_pdf(conn, deed_id, b"%PDF-1.4 original")
+    assert first == again
+
+    with pytest.raises(StoredPdfConflict) as exc:
+        store_deed_pdf(conn, deed_id, b"%PDF-1.4 DIFFERENT")
+    assert exc.value.stored_sha256 == first
+    assert "supersede" in str(exc.value)
+
+    conn.rollback()
+    with conn.cursor() as cur:
+        cur.execute("SELECT sha256 FROM deed_pdfs WHERE deed_id = %s", (deed_id,))
+        row = cur.fetchone()
+        assert row is None or row[0] == first, "the original must survive the refusal"
+        cur.execute("DELETE FROM deed_pdfs WHERE deed_id = %s", (deed_id,))
+        cur.execute("DELETE FROM deeds WHERE id = %s", (deed_id,))
+        cur.execute("DELETE FROM users WHERE id = %s", (user_id,))
+        conn.commit()
+    conn.close()

--- a/frontend/src/app/admin/components/Overview.tsx
+++ b/frontend/src/app/admin/components/Overview.tsx
@@ -14,15 +14,15 @@ function authHeaders() {
 }
 
 interface ExtendedStats extends StatSummary {
-  pdfs_this_week?: number;
-  scans_this_week?: number;
-  new_users_this_week?: number;
+  /** null = the verification service did not answer. Distinct from 0. */
+  scans_this_week?: number | null;
 }
 
 export default function OverviewTab(){
   const [stats, setStats] = useState<ExtendedStats | null>(null);
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState('');
+  const [scanErr, setScanErr] = useState('');
 
   useEffect(() => {
     let mounted = true;
@@ -30,25 +30,35 @@ export default function OverviewTab(){
       try{
         // Get main dashboard stats
         const s = await AdminApi.getSummary();
-        
-        // Get verification stats for scan count
-        let scans = 0;
+
+        // ADMIN1: this fetch used to swallow every failure into scans = 0,
+        // so a dead verification service rendered "QR Scans (Week): 0" —
+        // indistinguishable from a real zero. A failure now yields null,
+        // renders as "—", and says why underneath.
+        let scans: number | null = null;
+        let scanFailure = '';
         try {
           const verRes = await fetch(`${API_BASE}/admin/verification/stats`, {
             headers: { ...authHeaders() }
           });
           if (verRes.ok) {
             const verData = await verRes.json();
-            scans = verData.total_scans_week || 0;
+            scans = verData.total_scans_week ?? 0;
+          } else {
+            scanFailure = `verification stats unavailable (HTTP ${verRes.status})`;
           }
-        } catch {}
-        
+        } catch (e) {
+          scanFailure = e instanceof Error
+            ? `verification stats unavailable — ${e.message}`
+            : 'verification stats unavailable';
+        }
+
         if (mounted) {
-          setStats({
-            ...s,
-            pdfs_this_week: s.deeds_this_month || 0, // Approximate
-            scans_this_week: scans
-          });
+          // The old `pdfs_this_week: deeds_this_month // Approximate`
+          // field is gone: nothing rendered it, and a month labelled as
+          // a week is a wrong number waiting for a consumer.
+          setStats({ ...s, scans_this_week: scans });
+          setScanErr(scanFailure);
         }
       }catch(e:any){
         if (mounted) setErr(e.message || 'Failed to load');
@@ -58,6 +68,18 @@ export default function OverviewTab(){
     })();
     return ()=>{ mounted = false; };
   }, []);
+
+  function relativeTime(ts: string | null): string {
+    if (!ts) return '';
+    const then = new Date(ts).getTime();
+    if (isNaN(then)) return '';
+    const mins = Math.floor((Date.now() - then) / 60000);
+    if (mins < 1) return 'just now';
+    if (mins < 60) return `${mins}m ago`;
+    const hrs = Math.floor(mins / 60);
+    if (hrs < 24) return `${hrs}h ago`;
+    return `${Math.floor(hrs / 24)}d ago`;
+  }
 
   const skeleton = <div className="grid stats">
     {Array.from({length:4}).map((_,i)=> <div key={i} className="card skeleton" style={{height:92}} />)}
@@ -70,9 +92,50 @@ export default function OverviewTab(){
           <StatCard title="Total Users" value={stats?.total_users ?? '—'} />
           <StatCard title="Total Deeds" value={stats?.total_deeds ?? '—'} />
           <StatCard title="Deeds This Month" value={stats?.deeds_this_month ?? '—'} />
-          <StatCard title="QR Scans (Week)" value={stats?.scans_this_week ?? 0} />
+          <StatCard title="QR Scans (Week)" value={stats?.scans_this_week ?? '—'} />
         </>)}
       </div>
+
+      {scanErr && (
+        <div style={{ fontSize: 12, color: 'var(--dp-warn, #b26a00)', marginTop: -4 }}>
+          QR scan count shown as unavailable — {scanErr}
+        </div>
+      )}
+
+      {/* Recent activity — computed by /admin/dashboard since Phase 5 and
+          rendered by nobody until ADMIN1. Seven days of signups and deed
+          creations: the answer to "what has been happening?" */}
+      {!loading && (
+        <div className="card">
+          <div style={{ fontWeight: 700, fontSize: 16, marginBottom: 12 }}>
+            Recent activity <span style={{ fontWeight: 400, fontSize: 13, opacity: 0.6 }}>· last 7 days</span>
+          </div>
+          {(stats?.recent_activity?.length ?? 0) === 0 ? (
+            <div style={{ opacity: 0.7, fontSize: 14 }}>
+              No signups or deeds in the last 7 days.
+            </div>
+          ) : (
+            <div style={{ display: 'grid', gap: 10 }}>
+              {stats!.recent_activity!.map((ev, i) => (
+                <div key={i} className="hstack" style={{ gap: 10, alignItems: 'center' }}>
+                  <Badge kind={ev.type === 'user_signup' ? 'success' : 'neutral'}>
+                    {ev.type === 'user_signup' ? 'signup' : 'deed'}
+                  </Badge>
+                  <span style={{ fontSize: 14 }}>{ev.user}</span>
+                  {ev.deed_id != null && (
+                    <a href={`/admin?tab=deeds`} style={{ fontSize: 13, opacity: 0.8 }}>
+                      #{ev.deed_id}
+                    </a>
+                  )}
+                  <span style={{ marginLeft: 'auto', fontSize: 12, opacity: 0.6 }}>
+                    {relativeTime(ev.timestamp)}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
 
       <div className="card">
         <div className="hstack" style={{justifyContent:'space-between'}}>

--- a/frontend/src/app/admin/components/SystemTab.tsx
+++ b/frontend/src/app/admin/components/SystemTab.tsx
@@ -1,4 +1,21 @@
 'use client';
+/**
+ * System health — the screen an operator opens during an incident.
+ *
+ * ADMIN1 truth pass. Two problems lived here:
+ *
+ * 1. On a failed load it rendered the whole dashboard from zero/unknown
+ *    defaults, so a dead backend showed "Total Generated 0 · Avg Time
+ *    0ms" — numerals that read as measurements. It now renders the
+ *    failure and nothing else. A health screen that invents health is
+ *    worse than no health screen.
+ * 2. Values it displayed were fabricated upstream: the PDF engine was a
+ *    hardcoded "up", avg render time was a constant 0, and the
+ *    WeasyPrint count was asserted equal to a count of completed deeds.
+ *    Those are fixed in the backend; this file renders what the probe
+ *    actually reports, including "not measured" as an em-dash rather
+ *    than as a zero.
+ */
 import { useEffect, useState } from 'react';
 import StatCard from './StatCard';
 import Badge from './Badge';
@@ -11,18 +28,30 @@ function authHeaders() {
   return token ? { Authorization: `Bearer ${token}` } : {};
 }
 
+interface ServiceHealth {
+  status: string;
+  latency_ms?: number;
+  primary?: string;
+  error?: string | null;
+  note?: string;
+}
+
 interface SystemHealth {
-  database: { status: string; latency_ms: number };
-  pdf_engine: { status: string; primary: string };
-  sitex: { status: string; last_call?: string };
-  stripe: { status: string };
+  database: ServiceHealth;
+  pdf_engine: ServiceHealth;
+  sitex: ServiceHealth;
+  stripe: ServiceHealth;
 }
 
 interface PDFStats {
-  total_generated: number;
-  weasyprint_count: number;
-  avg_time_ms: number;
+  stored_pdfs: number;
+  completed_deeds: number;
+  completed_without_pdf: number;
+  /** null when nothing measures it — rendered as "—", never as 0. */
+  avg_time_ms: number | null;
+  engine: string;
   by_type: Record<string, number>;
+  error?: string;
 }
 
 interface SystemData {
@@ -30,24 +59,31 @@ interface SystemData {
   pdf_stats: PDFStats;
 }
 
-export default function SystemTab(){
+function StatusBadge({ service }: { service: ServiceHealth }) {
+  if (service.status === 'up') return <Badge kind="success">Online</Badge>;
+  if (service.status === 'not_monitored') return <Badge kind="neutral">Not monitored</Badge>;
+  if (service.status === 'unknown') return <Badge kind="neutral">Unknown</Badge>;
+  return <Badge kind="danger">Offline</Badge>;
+}
+
+export default function SystemTab() {
   const [data, setData] = useState<SystemData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
 
-  useEffect(()=>{
+  useEffect(() => {
     async function load() {
       try {
         const res = await fetch(`${API_BASE}/admin/system/overview`, {
-          headers: { ...authHeaders() }
+          headers: { ...authHeaders() },
         });
         if (res.ok) {
           setData(await res.json());
         } else {
-          setError('Failed to load system data');
+          setError(`Failed to load system data — HTTP ${res.status}`);
         }
-      } catch (e: any) {
-        setError(e.message || 'Failed to load');
+      } catch (e) {
+        setError(e instanceof Error ? e.message : 'Failed to load system data');
       } finally {
         setLoading(false);
       }
@@ -59,68 +95,94 @@ export default function SystemTab(){
     return (
       <div className="vstack">
         <div className="grid stats">
-          {[1,2,3,4].map(i => <div key={i} className="card skeleton" style={{height: 92}} />)}
+          {[1, 2, 3, 4].map((i) => <div key={i} className="card skeleton" style={{ height: 92 }} />)}
         </div>
-        <div className="card skeleton" style={{height: 200}} />
+        <div className="card skeleton" style={{ height: 200 }} />
       </div>
     );
   }
 
-  // Provide defaults if no data
-  const health = data?.health || {
-    database: { status: 'unknown', latency_ms: 0 },
-    pdf_engine: { status: 'unknown', primary: 'unknown' },
-    sitex: { status: 'unknown' },
-    stripe: { status: 'unknown' }
-  };
-  
-  const pdfStats = data?.pdf_stats || {
-    total_generated: 0,
-    weasyprint_count: 0,
-    avg_time_ms: 0,
-    by_type: {}
-  };
+  // Fail loudly. No defaults, no zeros — if we could not read the
+  // system's health, the only honest thing to show is that fact.
+  if (error || !data) {
+    return (
+      <div className="card" style={{ borderColor: 'var(--dp-danger)' }}>
+        <div style={{ fontWeight: 700, marginBottom: 6, color: 'var(--dp-danger)' }}>
+          System health unavailable
+        </div>
+        <div style={{ fontSize: 14, marginBottom: 10 }}>
+          {error || 'The backend returned no data.'}
+        </div>
+        <div style={{ fontSize: 13, opacity: 0.75 }}>
+          Nothing below is being shown as zero, because a zero here would be
+          indistinguishable from a real measurement. Check the API service
+          and reload.
+        </div>
+      </div>
+    );
+  }
+
+  const { health, pdf_stats: pdfStats } = data;
+  const stuck = pdfStats.completed_without_pdf || 0;
 
   return (
     <div className="vstack">
-      {error && (
+      {/* PDF pipeline */}
+      <div style={{ fontWeight: 700, fontSize: 16, marginBottom: 8 }}>PDF pipeline</div>
+      {pdfStats.error ? (
         <div className="card" style={{ borderColor: 'var(--dp-danger)', color: 'var(--dp-danger)' }}>
-          {error}
+          PDF statistics unavailable — {pdfStats.error}
         </div>
+      ) : (
+        <>
+          <div className="grid stats">
+            {/* Counted from deed_pdfs — rows whose bytes we actually
+                stored — not from deed status, which is a different fact. */}
+            <StatCard title="Stored PDFs" value={pdfStats.stored_pdfs} />
+            <StatCard title="Completed deeds" value={pdfStats.completed_deeds} />
+            <StatCard title="Completed without PDF" value={stuck} />
+            <StatCard
+              title="Avg render time"
+              value={pdfStats.avg_time_ms == null ? '—' : `${pdfStats.avg_time_ms}ms`}
+            />
+          </div>
+          {pdfStats.avg_time_ms == null && (
+            <div style={{ fontSize: 12, opacity: 0.65, marginTop: -4 }}>
+              Render time is not measured anywhere in the pipeline yet, so it is
+              shown as unavailable rather than as zero.
+            </div>
+          )}
+          {stuck > 0 && (
+            // The H1 silent-store class, visible from the console at last.
+            <div className="card" style={{ borderColor: 'var(--dp-warn, #b26a00)' }}>
+              <strong>{stuck}</strong> completed deed{stuck === 1 ? ' has' : 's have'} no
+              stored PDF. These are recoverable — the artifact regenerates on next
+              download — but a persistent count here means the store is failing.
+            </div>
+          )}
+        </>
       )}
 
-      {/* PDF Generation Stats */}
-      <div style={{ fontWeight: 700, fontSize: 16, marginBottom: 8 }}>PDF Generation</div>
-      <div className="grid stats">
-        <StatCard title="Total Generated" value={pdfStats.total_generated} />
-        {/* PS3: PDFShift removed — WeasyPrint is the engine. */}
-        <StatCard 
-          title="WeasyPrint" 
-          value={`${pdfStats.weasyprint_count} (${pdfStats.total_generated ? Math.round(pdfStats.weasyprint_count / pdfStats.total_generated * 100) : 0}%)`} 
-        />
-        <StatCard title="Avg Time" value={`${pdfStats.avg_time_ms}ms`} />
-      </div>
-
-      {/* By Deed Type */}
-      {Object.keys(pdfStats.by_type).length > 0 && (
+      {/* By deed type */}
+      {Object.keys(pdfStats.by_type || {}).length > 0 && (
         <div className="card">
-          <div style={{ fontWeight: 600, marginBottom: 12 }}>By Deed Type</div>
+          <div style={{ fontWeight: 600, marginBottom: 12 }}>Stored PDFs by deed type</div>
           <div style={{ display: 'grid', gap: 8 }}>
             {Object.entries(pdfStats.by_type).map(([type, count]) => (
               <div key={type} style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-                <div style={{ width: 140, fontSize: 13 }}>{formatDeedType(type)}</div>
+                <div style={{ width: 180, fontSize: 13 }}>{formatDeedType(type)}</div>
                 <div style={{ flex: 1, height: 8, background: 'var(--dp-border, #333)', borderRadius: 4, overflow: 'hidden' }}>
-                  <div 
-                    style={{ 
-                      height: '100%', 
-                      width: `${Math.round((count as number) / pdfStats.total_generated * 100)}%`,
+                  <div
+                    style={{
+                      height: '100%',
+                      width: `${pdfStats.stored_pdfs ? Math.round((count as number) / pdfStats.stored_pdfs * 100) : 0}%`,
                       background: 'var(--dp-primary, #7C4DFF)',
-                      borderRadius: 4
-                    }} 
+                      borderRadius: 4,
+                    }}
                   />
                 </div>
-                <div style={{ width: 80, fontSize: 13, textAlign: 'right' }}>
-                  {count} ({Math.round((count as number) / pdfStats.total_generated * 100)}%)
+                <div style={{ width: 90, fontSize: 13, textAlign: 'right' }}>
+                  {count} ({pdfStats.stored_pdfs ? Math.round((count as number) / pdfStats.stored_pdfs * 100) : 0}%)
                 </div>
               </div>
             ))}
@@ -128,53 +190,37 @@ export default function SystemTab(){
         </div>
       )}
 
-      {/* System Health */}
-      <div style={{ fontWeight: 700, fontSize: 16, marginBottom: 8, marginTop: 8 }}>System Health</div>
+      {/* Health */}
+      <div style={{ fontWeight: 700, fontSize: 16, marginBottom: 8, marginTop: 8 }}>System health</div>
       <div className="card">
         <table className="table">
           <thead>
-            <tr>
-              <th>Service</th>
-              <th>Status</th>
-              <th>Details</th>
-            </tr>
+            <tr><th>Service</th><th>Status</th><th>Details</th></tr>
           </thead>
           <tbody>
             <tr>
               <td>Database</td>
-              <td>
-                <Badge kind={health.database.status === 'up' ? 'success' : 'danger'}>
-                  {health.database.status === 'up' ? 'Online' : 'Offline'}
-                </Badge>
-              </td>
+              <td><StatusBadge service={health.database} /></td>
               <td style={{ fontSize: 12, opacity: 0.7 }}>{health.database.latency_ms}ms latency</td>
             </tr>
             <tr>
-              <td>PDF Engine</td>
-              <td>
-                <Badge kind={health.pdf_engine.status === 'up' ? 'success' : 'danger'}>
-                  {health.pdf_engine.status === 'up' ? 'Online' : 'Offline'}
-                </Badge>
+              <td>PDF engine</td>
+              <td><StatusBadge service={health.pdf_engine} /></td>
+              <td style={{ fontSize: 12, opacity: 0.7 }}>
+                {health.pdf_engine.error
+                  ? health.pdf_engine.error
+                  : `${health.pdf_engine.primary} — render probe passed`}
               </td>
-              <td style={{ fontSize: 12, opacity: 0.7 }}>Primary: {health.pdf_engine.primary}</td>
             </tr>
             <tr>
               <td>SiteX API</td>
-              <td>
-                <Badge kind={health.sitex.status === 'up' ? 'success' : health.sitex.status === 'unknown' ? 'neutral' : 'danger'}>
-                  {health.sitex.status === 'up' ? 'Online' : health.sitex.status === 'unknown' ? 'Unknown' : 'Offline'}
-                </Badge>
-              </td>
-              <td style={{ fontSize: 12, opacity: 0.7 }}>{health.sitex.last_call || '—'}</td>
+              <td><StatusBadge service={health.sitex} /></td>
+              <td style={{ fontSize: 12, opacity: 0.7 }}>{health.sitex.note || '—'}</td>
             </tr>
             <tr>
               <td>Stripe</td>
-              <td>
-                <Badge kind={health.stripe.status === 'up' ? 'success' : 'danger'}>
-                  {health.stripe.status === 'up' ? 'Online' : 'Offline'}
-                </Badge>
-              </td>
-              <td style={{ fontSize: 12, opacity: 0.7 }}>Payments & Subscriptions</td>
+              <td><StatusBadge service={health.stripe} /></td>
+              <td style={{ fontSize: 12, opacity: 0.7 }}>Payments &amp; subscriptions</td>
             </tr>
           </tbody>
         </table>
@@ -184,18 +230,5 @@ export default function SystemTab(){
 }
 
 function formatDeedType(type: string): string {
-  const mapping: Record<string, string> = {
-    'grant_deed': 'Grant Deed',
-    'grant_deed_ca': 'Grant Deed',
-    'quitclaim_deed': 'Quitclaim Deed',
-    'quitclaim_deed_ca': 'Quitclaim Deed',
-    'interspousal_transfer': 'Interspousal',
-    'interspousal_transfer_ca': 'Interspousal',
-    'warranty_deed': 'Warranty Deed',
-    'warranty_deed_ca': 'Warranty Deed',
-    'tax_deed': 'Tax Deed',
-    'tax_deed_ca': 'Tax Deed',
-  };
-  return mapping[type] || type.replace(/_/g, ' ');
+  return type.replace(/[-_]/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 }
-

--- a/frontend/src/lib/adminApi.ts
+++ b/frontend/src/lib/adminApi.ts
@@ -82,11 +82,30 @@ export type ApiKeyRequestRow = {
   created_at: string;
 };
 
+export type ActivityEvent = {
+  type: 'user_signup' | 'deed_created' | string;
+  user: string;
+  timestamp: string | null;
+  deed_id?: number;
+};
+
 export type StatSummary = {
   total_users: number;
   active_users: number;
   total_deeds: number;
   deeds_this_month?: number;
+  /**
+   * ADMIN1: /admin/dashboard has always computed a real 7-day signup +
+   * deed feed and no frontend rendered it. It is the closest thing the
+   * platform has to an activity timeline, and it was being thrown away.
+   */
+  recent_activity?: ActivityEvent[];
+  /**
+   * NOT RENDERED, and deliberately not typed as trustworthy: the
+   * backend derives these from plan counts times hardcoded prices
+   * (admin_inline.py), which contradicts the real Stripe figures on
+   * /admin/revenue. Use the Revenue tab for money.
+   */
   total_revenue?: number;
   monthly_revenue?: number;
 };


### PR DESCRIPTION
ADMIN0 found the one screen an operator opens during an incident partly hardcoded to look healthy, and two more rendering zeros that were really failures. The rule this pass installs: **a number shown to an operator is measured, or it is reported as absent — and anything unreadable says so.**

## The fabricated-health kill list — all three, as named

1. **`pdf_engine: {"status": "up"}`** was a literal with no probe of any kind. It's a real probe now: render a minimal document, check that PDF bytes come back. Cheap, no network, and it fails the way the real thing fails *because it is the real thing*. Verified both directions — green normally, `down` with the reason when the renderer is broken.
2. **`avg_time_ms`** was initialised to 0 and never assigned. Nothing in the platform times a render, so there's no honest number: it reports null, the UI renders an em-dash, and a line explains why. An absence stated beats a zero that reads as a measurement.
3. **`weasyprint_count = total_generated`** was an assertion dressed as a measurement — and `total_generated` counted deeds in status `completed`, which is deed *state*, not evidence a PDF exists. Counts now come from `deed_pdfs`, the table that actually knows.

That last change has a bonus: **`completed_without_pdf` is now countable from the console** — the H1 silent-store class, with a warning card when it's non-zero. One of ADMIN0's five recurring shell pastes, retired.

SiteX reported `"unknown"` as though it had been checked and come back inconclusive. It's `not_monitored` now, because nothing checks it.

## Fail loudly

The System tab rendered its full dashboard from zero defaults on a failed load — "Total Generated 0 · Avg Time 0ms" from a dead backend. It now renders the failure and nothing else, and says *why* it isn't showing zeros.

Overview's QR-scan fetch swallowed every failure into `scans = 0`. It yields null, renders `—`, and names the failure underneath. The dead `pdfs_this_week: deeds_this_month // Approximate` field is deleted: nothing rendered it, and a month labelled as a week is a wrong number waiting for a consumer.

**The 7-day activity feed is rendered.** `/admin/dashboard` has computed a real signup + deed feed since Phase 5 and no frontend ever displayed it — the closest thing the platform has to a timeline, thrown away every request.

## The money screen

Every revenue read was `try/except: return 0`, one carrying the comment *"subscriptions table doesn't exist yet, return zeros"*. Your table check confirmed it: **`subscriptions` did not exist at all**, so Revenue's $0 was never a real zero — it was the except branch, and no operator could tell the difference. Reads return UNKNOWN (null) plus a reason; the endpoint aggregates them into `errors`.

## Schema authority (H1)

Production had `invoices`, `payment_history`, `partners` via hand-run migrations; `subscriptions` was missing entirely. All four adopt into `create_tables()`. Shapes match `migrations/phase23/*.sql` and `add_partners_table_v2.py` exactly, so the CREATEs no-op against existing tables and the ALTER ladders converge anything the code needs — **safe whatever the row counts are**, which matters because I can't reach production to count them (see below).

`subscriptions` is created fresh from the `init_db` base plus the columns `phase23_006`'s ALTER-IF-EXISTS ladder adds — that migration could never have applied to a table that never existed.

## Doctrine §9 — insert-or-refuse

`store_deed_pdf` used `ON CONFLICT DO UPDATE SET pdf_data`, replacing stored bytes *and their sha256* in place. Identical bytes are now a no-op (the H1 self-heal path depends on that); different bytes raise `StoredPdfConflict` naming both hashes, which the existing call site already surfaces to the deed's owner.

Implemented as `ON CONFLICT DO NOTHING` + hash comparison rather than SELECT-then-INSERT, so two concurrent self-heal downloads can't produce a primary-key violation.

## ⚠️ Two things you need to know

**1. Creating `subscriptions` does not make the subscription write path work.** There is **no `INSERT INTO subscriptions` anywhere in the codebase** — I grepped it. The webhook's `customer.subscription.created` handler is an `UPDATE ... WHERE stripe_subscription_id = :sid`, so with the table now present a Stripe test event will update **zero rows** and still report `{"ok": true}`. The missing table was one bug; the missing INSERT is a second, and this PR fixes only the first. I did not absorb the upsert — it's a change to money-handling code that wasn't in the ruled scope. Flagging so your end-to-end test doesn't read as a mystery.

**2. I could not run the row counts you asked for.** I have no production database access — only the local test DB. The adoption is written to be correct whether those tables hold rows or not, so nothing is blocked; but I'd rather say that plainly than let "reconcile shapes freely if empty" look like it was verified. If you want the counts, `SELECT 'invoices', COUNT(*) FROM invoices UNION ALL SELECT 'payment_history', COUNT(*) FROM payment_history UNION ALL SELECT 'partners', COUNT(*) FROM partners;` answers it.

## Gates

| Gate | Result |
|---|---|
| Backend (live DB) | 337 passed |
| Six-flow baseline | ✔ unchanged |
| API baseline | ✔ unchanged |
| Jest | 344 passed (30 suites) |
| tsc | 94, flat |
| Production build | clean |

Both baselines holding through a change to the deed-store path is the signal that matters: legitimate regeneration is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_