### PR TITLE
ADMIN-BRAND: the console is a DeedPro surface, and amber means something

### DIFF
--- a/docs/BRAND.md
+++ b/docs/BRAND.md
@@ -62,6 +62,31 @@ These are the suggest→confirm→record doctrine expressed as color. A
 designer changing amber to blue is changing the product's honesty
 system, not a palette.
 
+### The admin console (ADMIN-BRAND)
+
+The console is an app surface and carries the same accent. Its tokens
+live in `frontend/src/app/admin/styles/tokens.css` — plain CSS variables
+rather than Tailwind classes, mirroring `brand.*`. Its accent was
+`#F57C00` orange until ADMIN-BRAND: a color on no other DeedPro surface,
+sitting in the family doctrine reserves for a meaning.
+
+The console has no officer decisions in it, so violet's "proposed legal
+choice" has nothing to attach to and purple is simply the accent there.
+Amber's meaning carries across with the nearest honest reading, stated
+rather than assumed: **a value that is real but must not be read at face
+value** — unconfirmed, unmeasured, or degraded. Absence ("not
+monitored", "not measured", an em-dash) is neutral gray, not amber:
+that is a fact about our instrumentation, not a warning about data.
+Failure is red. Amber never fills a control, because a fill describes an
+action and amber describes data.
+
+`adminBrand.test.ts` enforces this structurally, and enforces something
+a palette pin would miss: every `var(--dp-*)` an admin file references
+must be declared in `tokens.css`. Four tokens (`--dp-warn`, `--dp-error`,
+`--dp-muted`, `--dp-brand`) were referenced for months without ever being
+defined, each written with a hex fallback that therefore rendered every
+time — those surfaces were not reading the token file at all.
+
 ## Typography
 
 **Wordmark: Plus Jakarta Sans 800**, tracked `-0.025em` — a geometric-

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -4,8 +4,8 @@
 (not only in chat) so the list survives context windows. No credential
 values ever appear in this file — item names and status only.
 
-_Last corrected: 2026-08-03 (ADMIN0 rulings recorded: wave order,
-audit-log shape, supersession + VERIFY1 parked)._
+_Last corrected: 2026-08-03 (ADMIN1.5 split across #113/#114 recorded;
+ADMIN-BRAND #115 with its one extended reading flagged for the owner)._
 
 ## Open — owner's card
 
@@ -98,8 +98,17 @@ audit-log shape, supersession + VERIFY1 parked)._
 ## Approved wave — ADMIN (ADMIN0 audit, 2026-08-03)
 
 Order **re-approved 2026-08-03** after the browser audit:
-**ADMIN1 ✅ → BILL1 ✅ → ADMIN1.5 (+ADMIN-BRAND) → ADMIN3 → ADMIN2 →
+**ADMIN1 ✅ → BILL1 ✅ → ADMIN1.5 ✅ (+ADMIN-BRAND ✅) → ADMIN3 → ADMIN2 →
 ADMIN4 → ADMIN5 → ADMIN6.**
+
+ADMIN1.5 shipped in **two** PRs, which is worth recording so the
+sequencing sync reads correctly against the history: **#113** carried the
+serializer half (row type, field contract, the `/real` fossil, the CSV
+check) and **#114** the rest of the sharpened scope (reconciliation,
+stats-honesty relapse sweep, frictions). **ADMIN-BRAND is #115**, stacked
+on #114 because both touch the same three components.
+
+**Next: ADMIN3** (email outcome persistence).
 
 ADMIN3 was **promoted above ADMIN2**: it answers the 3 AM question, and
 ADMIN2's queue surface depends on knowing what failed. ADMIN5 needs a
@@ -114,12 +123,41 @@ we reach it.
   subclass, so rows serialised as JSON arrays and every by-name read
   came back undefined. Fixed at the row type (`HybridRow` — dict
   subclass AND index-addressable), with the field contract pinned
-  against real serialised output.
-- **ADMIN-BRAND** — the console adopts the BRAND2 tokens. Rides with or
-  immediately after ADMIN1.5. Not cosmetic: the current orange palette
-  predates the brand and collides with doctrine, since amber now means
-  unconfirmed external data. Decorative amber/violet dies; the doctrinal
-  colors appear in admin only with their meanings.
+  against real serialised output. **(#113)**
+- **ADMIN1.5, second half (#114)** — the numbers inside the fixed shape.
+  *Reconciliation:* the month card states its window and travels with a
+  rolling 30-day count; percentage charts name their denominator and say
+  so when n is too small to read as a distribution; the Verification tab
+  scopes itself to the partner-API lane it actually covers.
+  *Relapse sweep:* database latency was `int(seconds * 1000)`, which
+  truncated a healthy sub-millisecond probe to a "0ms" that read as a
+  measurement — and reported 0 under an Offline badge. Now
+  `perf_counter()`, and null on a failed probe. The Verification tab's
+  two fetches had no failure branch, so a 500 rendered as `?? 0` beside
+  "No verified documents yet".
+  *Frictions:* one shared pager that stops announcing "Page 1 / 1" over
+  an empty set, three distinguishable search states, and a stated,
+  changeable sort behind a server-side allowlist.
+- **ADMIN-BRAND** (#115) — the console adopts the BRAND2 tokens. Not
+  cosmetic: the orange palette predated the brand and collided with
+  doctrine, since amber means unconfirmed external data. Decorative
+  amber/violet is gone; the doctrinal colors appear in admin only with
+  their meanings, and those meanings are now written in `docs/BRAND.md`
+  beside the values.
+  **One reading was extended, not assumed — owner's to confirm or
+  narrow:** BRAND.md defines amber for the officer-facing flow
+  ("unconfirmed external data"). The console has no officer decisions in
+  it, so amber there means *a value that is real but must not be read at
+  face value* — unconfirmed, unmeasured, or degraded. Absence is neutral
+  gray and failure is red, so amber did not simply become "warning".
+  **Second finding, from the sweep:** four tokens (`--dp-warn`,
+  `--dp-error`, `--dp-muted`, `--dp-brand`) were referenced across the
+  console and **declared nowhere**. Every reference carried a hex
+  fallback, so those surfaces rendered the fallback every time and were
+  never reading the token file — including a `#333` border and a
+  `#1a1a2e` dark-navy chip on a light theme. A palette swap alone would
+  have left them orange-adjacent and untouched. Pinned now: every
+  `var(--dp-*)` must resolve to a declaration in `tokens.css`.
 
 - **ADMIN1 — truth pass + operator home.** Kills the fabricated System
   values (`pdf_engine` hardcoded `"up"`, `avg_time_ms` never assigned,

--- a/frontend/src/__tests__/adminBrand.test.ts
+++ b/frontend/src/__tests__/adminBrand.test.ts
@@ -1,0 +1,147 @@
+/**
+ * ADMIN-BRAND — the console is a DeedPro surface, and its colors mean
+ * what they mean everywhere else.
+ *
+ * Two separate problems, and the second is why this file checks a
+ * mechanism rather than a palette:
+ *
+ * 1. The console's accent was `#F57C00` orange. It appears on no other
+ *    DeedPro surface, and it sits in the amber family that BRAND.md
+ *    reserves for a MEANING — "unconfirmed external data". An operator
+ *    scanning for the amber that says "a machine suggested this, no
+ *    human has confirmed it" was reading past an orange used for nav
+ *    highlights, buttons and a logo tile.
+ *
+ * 2. Four tokens the console referenced — `--dp-warn`, `--dp-error`,
+ *    `--dp-muted`, `--dp-brand` — were never defined anywhere. Every one
+ *    was written as `var(--dp-warn, #b26a00)`, so the fallback hex
+ *    rendered every single time. The console was not styled by its token
+ *    file at all in those places; it was styled by whatever hex the last
+ *    author typed inside the parentheses, including a `#333` border and
+ *    a `#1a1a2e` dark-navy surface on a light theme.
+ *
+ * A palette pin would have caught the first and missed the second
+ * entirely. So the load-bearing test here is the one that resolves every
+ * referenced token against tokens.css: an undefined token cannot be
+ * rebranded, because nothing it says is being read.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ADMIN = path.join(__dirname, '..', 'app', 'admin');
+const TOKENS = path.join(ADMIN, 'styles', 'tokens.css');
+
+/** Every .tsx/.css file under src/app/admin. */
+function adminFiles(dir = ADMIN, acc: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) adminFiles(full, acc);
+    else if (/\.(tsx?|css)$/.test(entry.name)) acc.push(full);
+  }
+  return acc;
+}
+
+function withoutComments(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+}
+
+const FILES = adminFiles().map((f) => [path.relative(ADMIN, f), fs.readFileSync(f, 'utf8')] as const);
+const CODE = FILES.map(([name, src]) => [name, withoutComments(src)] as const);
+
+describe('every admin token resolves to a definition', () => {
+  const declared = new Set(
+    [...fs.readFileSync(TOKENS, 'utf8').matchAll(/^\s*(--dp-[a-z0-9-]+)\s*:/gm)]
+      .map((m) => m[1])
+  );
+
+  it('tokens.css declares the palette', () => {
+    expect(declared.size).toBeGreaterThan(20);
+  });
+
+  for (const [name, src] of CODE) {
+    if (name === 'styles/tokens.css') continue;
+    it(`${name} references only declared tokens`, () => {
+      const used = [...src.matchAll(/var\(\s*(--dp-[a-z0-9-]+)/g)].map((m) => m[1]);
+      const undeclared = [...new Set(used)].filter((t) => !declared.has(t));
+      expect(undeclared).toEqual([]);
+    });
+  }
+});
+
+describe('no color is spelled as a raw hex at a call site', () => {
+  for (const [name, src] of CODE) {
+    if (name === 'styles/tokens.css') continue;
+    it(`${name} reads colors from tokens`, () => {
+      // A hex fallback inside var() is the specific form that let four
+      // undefined tokens render their fallback for months.
+      expect(src).not.toMatch(/var\(\s*--dp-[a-z0-9-]+\s*,\s*#/);
+      const hexes = [...src.matchAll(/#[0-9a-fA-F]{3,8}\b/g)].map((m) => m[0]);
+      expect(hexes).toEqual([]);
+    });
+  }
+});
+
+describe('the accent is the brand, not the console\'s own orange', () => {
+  const tokens = fs.readFileSync(TOKENS, 'utf8');
+
+  it('the primary token is brand purple', () => {
+    expect(tokens).toMatch(/--dp-primary:\s*#7C4DFF/i);
+  });
+
+  it('the pre-brand orange family is gone from every admin file', () => {
+    // #F57C00 / #ea580c / #c2410c / #FF9800 — the old --dp-primary ramp
+    // and the sidebar logo gradient.
+    const ORANGE = /#(F57C00|FF9800|ea580c|c2410c|fff7ed|F26B2B)/i;
+    const offenders = FILES
+      .filter(([, src]) => ORANGE.test(withoutComments(src)))
+      .map(([name]) => name);
+    expect(offenders).toEqual([]);
+  });
+
+  it('the sidebar mark uses the brand ramp', () => {
+    const layout = fs.readFileSync(path.join(ADMIN, 'styles', 'admin-layout.css'), 'utf8');
+    expect(layout).toMatch(/\.admin-logo-icon[\s\S]{0,400}var\(--dp-primary\)/);
+  });
+});
+
+describe('doctrinal colors appear only with their meanings', () => {
+  const tokens = fs.readFileSync(TOKENS, 'utf8');
+
+  it('tokens.css states what amber, red and green mean here', () => {
+    // BRAND.md: "A designer changing amber to blue is changing the
+    // product's honesty system, not a palette." The meanings must be
+    // written down where the values are, or the next edit is a palette
+    // edit by default.
+    expect(tokens).toContain('unconfirmed');
+    expect(tokens).toMatch(/--dp-warning:\s*#F59E0B/i);
+    expect(tokens).toContain('--dp-absent');
+  });
+
+  it('amber never fills a control', () => {
+    // Fills are for actions; amber describes DATA. A filled amber button
+    // spends the doctrine color on something that carries no meaning —
+    // and this is precisely what the Suspend button used to do.
+    for (const [name, src] of CODE) {
+      if (!/\.tsx$/.test(name)) continue;
+      const fills = [...src.matchAll(/background:\s*'var\((--dp-warning[a-z-]*)\)'/g)];
+      expect(fills.map((m) => `${name}: ${m[1]}`)).toEqual([]);
+    }
+  });
+
+  it('absence is neutral, not amber', () => {
+    // "Not monitored" and "not measured" are facts about our
+    // instrumentation, not warnings about data.
+    const system = fs.readFileSync(path.join(ADMIN, 'components', 'SystemTab.tsx'), 'utf8');
+    expect(system).toMatch(/status === 'not_monitored'\)\s*return <Badge kind="neutral"/);
+  });
+
+  it('the amber used for body text is the legible one', () => {
+    // #F59E0B on a near-white wash does not clear contrast for text; a
+    // doctrine color that cannot be read does not carry its meaning.
+    for (const [name, src] of CODE) {
+      if (!/\.tsx$/.test(name)) continue;
+      expect(src).not.toMatch(/color:\s*'var\(--dp-warning\)'/);
+    }
+  });
+});

--- a/frontend/src/app/admin/components/ApiTab.tsx
+++ b/frontend/src/app/admin/components/ApiTab.tsx
@@ -139,13 +139,13 @@ export default function ApiTab() {
       {/* The full key is displayed exactly once — it is bcrypt-hashed at
           rest and cannot be recovered afterward. */}
       {minted && (
-        <div className="card" style={{ borderColor: 'var(--dp-brand, #7C4DFF)' }}>
+        <div className="card" style={{ borderColor: 'var(--dp-primary)' }}>
           <div style={{ fontWeight: 700, marginBottom: 8 }}>
             Copy this key now — it cannot be shown again
           </div>
           <code
             style={{
-              display: 'block', padding: '12px 14px', background: 'var(--dp-surface-2, #f7f8fa)',
+              display: 'block', padding: '12px 14px', background: 'var(--dp-surface-2)',
               borderRadius: 8, wordBreak: 'break-all', fontSize: 14, marginBottom: 12,
             }}
           >
@@ -190,7 +190,7 @@ export default function ApiTab() {
         )}
 
         {keys.length === 0 ? (
-          <div style={{ color: 'var(--dp-muted, #8a94a0)' }}>
+          <div style={{ color: 'var(--dp-text-dim)' }}>
             No API keys yet. Keys are issued manually — create one after you&apos;ve
             talked with the partner.
           </div>
@@ -241,7 +241,7 @@ export default function ApiTab() {
         </div>
 
         {requests.length === 0 ? (
-          <div style={{ color: 'var(--dp-muted, #8a94a0)' }}>
+          <div style={{ color: 'var(--dp-text-dim)' }}>
             No inquiries yet. Submissions from the API access form land here.
           </div>
         ) : (
@@ -261,7 +261,7 @@ export default function ApiTab() {
                       {r.notify_error && (
                         // The request survived an email failure — say so,
                         // rather than letting it look like it never came.
-                        <div style={{ fontSize: 12, color: 'var(--dp-warn, #b26a00)' }}>
+                        <div style={{ fontSize: 12, color: 'var(--dp-warning-strong)' }}>
                           notification email failed — {r.notify_error}
                         </div>
                       )}

--- a/frontend/src/app/admin/components/Overview.tsx
+++ b/frontend/src/app/admin/components/Overview.tsx
@@ -149,7 +149,7 @@ export default function OverviewTab(){
             </div>
           </div>
           {scanErr && (
-            <div style={{ fontSize: 12, color: 'var(--dp-warning)', marginTop: 8 }}>
+            <div style={{ fontSize: 12, color: 'var(--dp-warning-strong)', marginTop: 8 }}>
               Shown as unavailable — {scanErr}
             </div>
           )}

--- a/frontend/src/app/admin/components/SystemTab.tsx
+++ b/frontend/src/app/admin/components/SystemTab.tsx
@@ -177,7 +177,7 @@ export default function SystemTab() {
           )}
           {stuck > 0 && (
             // The H1 silent-store class, visible from the console at last.
-            <div className="card" style={{ borderColor: 'var(--dp-warn, #b26a00)' }}>
+            <div className="card" style={{ borderColor: 'var(--dp-warning-strong)' }}>
               <strong>{stuck}</strong> completed deed{stuck === 1 ? ' has' : 's have'} no
               stored PDF. These are recoverable — the artifact regenerates on next
               download — but a persistent count here means the store is failing.
@@ -209,7 +209,7 @@ export default function SystemTab() {
               is the count above, not all deeds.
             </div>
             {smallSample && (
-              <div style={{ fontSize: 12, color: 'var(--dp-warning)', marginBottom: 12 }}>
+              <div style={{ fontSize: 12, color: 'var(--dp-warning-strong)', marginBottom: 12 }}>
                 n = {base}. At this size each document is worth
                 ~{Math.round(100 / base)} percentage points, so treat the bars as
                 a tally with a scale, not as a distribution.
@@ -219,12 +219,12 @@ export default function SystemTab() {
               {Object.entries(pdfStats.by_type).map(([type, count]) => (
                 <div key={type} style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
                   <div style={{ width: 180, fontSize: 13 }}>{formatDeedType(type)}</div>
-                  <div style={{ flex: 1, height: 8, background: 'var(--dp-border, #333)', borderRadius: 4, overflow: 'hidden' }}>
+                  <div style={{ flex: 1, height: 8, background: 'var(--dp-border)', borderRadius: 4, overflow: 'hidden' }}>
                     <div
                       style={{
                         height: '100%',
                         width: `${share(count as number)}%`,
-                        background: 'var(--dp-primary, #7C4DFF)',
+                        background: 'var(--dp-primary)',
                         borderRadius: 4,
                       }}
                     />

--- a/frontend/src/app/admin/components/UsersTab.tsx
+++ b/frontend/src/app/admin/components/UsersTab.tsx
@@ -179,7 +179,7 @@ export default function UsersTab(){
               <div><strong>Stripe Customer:</strong> {modal.stripe_customer_id || '—'}</div>
               <div><strong>Deeds Created:</strong> {modal.deed_count ?? modal.deed_stats?.total ?? '—'}</div>
             </div>
-            <div className="hstack" style={{justifyContent:'flex-end', gap:8, paddingTop:12, borderTop:'1px solid var(--dp-border, #333)'}}>
+            <div className="hstack" style={{justifyContent:'flex-end', gap:8, paddingTop:12, borderTop:'1px solid var(--dp-border)'}}>
               <button 
                 className="button" 
                 onClick={()=>{

--- a/frontend/src/app/admin/components/VerificationTab.tsx
+++ b/frontend/src/app/admin/components/VerificationTab.tsx
@@ -221,7 +221,7 @@ export default function VerificationTab() {
               <tr key={doc.short_code}>
                 <td>
                   <code style={{ 
-                    background: 'var(--dp-surface, #1a1a2e)', 
+                    background: 'var(--dp-surface)', 
                     padding: '2px 6px', 
                     borderRadius: 4,
                     fontSize: 12
@@ -308,8 +308,8 @@ export default function VerificationTab() {
             </div>
 
             {selectedDoc.status === 'active' && (
-              <div style={{ borderTop: '1px solid var(--dp-border, #333)', paddingTop: 16 }}>
-                <div style={{ fontWeight: 600, marginBottom: 8, color: 'var(--dp-danger, #ef4444)' }}>
+              <div style={{ borderTop: '1px solid var(--dp-border)', paddingTop: 16 }}>
+                <div style={{ fontWeight: 600, marginBottom: 8, color: 'var(--dp-danger)' }}>
                   Revoke Document
                 </div>
                 <div style={{ fontSize: 12, opacity: 0.7, marginBottom: 12 }}>
@@ -324,7 +324,7 @@ export default function VerificationTab() {
                 />
                 <button 
                   className="button" 
-                  style={{ background: 'var(--dp-danger, #ef4444)', color: 'white' }}
+                  style={{ background: 'var(--dp-danger)', color: 'white' }}
                   onClick={handleRevoke}
                   disabled={revoking || !revokeReason.trim()}
                 >

--- a/frontend/src/app/admin/styles/admin-honest.css
+++ b/frontend/src/app/admin/styles/admin-honest.css
@@ -126,9 +126,13 @@
   color: var(--dp-success);
 }
 
+/* Amber carries a meaning (see tokens.css): the value is real but must
+   not be read at face value. The text uses the darker amber because
+   #F59E0B on a near-white wash does not clear contrast for body text —
+   the doctrine color must be legible to do its job. */
 .badge.warn {
   background: var(--dp-warning-light);
-  color: var(--dp-warning);
+  color: var(--dp-warning-strong);
 }
 
 .badge.danger {

--- a/frontend/src/app/admin/styles/admin-layout.css
+++ b/frontend/src/app/admin/styles/admin-layout.css
@@ -12,7 +12,7 @@
 /* Sidebar */
 .admin-sidebar {
   width: 260px;
-  background: #fff;
+  background: var(--dp-panel);
   border-right: 1px solid var(--dp-border);
   display: flex;
   flex-direction: column;
@@ -38,7 +38,10 @@
 .admin-logo-icon {
   width: 36px;
   height: 36px;
-  background: linear-gradient(135deg, #F57C00 0%, #FF9800 100%);
+  /* ADMIN-BRAND: was an orange gradient that appeared on no other
+     DeedPro surface. The console's mark now reads as the same product
+     as the app it administers. */
+  background: linear-gradient(135deg, var(--dp-primary) 0%, var(--dp-primary-active) 100%);
   border-radius: 10px;
   display: flex;
   align-items: center;

--- a/frontend/src/app/admin/styles/tokens.css
+++ b/frontend/src/app/admin/styles/tokens.css
@@ -1,42 +1,93 @@
+/* ============================================================
+   Admin console tokens — ADMIN-BRAND
+   ============================================================
+
+   The console predates the brand. Its accent was #F57C00 orange, which
+   is not a DeedPro color and, worse, sits in the amber family that
+   doctrine reserves for a meaning (see docs/BRAND.md → "Doctrinal colors
+   are brand"). An operator scanning this screen for the amber that says
+   "a machine suggested this, no human has confirmed it" was reading past
+   an orange used for buttons, nav highlights and a logo tile.
+
+   Two rules govern this file:
+
+   1. The accent is brand purple (#7C4DFF), matching every other
+      DeedPro surface. Admin is an app surface, not a separate product.
+   2. The doctrinal colors appear here only WITH their meanings —
+      never as decoration.
+
+   A note on scope, flagged rather than assumed: BRAND.md defines amber
+   as "unconfirmed external data" in the officer-facing flow. The admin
+   console has no officer decisions in it, so the nearest honest reading
+   is used below and stated explicitly rather than quietly widened.
+
+   Nothing here should be spelled as a raw hex at a call site. Every
+   admin surface reads these variables, and adminBrand.test.ts fails the
+   build if a component hardcodes a color or references a token this file
+   does not define — which is how four undefined tokens (--dp-warn,
+   --dp-error, --dp-muted, --dp-brand) spent months silently rendering
+   their fallback hex instead of anything in the palette. */
+
 :root{
-  /* Light Professional Theme */
+  /* Neutrals — light professional surface (unchanged; already on-brand) */
   --dp-bg: #f8fafc;
   --dp-bg-subtle: #f1f5f9;
   --dp-panel: #ffffff;
   --dp-panel-alt: #f8fafc;
   --dp-border: #e2e8f0;
   --dp-border-hover: #cbd5e1;
+
+  /* Ink — BRAND.md's wordmark ink for headings, slate for body/dim */
+  --dp-ink: #1F2B37;
   --dp-text: #1e293b;
   --dp-text-dim: #64748b;
   --dp-text-muted: #94a3b8;
-  
-  /* Brand - Subtle Orange Accent */
-  --dp-primary: #F57C00;
-  --dp-primary-light: #fff7ed;
-  --dp-primary-600: #ea580c;
-  --dp-primary-hover: #c2410c;
-  
-  /* Status Colors */
-  --dp-success: #059669;
-  --dp-success-light: #ecfdf5;
-  --dp-warning: #d97706;
-  --dp-warning-light: #fffbeb;
+
+  /* Brand — the single accent. tailwind.config.js `brand.*` is the
+     source of truth for these values; they are mirrored here because
+     the admin console is plain CSS, not Tailwind classes. */
+  --dp-primary: #7C4DFF;        /* brand-500 — actions, focus, nav */
+  --dp-primary-light: #F5F3FF;  /* brand-50  — active nav wash */
+  --dp-primary-600: #6a3de8;    /* brand-600 */
+  --dp-primary-hover: #6a3de8;
+  --dp-primary-active: #5b32d1; /* brand-700 */
+
+  /* ── Doctrinal colors — meanings, not decoration ──────────────
+     AMBER says the value on screen must not be read at face value:
+     unconfirmed, unmeasured, or degraded. It is the console's reading
+     of BRAND.md's "unconfirmed external data" — a number the machine
+     produced that no one has stood behind. It is NOT a warning-flavored
+     accent, and it never fills a button.
+
+     RED says something failed or is unavailable. An error, not a state.
+
+     GREEN says a probe completed and passed. Never a default. */
+  --dp-warning: #F59E0B;        /* warning.500 — matches the app */
+  --dp-warning-strong: #b45309; /* legible amber for body text */
+  --dp-warning-light: #FFFBEB;
   --dp-danger: #dc2626;
   --dp-danger-light: #fef2f2;
-  
+  --dp-success: #059669;
+  --dp-success-light: #ecfdf5;
+
+  /* Absence is neutral, not amber. "Not monitored", "not measured" and
+     "—" are facts about our instrumentation, not warnings about data. */
+  --dp-absent: #94a3b8;
+
   /* Shadows */
   --dp-shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.04);
   --dp-shadow: 0 1px 3px rgba(0, 0, 0, 0.08), 0 1px 2px rgba(0, 0, 0, 0.04);
   --dp-shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.08), 0 2px 4px -1px rgba(0, 0, 0, 0.04);
   --dp-shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.08), 0 4px 6px -2px rgba(0, 0, 0, 0.04);
-  
+
   /* Radius */
   --dp-radius: 12px;
   --dp-radius-sm: 8px;
   --dp-radius-xs: 6px;
   --dp-radius-full: 9999px;
-  
-  /* Hover */
+
+  /* Interaction surfaces */
   --dp-hover: #f1f5f9;
   --dp-surface: #f8fafc;
+  --dp-surface-2: #f1f5f9;
 }

--- a/frontend/src/app/admin/users/[id]/page.tsx
+++ b/frontend/src/app/admin/users/[id]/page.tsx
@@ -134,19 +134,23 @@ export default function UserDetailPage() {
           {!isEditing ? (
             <>
               <button className="button" onClick={() => setIsEditing(true)}>Edit</button>
-              <button 
-                className="button" 
-                style={{
-                  background: user.is_active ? 'var(--dp-warning, #f59e0b)' : 'var(--dp-success, #10b981)', 
-                  color: 'white'
-                }} 
+              {/* ADMIN-BRAND: this was a filled amber button. Amber
+                  describes DATA the reader should not take at face value;
+                  it does not describe an ACTION. A filled doctrine color
+                  on a control is the decorative use the ruling kills —
+                  and it also made Suspend compete with Delete for the
+                  eye. Outline treatment: present, deliberate, not
+                  shouting, and the colour vocabulary stays honest. */}
+              <button
+                className="button ghost"
+                style={{ borderColor: 'var(--dp-border-hover)' }}
                 onClick={handleSuspend}
               >
                 {user.is_active ? '⏸ Suspend' : '▶ Unsuspend'}
               </button>
               <button 
                 className="button" 
-                style={{background: 'var(--dp-error, #ef4444)', color: 'white'}} 
+                style={{background: 'var(--dp-danger)', color: 'white'}} 
                 onClick={handleDelete}
               >
                 Delete
@@ -174,7 +178,7 @@ export default function UserDetailPage() {
       </div>
       
       {error && (
-        <div className="card" style={{background: 'var(--dp-error, #ef4444)', color: 'white', marginBottom: 16, padding: 16}}>
+        <div className="card" style={{background: 'var(--dp-danger)', color: 'white', marginBottom: 16, padding: 16}}>
           <strong>Error:</strong> {error}
         </div>
       )}
@@ -222,9 +226,9 @@ export default function UserDetailPage() {
                   </div>
                   <div style={{display: 'flex', alignItems: 'center', gap: 8}}>
                     {user.is_active ? (
-                      <><span style={{color: 'var(--dp-success, #10b981)'}}>✅ Active</span> <span style={{opacity: 0.6, fontSize: 12}}>- Can login</span></>
+                      <><span style={{color: 'var(--dp-success)'}}>✅ Active</span> <span style={{opacity: 0.6, fontSize: 12}}>- Can login</span></>
                     ) : (
-                      <><span style={{color: 'var(--dp-error, #ef4444)'}}>❌ Suspended</span> <span style={{opacity: 0.6, fontSize: 12}}>- Cannot login</span></>
+                      <><span style={{color: 'var(--dp-danger)'}}>❌ Suspended</span> <span style={{opacity: 0.6, fontSize: 12}}>- Cannot login</span></>
                     )}
                   </div>
                 </div>
@@ -235,9 +239,9 @@ export default function UserDetailPage() {
                   </div>
                   <div style={{display: 'flex', alignItems: 'center', gap: 8}}>
                     {user.verified ? (
-                      <><span style={{color: 'var(--dp-success, #10b981)'}}>✅ Verified</span></>
+                      <><span style={{color: 'var(--dp-success)'}}>✅ Verified</span></>
                     ) : (
-                      <><span style={{color: 'var(--dp-warning, #f59e0b)'}}>⚠️ Not Verified</span></>
+                      <><span style={{color: 'var(--dp-warning-strong)'}}>⚠️ Not Verified</span></>
                     )}
                   </div>
                 </div>
@@ -339,7 +343,7 @@ export default function UserDetailPage() {
                 <div style={{fontWeight: 600}}>{user.deed_stats?.drafts ?? 0}</div>
               </div>
             </div>
-            <hr style={{border: 'none', borderTop: '1px solid var(--dp-border, #333)', margin: '8px 0'}} />
+            <hr style={{border: 'none', borderTop: '1px solid var(--dp-border)', margin: '8px 0'}} />
             <div>
               <div style={{opacity: 0.6, fontSize: 12, marginBottom: 4}}>Account Created</div>
               <div style={{fontWeight: 500}}>


### PR DESCRIPTION
> **Stacked on #114** — both touch the same three components, so this is based on that branch rather than `main`. GitHub retargets it to `main` automatically when #114 merges. Merge #114 first.

The console's accent was `#F57C00` orange. It appears on no other DeedPro surface, and it sits in the family `docs/BRAND.md` reserves for a **meaning** — "unconfirmed external data". An operator scanning this screen for the amber that says *a machine suggested this, no human has confirmed it* was reading past an orange used for nav highlights, buttons and a logo tile. The accent is brand purple now, matching the app it administers.

## The second finding, which a palette swap would have walked past

Four tokens the console references — `--dp-warn`, `--dp-error`, `--dp-muted`, `--dp-brand` — are **declared nowhere**. Every reference was written with a hex fallback:

```tsx
color: 'var(--dp-warn, #b26a00)'
borderTop: '1px solid var(--dp-border, #333)'
background: 'var(--dp-surface, #1a1a2e)'
```

So the fallback rendered every single time. Those surfaces were never reading the token file at all — they were styled by whatever hex the last author typed inside the parentheses, including a `#333` border and a `#1a1a2e` dark-navy chip on a light theme.

Which is why the load-bearing pin here is not the palette one. `adminBrand.test.ts` resolves every `var(--dp-*)` an admin file references against `tokens.css` and fails on an undeclared token, and separately forbids raw hex at call sites. **An undefined token cannot be rebranded, because nothing it says is being read.**

## Doctrinal colors, with their meanings

Written into `tokens.css` beside the values and into `docs/BRAND.md` — because BRAND.md's own rule is that changing amber is changing the honesty system, not the palette.

| color | means | never |
|---|---|---|
| amber | a value that is real but must not be read at face value — unconfirmed, unmeasured, degraded | fills a control; a fill describes an *action*, amber describes *data* |
| red | something failed or is unavailable | a state |
| green | a probe completed and passed | a default |
| neutral gray | absence — "not monitored", "not measured", an em-dash | — |

That last row is the one that keeps amber honest: an absence is a fact about our instrumentation, not a warning about data, so it does not get a doctrine color. The Suspend button's amber fill is gone (outline treatment — it was also competing with Delete for the eye).

## One reading extended — flagged, not decided

BRAND.md defines amber for the **officer-facing** flow. The console has no officer decisions in it, so I used the nearest honest reading above and recorded it in the ledger for you to confirm or narrow rather than widening the doctrine quietly. Violet's "proposed legal choice" has nothing to attach to in admin, so purple is simply the accent there.

## Also fixed while in the file

`.badge.warn` used `#F59E0B` as text on a near-white wash, which does not clear contrast. A doctrine color that cannot be read does not carry its meaning; body-text amber uses the darker ramp.

## Gates

| gate | result |
|---|---|
| jest | 412 passed, 32 suites |
| backend pytest | 362 passed |
| tsc | 94 — unchanged |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_