### PR TITLE
ADMIN3: the transport keeps a ledger, and the failures say why

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -259,6 +259,47 @@ def create_tables():
                 created_at TIMESTAMPTZ DEFAULT now()
             )""",
             "CREATE INDEX IF NOT EXISTS idx_api_key_requests_status ON api_key_requests(status, created_at)",
+            # ── ADMIN3: the transport ledger ─────────────────────────────
+            # Eleven email templates. Ten of their outcomes were printed
+            # to stdout and discarded; only api_key_requests persisted
+            # one (notified_at / notify_error), and it did so because
+            # that table IS a queue somebody has to work.
+            #
+            # The consequence is the 3 AM question nobody could answer:
+            # a customer says "I never got the approval email" and the
+            # only record is a log line on a container that has since
+            # restarted. Render keeps stdout for a while; "a while" is
+            # not an answer to "did we send it, and what did SendGrid
+            # say?"
+            #
+            # One row per ATTEMPT, written at the single choke point
+            # every template already passes through (utils/notifications
+            # ._send). `reason` is the S1 diagnosis string — the same
+            # actionable text that already reaches the logs, e.g. "from
+            # address does not match a verified Sender Identity" — kept
+            # rather than reduced to a boolean, because the boolean was
+            # never the part anybody needed.
+            #
+            # `recipient` is stored in full, deliberately. ADMIN4's
+            # ruling masks personal fields in the AUDIT log, where the
+            # value is evidence about an admin's action. Here the
+            # address IS the operational fact: "did jane@escrow.com get
+            # it" cannot be answered against a mask.
+            """CREATE TABLE IF NOT EXISTS email_log (
+                id BIGSERIAL PRIMARY KEY,
+                template VARCHAR(64) NOT NULL,
+                recipient TEXT NOT NULL,
+                subject TEXT,
+                status VARCHAR(10) NOT NULL,
+                reason TEXT,
+                user_id INTEGER,
+                context JSONB,
+                created_at TIMESTAMPTZ DEFAULT now()
+            )""",
+            "CREATE INDEX IF NOT EXISTS idx_email_log_created ON email_log(created_at DESC)",
+            "CREATE INDEX IF NOT EXISTS idx_email_log_status ON email_log(status, created_at DESC)",
+            "CREATE INDEX IF NOT EXISTS idx_email_log_template ON email_log(template, created_at DESC)",
+            "CREATE INDEX IF NOT EXISTS idx_email_log_recipient ON email_log(LOWER(recipient))",
             """CREATE TABLE IF NOT EXISTS api_rate_limits (
                 id SERIAL PRIMARY KEY,
                 api_key_id UUID,

--- a/backend/routers/admin_api_v2.py
+++ b/backend/routers/admin_api_v2.py
@@ -243,6 +243,135 @@ def export_deeds_csv(admin=Depends(get_current_admin)):
                     headers={"Content-Disposition": "attachment; filename=deeds.csv"})
 
 # ============================================================================
+# ADMIN3 — the email ledger, readable
+# ============================================================================
+#
+# Persistence without a reader is the defect this ticket exists to kill,
+# in a new costume: /admin/dashboard computed a 7-day activity feed for
+# three phases and no screen rendered it, so it may as well not have run.
+# A transport log nobody can open answers the 3 AM question exactly as
+# well as the stdout it replaced.
+
+EMAIL_SORTS: Dict[str, str] = {
+    "newest": "created_at DESC",
+    "oldest": "created_at ASC",
+}
+
+
+@router.get("/emails")
+def admin_email_log(
+    page: int = Query(1, ge=1),
+    limit: int = Query(50, ge=1, le=200),
+    status: Optional[str] = Query(None, description="sent|failed"),
+    template: Optional[str] = None,
+    search: Optional[str] = Query(None, description="recipient substring"),
+    sort: Optional[str] = None,
+    admin=Depends(get_current_admin),
+):
+    """Every send attempt we managed to record, newest first."""
+    order_sql = _order_by(EMAIL_SORTS, sort)
+    offset = (page - 1) * limit
+    conn = get_db_connection()
+    try:
+        with conn.cursor() as cur:
+            where, params = [], []
+            if status:
+                if status.lower() not in ("sent", "failed"):
+                    raise HTTPException(status_code=400, detail="status must be sent or failed")
+                where.append("status = %s")
+                params.append(status.lower())
+            if template:
+                where.append("template = %s")
+                params.append(template)
+            if search:
+                where.append("LOWER(recipient) LIKE %s")
+                params.append(f"%{search.lower()}%")
+            where_sql = f"WHERE {' AND '.join(where)}" if where else ""
+
+            cur.execute(f"SELECT COUNT(*) AS count FROM email_log {where_sql}", params)
+            total = cur.fetchone()["count"]
+
+            cur.execute(f"""
+                SELECT id, template, recipient, subject, status, reason,
+                       user_id, context, created_at
+                FROM email_log
+                {where_sql}
+                ORDER BY {order_sql}
+                LIMIT %s OFFSET %s
+            """, params + [limit, offset])
+            rows = cur.fetchall()
+    finally:
+        conn.close()
+
+    return {"page": page, "limit": limit, "total": total,
+            "sort": (sort or DEFAULT_SORT).lower(), "items": rows}
+
+
+@router.get("/emails/stats")
+def admin_email_stats(days: int = Query(7, ge=1, le=90),
+                      admin=Depends(get_current_admin)):
+    """Sent/failed counts over a window, plus what actually went wrong.
+
+    `failures_by_reason` is the part worth having. A count of failures
+    tells an operator that something is broken; the S1 reason string
+    tells them it is an unverified sender identity, which is a fix
+    rather than an investigation.
+    """
+    conn = get_db_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute("""
+                SELECT COUNT(*) FILTER (WHERE status = 'sent')   AS sent,
+                       COUNT(*) FILTER (WHERE status = 'failed') AS failed,
+                       COUNT(*)                                  AS total,
+                       MIN(created_at)                           AS first_recorded
+                FROM email_log
+                WHERE created_at >= NOW() - (%s || ' days')::interval
+            """, (days,))
+            totals = cur.fetchone()
+
+            cur.execute("""
+                SELECT template,
+                       COUNT(*) FILTER (WHERE status = 'sent')   AS sent,
+                       COUNT(*) FILTER (WHERE status = 'failed') AS failed
+                FROM email_log
+                WHERE created_at >= NOW() - (%s || ' days')::interval
+                GROUP BY template
+                ORDER BY COUNT(*) DESC
+            """, (days,))
+            by_template = cur.fetchall()
+
+            cur.execute("""
+                SELECT reason, COUNT(*) AS count
+                FROM email_log
+                WHERE status = 'failed' AND reason IS NOT NULL
+                  AND created_at >= NOW() - (%s || ' days')::interval
+                GROUP BY reason
+                ORDER BY COUNT(*) DESC
+                LIMIT 10
+            """, (days,))
+            failures_by_reason = cur.fetchall()
+
+            # The window's oldest row overall — so the UI can say "we
+            # have only been recording since X" instead of letting a
+            # young table read as a quiet one.
+            cur.execute("SELECT MIN(created_at) AS since FROM email_log")
+            since = cur.fetchone()["since"]
+    finally:
+        conn.close()
+
+    return {
+        "window_days": days,
+        "sent": totals["sent"] or 0,
+        "failed": totals["failed"] or 0,
+        "total": totals["total"] or 0,
+        "recording_since": since.isoformat() if since else None,
+        "by_template": by_template,
+        "failures_by_reason": failures_by_reason,
+    }
+
+
+# ============================================================================
 # PHASE 12-3: USER CRUD OPERATIONS
 # ============================================================================
 

--- a/backend/tests/snapshots/openapi_routes.json
+++ b/backend/tests/snapshots/openapi_routes.json
@@ -53,6 +53,14 @@
  ],
  [
   "GET",
+  "/admin/emails"
+ ],
+ [
+  "GET",
+  "/admin/emails/stats"
+ ],
+ [
+  "GET",
   "/admin/export/deeds.csv"
  ],
  [

--- a/backend/tests/test_admin15_reconciliation.py
+++ b/backend/tests/test_admin15_reconciliation.py
@@ -137,9 +137,19 @@ def test_sort_keys_resolve_through_a_map_and_never_reach_sql_directly():
 def test_the_applied_sort_is_echoed_to_the_client():
     """The console states its sort. It can only do that honestly if the
     server says which one it used rather than the client assuming its
-    request was honoured."""
+    request was honoured.
+
+    Counted rather than fixed at 2 (ADMIN3 added a third sorted list):
+    the property is "every list that accepts a sort echoes one", so the
+    pin compares the two populations instead of memorising a number.
+    """
     src = code_only(ADMIN_V2)
-    assert src.count('"sort": (sort or DEFAULT_SORT).lower()') == 2
+    accepts_sort = len(re.findall(r"_order_by\(", src)) - 1  # minus the def
+    echoes = src.count('"sort": (sort or DEFAULT_SORT).lower()')
+    assert echoes == accepts_sort >= 2, (
+        f"{accepts_sort} endpoints resolve a sort but {echoes} echo it — a "
+        "list that sorts silently is the defect this replaced"
+    )
 
 
 # ── Live-DB reconciliation ───────────────────────────────────────────

--- a/backend/tests/test_admin3_email_outcomes.py
+++ b/backend/tests/test_admin3_email_outcomes.py
@@ -1,0 +1,284 @@
+"""ADMIN3 — the transport ledger.
+
+THE 3 AM QUESTION. A customer says "I never got the approval email."
+Before this ticket the only record was a `print()` on a Render container
+that had since restarted. Eleven templates; ten of their outcomes were
+formatted into a log line and dropped. The eleventh — the API-access
+funnel — persisted its outcome, and it is worth being precise about WHY,
+because the reason is the design of this PR: `api_key_requests` is a work
+queue somebody stares at, so losing a send outcome there was immediately
+painful. Nothing made the other ten hurt, so nothing fixed them.
+
+The fix is therefore not "add persistence to eleven call sites" — eleven
+places that must remember is a place that will be forgotten. It is one
+choke point that every template already passes through, and a pin that
+says nothing may go around it.
+
+CI-safe (no database) except where marked.
+"""
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+BACKEND = Path(__file__).resolve().parents[1]
+NOTIFICATIONS = BACKEND / "utils" / "notifications.py"
+
+
+def code_only(path: Path) -> str:
+    """Source minus docstrings and comments — a comment explaining a
+    removed pattern quotes it. (Fifth copy; the consolidation into a
+    shared util is ledgered as opportunistic.)"""
+    src = path.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            doc = ast.get_docstring(node, clean=False)
+            if doc:
+                src = src.replace(doc, "")
+    return "\n".join(l for l in src.splitlines() if not l.lstrip().startswith("#"))
+
+
+# ── The choke point ──────────────────────────────────────────────────
+
+def test_exactly_one_call_reaches_the_transport():
+    """`send_email_with_reason` is the transport. If a sender calls it
+    directly it skips the ledger, and the skip is invisible: the email
+    goes out, nothing errors, and the row simply is not there. That is
+    the failure mode this pin exists for — silence, not breakage."""
+    src = code_only(NOTIFICATIONS)
+    calls = re.findall(r"send_email_with_reason\(", src)
+    assert len(calls) == 1, (
+        f"{len(calls)} calls to the transport — every send must go through "
+        "_send() or its outcome is never recorded, and nothing will fail "
+        "to tell you"
+    )
+
+
+def test_no_module_outside_notifications_sends_mail():
+    """A second transport user elsewhere in the codebase would bypass the
+    ledger the same way, one directory further from where anyone looks."""
+    offenders = []
+    for path in BACKEND.rglob("*.py"):
+        if {"tests", "__pycache__"} & set(path.parts):
+            continue
+        if path.name in ("notifications.py", "email.py"):
+            continue
+        if "send_email_with_reason" in path.read_text(encoding="utf-8", errors="ignore"):
+            offenders.append(str(path.relative_to(BACKEND)))
+    assert offenders == [], f"the transport is called outside the choke point: {offenders}"
+
+
+def test_every_template_routes_through_send():
+    """All eleven, named. A template that renders and sends without a
+    `_send` name is a template whose rows land under the wrong label —
+    which is worse than no label, because the log then lies quietly."""
+    import sys
+    sys.path.insert(0, str(BACKEND))
+    from utils.notifications import TEMPLATES
+
+    src = code_only(NOTIFICATIONS)
+    named = set(re.findall(r'_send\(\s*"([a-z_]+)"', src))
+    assert named == set(TEMPLATES), (
+        f"declared TEMPLATES and actual _send labels disagree: "
+        f"only-declared={set(TEMPLATES) - named}, only-used={named - set(TEMPLATES)}"
+    )
+    assert len(TEMPLATES) == 11
+
+
+# ── The recorder's two constraints ───────────────────────────────────
+
+def test_the_recorder_cannot_break_the_send_path():
+    """Recording an outcome is strictly less important than the thing it
+    records. A ledger write that 500s a registration would be a worse bug
+    than the one being fixed."""
+    import sys
+    sys.path.insert(0, str(BACKEND))
+    import utils.notifications as notif
+
+    # A recorder that raises internally must still return normally.
+    original = notif.get_db_connection if hasattr(notif, "get_db_connection") else None
+    assert original is None, "the connection is imported inside _record, by design"
+
+    # Call it with no DATABASE_URL reachable — it must not raise.
+    notif._record("welcome", "nobody@example.com", "s", True, None, None, None)
+
+
+def test_the_recorder_uses_its_own_connection_not_the_callers():
+    """The A1 metering defect, in one assertion.
+
+    That code wrote a usage row inside the CALLER's transaction. The
+    INSERT failed, Postgres marked the transaction ABORTED, and the
+    caller's later commit() silently discarded a real deed while
+    returning 200. A logging write must never be able to do that, so
+    _record opens a short-lived autocommit connection of its own and
+    closes it.
+    """
+    src = code_only(NOTIFICATIONS)
+    record = src[src.index("def _record("):src.index("def _send(")]
+    assert "get_db_connection()" in record
+    assert "autocommit = True" in record
+    assert "conn.close()" in record
+    # It must not accept a connection from its caller — that is the door.
+    assert not re.search(r"def _record\([^)]*conn[^)]*\)", src)
+
+
+def test_a_failed_recording_is_loud():
+    """Doctrine §4 says errors are never swallowed. This one must be
+    caught (see above), so it is caught LOUDLY — with a greppable prefix,
+    and with the admin surface stating it shows only what it managed to
+    record. An honest gap beats a silent one."""
+    src = NOTIFICATIONS.read_text(encoding="utf-8")
+    assert "[email-log]" in src
+
+
+def test_success_rows_carry_no_reason_and_failures_do():
+    """A `reason` on a sent row is noise; a sent row is its own reason.
+    A failure without one is the boolean this ticket replaced."""
+    src = code_only(NOTIFICATIONS)
+    assert '"sent" if ok else "failed"' in src
+    assert "(reason or None) if not ok else None" in src
+
+
+# ── Schema authority ─────────────────────────────────────────────────
+
+def test_email_log_lives_in_the_one_schema_authority():
+    """H1: create_tables() is the single authority. A table created by a
+    hand-run migration is the class of thing ADMIN1 spent a PR adopting
+    (subscriptions was MISSING ENTIRELY in production for that reason)."""
+    src = (BACKEND / "database.py").read_text(encoding="utf-8")
+    assert "CREATE TABLE IF NOT EXISTS email_log" in src
+    for idx in ("idx_email_log_created", "idx_email_log_status",
+                "idx_email_log_template", "idx_email_log_recipient"):
+        assert idx in src, f"{idx} missing — this table is read by filtered queries"
+
+
+# ── Live DB ──────────────────────────────────────────────────────────
+
+@pytest.fixture(scope="module", autouse=True)
+def schema_ready():
+    """`email_log` exists because create_tables() made it — which only
+    happens once something imports the app. Ordering-dependent setup is
+    how a suite grows a test that passes second and fails first, so this
+    states the dependency instead of inheriting it from whichever test
+    happened to run earlier.
+
+    The thread join is not optional: importing `database` starts the
+    daemon "schema-convergence" thread, and touching tables while it is
+    mid-DDL deadlocks (it holds ACCESS EXCLUSIVE, we hold ACCESS SHARE).
+    That deadlock has hung this suite twice.
+    """
+    import os
+    if not os.getenv("DATABASE_URL"):
+        return
+    import threading
+    import database  # noqa: F401 — the import is what starts convergence
+    for t in threading.enumerate():
+        if t.name == "schema-convergence":
+            t.join(timeout=120)
+
+
+@pytest.mark.skipif(not __import__("os").getenv("DATABASE_URL"),
+                    reason="live test DB required")
+def test_a_failed_send_is_recorded_with_its_reason():
+    """End to end, on the failure path that actually happens: no
+    SENDGRID_API_KEY. The send fails, the reason names why, and the row
+    survives the request that produced it."""
+    import os
+    import sys
+    sys.path.insert(0, str(BACKEND))
+    import psycopg2
+    from utils.notifications import send_welcome_with_reason
+
+    assert not os.getenv("SENDGRID_API_KEY"), "this test asserts the unconfigured path"
+
+    ok, reason = send_welcome_with_reason("ledger@admin.example", "Ledger Test")
+    assert ok is False
+    assert "SENDGRID_API_KEY" in (reason or "")
+
+    conn = psycopg2.connect(os.environ["DATABASE_URL"])
+    conn.autocommit = True
+    with conn.cursor() as cur:
+        cur.execute("""SELECT template, recipient, status, reason
+                       FROM email_log WHERE recipient = %s
+                       ORDER BY created_at DESC LIMIT 1""",
+                    ("ledger@admin.example",))
+        row = cur.fetchone()
+    conn.close()
+
+    assert row is not None, "the send happened and the ledger has no row for it"
+    assert row[0] == "welcome"
+    assert row[2] == "failed"
+    assert "SENDGRID_API_KEY" in row[3], "the reason was reduced to a boolean again"
+
+
+@pytest.mark.skipif(not __import__("os").getenv("DATABASE_URL"),
+                    reason="live test DB required")
+def test_the_admin_surface_reads_the_ledger():
+    import os
+    import psycopg2
+    from fastapi.testclient import TestClient
+    from main import app
+
+    email, password = "emails@admin.example", "Emails!Passw0rd"
+    client = TestClient(app)
+    conn = psycopg2.connect(os.environ["DATABASE_URL"])
+    conn.autocommit = True
+    with conn.cursor() as cur:
+        cur.execute("""DELETE FROM user_profiles WHERE user_id IN
+                       (SELECT id FROM users WHERE email = %s)""", (email,))
+        cur.execute("DELETE FROM users WHERE email = %s", (email,))
+    conn.close()
+
+    client.post("/users/register", json={
+        "email": email, "password": password, "confirm_password": password,
+        "full_name": "Email Admin", "role": "escrow_officer",
+        "state": "CA", "agree_terms": True})
+    conn = psycopg2.connect(os.environ["DATABASE_URL"])
+    conn.autocommit = True
+    with conn.cursor() as cur:
+        cur.execute("UPDATE users SET role = 'admin' WHERE email = %s", (email,))
+    conn.close()
+
+    token = client.post("/users/login", json={
+        "email": email, "password": password}).json()["access_token"]
+    auth = {"Authorization": f"Bearer {token}"}
+
+    # Registration itself sends two emails (admin ping + welcome), so the
+    # ledger cannot be empty by the time we look.
+    listing = client.get("/admin/emails?limit=10", headers=auth).json()
+    assert listing["total"] > 0, "registration sent mail and the ledger is empty"
+    assert isinstance(listing["items"][0], dict), "rows must serialise as objects (#113)"
+    for field in ("id", "template", "recipient", "status", "created_at"):
+        assert field in listing["items"][0], f"the console reads {field}"
+
+    failed = client.get("/admin/emails?status=failed&limit=5", headers=auth).json()
+    assert all(i["status"] == "failed" for i in failed["items"])
+    assert client.get("/admin/emails?status=nonsense", headers=auth).status_code == 400
+
+    by_template = client.get("/admin/emails?template=welcome&limit=5", headers=auth).json()
+    assert all(i["template"] == "welcome" for i in by_template["items"])
+
+    stats = client.get("/admin/emails/stats?days=7", headers=auth).json()
+    assert stats["total"] == stats["sent"] + stats["failed"]
+    assert stats["recording_since"] is not None, (
+        "the UI needs this to say 'we have only been recording since X' — "
+        "without it a young table reads as a quiet month"
+    )
+    # Unconfigured email in tests means every attempt failed with a reason.
+    assert stats["failed"] > 0 and stats["failures_by_reason"], (
+        "failures were counted but their reasons were not kept — the count "
+        "says something is broken, the reason says which thing"
+    )
+
+
+@pytest.mark.skipif(not __import__("os").getenv("DATABASE_URL"),
+                    reason="live test DB required")
+def test_the_api_key_funnel_still_records_on_its_own_row():
+    """ADMIN3 adds a transport ledger; it does not take the funnel's
+    queue status away. `api_key_requests.notify_error` is that request's
+    OWN state — a thing to work — while email_log is the transport's
+    history. Both, deliberately."""
+    src = (BACKEND / "routers" / "api_key_requests.py").read_text(encoding="utf-8")
+    assert "notify_error = %s" in src

--- a/backend/tests/test_api_key_requests.py
+++ b/backend/tests/test_api_key_requests.py
@@ -63,9 +63,16 @@ def test_request_table_is_in_the_schema_authority():
 
 
 def test_the_ops_email_uses_the_one_transport():
+    """ADMIN3: same deliberate correction as in test_email_system — this
+    matched the literal transport call inside the sender, so it broke
+    when a recording step was inserted in front of the transport without
+    changing anything it meant to protect. The property is that this
+    sender reaches the ONE transport; it now does so through the choke
+    point, which is where the outcome gets persisted."""
     from utils import notifications
     src = inspect.getsource(notifications.notify_api_key_request)
-    assert "send_email_with_reason" in src
+    assert '_send("admin_api_key_request"' in src
+    assert "send_email_with_reason" in inspect.getsource(notifications._send)
 
 
 # ── End to end (live DB) ─────────────────────────────────────────────

--- a/backend/tests/test_email_system.py
+++ b/backend/tests/test_email_system.py
@@ -241,14 +241,41 @@ def test_approval_creates_in_app_record_before_email():
 
 
 def test_every_sender_returns_reason_tuples():
+    """Every sender reaches the one honest transport, and its (ok, reason)
+    survives.
+
+    ADMIN3 changed this pin DELIBERATELY, and the reason is the lesson
+    from #113: it asserted that each sender's source contained the
+    literal `send_email_with_reason(` — the SPELLING of the arrangement,
+    not the property. When ADMIN3 put a recording step between the
+    senders and the transport, every sender still reached the transport
+    and still returned its reason; only the spelling moved. A pin that
+    fails on a strictly stronger arrangement is guarding syntax.
+
+    What is asserted now is the property in two halves: each sender goes
+    through the single choke point, and that choke point is the only
+    thing that touches the transport (pinned in
+    test_admin3_email_outcomes.py, which fails if a second call appears).
+    """
     import inspect
     from utils import notifications as n
+    # `send_email_with_reason` is imported into this namespace and its
+    # name starts with "send_", so the old collector swept up the
+    # TRANSPORT and asserted the transport called itself — which passed
+    # only because its own `def` line contains its own name. Excluded by
+    # name: it is the thing being reached, not a thing that reaches.
+    TRANSPORT = {"send_email_with_reason"}
     senders = [f for name, f in vars(n).items()
-               if callable(f) and (name.startswith("send_") or name.startswith("notify_"))]
+               if callable(f) and name not in TRANSPORT
+               and (name.startswith("send_") or name.startswith("notify_"))]
     assert len(senders) >= 9
     for f in senders:
         src = inspect.getsource(f)
-        assert "send_email_with_reason(" in src, f"{f.__name__} bypasses the reason contract"
+        assert "_send(" in src, f"{f.__name__} bypasses the choke point"
+    # And the choke point still preserves the reason it was built for.
+    choke = inspect.getsource(n._send)
+    assert "send_email_with_reason(" in choke
+    assert "return ok, reason" in choke
 
 
 def test_viewed_revoked_expired_stay_email_silent():

--- a/backend/utils/notifications.py
+++ b/backend/utils/notifications.py
@@ -7,12 +7,94 @@ covers every event). Templates live in utils.email_templates; this
 module wires event data to them and creates in-app records where the
 event must be unlosable regardless of email transport.
 """
-from typing import Optional, Tuple
+import json
+from typing import Any, Dict, Optional, Tuple
 
 from utils import email_templates
 from utils.email import send_email_with_reason
 
 SendResult = Tuple[bool, Optional[str]]
+
+# The eleven template names, as they appear in email_log.template. Named
+# here rather than derived from the function name so a refactor cannot
+# silently rewrite history: the log is a record, and a record whose
+# vocabulary drifts with the code is not one.
+TEMPLATES = (
+    "share_invite", "share_reminder", "share_approved", "share_rejected",
+    "deed_completed", "password_reset", "verify_email", "password_changed",
+    "welcome", "admin_api_key_request", "admin_new_user",
+)
+
+
+def _record(template: str, recipient: str, subject: str, ok: bool,
+            reason: Optional[str], user_id: Optional[int],
+            context: Optional[Dict[str, Any]]) -> None:
+    """Persist one send ATTEMPT. Best-effort, and never raises.
+
+    ADMIN3. Two constraints shape this function, and both are scars.
+
+    1. IT MUST NOT BREAK THE SEND PATH. Recording an outcome is strictly
+       less important than the thing it records; a logging failure that
+       500s a registration would be a worse bug than the one being
+       fixed. So every failure here is caught.
+
+    2. IT MUST USE ITS OWN CONNECTION. This is the A1 metering defect,
+       and it is worth being explicit about because it cost a deed. That
+       code wrote a usage row inside the CALLER's transaction; the
+       INSERT failed, Postgres put the transaction in the ABORTED state,
+       and the caller's later `commit()` silently discarded a real deed
+       while returning 200. A short-lived autocommit connection cannot
+       do that to anybody.
+
+    Constraint 1 does mean a swallowed error, which is doctrine §4's
+    territory — so it is swallowed LOUDLY, with a prefix an operator can
+    grep, and the admin surface states that it can only show attempts it
+    managed to record. An honest gap beats a silent one.
+    """
+    conn = None
+    try:
+        from database import get_db_connection
+        conn = get_db_connection()
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute(
+                """INSERT INTO email_log
+                       (template, recipient, subject, status, reason, user_id, context)
+                   VALUES (%s, %s, %s, %s, %s, %s, %s)""",
+                (template[:64], recipient[:320], (subject or "")[:500],
+                 "sent" if ok else "failed", (reason or None) if not ok else None,
+                 user_id, json.dumps(context) if context else None),
+            )
+    except Exception as e:
+        # Not silent: this is the one place the ledger can lose a row,
+        # and it says so where an operator will find it.
+        print(f"[email-log] ⚠️ could not record {template} to {recipient}: "
+              f"{type(e).__name__}: {str(e)[:200]}")
+    finally:
+        if conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+
+def _send(template: str, recipient: str, rendered, *,
+          user_id: Optional[int] = None,
+          context: Optional[Dict[str, Any]] = None) -> SendResult:
+    """Render → send → record. THE choke point.
+
+    Every template goes through here, which is the whole design: the
+    alternative was eleven call sites each remembering to persist their
+    own outcome, and eleven places that must remember is a place that
+    will be forgotten. A3 proved the pattern works and proved how it
+    fails to spread — `api_key_requests` persisted its outcome because
+    that table is a work queue somebody stares at, and the other ten
+    never got it because nothing forced them to.
+    """
+    subject, html, text = rendered
+    ok, reason = send_email_with_reason(recipient, subject, html, text)
+    _record(template, recipient, subject, ok, reason, user_id, context)
+    return ok, reason
 
 
 def create_notification(conn, user_id: int, ntype: str, title: str, message: str, link: Optional[str] = None) -> int:
@@ -35,64 +117,63 @@ def send_share_notification_with_reason(recipient_email: str, recipient_name: st
                                         owner_name: str, deed_type: str, share_link: str,
                                         property_address: Optional[str] = None,
                                         expires_at: Optional[str] = None) -> SendResult:
-    subject, html, text = email_templates.share_invite(
-        recipient_name, owner_name, deed_type, property_address, share_link, expires_at)
-    return send_email_with_reason(recipient_email, subject, html, text)
+    return _send("share_invite", recipient_email, email_templates.share_invite(
+        recipient_name, owner_name, deed_type, property_address, share_link, expires_at),
+        context={"deed_type": deed_type, "property_address": property_address})
 
 
 def send_share_reminder_with_reason(recipient_email: str, recipient_name: str,
                                     owner_name: str, deed_type: str,
                                     property_address: Optional[str], share_link: str,
                                     hours_remaining: int) -> SendResult:
-    subject, html, text = email_templates.share_reminder(
-        recipient_name, owner_name, deed_type, property_address, share_link, hours_remaining)
-    return send_email_with_reason(recipient_email, subject, html, text)
+    return _send("share_reminder", recipient_email, email_templates.share_reminder(
+        recipient_name, owner_name, deed_type, property_address, share_link, hours_remaining),
+        context={"deed_type": deed_type, "hours_remaining": hours_remaining})
 
 
 def send_share_approved_with_reason(owner_email: str, owner_name: str, deed_type: str,
                                     property_address: Optional[str], reviewer_email: str,
                                     comments: Optional[str], view_link: str) -> SendResult:
-    subject, html, text = email_templates.share_approved(
-        owner_name, deed_type, property_address, reviewer_email, comments, view_link)
-    return send_email_with_reason(owner_email, subject, html, text)
+    return _send("share_approved", owner_email, email_templates.share_approved(
+        owner_name, deed_type, property_address, reviewer_email, comments, view_link),
+        context={"deed_type": deed_type, "reviewer_email": reviewer_email})
 
 
 def send_share_rejected_with_reason(owner_email: str, owner_name: str, deed_type: str,
                                     property_address: Optional[str], reviewer_email: str,
                                     comments: Optional[str], view_link: str) -> SendResult:
-    subject, html, text = email_templates.share_rejected(
-        owner_name, deed_type, property_address, reviewer_email, comments, view_link)
-    return send_email_with_reason(owner_email, subject, html, text)
+    return _send("share_rejected", owner_email, email_templates.share_rejected(
+        owner_name, deed_type, property_address, reviewer_email, comments, view_link),
+        context={"deed_type": deed_type, "reviewer_email": reviewer_email})
 
 
 def send_deed_completion_notification(user_email: str, user_name: str, deed_type: str,
                                       property_address: str, deed_id: int,
                                       preview_link: str) -> SendResult:
-    subject, html, text = email_templates.deed_completed(
-        user_name, deed_type, property_address, deed_id, preview_link)
-    return send_email_with_reason(user_email, subject, html, text)
+    return _send("deed_completed", user_email, email_templates.deed_completed(
+        user_name, deed_type, property_address, deed_id, preview_link),
+        context={"deed_id": deed_id, "deed_type": deed_type})
 
 
 def send_password_reset_with_reason(user_email: str, full_name: str,
                                     reset_url: str, ttl_hours: int) -> SendResult:
-    subject, html, text = email_templates.password_reset(full_name, reset_url, ttl_hours)
-    return send_email_with_reason(user_email, subject, html, text)
+    return _send("password_reset", user_email,
+                 email_templates.password_reset(full_name, reset_url, ttl_hours))
 
 
 def send_verify_email_with_reason(user_email: str, full_name: str,
                                   verify_url: str) -> SendResult:
-    subject, html, text = email_templates.verify_email(full_name, verify_url)
-    return send_email_with_reason(user_email, subject, html, text)
+    return _send("verify_email", user_email,
+                 email_templates.verify_email(full_name, verify_url))
 
 
 def send_password_changed_with_reason(user_email: str, full_name: str) -> SendResult:
-    subject, html, text = email_templates.password_changed(full_name)
-    return send_email_with_reason(user_email, subject, html, text)
+    return _send("password_changed", user_email,
+                 email_templates.password_changed(full_name))
 
 
 def send_welcome_with_reason(user_email: str, full_name: str) -> SendResult:
-    subject, html, text = email_templates.welcome(full_name)
-    return send_email_with_reason(user_email, subject, html, text)
+    return _send("welcome", user_email, email_templates.welcome(full_name))
 
 
 def notify_api_key_request(admin_email: str, company_name: str, contact_email: str,
@@ -101,9 +182,11 @@ def notify_api_key_request(admin_email: str, company_name: str, contact_email: s
     """A3: an API-access inquiry reached us. The row is already stored —
     this is the ping, and its reason is recorded on the row when it
     fails, so a lost email cannot lose the request."""
-    subject, html, text = email_templates.admin_api_key_request(
-        company_name, contact_email, business_type, expected_volume, use_case, request_id)
-    return send_email_with_reason(admin_email, subject, html, text)
+    return _send("admin_api_key_request", admin_email,
+                 email_templates.admin_api_key_request(
+                     company_name, contact_email, business_type,
+                     expected_volume, use_case, request_id),
+                 context={"request_id": request_id, "company_name": company_name})
 
 
 def notify_new_user_registration(admin_email: str, user_email: str, user_name: str,
@@ -113,5 +196,6 @@ def notify_new_user_registration(admin_email: str, user_email: str, user_name: s
     the admin ops ping silently never sent. It exists now, minimal by
     ruling: registrant email + timestamp, nothing more (user_name is
     accepted for call-site compatibility and deliberately unused)."""
-    subject, html, text = email_templates.admin_new_user(user_email, user_id)
-    return send_email_with_reason(admin_email, subject, html, text)
+    return _send("admin_new_user", admin_email,
+                 email_templates.admin_new_user(user_email, user_id),
+                 user_id=user_id, context={"registrant": user_email})

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -108,7 +108,16 @@ check) and **#114** the rest of the sharpened scope (reconciliation,
 stats-honesty relapse sweep, frictions). **ADMIN-BRAND is #115**, stacked
 on #114 because both touch the same three components.
 
-**Next: ADMIN3** (email outcome persistence).
+**Next: ADMIN2** (share lifecycle console) — ADMIN3 shipped as #116.
+
+### Ledgered trigger — browser-audit re-run
+
+Owner-set, 2026-08-03: when **ADMIN-BRAND (#115) and ADMIN3 (#116) are
+merged AND deployed**, re-run the browser click-drill audit. The last
+run's five drills went fail, fail, unanswerable, empty, unverifiable.
+The re-run is the before/after that shows whether the wave did what it
+claimed — and it is a production click-through, so it is the owner's,
+not delegable.
 
 ADMIN3 was **promoted above ADMIN2**: it answers the 3 AM question, and
 ADMIN2's queue surface depends on knowing what failed. ADMIN5 needs a
@@ -174,9 +183,22 @@ we reach it.
 - **ADMIN2 — share lifecycle console.** The largest visibility hole:
   `deed_shares` records sent → viewed → approved/rejected/revoked/
   expired plus rejection feedback, and no admin surface reads any of it.
-- **ADMIN3 — email outcome persistence.** Generalize the one working
-  pattern (`api_key_requests.notify_error`) to the other ten templates;
-  10 of 11 send outcomes are currently printed and discarded.
+- **ADMIN3 — email outcome persistence (#116).** Generalize the one
+  working pattern (`api_key_requests.notify_error`) to the other ten
+  templates; 10 of 11 send outcomes were printed and discarded.
+  **Built as a choke point, not eleven edits:** every sender already
+  ended in one call to the transport, so persistence went there. Adding
+  it at eleven call sites would have repeated the reason the gap
+  existed — `api_key_requests` persisted its outcome only because that
+  table is a work queue somebody stares at; nothing made the other ten
+  hurt, so nothing fixed them. New `email_log` table (in
+  `create_tables()` per H1) carrying the S1 diagnosis string rather than
+  a boolean, plus an **Emails** tab linked from the sidebar.
+  Two design notes worth keeping: the recorder uses its OWN autocommit
+  connection (writing into the caller's transaction is the A1 metering
+  defect that silently discarded a deed), and its failures are caught —
+  a ledger write must never 500 a registration — so they are caught
+  LOUDLY and the tab states it shows attempts it managed to record.
 - **ADMIN4 — admin audit log.** UNBLOCKED by the ruling below.
 - **ADMIN5 — orphan wiring.** ~18 admin endpoints have no caller; the
   cheap wins are per-key error rates, deed PDF open, a partners tab,

--- a/frontend/src/__tests__/adminBrand.test.ts
+++ b/frontend/src/__tests__/adminBrand.test.ts
@@ -105,6 +105,55 @@ describe('the accent is the brand, not the console\'s own orange', () => {
   });
 });
 
+describe('the admin palette mirrors the brand source of truth', () => {
+  /**
+   * ADMIN-BRAND follow-up, added in the ADMIN3 PR (flagged, not
+   * smuggled). BRAND.md names `tailwind.config.js` `brand.*` as the
+   * single source for the brand colors. The console is plain CSS and
+   * cannot read Tailwind classes, so `tokens.css` MIRRORS those values
+   * — and every other mirror in this codebase is pinned bidirectionally
+   * (form_families.py ↔ formRegistry.ts, dtt_rates.py ↔ dttCalc.ts,
+   * api_catalog.py ↔ apiDocs.ts). This one shipped without its pin, so
+   * a brand change in Tailwind would have silently left admin behind —
+   * which is precisely the drift that produced an orange console in the
+   * first place.
+   */
+  const tailwind = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'tailwind.config.js'), 'utf8');
+  const tokens = fs.readFileSync(TOKENS, 'utf8');
+
+  function brandShade(shade: string): string {
+    const m = tailwind.match(new RegExp(`${shade}:\\s*'(#[0-9a-fA-F]{6})'`));
+    if (!m) throw new Error(`brand.${shade} not found in tailwind.config.js`);
+    return m[1].toLowerCase();
+  }
+
+  function adminToken(name: string): string {
+    const m = tokens.match(new RegExp(`${name}:\\s*(#[0-9a-fA-F]{6})`));
+    if (!m) throw new Error(`${name} not found in tokens.css`);
+    return m[1].toLowerCase();
+  }
+
+  const MIRRORED: Array<[string, string]> = [
+    ['--dp-primary', '500'],
+    ['--dp-primary-600', '600'],
+    ['--dp-primary-active', '700'],
+    ['--dp-primary-light', '50'],
+  ];
+
+  for (const [token, shade] of MIRRORED) {
+    it(`${token} equals tailwind brand.${shade}`, () => {
+      expect(adminToken(token)).toBe(brandShade(shade));
+    });
+  }
+
+  it('the doctrinal amber matches the app\'s warning.500', () => {
+    const m = tailwind.match(/warning:\s*\{[\s\S]{0,200}?DEFAULT:\s*'(#[0-9a-fA-F]{6})'/);
+    expect(m).not.toBeNull();
+    expect(adminToken('--dp-warning')).toBe(m![1].toLowerCase());
+  });
+});
+
 describe('doctrinal colors appear only with their meanings', () => {
   const tokens = fs.readFileSync(TOKENS, 'utf8');
 

--- a/frontend/src/__tests__/adminConsoleHonesty.test.ts
+++ b/frontend/src/__tests__/adminConsoleHonesty.test.ts
@@ -165,6 +165,59 @@ describe('search says which of its three states it is in', () => {
   }
 });
 
+describe('ADMIN3 — the email ledger states what it can and cannot know', () => {
+  const src = readAdmin('components', 'EmailsTab.tsx');
+
+  it('says recording is best-effort rather than implying completeness', () => {
+    // The recorder must never break a send, so it swallows its own
+    // failures. A screen built on a best-effort log that presents itself
+    // as complete is a fabricated success one level up.
+    expect(src).toContain('not a proof of');
+    expect(src).toContain('completeness');
+  });
+
+  it('states when recording began', () => {
+    // Without this a table created yesterday reads exactly like a quiet
+    // month, and "0 failures" over a window that predates the log is not
+    // a clean bill of health.
+    expect(src).toContain('recording_since');
+    expect(src).toContain('Recording began');
+  });
+
+  it('surfaces WHY sends failed, not just how many', () => {
+    expect(src).toContain('failures_by_reason');
+    expect(src).toContain('Why sends failed');
+  });
+
+  it('renders an em-dash, not a zero, when stats are unavailable', () => {
+    const code = withoutComments(src);
+    expect(code).not.toMatch(/stats\?\.\w+\s*\?\?\s*0/);
+    expect(code).toContain("stats?.sent ?? '—'");
+    expect(code).toContain('Not shown as zero');
+  });
+
+  it('does not compute a delivery rate out of nothing', () => {
+    // 0/0 renders as NaN% or, worse, 100%. An unattempted window has no
+    // rate, and saying so beats inventing one.
+    expect(src).toMatch(/stats && stats\.total > 0/);
+    expect(src).toContain('no attempts recorded');
+  });
+
+  it('distinguishes a failed request from an empty log', () => {
+    expect(src).toContain('not an empty log');
+  });
+
+  it('is reachable from the sidebar, not only by URL', () => {
+    // The A3 lesson: the API screens existed for months and nothing
+    // linked to them, so they could only be found by typing a URL.
+    const layout = readAdmin('layout.tsx');
+    expect(layout).toContain("id: 'emails'");
+    expect(layout).toContain('/admin?tab=emails');
+    const page = readAdmin('page.tsx');
+    expect(page).toContain('emails: {');
+  });
+});
+
 describe('the lists state their sort', () => {
   it('the sort options mirror the server allowlist', () => {
     const client = fs.readFileSync(

--- a/frontend/src/app/admin/components/EmailsTab.tsx
+++ b/frontend/src/app/admin/components/EmailsTab.tsx
@@ -1,0 +1,254 @@
+'use client';
+/**
+ * ADMIN3 — the transport ledger, readable.
+ *
+ * The 3 AM question is "the customer says they never got the approval
+ * email — did we send it, and what did SendGrid say?" Before this,
+ * the answer lived in a `print()` on a container that had since
+ * restarted. Eleven templates, ten of their outcomes discarded; only
+ * the API-access funnel persisted one, and only because that table is a
+ * work queue somebody stares at.
+ *
+ * Two honesty rules govern this screen:
+ *
+ * 1. It shows attempts we MANAGED TO RECORD. The recorder is
+ *    best-effort by design — a logging failure must never 500 a
+ *    registration — so a dropped row is possible and the screen says so
+ *    rather than presenting itself as complete.
+ * 2. It states when recording STARTED. A table created yesterday looks
+ *    exactly like a quiet month if you do not say that. "0 failures"
+ *    over a window that predates the log is not a clean bill of health.
+ */
+import { useEffect, useState } from 'react';
+import { AdminApi, EmailLogRow, EmailStats } from '@/lib/adminApi';
+import StatCard from './StatCard';
+import Badge from './Badge';
+import Pager from './Pager';
+
+const TEMPLATES = [
+  'share_invite', 'share_reminder', 'share_approved', 'share_rejected',
+  'deed_completed', 'password_reset', 'verify_email', 'password_changed',
+  'welcome', 'admin_api_key_request', 'admin_new_user',
+];
+
+function prettyTemplate(t: string): string {
+  return t.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export default function EmailsTab(){
+  const [rows, setRows] = useState<EmailLogRow[]>([]);
+  const [stats, setStats] = useState<EmailStats | null>(null);
+  const [page, setPage] = useState(1);
+  const [limit] = useState(25);
+  const [total, setTotal] = useState(0);
+  const [status, setStatus] = useState('');
+  const [template, setTemplate] = useState('');
+  const [search, setSearch] = useState('');
+  const [appliedSearch, setAppliedSearch] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState('');
+  const [statsError, setStatsError] = useState('');
+  const [detail, setDetail] = useState<EmailLogRow | null>(null);
+
+  async function load(nextPage = page){
+    setLoading(true);
+    setLoadError('');
+    try{
+      const res = await AdminApi.searchEmails(nextPage, limit, status, template, search);
+      setRows(res.items); setTotal(res.total); setAppliedSearch(search);
+    }catch(e){
+      setRows([]); setTotal(0);
+      setLoadError(e instanceof Error ? e.message : 'Failed to load the email log');
+    }finally{
+      setLoading(false);
+    }
+  }
+
+  useEffect(()=>{ load(); /* eslint-disable-next-line */ }, [page, status, template]);
+
+  useEffect(()=>{
+    (async () => {
+      try{
+        setStats(await AdminApi.getEmailStats(7));
+      }catch(e){
+        setStats(null);
+        setStatsError(e instanceof Error ? e.message : 'stats unavailable');
+      }
+    })();
+  }, []);
+
+  const pageCount = Math.ceil(total / limit);
+  const filtered = appliedSearch !== '' || status !== '' || template !== '';
+  const noMatches = !loading && !loadError && rows.length === 0 && filtered;
+
+  function clearFilters(){ setStatus(''); setTemplate(''); setSearch(''); setPage(1); load(1); }
+
+  return (
+    <div className="vstack">
+      {/* Provenance before numbers — the ADMIN1.5 habit. */}
+      <div className="card">
+        <div style={{fontWeight:600, marginBottom:4}}>What this records</div>
+        <div style={{fontSize:13, opacity:.75}}>
+          One row per send attempt, written at the single point every one of the
+          eleven templates passes through. Recording is best-effort so that a
+          logging failure can never break a registration or a share — which
+          means this is every attempt we managed to record, not a proof of
+          completeness.
+          {stats?.recording_since
+            ? <> Recording began {new Date(stats.recording_since).toLocaleDateString()};
+                anything before that date was printed to the container log and is gone.</>
+            : <> Nothing has been recorded yet.</>}
+        </div>
+      </div>
+
+      <div className="grid stats">
+        <StatCard title="Sent · last 7 days" value={stats?.sent ?? '—'} />
+        <StatCard title="Failed · last 7 days" value={stats?.failed ?? '—'} />
+        <StatCard title="Attempts · last 7 days" value={stats?.total ?? '—'} />
+        <StatCard
+          title="Delivery rate"
+          value={stats && stats.total > 0
+            ? `${Math.round((stats.sent / stats.total) * 100)}%`
+            : '—'}
+          sub={stats && stats.total > 0 ? `of ${stats.total} attempts` : 'no attempts recorded'}
+        />
+      </div>
+
+      {statsError && (
+        <div className="card" style={{borderColor:'var(--dp-danger)', color:'var(--dp-danger)'}}>
+          Email statistics unavailable — {statsError}. Not shown as zero.
+        </div>
+      )}
+
+      {/* The actionable half: a failure count says something is broken,
+          the reason says which thing and how to fix it. */}
+      {stats && stats.failures_by_reason.length > 0 && (
+        <div className="card" style={{borderColor:'var(--dp-warning-strong)'}}>
+          <div style={{fontWeight:600, marginBottom:8}}>Why sends failed · last 7 days</div>
+          <div style={{display:'grid', gap:6}}>
+            {stats.failures_by_reason.map((f, i) => (
+              <div key={i} className="hstack" style={{justifyContent:'space-between', gap:12}}>
+                <code style={{fontSize:12}}>{f.reason}</code>
+                <span style={{fontSize:13, opacity:.7, whiteSpace:'nowrap'}}>{f.count}×</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="hstack" style={{justifyContent:'space-between'}}>
+        <div className="hstack">
+          <input className="input" placeholder="Search recipient..." style={{width:280}}
+                 value={search} onChange={e=>setSearch(e.target.value)}
+                 onKeyDown={e=>{ if(e.key==='Enter'){ setPage(1); load(1); } }} />
+          <button className="button ghost" onClick={()=>{ setPage(1); load(1); }}>Search</button>
+          <select className="select" value={status} onChange={e=>{ setPage(1); setStatus(e.target.value); }}>
+            <option value="">All outcomes</option>
+            <option value="sent">Sent</option>
+            <option value="failed">Failed</option>
+          </select>
+          <select className="select" value={template} onChange={e=>{ setPage(1); setTemplate(e.target.value); }}>
+            <option value="">All templates</option>
+            {TEMPLATES.map(t => <option key={t} value={t}>{prettyTemplate(t)}</option>)}
+          </select>
+        </div>
+        <Pager page={page} pageCount={pageCount} total={total} noun="attempt"
+               loading={loading} onPage={setPage} />
+      </div>
+
+      <div className="card">
+        <table className="table">
+          <thead>
+            <tr>
+              <th>When</th>
+              <th>Template</th>
+              <th>Recipient</th>
+              <th>Outcome</th>
+              <th>Reason</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading ? (
+              <tr><td colSpan={6}>
+                <div className="skeleton" style={{height:42}}/>
+                <div className="skeleton" style={{height:42, marginTop:8}}/>
+              </td></tr>
+            ) : loadError ? (
+              <tr><td colSpan={6} style={{color:'var(--dp-danger)'}}>
+                Could not load the email log — {loadError}. This is a failed
+                request, not an empty log.
+              </td></tr>
+            ) : noMatches ? (
+              <tr><td colSpan={6} style={{opacity:.8}}>
+                No attempts match the current filters.{' '}
+                <button className="button ghost" onClick={clearFilters}>Clear filters</button>
+              </td></tr>
+            ) : rows.length === 0 ? (
+              <tr><td colSpan={6} style={{opacity:.75}}>
+                No send attempts recorded yet.
+              </td></tr>
+            ) : rows.map(r => (
+              <tr key={r.id}>
+                <td style={{whiteSpace:'nowrap'}}>
+                  {r.created_at ? new Date(r.created_at).toLocaleString() : '—'}
+                </td>
+                <td>{prettyTemplate(r.template)}</td>
+                <td>{r.recipient}</td>
+                <td>
+                  <Badge kind={r.status === 'sent' ? 'success' : 'danger'}>{r.status}</Badge>
+                </td>
+                <td style={{maxWidth:320, overflow:'hidden', textOverflow:'ellipsis', whiteSpace:'nowrap'}}>
+                  {r.reason || (r.status === 'sent' ? '—' : 'no reason recorded')}
+                </td>
+                <td style={{textAlign:'right'}}>
+                  <button className="button ghost" onClick={()=>setDetail(r)}>View</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {detail && (
+        <div className="modal-backdrop" onClick={()=>setDetail(null)}>
+          <div className="modal" onClick={e=>e.stopPropagation()} style={{maxWidth:600}}>
+            <div className="hstack" style={{justifyContent:'space-between', marginBottom:16}}>
+              <div style={{fontWeight:700, fontSize:16}}>Send attempt #{detail.id}</div>
+              <button className="button ghost" onClick={()=>setDetail(null)}>Close</button>
+            </div>
+            <div style={{display:'grid', gap:10, fontSize:13}}>
+              <div><strong>Template:</strong> {prettyTemplate(detail.template)}</div>
+              <div><strong>Recipient:</strong> {detail.recipient}</div>
+              <div><strong>Subject:</strong> {detail.subject || '—'}</div>
+              <div><strong>Outcome:</strong>{' '}
+                <Badge kind={detail.status === 'sent' ? 'success' : 'danger'}>{detail.status}</Badge>
+              </div>
+              {detail.status === 'failed' && (
+                <div>
+                  <strong>Reason:</strong>
+                  <div style={{marginTop:4, padding:'8px 10px', background:'var(--dp-surface-2)',
+                               borderRadius:'var(--dp-radius-xs)', fontFamily:'monospace', fontSize:12}}>
+                    {detail.reason || 'no reason recorded'}
+                  </div>
+                </div>
+              )}
+              {detail.context && (
+                <div>
+                  <strong>Context:</strong>
+                  <div style={{marginTop:4, padding:'8px 10px', background:'var(--dp-surface-2)',
+                               borderRadius:'var(--dp-radius-xs)', fontFamily:'monospace', fontSize:12}}>
+                    {JSON.stringify(detail.context)}
+                  </div>
+                </div>
+              )}
+              <div><strong>Recorded:</strong>{' '}
+                {detail.created_at ? new Date(detail.created_at).toLocaleString() : '—'}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -63,6 +63,12 @@ const Icons = {
       <line x1="21" y1="12" x2="9" y2="12"/>
     </svg>
   ),
+  Mail: () => (
+    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+      <rect x="2" y="4" width="20" height="16" rx="2"/>
+      <polyline points="2,7 12,13 22,7"/>
+    </svg>
+  ),
   Home: () => (
     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
       <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
@@ -81,6 +87,8 @@ const NAV_ITEMS = [
   // A3: reachable at last — the key admin screens existed but nothing
   // linked to them, so they could only be found by typing a URL.
   { id: 'api', label: 'API', icon: Icons.Plug, href: '/admin?tab=api' },
+  // ADMIN3: the transport ledger. Linked, not URL-only — the A3 lesson.
+  { id: 'emails', label: 'Emails', icon: Icons.Mail, href: '/admin?tab=emails' },
 ];
 
 export default function AdminLayout({ children }: { children: React.ReactNode }) {

--- a/frontend/src/app/admin/page.tsx
+++ b/frontend/src/app/admin/page.tsx
@@ -8,6 +8,7 @@ import VerificationTab from './components/VerificationTab';
 import RevenueTab from './components/RevenueTab';
 import SystemTab from './components/SystemTab';
 import ApiTab from './components/ApiTab';
+import EmailsTab from './components/EmailsTab';
 import { FEATURE_FLAGS } from '@/config/featureFlags';
 import './styles/tokens.css';
 import './styles/admin-honest.css';
@@ -50,6 +51,13 @@ const TABS: Record<string, { title: string; description: string; component: () =
     title: 'API',
     description: 'Partner API keys, usage, and access inquiries',
     component: () => <ApiTab/>
+  },
+  // ADMIN3: eleven templates whose outcomes were printed and discarded.
+  // The transport is observable for the first time.
+  emails: {
+    title: 'Emails',
+    description: 'Every send attempt, and why the failures failed',
+    component: () => <EmailsTab/>
   },
 };
 

--- a/frontend/src/lib/adminApi.ts
+++ b/frontend/src/lib/adminApi.ts
@@ -102,6 +102,38 @@ export type ApiKeyRequestRow = {
   created_at: string;
 };
 
+/**
+ * ADMIN3 — one recorded send attempt. Mirrors `email_log` and the
+ * eleven `TEMPLATES` in backend/utils/notifications.py.
+ */
+export type EmailLogRow = {
+  id: number;
+  template: string;
+  recipient: string;
+  subject?: string | null;
+  status: 'sent' | 'failed';
+  /** The S1 diagnosis string on failure — actionable, not a boolean. */
+  reason?: string | null;
+  user_id?: number | null;
+  context?: Record<string, unknown> | null;
+  created_at: string;
+};
+
+export type EmailStats = {
+  window_days: number;
+  sent: number;
+  failed: number;
+  total: number;
+  /**
+   * When the ledger started. Without this a table created yesterday
+   * reads exactly like a quiet month, and "0 failures" over a window
+   * that predates the log is not a clean bill of health.
+   */
+  recording_since: string | null;
+  by_template: Array<{ template: string; sent: number; failed: number }>;
+  failures_by_reason: Array<{ reason: string; count: number }>;
+};
+
 export type ActivityEvent = {
   type: 'user_signup' | 'deed_created' | string;
   user: string;
@@ -269,6 +301,17 @@ export const AdminApi = {
   },
   
   getDeed: (id: number) => http<DeedRow>(`/admin/deeds/${id}`),
+
+  // ADMIN3 — the transport ledger.
+  searchEmails: (page = 1, limit = 25, status = '', template = '', search = '') => {
+    const qs = new URLSearchParams({ page: String(page), limit: String(limit) });
+    if (status) qs.set('status', status);
+    if (template) qs.set('template', template);
+    if (search) qs.set('search', search);
+    return http<Paged<EmailLogRow>>(`/admin/emails?${qs.toString()}`);
+  },
+
+  getEmailStats: (days = 7) => http<EmailStats>(`/admin/emails/stats?days=${days}`),
 
   // Revenue Analytics
   getRevenue: () => http<RevenueSummary>('/admin/revenue'),


### PR DESCRIPTION
**The 3 AM question.** A customer says *"I never got the approval email."* Eleven templates existed; ten of their outcomes were formatted into a `print()` and dropped on a Render container that has since restarted.

The eleventh persisted its outcome, and **why** it did is the design of this PR: `api_key_requests` is a work queue somebody stares at, so losing a send outcome there hurt immediately. Nothing made the other ten hurt, so nothing fixed them. Adding persistence to eleven call sites would have repeated exactly that — eleven places that must remember is a place that will be forgotten.

## One choke point

Every sender already ended in `return send_email_with_reason(...)`. They now end in `_send(template, recipient, rendered, …)`, which renders, sends, and records. One row per **attempt** in `email_log`, carrying the S1 diagnosis string rather than a boolean — *"from address does not match a verified Sender Identity"* is a fix; `False` is an investigation.

Pinned as a property, not a spelling: exactly one call reaches the transport, no module outside `notifications.py` touches it, and the declared `TEMPLATES` tuple must equal the set of labels actually passed to `_send`.

That last pin matters because of how this fails. A sender that skips the ledger **does not break** — the mail goes out, nothing errors, and the row simply is not there. Silence is the failure mode, so the pin has to be the thing that breaks.

## The recorder's two constraints, both scars

1. **It cannot break the send path.** A ledger write that 500s a registration would be a worse bug than the one being fixed.
2. **It cannot use the caller's connection.** This is the A1 metering defect and it's worth naming: that code wrote inside the caller's transaction, the INSERT failed, Postgres marked the transaction `ABORTED`, and the caller's later `commit()` silently discarded a real deed while returning 200. `_record` opens a short-lived autocommit connection and closes it.

Constraint 1 means a swallowed error, which is doctrine §4's territory — so it's swallowed **loudly**, with a greppable prefix, and the admin surface states it shows *attempts it managed to record* rather than presenting itself as complete.

## Readable, or it did not happen

`/admin/dashboard` computed a 7-day activity feed for three phases and no screen rendered it. A transport log nobody can open answers the 3 AM question exactly as well as the stdout it replaced.

So: an **Emails** tab, linked from the sidebar (the A3 lesson — the API screens existed for months reachable only by typing a URL), with filters by outcome/template/recipient, per-attempt detail, and a failures-by-reason panel. It states when recording began — a table created yesterday reads exactly like a quiet month — and it declines to compute a delivery rate over zero attempts.

## Two pins corrected deliberately

`test_every_sender_returns_reason_tuples` and `test_the_ops_email_uses_the_one_transport` asserted that each sender's source contained the literal `send_email_with_reason(`. Both broke on an arrangement that is *strictly stronger* — every sender still reaches the one transport and still returns its reason; only the spelling moved. **They guarded syntax.** They now assert the property.

The first had a second, funnier version of the same disease: it swept the **transport itself** into its list of senders (`send_email_with_reason` starts with `send_`) and asserted the transport called itself — which passed only because that function's own `def` line contains its own name.

## Also included — flagged, not smuggled

The ADMIN-BRAND mirror pin that ticket shipped without. `tokens.css` mirrors `tailwind.config.js` `brand.*`, and every other mirror in this codebase is pinned bidirectionally. Without it, a brand change in Tailwind silently leaves admin behind — which is the drift that produced an orange console in the first place. Ten lines of test; a standalone PR for it seemed like ceremony.

## Gates

| gate | result |
|---|---|
| backend pytest | 373 passed (was 362) |
| jest | 426 passed, 32 suites |
| six-flow baseline | verify OK |
| API baseline | verify OK |
| tsc | 94 — unchanged |
| OpenAPI snapshot | re-recorded — exactly two additive routes (`GET /admin/emails`, `GET /admin/emails/stats`), nothing removed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_