### PR TITLE
ADMIN1.5 remainder: the console's numbers say what window they measure

### DIFF
--- a/backend/routers/admin_api_v2.py
+++ b/backend/routers/admin_api_v2.py
@@ -20,18 +20,59 @@ router = APIRouter(prefix="/admin", tags=["Admin v2"])
 # Note: get_db_connection() uses RealDictCursor, so fetchall() already returns dicts
 # No need for a _dictify helper function
 
+# ── Sort whitelists (ADMIN1.5 frictions) ─────────────────────────────
+#
+# Both lists were hard-sorted `created_at DESC` with nothing on screen
+# saying so, which is a small dishonesty of the same family as an
+# unlabelled denominator: the operator reads an order into a list that
+# the list never claimed. The console now names its sort and can change
+# it — through these maps and ONLY these maps.
+#
+# The ORDER BY fragment is interpolated into an f-string (the WHERE
+# clause already is), so an unmapped key must never reach SQL. A dict
+# lookup with a default, not a format of user input: an allowlist that
+# cannot be spelled around is the difference between a sort control and
+# an injection point.
+USER_SORTS: Dict[str, str] = {
+    "newest": "u.created_at DESC NULLS LAST",
+    "oldest": "u.created_at ASC NULLS LAST",
+    "email": "LOWER(u.email) ASC",
+    "deeds": "deed_count DESC, u.created_at DESC",
+    "last_login": "u.last_login DESC NULLS LAST",
+}
+DEED_SORTS: Dict[str, str] = {
+    "newest": "d.created_at DESC NULLS LAST",
+    "oldest": "d.created_at ASC NULLS LAST",
+    "updated": "d.updated_at DESC NULLS LAST",
+    "type": "d.deed_type ASC, d.created_at DESC",
+}
+DEFAULT_SORT = "newest"
+
+
+def _order_by(sorts: Dict[str, str], requested: Optional[str]) -> str:
+    """Resolve a sort key to SQL, or 400. Never interpolate the input."""
+    key = (requested or DEFAULT_SORT).lower()
+    if key not in sorts:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown sort '{requested}'. Valid: {', '.join(sorted(sorts))}",
+        )
+    return sorts[key]
+
 @router.get("/users/search")
 def admin_users_search(
     page: int = Query(1, ge=1),
     limit: int = Query(50, ge=1, le=200),
     search: Optional[str] = None,
     role: Optional[str] = None,
+    sort: Optional[str] = Query(None, description="newest|oldest|email|deeds|last_login"),
     admin=Depends(get_current_admin)
 ):
     """
     Paginated, searchable users list.
     Safe and additive to any existing /admin/users route.
     """
+    order_sql = _order_by(USER_SORTS, sort)
     offset = (page - 1) * limit
     conn = get_db_connection()
     with conn.cursor() as cur:
@@ -55,12 +96,13 @@ def admin_users_search(
                    (SELECT COUNT(*) FROM deeds d WHERE d.user_id = u.id) as deed_count
             FROM users u
             {where_sql}
-            ORDER BY u.created_at DESC
+            ORDER BY {order_sql}
             LIMIT %s OFFSET %s
         """, params + [limit, offset])
         rows = cur.fetchall()  # Already returns list of dicts (RealDictCursor)
 
-    return {"page": page, "limit": limit, "total": total, "items": rows}
+    return {"page": page, "limit": limit, "total": total,
+            "sort": (sort or DEFAULT_SORT).lower(), "items": rows}
 
 @router.get("/users/{user_id}")
 def admin_user_detail(user_id: int, admin=Depends(get_current_admin)):
@@ -106,11 +148,13 @@ def admin_deeds_search(
     search: Optional[str] = None,
     status: Optional[str] = None,
     user_id: Optional[int] = None,
+    sort: Optional[str] = Query(None, description="newest|oldest|updated|type"),
     admin=Depends(get_current_admin)
 ):
     """
     Paginated, searchable deeds list (per-user via user_id).
     """
+    order_sql = _order_by(DEED_SORTS, sort)
     offset = (page - 1) * limit
     conn = get_db_connection()
     with conn.cursor() as cur:
@@ -142,12 +186,13 @@ def admin_deeds_search(
             FROM deeds d
             LEFT JOIN users u ON u.id = d.user_id
             {where_sql}
-            ORDER BY d.created_at DESC
+            ORDER BY {order_sql}
             LIMIT %s OFFSET %s
         """, params + [limit, offset])
         rows = cur.fetchall()  # Already returns list of dicts (RealDictCursor)
 
-    return {"page": page, "limit": limit, "total": total, "items": rows}
+    return {"page": page, "limit": limit, "total": total,
+            "sort": (sort or DEFAULT_SORT).lower(), "items": rows}
 
 @router.get("/deeds/{deed_id}")
 def admin_deed_detail(deed_id: int, admin=Depends(get_current_admin)):

--- a/backend/routers/admin_inline.py
+++ b/backend/routers/admin_inline.py
@@ -49,12 +49,27 @@ def admin_dashboard():
             cur.execute("SELECT COUNT(*) FROM deeds")
             total_deeds = cur.fetchone()[0]
 
-            # Get deeds this month
+            # Deeds this month — and the two facts that make it readable.
+            #
+            # ADMIN1.5 reconciliation. This number is a CALENDAR-MONTH
+            # count, so on the 1st through the 3rd of a month it reads
+            # near zero on a platform that has been busy all along, and
+            # the operator's first reading is "we collapsed". The count
+            # was never wrong; the card was unlabelled. Two additions fix
+            # that without touching the semantics: the window's start
+            # date travels with the number so the UI can say WHICH month
+            # it means, and a rolling 30-day count sits beside it as the
+            # figure that does not reset at midnight on the 1st.
             cur.execute("""
-                SELECT COUNT(*) FROM deeds
-                WHERE created_at >= DATE_TRUNC('month', CURRENT_DATE)
+                SELECT COUNT(*) FILTER (WHERE created_at >= DATE_TRUNC('month', CURRENT_DATE)) AS this_month,
+                       COUNT(*) FILTER (WHERE created_at >= NOW() - INTERVAL '30 days') AS last_30,
+                       DATE_TRUNC('month', CURRENT_DATE)::date AS month_start
+                FROM deeds
             """)
-            deeds_this_month = cur.fetchone()[0]
+            month_row = cur.fetchone()
+            deeds_this_month = month_row[0] or 0
+            deeds_last_30_days = month_row[1] or 0
+            month_window_start = month_row[2].isoformat() if month_row[2] else None
 
             # Get subscription breakdown
             cur.execute("""
@@ -100,6 +115,9 @@ def admin_dashboard():
             "active_users": active_users,
             "total_deeds": total_deeds,
             "deeds_this_month": deeds_this_month,
+            # The label the console needs in order to state its own window.
+            "deeds_this_month_since": month_window_start,
+            "deeds_last_30_days": deeds_last_30_days,
             "total_revenue": total_revenue,
             "monthly_revenue": monthly_revenue,
             "subscription_breakdown": {
@@ -138,15 +156,29 @@ def admin_dashboard():
 def admin_system_overview():
     """Get system overview with real health checks and PDF stats - Phase 5D"""
     # Check database health
+    #
+    # ADMIN1.5 relapse sweep. This measured with `time.time()` and cast
+    # the result to `int` milliseconds, so a healthy same-region probe —
+    # which lands well under a millisecond — truncated to 0 and the
+    # console reported "0ms latency". A zero produced by rounding is
+    # exactly the failure ADMIN1 spent a PR removing: a numeral that
+    # reads as a measurement and is not one. It is also the WRONG clock:
+    # `time.time()` is wall-clock and can step backwards under NTP.
+    #
+    # `perf_counter()` is monotonic, the value keeps sub-millisecond
+    # resolution, and on a failed probe it is None rather than 0 — a
+    # database that did not answer has no latency, and saying "0ms"
+    # under an Offline badge was the most confident wrong number on the
+    # screen.
     db_status = "down"
-    db_latency = 0
+    db_latency = None
     try:
         import time
-        start = time.time()
+        start = time.perf_counter()
         with db.conn.cursor() as cur:
             cur.execute("SELECT 1")
             cur.fetchone()
-        db_latency = int((time.time() - start) * 1000)
+        db_latency = round((time.perf_counter() - start) * 1000, 3)
         db_status = "up"
     except Exception as e:
         print(f"DB health check failed: {e}")

--- a/backend/tests/test_admin15_reconciliation.py
+++ b/backend/tests/test_admin15_reconciliation.py
@@ -1,0 +1,210 @@
+"""ADMIN1.5 remainder — reconciliation, the relapse sweep, and the sort
+allowlist.
+
+PR #113 fixed the SHAPE of the admin console's data (rows are objects
+again, the drill-downs resolve). These are the numbers *inside* that
+shape, and the browser audit's reading of them:
+
+- "Deeds This Month: 0" on a platform that had not stopped — a calendar
+  count with no window stated, read on the 2nd of a month.
+- "0ms latency" under a green Database badge — `int(seconds * 1000)`
+  truncating a sub-millisecond probe, which is a zero manufactured by
+  rounding rather than measured.
+- A percentage bar chart drawn over a handful of rows with its
+  denominator nowhere on screen.
+
+Each is the same defect ADMIN1 was fired to remove, wearing different
+clothes: a number that looks like a measurement and is not one. The pins
+below assert the honest form rather than the current spelling, because
+the last round taught us that a pin matching a spelling guards a
+spelling.
+
+CI-safe (no database) except where marked.
+"""
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+BACKEND = Path(__file__).resolve().parents[1]
+ADMIN_INLINE = BACKEND / "routers" / "admin_inline.py"
+ADMIN_V2 = BACKEND / "routers" / "admin_api_v2.py"
+
+
+def code_only(path: Path) -> str:
+    """Source with docstrings and comments stripped.
+
+    A comment explaining why a pattern was removed necessarily quotes
+    that pattern, so a naive grep trips on the explanation. This has now
+    happened five times across four suites; the shared-util consolidation
+    is ledgered as opportunistic and this file uses the same helper shape
+    as its siblings so the eventual merge is mechanical.
+    """
+    src = path.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            doc = ast.get_docstring(node, clean=False)
+            if doc:
+                src = src.replace(doc, "")
+    return "\n".join(
+        line for line in src.splitlines()
+        if not line.lstrip().startswith("#")
+    )
+
+
+# ── The month boundary ───────────────────────────────────────────────
+
+def test_the_month_count_travels_with_its_window():
+    """A calendar-month count is not wrong on the 2nd — it is unlabelled.
+    The window start and a rolling 30-day figure ship alongside it so the
+    console can say which month it means and offer the number that does
+    not reset at midnight on the 1st."""
+    src = code_only(ADMIN_INLINE)
+    assert "deeds_this_month_since" in src, "the month window is not stated"
+    assert "deeds_last_30_days" in src, "no rolling figure to reconcile against"
+    assert "DATE_TRUNC('month', CURRENT_DATE)" in src, (
+        "the calendar-month semantics should be kept, not quietly redefined"
+    )
+    assert "INTERVAL '30 days'" in src
+
+
+def test_the_rolling_and_calendar_counts_are_separate_reads():
+    """One is not derived from the other. If a future edit computes the
+    30-day figure FROM the month figure they stop being independent and
+    the reconciliation stops reconciling anything."""
+    src = code_only(ADMIN_INLINE)
+    assert not re.search(r"deeds_last_30_days\s*=\s*deeds_this_month", src)
+    assert not re.search(r"deeds_this_month\s*=\s*deeds_last_30_days", src)
+
+
+# ── The 0ms relapse ──────────────────────────────────────────────────
+
+def test_latency_is_measured_on_a_monotonic_clock_without_truncation():
+    """`int((time.time() - start) * 1000)` fails twice: it truncates a
+    healthy sub-millisecond probe to 0, and it reads a wall clock that
+    can step backwards under NTP."""
+    src = code_only(ADMIN_INLINE)
+    assert "perf_counter" in src, "latency should be measured monotonically"
+    assert not re.search(r"int\(\s*\(?\s*time\.time\(\)", src), (
+        "latency is being truncated to whole milliseconds again — a "
+        "sub-millisecond probe renders as the string '0ms latency', which "
+        "is a zero produced by rounding, not by measurement"
+    )
+
+
+def test_a_database_that_did_not_answer_reports_no_latency():
+    """The initial value governs the failure path. `db_latency = 0` meant
+    a dead database rendered '0ms' under an Offline badge — the fastest
+    number on the screen, attached to the thing that was down."""
+    src = code_only(ADMIN_INLINE)
+    assert re.search(r"db_latency\s*=\s*None", src), (
+        "latency must start as None so a failed probe reports an absence"
+    )
+    assert not re.search(r"db_latency\s*=\s*0\b", src)
+
+
+# ── The sort allowlist ───────────────────────────────────────────────
+
+def test_sort_keys_resolve_through_a_map_and_never_reach_sql_directly():
+    """The ORDER BY fragment is interpolated into an f-string next to an
+    interpolated WHERE clause. That is safe only while every value comes
+    from a fixed map — so the pin is on the mechanism, not on a list of
+    bad inputs nobody can enumerate."""
+    import sys
+    sys.path.insert(0, str(BACKEND))
+    from routers.admin_api_v2 import USER_SORTS, DEED_SORTS, _order_by
+    from fastapi import HTTPException
+
+    for sorts in (USER_SORTS, DEED_SORTS):
+        assert "newest" in sorts, "the documented default must exist"
+        # An absent or empty `?sort=` is the default, not an error.
+        assert _order_by(sorts, None) == sorts["newest"]
+        assert _order_by(sorts, "") == sorts["newest"]
+        for hostile in ["1; DROP TABLE users", "u.email); --", "newest DESC",
+                        "newest;--", "NEWEST, id"]:
+            with pytest.raises(HTTPException) as exc:
+                _order_by(sorts, hostile)
+            assert exc.value.status_code == 400
+
+    src = code_only(ADMIN_V2)
+    # No path from the raw query parameter into the SQL string.
+    assert not re.search(r"ORDER BY\s*\{sort\}", src)
+    assert "ORDER BY {order_sql}" in src
+
+
+def test_the_applied_sort_is_echoed_to_the_client():
+    """The console states its sort. It can only do that honestly if the
+    server says which one it used rather than the client assuming its
+    request was honoured."""
+    src = code_only(ADMIN_V2)
+    assert src.count('"sort": (sort or DEFAULT_SORT).lower()') == 2
+
+
+# ── Live-DB reconciliation ───────────────────────────────────────────
+
+@pytest.mark.skipif(not __import__("os").getenv("DATABASE_URL"),
+                    reason="live test DB required")
+def test_the_dashboard_serves_both_windows_and_the_label():
+    import os
+    import psycopg2
+    from fastapi.testclient import TestClient
+    from main import app
+
+    email, password = "recon@admin.example", "Recon!Passw0rd"
+    client = TestClient(app)
+    conn = psycopg2.connect(os.environ["DATABASE_URL"])
+    conn.autocommit = True
+    with conn.cursor() as cur:
+        cur.execute("""DELETE FROM user_profiles WHERE user_id IN
+                       (SELECT id FROM users WHERE email = %s)""", (email,))
+        cur.execute("DELETE FROM users WHERE email = %s", (email,))
+    conn.close()
+
+    client.post("/users/register", json={
+        "email": email, "password": password, "confirm_password": password,
+        "full_name": "Recon Admin", "role": "escrow_officer",
+        "state": "CA", "agree_terms": True})
+    conn = psycopg2.connect(os.environ["DATABASE_URL"])
+    conn.autocommit = True
+    with conn.cursor() as cur:
+        cur.execute("UPDATE users SET role = 'admin' WHERE email = %s", (email,))
+    conn.close()
+
+    token = client.post("/users/login", json={
+        "email": email, "password": password}).json()["access_token"]
+    auth = {"Authorization": f"Bearer {token}"}
+
+    data = client.get("/admin/dashboard", headers=auth).json()
+    assert "deeds_this_month" in data
+    assert "deeds_last_30_days" in data
+    assert re.fullmatch(r"\d{4}-\d{2}-01", data["deeds_this_month_since"]), (
+        "the window label must be the first of a month — it is what the "
+        "console renders as 'since Aug 1'"
+    )
+    # The calendar month is a subset of the trailing 30 days for any
+    # month shorter than 31 days into itself; the invariant that always
+    # holds is that neither exceeds the total.
+    assert data["deeds_this_month"] <= data["total_deeds"]
+    assert data["deeds_last_30_days"] <= data["total_deeds"]
+
+    # Sorting is real, not decorative: two orders, two answers.
+    newest = client.get("/admin/users/search?limit=5&sort=newest", headers=auth).json()
+    oldest = client.get("/admin/users/search?limit=5&sort=oldest", headers=auth).json()
+    assert newest["sort"] == "newest" and oldest["sort"] == "oldest"
+    if newest["total"] > 1:
+        assert newest["items"][0]["id"] != oldest["items"][0]["id"]
+
+    assert client.get("/admin/users/search?sort=nonsense", headers=auth).status_code == 400
+    assert client.get("/admin/deeds/search?sort=nonsense", headers=auth).status_code == 400
+
+    # Latency is a measurement or an absence — never a rounded zero.
+    health = client.get("/admin/system/overview", headers=auth).json()["health"]
+    latency = health["database"]["latency_ms"]
+    if health["database"]["status"] == "up":
+        assert latency is not None and latency > 0, (
+            "a completed probe reported zero elapsed time — the truncation is back"
+        )
+    else:
+        assert latency is None

--- a/frontend/src/__tests__/adminConsoleHonesty.test.ts
+++ b/frontend/src/__tests__/adminConsoleHonesty.test.ts
@@ -1,0 +1,190 @@
+/**
+ * ADMIN1.5 remainder — the console says what it is showing.
+ *
+ * The browser audit read four numbers off the admin console and got four
+ * wrong impressions, none of them from a wrong number:
+ *
+ *   "Deeds This Month: 0"   — a calendar count, read on the 2nd
+ *   "0ms latency"           — a sub-millisecond probe, truncated
+ *   a percentage bar chart  — drawn over a handful of rows
+ *   "Total Documents: 0"    — a failed fetch, rendered as a fact
+ *
+ * Every one is the ADMIN1 defect class surviving in a place ADMIN1 did
+ * not look. These pins assert the labels and the absences, because the
+ * numbers themselves were never the problem.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+
+function readAdmin(...segments: string[]): string {
+  return fs.readFileSync(
+    path.join(__dirname, '..', 'app', 'admin', ...segments), 'utf8');
+}
+
+/** Comments explaining a removed pattern quote that pattern. */
+function withoutComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+}
+
+describe('the two deed windows are labelled and reconciled', () => {
+  const src = readAdmin('components', 'Overview.tsx');
+
+  it('names the window each count measures', () => {
+    expect(src).toContain('Deeds — last 30 days');
+    expect(src).toContain('Deeds — this calendar month');
+    // The bare label that produced the "we collapsed" reading.
+    expect(withoutComments(src)).not.toContain('"Deeds This Month"');
+  });
+
+  it('states the calendar window\'s start date rather than implying today', () => {
+    expect(src).toContain('deeds_this_month_since');
+    expect(src).toContain('since ${since}');
+  });
+
+  it('explains that the two figures are expected to disagree', () => {
+    expect(src).toMatch(/expected to\s*\n?\s*disagree/);
+  });
+});
+
+describe('the verification count carries its provenance', () => {
+  const src = readAdmin('components', 'Overview.tsx');
+
+  it('no longer claims to count platform-wide QR scans', () => {
+    expect(withoutComments(src)).not.toContain('QR Scans (Week)');
+  });
+
+  it('says the count is partner-API only and why', () => {
+    expect(src).toContain('Partner-API documents only');
+    expect(src).toMatch(/wizard are not\s*\n?\s*issued verification codes/);
+  });
+});
+
+describe('the Verification tab scopes itself before it counts', () => {
+  const src = readAdmin('components', 'VerificationTab.tsx');
+
+  it('leads with the lane it covers', () => {
+    expect(src).toContain('Partner-API documents only');
+    expect(src).toContain('VERIFY1');
+  });
+
+  it('renders an em-dash, not a zero, when the stats call failed', () => {
+    const code = withoutComments(src);
+    expect(code).not.toMatch(/stats\?\.\w+\s*\?\?\s*0/);
+    expect(code).toMatch(/stats\?\.total_documents\s*\?\?\s*'—'/);
+  });
+
+  it('distinguishes an empty list from an unanswered request', () => {
+    expect(src).toContain('docsLoaded');
+    expect(src).toContain('it is an unanswered request');
+    // Both fetches must have an else branch that records the failure.
+    expect((src.match(/failures\.push\(/g) || []).length).toBe(2);
+  });
+
+  it('stops promising rows that this lane can never produce', () => {
+    // The old empty state said documents appear "when deeds are
+    // generated with QR codes" — which wizard deeds never are.
+    expect(withoutComments(src)).not.toContain('generated with QR codes');
+  });
+});
+
+describe('system health reports latency honestly', () => {
+  const src = readAdmin('components', 'SystemTab.tsx');
+
+  it('renders sub-millisecond probes as such instead of as zero', () => {
+    expect(src).toContain('formatLatency');
+    expect(src).toContain("'<1ms'");
+  });
+
+  it('shows no latency at all when the probe did not complete', () => {
+    expect(src).toContain('the probe did not complete');
+    expect(withoutComments(src)).not.toContain('{health.database.latency_ms}ms');
+  });
+});
+
+describe('percentage charts state their denominator', () => {
+  const src = readAdmin('components', 'SystemTab.tsx');
+
+  it('names the base the shares are taken from', () => {
+    expect(src).toMatch(/Shares of \{base\} stored PDF/);
+    expect(src).toContain('{count} of {base}');
+  });
+
+  it('warns when the sample is too small to read as a distribution', () => {
+    expect(src).toContain('SMALL_SAMPLE_THRESHOLD');
+    expect(src).toMatch(/n = \{base\}/);
+  });
+});
+
+describe('pagination describes a place that exists', () => {
+  const pager = readAdmin('components', 'Pager.tsx');
+
+  it('says "No users" rather than "Page 1 of 1" over an empty set', () => {
+    expect(pager).toContain('No ${noun}s');
+    expect(withoutComments(pager)).not.toContain('Math.max(1, Math.ceil');
+  });
+
+  it('shows the total alongside the position', () => {
+    expect(pager).toContain('{total} {noun}');
+  });
+
+  for (const tab of ['UsersTab.tsx', 'DeedsTab.tsx']) {
+    it(`${tab} uses the shared pager instead of its own copy`, () => {
+      const src = readAdmin('components', tab);
+      expect(src).toContain("from './Pager'");
+      expect(withoutComments(src)).not.toMatch(/Page \{page\} \/ \{Math\.max/);
+    });
+  }
+});
+
+describe('search says which of its three states it is in', () => {
+  for (const tab of ['UsersTab.tsx', 'DeedsTab.tsx']) {
+    const src = readAdmin('components', tab);
+
+    it(`${tab} distinguishes searching, no-matches, and genuinely empty`, () => {
+      expect(src).toContain('appliedSearch');
+      expect(src).toContain('Searching for');
+      expect(src).toContain('noMatches');
+      // The single ambiguous string that used to cover all three.
+      const code = withoutComments(src);
+      expect(code).not.toMatch(/>No users<|>No deeds</);
+    });
+
+    it(`${tab} offers a way out of a filter that matched nothing`, () => {
+      expect(src).toMatch(/Clear the search|Clear filters/);
+    });
+
+    it(`${tab} does not render an empty table for a failed request`, () => {
+      expect(src).toContain('loadError');
+      expect(src).toContain('not an empty table');
+    });
+
+    it(`${tab} loads once on mount, not twice`, () => {
+      expect(src).toContain('firstRun');
+    });
+  }
+});
+
+describe('the lists state their sort', () => {
+  it('the sort options mirror the server allowlist', () => {
+    const client = fs.readFileSync(
+      path.join(__dirname, '..', 'lib', 'adminApi.ts'), 'utf8');
+    // Mirror pin: these keys must exist in USER_SORTS/DEED_SORTS in
+    // backend/routers/admin_api_v2.py, which rejects anything else with
+    // a 400. A key added here and not there is a broken control.
+    for (const key of ['newest', 'oldest', 'email', 'deeds', 'last_login']) {
+      expect(client).toContain(`key: '${key}'`);
+    }
+    for (const key of ['updated', 'type']) {
+      expect(client).toContain(`key: '${key}'`);
+    }
+  });
+
+  for (const tab of ['UsersTab.tsx', 'DeedsTab.tsx']) {
+    it(`${tab} exposes the sort rather than applying one silently`, () => {
+      const src = readAdmin('components', tab);
+      expect(src).toMatch(/SORT_OPTIONS/);
+      expect(src).toContain('setSort');
+    });
+  }
+});

--- a/frontend/src/app/admin/components/DeedsTab.tsx
+++ b/frontend/src/app/admin/components/DeedsTab.tsx
@@ -1,7 +1,8 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
-import { AdminApi, DeedRow } from '@/lib/adminApi';
+import { AdminApi, DeedRow, DEED_SORT_OPTIONS } from '@/lib/adminApi';
+import Pager from './Pager';
 
 export default function DeedsTab(){
   // Per-user view: /admin?tab=deeds&user=<id> (linked from the user detail page)
@@ -14,48 +15,84 @@ export default function DeedsTab(){
   const [total, setTotal] = useState(0);
   const [search, setSearch] = useState('');
   const [status, setStatus] = useState('');
+  const [sort, setSort] = useState('newest');
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState('');
   const [modal, setModal] = useState<DeedRow | null>(null);
+  const [appliedSearch, setAppliedSearch] = useState('');
+  const firstRun = useRef(true);
 
-  async function load(){
+  async function load(nextPage = page){
     setLoading(true);
+    setLoadError('');
     try{
-      const res = await AdminApi.searchDeeds(page, limit, search, status, userId);
-      setRows(res.items); setTotal(res.total);
+      const res = await AdminApi.searchDeeds(nextPage, limit, search, status, userId, sort);
+      setRows(res.items); setTotal(res.total); setAppliedSearch(search);
+    }catch(e){
+      setRows([]); setTotal(0);
+      setLoadError(e instanceof Error ? e.message : 'Failed to load deeds');
     }finally{
       setLoading(false);
     }
   }
-  useEffect(()=>{ load(); /* eslint-disable-next-line */ }, [page, status]);
+  // A status or sort change resets to page 1 at the control (below), so
+  // this effect never re-queries page 3 of a result set that now has one
+  // page — the "Page 3 / 1 over an empty table" the audit hit.
+  useEffect(()=>{ load(); /* eslint-disable-next-line */ }, [page, status, sort]);
 
   useEffect(()=>{
-    const t = setTimeout(()=>{ setPage(1); load(); }, 300);
+    if (firstRun.current){ firstRun.current = false; return; }
+    const t = setTimeout(()=>{ setPage(1); load(1); }, 300);
     return ()=> clearTimeout(t);
+    /* eslint-disable-next-line */
   }, [search]);
+
+  const pageCount = Math.ceil(total / limit);
+  const searching = loading && search !== appliedSearch;
+  const filtered = appliedSearch !== '' || status !== '' || userId != null;
+  const noMatches = !loading && !loadError && rows.length === 0 && filtered;
+
+  function clearFilters(){
+    setStatus('');
+    setSearch('');
+    setPage(1);
+  }
 
   return (
     <div className="vstack">
       <div className="hstack" style={{justifyContent:'space-between'}}>
         <div className="hstack">
           <input className="input" placeholder="Search deeds..." value={search} onChange={e=>setSearch(e.target.value)} style={{width:320}} />
-          <select className="select" value={status} onChange={e=>setStatus(e.target.value)}>
+          <select className="select" value={status} onChange={e=>{ setPage(1); setStatus(e.target.value); }}>
             <option value="">All</option>
             <option value="completed">Completed</option>
             <option value="draft">Draft (pending)</option>
             <option value="deleted">Deleted</option>
           </select>
+          <label className="hstack" style={{gap:6, fontSize:13, opacity:.8}}>
+            Sort
+            <select className="select" value={sort} onChange={e=>{ setPage(1); setSort(e.target.value); }}>
+              {DEED_SORT_OPTIONS.map(o => (
+                <option key={o.key} value={o.key}>{o.label}</option>
+              ))}
+            </select>
+          </label>
           {userId != null && (
             <span style={{fontSize:13, opacity:.7}}>Filtered to user #{userId}</span>
           )}
         </div>
-        <div className="hstack">
-          <div style={{opacity:.7, fontSize:13}}>
-            Page {page} / {Math.max(1, Math.ceil(total/limit))}
-          </div>
-          <button className="button ghost" onClick={()=> setPage(p=>Math.max(1,p-1))} disabled={page<=1}>Prev</button>
-          <button className="button" onClick={()=> setPage(p=> p+1)} disabled={page*limit>=total}>Next</button>
-        </div>
+        <Pager page={page} pageCount={pageCount} total={total} noun="deed"
+               loading={loading} onPage={setPage} />
       </div>
+
+      {searching && (
+        <div style={{fontSize:13, opacity:.7}}>Searching for “{search}”…</div>
+      )}
+      {!searching && appliedSearch && !loadError && (
+        <div style={{fontSize:13, opacity:.7}}>
+          {total} result{total === 1 ? '' : 's'} for “{appliedSearch}”
+        </div>
+      )}
 
       <div className="card">
         <table className="table">
@@ -76,8 +113,27 @@ export default function DeedsTab(){
                 <div className="skeleton" style={{height:42, marginTop:8}}/>
                 <div className="skeleton" style={{height:42, marginTop:8}}/>
               </td></tr>
+            ) : loadError ? (
+              <tr><td colSpan={6} style={{color:'var(--dp-danger)'}}>
+                Could not load deeds — {loadError}. This is a failed request,
+                not an empty table.
+              </td></tr>
+            ) : noMatches ? (
+              <tr><td colSpan={6} style={{opacity:.8}}>
+                No deeds match the current filters
+                {appliedSearch && <> (“{appliedSearch}”)</>}
+                {status && <> · status {status}</>}
+                {userId != null && <> · user #{userId}</>}.{' '}
+                {userId == null && (
+                  <button className="button ghost" onClick={clearFilters}>
+                    Clear filters
+                  </button>
+                )}
+              </td></tr>
             ) : rows.length === 0 ? (
-              <tr><td colSpan={6} style={{opacity:.75}}>No deeds</td></tr>
+              <tr><td colSpan={6} style={{opacity:.75}}>
+                No deeds have been created yet.
+              </td></tr>
             ) : rows[0] && rows[0].id === undefined ? (
               // Hardening (see UsersTab): a broken row shape announces
               // itself instead of rendering a table of blanks whose

--- a/frontend/src/app/admin/components/Overview.tsx
+++ b/frontend/src/app/admin/components/Overview.tsx
@@ -85,20 +85,74 @@ export default function OverviewTab(){
     {Array.from({length:4}).map((_,i)=> <div key={i} className="card skeleton" style={{height:92}} />)}
   </div>;
 
+  /** "2026-08-01" → "Aug 1" — the window the month card actually means. */
+  function monthWindowLabel(iso?: string | null): string {
+    if (!iso) return 'the 1st';
+    const d = new Date(`${iso}T00:00:00`);
+    if (isNaN(d.getTime())) return 'the 1st';
+    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  }
+
+  const since = monthWindowLabel(stats?.deeds_this_month_since);
+
   return (
     <div className="vstack">
       <div className="grid stats">
         {loading ? skeleton : (<>
           <StatCard title="Total Users" value={stats?.total_users ?? '—'} />
           <StatCard title="Total Deeds" value={stats?.total_deeds ?? '—'} />
-          <StatCard title="Deeds This Month" value={stats?.deeds_this_month ?? '—'} />
-          <StatCard title="QR Scans (Week)" value={stats?.scans_this_week ?? '—'} />
+          {/* ADMIN1.5 reconciliation: both windows, both labelled. The
+              card used to read "Deeds This Month" with no window stated,
+              so on the 2nd of a month a healthy platform reported 0 and
+              the number read as a collapse rather than as a calendar. */}
+          <StatCard
+            title="Deeds — last 30 days"
+            value={stats?.deeds_last_30_days ?? '—'}
+            sub="rolling window"
+          />
+          <StatCard
+            title="Deeds — this calendar month"
+            value={stats?.deeds_this_month ?? '—'}
+            sub={`since ${since}`}
+          />
         </>)}
       </div>
 
-      {scanErr && (
-        <div style={{ fontSize: 12, color: 'var(--dp-warn, #b26a00)', marginTop: -4 }}>
-          QR scan count shown as unavailable — {scanErr}
+      {!loading && (
+        <div style={{ fontSize: 12, opacity: 0.7, marginTop: -4 }}>
+          The two deed counts measure different windows and are expected to
+          disagree — early in a month the calendar figure is a fraction of the
+          rolling one. Neither is a trend; trends arrive with ADMIN6.
+        </div>
+      )}
+
+      {/* QR verifications — stated with its provenance.
+          `total_scans_week` counts rows in `verification_log`, and the
+          only writer of the `document_authenticity` codes those scans
+          resolve against is the partner-API lane
+          (routers/api_v1/router.py). Wizard deeds carry a stored PDF
+          hash but no short code (VERIFY1, parked), so they cannot appear
+          here. Labelling this "QR Scans (Week)" invited the reading that
+          it covered the whole platform. */}
+      {!loading && (
+        <div className="card">
+          <div className="hstack" style={{ justifyContent: 'space-between', alignItems: 'baseline' }}>
+            <div>
+              <div style={{ fontWeight: 600 }}>Verification scans · last 7 days</div>
+              <div style={{ fontSize: 12, opacity: 0.7, marginTop: 2 }}>
+                Partner-API documents only — deeds made in the wizard are not
+                issued verification codes, so they are not counted here.
+              </div>
+            </div>
+            <div style={{ fontSize: 28, fontWeight: 700 }}>
+              {stats?.scans_this_week ?? '—'}
+            </div>
+          </div>
+          {scanErr && (
+            <div style={{ fontSize: 12, color: 'var(--dp-warning)', marginTop: 8 }}>
+              Shown as unavailable — {scanErr}
+            </div>
+          )}
         </div>
       )}
 

--- a/frontend/src/app/admin/components/Pager.tsx
+++ b/frontend/src/app/admin/components/Pager.tsx
@@ -1,0 +1,59 @@
+'use client';
+/**
+ * ADMIN1.5 — one pager, and it tells the truth about where you are.
+ *
+ * The Users and Deeds tabs each carried their own copy of:
+ *
+ *     Page {page} / {Math.max(1, Math.ceil(total/limit))}
+ *     <button disabled={page*limit>=total}>Next</button>
+ *
+ * Three problems, all small, all the kind that make an operator distrust
+ * a console:
+ *
+ * 1. `Math.max(1, …)` reported "Page 1 / 1" over an empty result set —
+ *    a page that does not exist, announced with confidence.
+ * 2. The page number came from local state and the total from the last
+ *    response, so during a filter change the header could read
+ *    "Page 3 / 1" while the table below showed nothing. The count and
+ *    the position were describing different result sets.
+ * 3. The total was never shown. "Page 2 of 4" is a worse answer than
+ *    "Page 2 of 4 · 87 users" for every question an admin actually has.
+ *
+ * The fix is not cleverness — it is refusing to render a position when
+ * there is nothing to be positioned in.
+ */
+type PagerProps = {
+  page: number;
+  /** Total pages, unclamped: 0 when there are no results at all. */
+  pageCount: number;
+  total: number;
+  /** Singular noun for the row type, e.g. "user" — pluralised here. */
+  noun: string;
+  loading?: boolean;
+  onPage: (next: number) => void;
+};
+
+export default function Pager({ page, pageCount, total, noun, loading, onPage }: PagerProps){
+  const empty = total === 0;
+  return (
+    <div className="hstack">
+      <div style={{opacity:.7, fontSize:13}}>
+        {loading ? 'Loading…' : empty ? (
+          `No ${noun}s`
+        ) : (
+          <>Page {Math.min(page, pageCount)} of {pageCount} · {total} {noun}{total === 1 ? '' : 's'}</>
+        )}
+      </div>
+      <button
+        className="button ghost"
+        onClick={()=> onPage(Math.max(1, page - 1))}
+        disabled={loading || page <= 1}
+      >Prev</button>
+      <button
+        className="button"
+        onClick={()=> onPage(page + 1)}
+        disabled={loading || empty || page >= pageCount}
+      >Next</button>
+    </div>
+  );
+}

--- a/frontend/src/app/admin/components/SystemTab.tsx
+++ b/frontend/src/app/admin/components/SystemTab.tsx
@@ -30,10 +30,28 @@ function authHeaders() {
 
 interface ServiceHealth {
   status: string;
-  latency_ms?: number;
+  /** null when the probe did not complete — a service that never
+   *  answered has no latency, and "0ms" under an Offline badge was the
+   *  most confident wrong number on this screen. */
+  latency_ms?: number | null;
   primary?: string;
   error?: string | null;
   note?: string;
+}
+
+/**
+ * ADMIN1.5 relapse sweep. The backend measured latency as
+ * `int(seconds * 1000)`, so every healthy same-region probe truncated to
+ * 0 and the console said "0ms latency" — a zero manufactured by
+ * rounding, which is the exact failure ADMIN1 removed elsewhere. The
+ * probe keeps sub-millisecond resolution now; this renders it without
+ * inventing precision it does not have.
+ */
+function formatLatency(ms: number | null | undefined): string {
+  if (ms == null) return 'not measured';
+  if (ms < 1) return '<1ms';
+  if (ms < 10) return `${ms.toFixed(1)}ms`;
+  return `${Math.round(ms)}ms`;
 }
 
 interface SystemHealth {
@@ -58,6 +76,11 @@ interface SystemData {
   health: SystemHealth;
   pdf_stats: PDFStats;
 }
+
+/** Below this many observations, a percentage chart is arithmetic on a
+ *  handful of rows. Named rather than inlined so the threshold is a
+ *  stated editorial choice and can be pinned by test. */
+const SMALL_SAMPLE_THRESHOLD = 20;
 
 function StatusBadge({ service }: { service: ServiceHealth }) {
   if (service.status === 'up') return <Badge kind="success">Online</Badge>;
@@ -163,32 +186,59 @@ export default function SystemTab() {
         </>
       )}
 
-      {/* By deed type */}
-      {Object.keys(pdfStats.by_type || {}).length > 0 && (
-        <div className="card">
-          <div style={{ fontWeight: 600, marginBottom: 12 }}>Stored PDFs by deed type</div>
-          <div style={{ display: 'grid', gap: 8 }}>
-            {Object.entries(pdfStats.by_type).map(([type, count]) => (
-              <div key={type} style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
-                <div style={{ width: 180, fontSize: 13 }}>{formatDeedType(type)}</div>
-                <div style={{ flex: 1, height: 8, background: 'var(--dp-border, #333)', borderRadius: 4, overflow: 'hidden' }}>
-                  <div
-                    style={{
-                      height: '100%',
-                      width: `${pdfStats.stored_pdfs ? Math.round((count as number) / pdfStats.stored_pdfs * 100) : 0}%`,
-                      background: 'var(--dp-primary, #7C4DFF)',
-                      borderRadius: 4,
-                    }}
-                  />
-                </div>
-                <div style={{ width: 90, fontSize: 13, textAlign: 'right' }}>
-                  {count} ({pdfStats.stored_pdfs ? Math.round((count as number) / pdfStats.stored_pdfs * 100) : 0}%)
-                </div>
+      {/* By deed type — with its denominator stated.
+          ADMIN1.5: this drew percentage bars off `stored_pdfs` without
+          ever naming that base. At the sample sizes this platform
+          currently has, one deed moves a bar twenty points, and a
+          confident-looking distribution chart is the most persuasive way
+          to show a reader something that is not there. The base is now
+          named in the heading, the count leads and the share follows,
+          and below a threshold the chart says outright that the shares
+          are arithmetic rather than signal. */}
+      {Object.keys(pdfStats.by_type || {}).length > 0 && (() => {
+        const base = pdfStats.stored_pdfs || 0;
+        const share = (count: number) => (base ? Math.round((count / base) * 100) : 0);
+        const smallSample = base > 0 && base < SMALL_SAMPLE_THRESHOLD;
+        return (
+          <div className="card">
+            <div style={{ fontWeight: 600, marginBottom: 4 }}>
+              Stored PDFs by deed type
+            </div>
+            <div style={{ fontSize: 12, opacity: 0.7, marginBottom: 12 }}>
+              Shares of {base} stored PDF{base === 1 ? '' : 's'} — the denominator
+              is the count above, not all deeds.
+            </div>
+            {smallSample && (
+              <div style={{ fontSize: 12, color: 'var(--dp-warning)', marginBottom: 12 }}>
+                n = {base}. At this size each document is worth
+                ~{Math.round(100 / base)} percentage points, so treat the bars as
+                a tally with a scale, not as a distribution.
               </div>
-            ))}
+            )}
+            <div style={{ display: 'grid', gap: 8 }}>
+              {Object.entries(pdfStats.by_type).map(([type, count]) => (
+                <div key={type} style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+                  <div style={{ width: 180, fontSize: 13 }}>{formatDeedType(type)}</div>
+                  <div style={{ flex: 1, height: 8, background: 'var(--dp-border, #333)', borderRadius: 4, overflow: 'hidden' }}>
+                    <div
+                      style={{
+                        height: '100%',
+                        width: `${share(count as number)}%`,
+                        background: 'var(--dp-primary, #7C4DFF)',
+                        borderRadius: 4,
+                      }}
+                    />
+                  </div>
+                  <div style={{ width: 120, fontSize: 13, textAlign: 'right' }}>
+                    {count} of {base}{' '}
+                    <span style={{ opacity: 0.6 }}>({share(count as number)}%)</span>
+                  </div>
+                </div>
+              ))}
+            </div>
           </div>
-        </div>
-      )}
+        );
+      })()}
 
       {/* Health */}
       <div style={{ fontWeight: 700, fontSize: 16, marginBottom: 8, marginTop: 8 }}>System health</div>
@@ -201,7 +251,11 @@ export default function SystemTab() {
             <tr>
               <td>Database</td>
               <td><StatusBadge service={health.database} /></td>
-              <td style={{ fontSize: 12, opacity: 0.7 }}>{health.database.latency_ms}ms latency</td>
+              <td style={{ fontSize: 12, opacity: 0.7 }}>
+                {health.database.status === 'up'
+                  ? `${formatLatency(health.database.latency_ms)} — single SELECT 1 round trip`
+                  : 'no latency to report — the probe did not complete'}
+              </td>
             </tr>
             <tr>
               <td>PDF engine</td>

--- a/frontend/src/app/admin/components/UsersTab.tsx
+++ b/frontend/src/app/admin/components/UsersTab.tsx
@@ -1,7 +1,8 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { AdminApi, UserRow, UserDetail } from '@/lib/adminApi';
+import { AdminApi, UserRow, UserDetail, USER_SORT_OPTIONS } from '@/lib/adminApi';
+import Pager from './Pager';
 
 export default function UsersTab(){
   const router = useRouter();
@@ -10,37 +11,84 @@ export default function UsersTab(){
   const [limit] = useState(25);
   const [total, setTotal] = useState(0);
   const [search, setSearch] = useState('');
+  const [sort, setSort] = useState('newest');
   const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState('');
   const [modal, setModal] = useState<UserDetail | null>(null);
+  /** The query the rows on screen actually answer. `search` is what the
+   *  operator is typing; conflating the two is why "no matches" and
+   *  "still typing" looked the same. */
+  const [appliedSearch, setAppliedSearch] = useState('');
+  const firstRun = useRef(true);
 
-  async function load(){
+  async function load(nextPage = page){
     setLoading(true);
+    setLoadError('');
     try{
-      const res = await AdminApi.searchUsers(page, limit, search);
-      setRows(res.items); setTotal(res.total);
+      const res = await AdminApi.searchUsers(nextPage, limit, search, sort);
+      setRows(res.items); setTotal(res.total); setAppliedSearch(search);
+    }catch(e){
+      // Doctrine §4: a failed search is not an empty result set.
+      setRows([]); setTotal(0);
+      setLoadError(e instanceof Error ? e.message : 'Failed to load users');
     }finally{
       setLoading(false);
     }
   }
-  useEffect(()=>{ load(); /* eslint-disable-next-line */ }, [page]);
+  useEffect(()=>{ load(); /* eslint-disable-next-line */ }, [page, sort]);
 
   useEffect(()=>{
-    const t = setTimeout(()=>{ setPage(1); load(); }, 300);
+    // Skip the mount pass: this effect used to fire alongside the one
+    // above, so opening the tab issued two identical requests and the
+    // table flickered through two loads.
+    if (firstRun.current){ firstRun.current = false; return; }
+    const t = setTimeout(()=>{
+      // Reset to page 1 AND load page 1. Setting page here and letting
+      // the other effect re-fetch meant a search from page 3 briefly
+      // queried page 3 of the new result set — the "Page 3 of 1" the
+      // audit hit, with an empty table under it.
+      setPage(1);
+      load(1);
+    }, 300);
     return ()=> clearTimeout(t);
+    /* eslint-disable-next-line */
   }, [search]);
+
+  const pageCount = Math.ceil(total / limit);
+  const searching = loading && search !== appliedSearch;
+  const noMatches = !loading && !loadError && rows.length === 0 && appliedSearch !== '';
 
   return (
     <div className="vstack">
       <div className="hstack" style={{justifyContent:'space-between'}}>
-        <input className="input" placeholder="Search users..." value={search} onChange={e=>setSearch(e.target.value)} style={{width:320}} />
         <div className="hstack">
-          <div style={{opacity:.7, fontSize:13}}>
-            Page {page} / {Math.max(1, Math.ceil(total/limit))}
-          </div>
-          <button className="button ghost" onClick={()=> setPage(p=>Math.max(1,p-1))} disabled={page<=1}>Prev</button>
-          <button className="button" onClick={()=> setPage(p=> p+1)} disabled={page*limit>=total}>Next</button>
+          <input className="input" placeholder="Search users..." value={search} onChange={e=>setSearch(e.target.value)} style={{width:320}} />
+          {search && (
+            <button className="button ghost" onClick={()=> setSearch('')}>Clear</button>
+          )}
+          <label className="hstack" style={{gap:6, fontSize:13, opacity:.8}}>
+            Sort
+            <select className="select" value={sort} onChange={e=>{ setPage(1); setSort(e.target.value); }}>
+              {USER_SORT_OPTIONS.map(o => (
+                <option key={o.key} value={o.key}>{o.label}</option>
+              ))}
+            </select>
+          </label>
         </div>
+        <Pager page={page} pageCount={pageCount} total={total} noun="user"
+               loading={loading} onPage={setPage} />
       </div>
+
+      {/* Search feedback: three distinct states, none of which used to
+          be distinguishable from "the table is empty". */}
+      {searching && (
+        <div style={{fontSize:13, opacity:.7}}>Searching for “{search}”…</div>
+      )}
+      {!searching && appliedSearch && !loadError && (
+        <div style={{fontSize:13, opacity:.7}}>
+          {total} result{total === 1 ? '' : 's'} for “{appliedSearch}”
+        </div>
+      )}
 
       <div className="card">
         <table className="table">
@@ -62,8 +110,25 @@ export default function UsersTab(){
                 <div className="skeleton" style={{height:42, marginTop:8}}/>
                 <div className="skeleton" style={{height:42, marginTop:8}}/>
               </td></tr>
+            ) : loadError ? (
+              <tr><td colSpan={7} style={{color:'var(--dp-danger)'}}>
+                Could not load users — {loadError}. This is a failed request,
+                not an empty table.
+              </td></tr>
+            ) : noMatches ? (
+              // "No users" was shown for both an empty platform and a
+              // search that matched nothing, so the operator could not
+              // tell a typo from a fact.
+              <tr><td colSpan={7} style={{opacity:.8}}>
+                No users match “{appliedSearch}”.{' '}
+                <button className="button ghost" onClick={()=> setSearch('')}>
+                  Clear the search
+                </button>
+              </td></tr>
             ) : rows.length === 0 ? (
-              <tr><td colSpan={7} style={{opacity:.75}}>No users</td></tr>
+              <tr><td colSpan={7} style={{opacity:.75}}>
+                No users have registered yet.
+              </td></tr>
             ) : rows[0] && rows[0].id === undefined ? (
               // HARDENING, not the cure (that is the serializer fix in
               // ADMIN1.5). A malformed row shape used to render as a

--- a/frontend/src/app/admin/components/VerificationTab.tsx
+++ b/frontend/src/app/admin/components/VerificationTab.tsx
@@ -42,25 +42,49 @@ export default function VerificationTab() {
   const [revoking, setRevoking] = useState(false);
   const [revokeReason, setRevokeReason] = useState('');
 
+  /** Whether the document list is a real answer or an unanswered call.
+   *  An empty array from a failed fetch renders identically to an empty
+   *  database — doctrine §4, and this tab had exactly that hole. */
+  const [docsLoaded, setDocsLoaded] = useState(false);
+
   async function loadData() {
     setLoading(true);
     setError('');
+    setDocsLoaded(false);
     try {
-      // Load stats
+      // ADMIN1.5 relapse sweep. Both fetches used to be `if (res.ok)`
+      // with no else: a 500 left `stats` null and `documents` empty, and
+      // the cards below rendered `?? 0` while the table said "No
+      // verified documents yet". A dead endpoint was indistinguishable
+      // from a quiet platform — the fabricated-success pattern ADMIN1
+      // was fired to remove, still alive on this tab.
+      const failures: string[] = [];
+
       const statsRes = await fetch(`${API_BASE}/admin/verification/stats`, {
         headers: { ...authHeaders() }
       });
       if (statsRes.ok) {
         setStats(await statsRes.json());
+      } else {
+        setStats(null);
+        failures.push(`stats (HTTP ${statsRes.status})`);
       }
 
-      // Load documents
       const docsRes = await fetch(`${API_BASE}/admin/verification/documents?limit=50`, {
         headers: { ...authHeaders() }
       });
       if (docsRes.ok) {
         const data = await docsRes.json();
         setDocuments(data.items || []);
+        setDocsLoaded(true);
+      } else {
+        setDocuments([]);
+        failures.push(`documents (HTTP ${docsRes.status})`);
+      }
+
+      if (failures.length) {
+        setError(`Verification data unavailable — ${failures.join(', ')}. `
+          + 'Nothing below is being shown as zero.');
       }
     } catch (e: any) {
       setError(e.message || 'Failed to load verification data');
@@ -117,12 +141,37 @@ export default function VerificationTab() {
 
   return (
     <div className="vstack">
-      {/* Stats Cards */}
+      {/* What this tab covers — stated before the numbers.
+          `document_authenticity` has exactly one live writer:
+          routers/api_v1/router.py, the partner-API lane.
+          `create_document_authenticity` in routers/verification.py has
+          zero callers, so a deed made in the wizard gets a stored PDF
+          hash and no short code. Every count on this tab is therefore an
+          API-lane count. Unlabelled, "Total Documents" read as "every
+          document DeedPro has ever issued", which is off by the entire
+          wizard. Whether wizard deeds should be publicly verifiable is
+          VERIFY1 — a parked product question, not a bug to paper over. */}
+      <div className="card" style={{ borderColor: 'var(--dp-border)' }}>
+        <div style={{ fontWeight: 600, marginBottom: 4 }}>
+          Partner-API documents only
+        </div>
+        <div style={{ fontSize: 13, opacity: 0.75 }}>
+          Verification codes are issued by the partner API. Deeds created in the
+          wizard are stored with a PDF hash but no short code, so they never
+          appear here and are not counted below. Public verification for wizard
+          deeds is an open product decision (VERIFY1), not a gap in this table.
+        </div>
+      </div>
+
+      {/* Stats Cards — em-dash, never 0, when the stats call failed.
+          `?? 0` here was a silent zero of the same family as the Revenue
+          and QR ones ADMIN1 killed: it turned "we could not ask" into
+          "the answer is none". */}
       <div className="grid stats">
-        <StatCard title="Total Documents" value={stats?.total_documents ?? 0} />
-        <StatCard title="Active" value={stats?.active_documents ?? 0} />
-        <StatCard title="Revoked" value={stats?.revoked_documents ?? 0} />
-        <StatCard title="Scans Today" value={stats?.total_scans_today ?? 0} />
+        <StatCard title="Total Documents" value={stats?.total_documents ?? '—'} />
+        <StatCard title="Active" value={stats?.active_documents ?? '—'} />
+        <StatCard title="Revoked" value={stats?.revoked_documents ?? '—'} />
+        <StatCard title="Scans Today" value={stats?.total_scans_today ?? '—'} />
       </div>
 
       {error && (
@@ -135,9 +184,11 @@ export default function VerificationTab() {
       <div className="card">
         <div className="hstack" style={{ justifyContent: 'space-between', marginBottom: 16 }}>
           <div style={{ fontWeight: 700, fontSize: 16 }}>Verified Documents</div>
-          <Badge kind="neutral">{documents.length} documents</Badge>
+          <Badge kind="neutral">
+            {docsLoaded ? `${documents.length} documents` : 'count unavailable'}
+          </Badge>
         </div>
-        
+
         <table className="table">
           <thead>
             <tr>
@@ -151,10 +202,19 @@ export default function VerificationTab() {
             </tr>
           </thead>
           <tbody>
-            {documents.length === 0 ? (
+            {!docsLoaded ? (
+              <tr>
+                <td colSpan={7} style={{ color: 'var(--dp-danger)', textAlign: 'center', padding: 24 }}>
+                  The document list did not load. This is not an empty table —
+                  it is an unanswered request.
+                </td>
+              </tr>
+            ) : documents.length === 0 ? (
               <tr>
                 <td colSpan={7} style={{ opacity: 0.75, textAlign: 'center', padding: 24 }}>
-                  No verified documents yet. Documents will appear here when deeds are generated with QR codes.
+                  No partner-API documents yet. A row appears here when a deed is
+                  generated through the partner API, which issues the short code.
+                  Wizard deeds are never listed here — see the note above.
                 </td>
               </tr>
             ) : documents.map(doc => (

--- a/frontend/src/lib/adminApi.ts
+++ b/frontend/src/lib/adminApi.ts
@@ -9,12 +9,32 @@
 // TYPES
 // ============================================================================
 
-export type Paged<T> = { 
-  items: T[]; 
-  page: number; 
-  limit: number; 
-  total: number 
+export type Paged<T> = {
+  items: T[];
+  page: number;
+  limit: number;
+  total: number;
+  /** The sort the server actually applied — echoed so the UI can say it
+   *  rather than assume it. See USER_SORTS/DEED_SORTS in admin_api_v2. */
+  sort?: string;
 };
+
+/** Sort keys the users list accepts. Mirrors USER_SORTS server-side. */
+export const USER_SORT_OPTIONS: Array<{ key: string; label: string }> = [
+  { key: 'newest', label: 'Newest first' },
+  { key: 'oldest', label: 'Oldest first' },
+  { key: 'email', label: 'Email A–Z' },
+  { key: 'deeds', label: 'Most deeds' },
+  { key: 'last_login', label: 'Last login' },
+];
+
+/** Sort keys the deeds list accepts. Mirrors DEED_SORTS server-side. */
+export const DEED_SORT_OPTIONS: Array<{ key: string; label: string }> = [
+  { key: 'newest', label: 'Newest first' },
+  { key: 'oldest', label: 'Oldest first' },
+  { key: 'updated', label: 'Recently updated' },
+  { key: 'type', label: 'Deed type' },
+];
 
 export type ApiKeyRow = {
   id: string;
@@ -93,7 +113,19 @@ export type StatSummary = {
   total_users: number;
   active_users: number;
   total_deeds: number;
+  /**
+   * A CALENDAR-MONTH count. On the 2nd of a month it is near zero on a
+   * platform that never slowed down — which is why it never travels
+   * alone any more: `deeds_this_month_since` states the window it
+   * means, and `deeds_last_30_days` is the figure that does not reset
+   * at midnight on the 1st. Rendering this number without its label was
+   * the "This Month 0" the browser audit read as a collapse.
+   */
   deeds_this_month?: number;
+  /** ISO date the calendar-month window opens on. */
+  deeds_this_month_since?: string | null;
+  /** Rolling 30-day deed count — the reconciling figure. */
+  deeds_last_30_days?: number;
   /**
    * ADMIN1: /admin/dashboard has always computed a real 7-day signup +
    * deed feed and no frontend rendered it. It is the closest thing the
@@ -217,16 +249,19 @@ export const AdminApi = {
   getSummary: () => http<StatSummary>('/admin/dashboard'),
 
   // Users Management
-  searchUsers: (page = 1, limit = 25, search = '') =>
-    http<Paged<UserRow>>(`/admin/users/search?page=${page}&limit=${limit}&search=${encodeURIComponent(search)}`),
+  searchUsers: (page = 1, limit = 25, search = '', sort = 'newest') =>
+    http<Paged<UserRow>>(
+      `/admin/users/search?page=${page}&limit=${limit}` +
+      `&search=${encodeURIComponent(search)}&sort=${encodeURIComponent(sort)}`
+    ),
   
   getUser: (id: number) => http<UserDetail>(`/admin/users/${id}`),
 
   // Deeds Management — /admin/deeds/search is the real endpoint: honest
   // statuses (draft/completed/deleted) and a working status + user filter.
   // (Its predecessor /admin/deeds hardcoded every status to "completed".)
-  searchDeeds: (page = 1, limit = 25, search = '', status = '', userId?: number) => {
-    const qs = new URLSearchParams({ page: String(page), limit: String(limit) });
+  searchDeeds: (page = 1, limit = 25, search = '', status = '', userId?: number, sort = 'newest') => {
+    const qs = new URLSearchParams({ page: String(page), limit: String(limit), sort });
     if (search) qs.set('search', search);
     if (status) qs.set('status', status);
     if (userId != null) qs.set('user_id', String(userId));


### PR DESCRIPTION
PR #113 fixed the **shape** of the admin console's data — rows serialise as objects, the drill-downs resolve. This is the rest of the sharpened ADMIN1.5 scope: the numbers *inside* that shape.

Four readings the browser audit took off the screen. Every one gave a wrong impression, and not one of them came from a wrong number.

## Reconciliation

**"Deeds This Month: 0."** A calendar-month count read on the 2nd of a month. The count was correct; the card was unlabelled, so a healthy platform read as a collapse. The window's start date now travels with the number (`deeds_this_month_since`) and a rolling 30-day count sits beside it, with a line stating the two are expected to disagree.

**Labelled denominators.** The by-deed-type bar chart drew percentages off `stored_pdfs` and never named that base. The denominator is now in the heading, the count leads and the share follows (`3 of 7 (43%)`), and below n=20 the chart says outright that each document is worth ~5 points — at these sample sizes a confident distribution chart is the most persuasive way to show a reader something that is not there.

**The Verification tab's lane.** `document_authenticity` has exactly one live writer: `routers/api_v1/router.py`, the partner API. `create_document_authenticity` in `routers/verification.py` has zero callers, so wizard deeds carry a stored PDF hash and no short code — VERIFY1, parked. Unlabelled, "Total Documents" read as *every document DeedPro has issued*, off by the entire wizard. The tab now scopes itself before it counts, and its empty state stops promising rows this lane cannot produce ("documents will appear here when deeds are generated with QR codes" — they will not).

## Stats-honesty relapse sweep

The ADMIN1 defect class, alive in places ADMIN1 did not look.

**0ms.** `db_latency = int((time.time() - start) * 1000)` — a healthy same-region probe lands well under a millisecond and truncated to `0`, so the console reported "0ms latency". A zero manufactured by rounding is exactly what ADMIN1 spent a PR removing. It was also the wrong clock: `time.time()` is wall-clock and steps under NTP. Measured on `perf_counter()` now, and **null rather than 0 when the probe fails** — a database that did not answer has no latency, and "0ms" under an Offline badge was the most confident wrong number on the screen.

**Swallowed failures on the Verification tab.** Both fetches were `if (res.ok)` with no `else`. A 500 left the cards rendering `?? 0` while the table said "No verified documents yet" — a dead endpoint indistinguishable from a quiet platform. Doctrine §4, on a tab ADMIN1 never opened. Stats now render an em-dash, the list distinguishes "empty" from "unanswered", and the failure is named.

**QR source.** The Overview card is labelled with its lane and its window rather than "QR Scans (Week)".

## Frictions

- **One shared `Pager`.** `Math.max(1, …)` reported "Page 1 / 1" over an empty result set — a page that does not exist, announced with confidence. The position came from local state and the total from the last response, so during a filter change the header read "Page 3 / 1" above an empty table: the count and the position were describing different result sets. It now says "No deeds", or the position with the total beside it.
- **Search feedback.** Three states — searching, matched nothing, genuinely empty — all rendered as one blank table. Each is named, the query is quoted back, there is a way out of a filter that matched nothing, and a failed request is no longer an empty table.
- **Double load on mount.** Both tabs fired two identical requests when opened.
- **Default sort.** Both lists were hard-sorted `created_at DESC` with nothing on screen saying so. The sort is stated and changeable, and the server echoes the sort it applied rather than the client assuming its request was honoured.

### One thing worth a second look

The `ORDER BY` fragment is interpolated into an f-string that already interpolates a `WHERE` clause. That is safe **only** while every value comes from a fixed map, so `sort` resolves through `USER_SORTS` / `DEED_SORTS` with a 400 on miss — a dict lookup, never a format of user input. The pin (`test_sort_keys_resolve_through_a_map_and_never_reach_sql_directly`) asserts the mechanism rather than a list of hostile strings nobody can enumerate.

## Not in this PR

**ADMIN-BRAND** follows immediately as its own PR — the console's `--dp-primary` is still the pre-brand orange, and `--dp-warn` is referenced in three places without ever being defined, so it silently falls back to a hardcoded hex every time.

## Gates

| gate | result |
|---|---|
| backend pytest | 362 passed (was 355) |
| jest | 372 passed, 31 suites |
| six-flow baseline | verify OK |
| API baseline | verify OK |
| tsc | 94 — unchanged |
| OpenAPI snapshot | untouched; it pins (method, path) and `sort` is an additive optional query param |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_