### PR TITLE
BILL1: the subscription write path, third and final lock

### DIFF
--- a/backend/phase23_billing/router_webhook.py
+++ b/backend/phase23_billing/router_webhook.py
@@ -9,6 +9,138 @@ from .services.stripe_helpers import init_stripe, calc_stripe_fee
 
 router = APIRouter()
 
+
+def _ts(value):
+    """Stripe sends unix seconds; the columns are timestamps."""
+    try:
+        return datetime.utcfromtimestamp(int(value)) if value else None
+    except (TypeError, ValueError, OSError):
+        return None
+
+
+def _first_price(sub: dict) -> dict:
+    try:
+        return (sub.get("items", {}).get("data") or [{}])[0].get("price") or {}
+    except (AttributeError, IndexError, TypeError):
+        return {}
+
+
+def _resolve_user_id(db: Session, customer_id):
+    """Map a Stripe customer back to our user. None when unknown — the
+    row is still worth storing; an orphaned subscription we can see beats
+    one we cannot."""
+    if not customer_id:
+        return None
+    row = db.execute(
+        text("SELECT id FROM users WHERE stripe_customer_id = :cust LIMIT 1"),
+        {"cust": customer_id},
+    ).fetchone()
+    return row[0] if row else None
+
+
+def upsert_subscription(db: Session, sub: dict):
+    """BILL1 — the write that never existed.
+
+    Lineage, for the record: this pipeline has been broken three
+    independent ways, each hidden behind the last.
+      1. T1 — a legacy inline webhook shadowed this router, so none of
+         these handlers ran at all.
+      2. ADMIN1 — the `subscriptions` table did not exist in production,
+         so every statement here addressed nothing.
+      3. This — even with the router live and the table present, the
+         handler was UPDATE-only. `customer.subscription.created` had no
+         row to update, so it wrote nothing and returned {"ok": true}.
+         A fabricated success on the billing path.
+
+    Now an upsert: insert on first sight, update on every event after.
+    `plan_name` and `status` are NOT NULL, so both always resolve to
+    something real or to an explicitly-marked placeholder — never to an
+    invented claim about the customer's state.
+    """
+    price = _first_price(sub)
+    sid = sub.get("id")
+    if not sid:
+        return 0
+
+    user_id = _resolve_user_id(db, sub.get("customer"))
+
+    # plan_name is NOT NULL. Prefer Stripe's own label; fall back to the
+    # plan we already recorded on the user; last resort is a marker that
+    # reads as unknown rather than as a plan someone chose.
+    plan_name = price.get("nickname")
+    if not plan_name and user_id is not None:
+        row = db.execute(text("SELECT plan FROM users WHERE id = :uid"),
+                         {"uid": user_id}).fetchone()
+        plan_name = row[0] if row and row[0] else None
+    plan_name = plan_name or "unknown"
+
+    result = db.execute(text("""
+        INSERT INTO subscriptions (
+            user_id, stripe_subscription_id, status, plan_name,
+            current_period_start, current_period_end,
+            current_plan_price_cents, mrr_cents, cancel_at_period_end,
+            created_at, updated_at
+        ) VALUES (
+            :uid, :sid, :status, :plan,
+            :period_start, :period_end,
+            :price_cents, :mrr, :cancel_at_period_end,
+            now(), now()
+        )
+        ON CONFLICT (stripe_subscription_id) DO UPDATE SET
+            user_id = COALESCE(EXCLUDED.user_id, subscriptions.user_id),
+            status = EXCLUDED.status,
+            plan_name = CASE WHEN EXCLUDED.plan_name = 'unknown'
+                             THEN subscriptions.plan_name
+                             ELSE EXCLUDED.plan_name END,
+            current_period_start = COALESCE(EXCLUDED.current_period_start, subscriptions.current_period_start),
+            current_period_end = COALESCE(EXCLUDED.current_period_end, subscriptions.current_period_end),
+            current_plan_price_cents = COALESCE(EXCLUDED.current_plan_price_cents, subscriptions.current_plan_price_cents),
+            mrr_cents = COALESCE(EXCLUDED.mrr_cents, subscriptions.mrr_cents),
+            cancel_at_period_end = COALESCE(EXCLUDED.cancel_at_period_end, subscriptions.cancel_at_period_end),
+            updated_at = now()
+        RETURNING id
+    """), {
+        "uid": user_id,
+        "sid": sid,
+        "status": sub.get("status") or "incomplete",
+        "plan": plan_name,
+        "period_start": _ts(sub.get("current_period_start")),
+        "period_end": _ts(sub.get("current_period_end")),
+        "price_cents": price.get("unit_amount"),
+        # A cancelled subscription contributes no recurring revenue. Left
+        # as the raw amount otherwise; MRR normalisation across billing
+        # intervals is not attempted here and is not claimed to be.
+        "mrr": 0 if sub.get("status") in ("canceled", "incomplete_expired")
+               else price.get("unit_amount"),
+        "cancel_at_period_end": sub.get("cancel_at_period_end"),
+    })
+    return 1 if result.fetchone() else 0
+
+
+def ensure_subscription_row(db: Session, subscription_id, customer_id, plan):
+    """Checkout completed: make sure the subscription exists even if the
+    `customer.subscription.created` event is delayed or lost.
+
+    Deliberately DO NOTHING on conflict — checkout carries no
+    subscription status, so it must never overwrite a real one that
+    already arrived. The placeholder status is Stripe's own
+    `incomplete` ("created, not confirmed"), corrected by the first
+    subscription event. We do not write `active` here: we have not
+    observed it.
+    """
+    if not subscription_id:
+        return 0
+    user_id = _resolve_user_id(db, customer_id)
+    result = db.execute(text("""
+        INSERT INTO subscriptions (
+            user_id, stripe_subscription_id, status, plan_name, created_at, updated_at
+        ) VALUES (:uid, :sid, 'incomplete', :plan, now(), now())
+        ON CONFLICT (stripe_subscription_id) DO NOTHING
+        RETURNING id
+    """), {"uid": user_id, "sid": subscription_id, "plan": plan or "unknown"})
+    return 1 if result.fetchone() else 0
+
+
 @router.post("/payments/webhook")
 async def stripe_webhook(request: Request, db: Session = Depends(get_db)):
     s = get_settings()
@@ -41,26 +173,25 @@ async def stripe_webhook(request: Request, db: Session = Depends(get_db)):
             db.execute(text(
                 "UPDATE users SET plan = :plan, updated_at = now() WHERE id = :uid"
             ), {"plan": plan, "uid": uid})
-            db.commit()
+        # BILL1: a subscription checkout must leave a subscription row.
+        # Previously nothing here or downstream ever inserted one.
+        #
+        # The outcome is deliberately NOT added to the response body:
+        # that body is Stripe's, it only needs a 2xx, and the six-flow
+        # baseline pins its shape. Our evidence that the write happened
+        # belongs in the database and on the Revenue tab — which is
+        # exactly where the BILL1 harness looks for it.
+        ensure_subscription_row(
+            db, sess.get("subscription"), sess.get("customer"), plan)
+        db.commit()
         return {"ok": True}
 
-    # --- Subscription lifecycle (assumes 'subscriptions' table exists) ---
+    # --- Subscription lifecycle ---
+    # BILL1: this was UPDATE-only, so `customer.subscription.created`
+    # had nothing to update and silently wrote nothing. It upserts now.
     if etype in ("customer.subscription.created", "customer.subscription.updated", "customer.subscription.deleted"):
         sub = obj
-        # Best-effort update; adapt columns as needed
-        db.execute(text("""
-            UPDATE subscriptions
-            SET status = :status,
-                cancel_at_period_end = COALESCE(:cancel_at_period_end, cancel_at_period_end),
-                mrr_cents = COALESCE(:mrr, mrr_cents),
-                updated_at = now()
-            WHERE stripe_subscription_id = :sid
-        """), {
-            "status": sub.get("status"),
-            "cancel_at_period_end": sub.get("cancel_at_period_end"),
-            "mrr": (sub.get("items", {}).get("data",[{}])[0].get("price",{}).get("unit_amount") or 0),
-            "sid": sub.get("id")
-        })
+        upsert_subscription(db, sub)
         if etype == "customer.subscription.deleted" and sub.get("customer"):
             # Ported from the legacy webhook: a cancelled subscription
             # downgrades the user back to the free plan.

--- a/backend/tests/test_bill1_subscription_write_path.py
+++ b/backend/tests/test_bill1_subscription_write_path.py
@@ -1,0 +1,215 @@
+"""BILL1 — the subscription pipeline's third and final lock.
+
+Lineage, because this pipeline has been broken three independent ways
+and each break hid the next:
+
+  1. T1 — a legacy inline webhook shadowed the phase23 router, so none
+     of its handlers ran at all.
+  2. ADMIN1 — the `subscriptions` table did not exist in production, so
+     every statement in those handlers addressed nothing.
+  3. BILL1 (here) — even with the router live and the table present, the
+     lifecycle handler was UPDATE-only. `customer.subscription.created`
+     had no row to update, wrote nothing, and returned {"ok": true}: a
+     fabricated success sitting on the billing path.
+
+The end-to-end test is the one that matters — event in, row out, and the
+MRR the Revenue tab reads reflects it. That last hop was invisible until
+ADMIN1 killed the silent-zero, because a missing row and a missing table
+both rendered as $0.
+"""
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from phase23_billing.deps import get_db
+from phase23_billing.router_webhook import router
+
+LIVE_DB = os.getenv("DATABASE_URL")
+
+SUB_ID = "sub_bill1_test"
+CUSTOMER_ID = "cus_bill1_test"
+TEST_EMAIL = "bill1@subscription.test"
+
+
+def _subscription_event(etype, status="active", unit_amount=2999,
+                        cancel_at_period_end=False, nickname="Professional"):
+    return {
+        "type": etype,
+        "data": {"object": {
+            "id": SUB_ID,
+            "customer": CUSTOMER_ID,
+            "status": status,
+            "cancel_at_period_end": cancel_at_period_end,
+            "current_period_start": 1754179200,
+            "current_period_end": 1756857600,
+            "items": {"data": [{"price": {"unit_amount": unit_amount,
+                                          "nickname": nickname}}]},
+        }},
+    }
+
+
+def _post(client, event):
+    stripe_stub = MagicMock()
+    stripe_stub.Webhook.construct_event.return_value = event
+    with patch("phase23_billing.router_webhook.init_stripe", return_value=stripe_stub):
+        return client.post("/payments/webhook", json={},
+                           headers={"stripe-signature": "t=1,v1=stub"})
+
+
+# ── Structural: the write exists at all ──────────────────────────────
+
+def test_an_insert_path_exists():
+    """The defect in one line: there was no INSERT INTO subscriptions
+    anywhere in the codebase."""
+    import inspect
+    from phase23_billing import router_webhook
+    src = inspect.getsource(router_webhook)
+    assert "INSERT INTO subscriptions" in src
+    assert "ON CONFLICT (stripe_subscription_id) DO UPDATE" in src
+
+
+def test_checkout_never_overwrites_an_observed_status():
+    """Stripe does not guarantee event ordering. Checkout carries no
+    subscription status, so it must not clobber one that already
+    arrived — hence DO NOTHING, not DO UPDATE."""
+    import inspect
+    from phase23_billing.router_webhook import ensure_subscription_row
+    src = inspect.getsource(ensure_subscription_row)
+    assert "DO NOTHING" in src
+    assert "'active'" not in src, "checkout must not claim a status it did not observe"
+
+
+# ── End to end against a real database ───────────────────────────────
+
+@pytest.fixture
+def live_client():
+    """Real session, real table, real SQL — the layer where all three
+    breaks in this pipeline lived."""
+    from phase23_billing.deps import SessionLocal
+
+    session = SessionLocal()
+    session.execute(text("DELETE FROM subscriptions WHERE stripe_subscription_id = :s"),
+                    {"s": SUB_ID})
+    session.execute(text("DELETE FROM users WHERE email = :e"), {"e": TEST_EMAIL})
+    session.execute(text("""
+        INSERT INTO users (email, password_hash, full_name, role, state, plan, stripe_customer_id)
+        VALUES (:e, 'x', 'BILL1 Tester', 'escrow_officer', 'CA', 'free', :c)
+    """), {"e": TEST_EMAIL, "c": CUSTOMER_ID})
+    session.commit()
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_db] = lambda: session
+    yield TestClient(app), session
+
+    session.execute(text("DELETE FROM subscriptions WHERE stripe_subscription_id = :s"),
+                    {"s": SUB_ID})
+    session.execute(text("DELETE FROM users WHERE email = :e"), {"e": TEST_EMAIL})
+    session.commit()
+    session.close()
+
+
+@pytest.mark.skipif(not LIVE_DB, reason="live test DB required")
+def test_created_event_inserts_a_row(live_client):
+    client, session = live_client
+    assert _post(client, _subscription_event("customer.subscription.created")).status_code == 200
+
+    row = session.execute(text("""
+        SELECT status, plan_name, mrr_cents, user_id, current_plan_price_cents
+        FROM subscriptions WHERE stripe_subscription_id = :s
+    """), {"s": SUB_ID}).fetchone()
+    assert row is not None, "the created event still wrote nothing"
+    assert row[0] == "active"
+    assert row[1] == "Professional"
+    assert row[2] == 2999
+    assert row[3] is not None, "the Stripe customer should resolve to our user"
+    assert row[4] == 2999
+
+
+@pytest.mark.skipif(not LIVE_DB, reason="live test DB required")
+def test_the_revenue_tab_sees_it(live_client):
+    """The whole point: event in → row exists → MRR reflects it. This hop
+    was unobservable before ADMIN1, because a missing row and a missing
+    table both rendered as a confident $0."""
+    from phase23_billing.services.revenue import mrr_arr
+
+    client, session = live_client
+    baseline = mrr_arr(session)["mrr_cents"]
+    assert baseline is not None, "revenue reads should not be failing"
+
+    _post(client, _subscription_event("customer.subscription.created"))
+
+    after = mrr_arr(session)
+    assert after["errors"] == []
+    assert after["mrr_cents"] == baseline + 2999
+    assert after["arr_cents"] == (baseline + 2999) * 12
+
+
+@pytest.mark.skipif(not LIVE_DB, reason="live test DB required")
+def test_subsequent_events_update_rather_than_duplicate(live_client):
+    client, session = live_client
+    _post(client, _subscription_event("customer.subscription.created"))
+    _post(client, _subscription_event("customer.subscription.updated",
+                                      unit_amount=9999, cancel_at_period_end=True))
+
+    rows = session.execute(text("""
+        SELECT status, mrr_cents, cancel_at_period_end
+        FROM subscriptions WHERE stripe_subscription_id = :s
+    """), {"s": SUB_ID}).fetchall()
+    assert len(rows) == 1, "the upsert must not duplicate on repeat events"
+    assert rows[0][1] == 9999
+    assert rows[0][2] is True
+
+
+@pytest.mark.skipif(not LIVE_DB, reason="live test DB required")
+def test_cancellation_zeroes_mrr_and_downgrades_the_user(live_client):
+    client, session = live_client
+    _post(client, _subscription_event("customer.subscription.created"))
+    _post(client, _subscription_event("customer.subscription.deleted", status="canceled"))
+
+    row = session.execute(text("""
+        SELECT status, mrr_cents FROM subscriptions WHERE stripe_subscription_id = :s
+    """), {"s": SUB_ID}).fetchone()
+    assert row[0] == "canceled"
+    assert row[1] == 0, "a cancelled subscription contributes no recurring revenue"
+
+    plan = session.execute(text("SELECT plan FROM users WHERE email = :e"),
+                           {"e": TEST_EMAIL}).fetchone()[0]
+    assert plan == "free"
+
+
+@pytest.mark.skipif(not LIVE_DB, reason="live test DB required")
+def test_checkout_ensures_a_row_when_the_subscription_event_is_missing(live_client):
+    """Belt and braces: if `customer.subscription.created` is delayed or
+    lost, the checkout still leaves us a subscription we can see."""
+    client, session = live_client
+    _post(client, {
+        "type": "checkout.session.completed",
+        "data": {"object": {
+            "subscription": SUB_ID, "customer": CUSTOMER_ID,
+            "client_reference_id": None,
+            "metadata": {"plan": "professional"},
+        }},
+    })
+
+    row = session.execute(text("""
+        SELECT status, plan_name, user_id FROM subscriptions
+        WHERE stripe_subscription_id = :s
+    """), {"s": SUB_ID}).fetchone()
+    assert row is not None
+    assert row[0] == "incomplete", "checkout must not claim an unobserved status"
+    assert row[1] == "professional"
+    assert row[2] is not None
+
+    # ...and the real event, arriving later, corrects it without duplicating.
+    _post(client, _subscription_event("customer.subscription.created"))
+    rows = session.execute(text("""
+        SELECT status, plan_name FROM subscriptions WHERE stripe_subscription_id = :s
+    """), {"s": SUB_ID}).fetchall()
+    assert len(rows) == 1
+    assert rows[0][0] == "active"
+    assert rows[0][1] == "Professional"

--- a/backend/tests/test_phase23_webhook.py
+++ b/backend/tests/test_phase23_webhook.py
@@ -94,7 +94,12 @@ def test_subscription_deleted_downgrades_user_to_free():
         }},
     })
     assert resp.status_code == 200
-    assert len(statements_matching(session, "UPDATE subscriptions")) == 1
+    # BILL1 changed the statement shape deliberately: the handler was
+    # UPDATE-only, so a subscription we had never seen had no row to
+    # update and the event wrote nothing. It upserts now — the intent
+    # this test guards (the subscriptions table is touched, and the user
+    # is downgraded below) is unchanged.
+    assert len(statements_matching(session, "INSERT INTO subscriptions")) == 1
     downgrades = statements_matching(session, "UPDATE users SET plan = 'free'")
     assert len(downgrades) == 1
     assert downgrades[0][1] == {"cust": "cus_abc"}


### PR DESCRIPTION
This pipeline has been broken **three independent ways**, and each break hid the next:

1. **T1** — a legacy inline webhook shadowed the phase23 router, so none of its handlers ran at all.
2. **ADMIN1** — the `subscriptions` table did not exist in production, so every statement in those handlers addressed nothing.
3. **This** — even with the router live and the table present, the lifecycle handler was UPDATE-only. `customer.subscription.created` had no row to update, wrote nothing, and returned `{"ok": true}`. A fabricated success on the billing path, and the last one known to be left in the platform.

## The write

`customer.subscription.created/updated/deleted` now **upsert**: insert on first sight, update on every event after, keyed on `stripe_subscription_id`. The row carries status, plan, both period bounds, price, MRR and `cancel_at_period_end`, and resolves `user_id` from `users.stripe_customer_id`.

`checkout.session.completed` also ensures a row exists, so a delayed or lost subscription event can't leave a paid customer invisible. That path is deliberately `INSERT ... DO NOTHING` rather than `DO UPDATE`: **Stripe does not guarantee event ordering**, and checkout carries no subscription status, so it must never overwrite a real one that already arrived. Its placeholder is Stripe's own `incomplete` — I don't write `active` there, because we haven't observed it.

Two `NOT NULL` columns forced small decisions, both made in the direction of not inventing facts:
- `plan_name` prefers Stripe's price nickname, falls back to the plan already on the user, and only then to a literal `"unknown"` that reads as unknown rather than as a plan someone chose.
- A cancelled subscription records `mrr_cents = 0`, since it contributes no recurring revenue. MRR normalisation across billing intervals is not attempted and not claimed.

## Verified end to end

Against a live database — the layer where all three breaks lived:

**event in → row exists → the MRR the Revenue tab reads reflects it.**

That last hop was *unobservable* before ADMIN1, because a missing row and a missing table both rendered as a confident $0. Also covered: repeat events update rather than duplicate; cancellation zeroes MRR and downgrades the user to free; a checkout-only path is corrected by the later real event without duplicating.

## Two deliberate choices worth flagging

**One existing pin was updated, not deleted.** `test_phase23_webhook` asserted the statement shape `"UPDATE subscriptions"` — which is precisely the defect. It now asserts the upsert. The behaviour it guards (the table is touched, the user is downgraded) is unchanged.

**The webhook response body is not extended with the write outcome.** I had added a `subscription_row_created` flag and removed it: that body is Stripe's, it only needs a 2xx, and the six-flow baseline pins its shape. Evidence that the write happened belongs in the database and on the Revenue tab — which is where the harness looks for it. The result is that both baselines pass with no re-record.

## Gates

| Gate | Result |
|---|---|
| Backend (live DB) | 344 passed |
| Six-flow baseline | ✔ unchanged, no re-record |
| API baseline | ✔ unchanged |
| Jest | 344 passed |
| tsc | 94, flat |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_