### PR TITLE
T-0: the generation gate stops promising a record it cannot keep

### DIFF
--- a/frontend/src/__tests__/confirmationModel.test.ts
+++ b/frontend/src/__tests__/confirmationModel.test.ts
@@ -136,11 +136,40 @@ describe('U2.2 — no immortal toasts', () => {
 });
 
 describe('U2.3 — immutability copy carries the correction path', () => {
-  it('the gate modal explains how to fix a generated deed', () => {
+  /**
+   * T-0 CHANGED THIS PIN DELIBERATELY. Worth reading, because the pin was
+   * doing its job and was still wrong.
+   *
+   * U2.3's intent is right and survives intact: telling an officer the
+   * document is immutable, without telling them what to do about it, is a
+   * dead end on the one screen where they are deciding whether to press
+   * the button. The copy must carry a path forward.
+   *
+   * What U2.3 could not know is that the path it pinned did not exist.
+   * "Generate a corrected deed — the record keeps both" describes
+   * SUPERSESSION, and `deeds` has no lineage: no superseded_by, no status
+   * beyond draft/completed/deleted, nothing relating the two rows. Both
+   * deeds are kept, so the sentence is half true, and the half that is
+   * false is the word "corrected" — it promises a recorded relationship.
+   *
+   * So the pin now asserts the INTENT (a path forward is offered) rather
+   * than the SPELLING of a specific promise. T-5 builds the lineage; when
+   * it exists, the stronger sentence can come back and this pin can go
+   * back to naming it.
+   */
+  it('the gate modal tells the officer what to do about immutability', () => {
     const src = readSource('features', 'builder', 'DeedBuilder.tsx');
     expect(src).toContain('stored immutably');
-    expect(src).toContain('Generate a corrected deed');
-    expect(src).toContain('the record keeps both');
+    // A path forward, stated in terms of what is true today.
+    expect(src).toMatch(/cannot be edited/i);
+    expect(src).toMatch(/make any changes now/i);
+  });
+
+  it('and does not describe a correction the record cannot show', () => {
+    const src = readSource('features', 'builder', 'DeedBuilder.tsx')
+      .replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+    expect(src).not.toContain('Generate a corrected deed');
+    expect(src).not.toContain('the record keeps both');
   });
 });
 

--- a/frontend/src/__tests__/gateTruth.test.ts
+++ b/frontend/src/__tests__/gateTruth.test.ts
@@ -9,6 +9,8 @@
  * tests pin both truths and the one-source derivation that replaces them.
  */
 import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
 import { collectCandidateFields } from '../lib/provenance';
 import { deriveSectionTruth } from '../lib/deedValidation';
 import type { DeedBuilderState } from '../types/builder';
@@ -92,5 +94,38 @@ describe('one truth: the counter derives from gate math', () => {
     const gateWouldBlock = collectCandidateFields(s).length > 0;
     expect(gateWouldBlock).toBe(true);
     expect(truth.completedCount).toBeLessThan(truth.totalSections);
+  });
+});
+
+/**
+ * T-0 — the gate does not promise a record it cannot keep.
+ *
+ * RETIRE THIS BLOCK IN T-5, not before. The sentence it forbids is not
+ * wrong forever; it is wrong *today*. "Generate a corrected deed — the
+ * record keeps both" describes supersession lineage, and `deeds` has
+ * none: no superseded_by, no status past draft/completed/deleted, no
+ * surface relating the pair. `document_authenticity` has the shape
+ * (status + superseded_by self-FK) and is written only by the partner-API
+ * lane, so no wizard deed has ever had a lineage row.
+ *
+ * When T-5 mirrors that shape onto `deeds`, the sentence becomes true and
+ * should come back — delete this describe block in the same PR that makes
+ * it honest, so the copy and the record change together.
+ */
+describe('T-0 — the generation gate claims only what the record holds', () => {
+  const src = fs.readFileSync(
+    path.join(__dirname, '..', 'features', 'builder', 'DeedBuilder.tsx'), 'utf8');
+  // The explanatory comment necessarily quotes the removed sentence.
+  const code = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+
+  it('does not offer a "corrected deed" whose correction is recorded nowhere', () => {
+    expect(code).not.toMatch(/corrected deed/i);
+    expect(code).not.toMatch(/record keeps both/i);
+  });
+
+  it('still tells the officer the document is final and uneditable', () => {
+    // Removing the false half must not remove the true warning with it.
+    expect(code).toContain('stored immutably');
+    expect(code).toMatch(/cannot be edited/i);
   });
 });

--- a/frontend/src/features/builder/DeedBuilder.tsx
+++ b/frontend/src/features/builder/DeedBuilder.tsx
@@ -431,9 +431,29 @@ function DeedBuilderInner({ deedType, initialProperty, resumeDeedId }: DeedBuild
           <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
             <div className="w-full max-w-xl bg-white rounded-xl shadow-2xl p-6 max-h-[85vh] overflow-y-auto">
               <h2 className="text-lg font-semibold text-gray-900 mb-1">Ready to generate?</h2>
+              {/* T-0 — INTERIM COPY, and the reason is worth reading before
+                  anyone "improves" it back.
+
+                  This paragraph used to end: "Need changes? Generate a
+                  corrected deed — the record keeps both." Both halves of
+                  that sentence sound true and the pair is not. Generating
+                  again does keep both rows — but nothing records that the
+                  second deed corrects the first. There is no lineage: no
+                  superseded_by, no status beyond draft/completed/deleted,
+                  no surface that shows the pair as related. The word
+                  "corrected" promised a relationship the record does not
+                  hold, on the one screen where an officer is deciding
+                  whether it is safe to press the button.
+
+                  T-5 builds that lineage (document_authenticity already
+                  proves the shape: status + superseded_by self-FK). When it
+                  is real, the sentence comes back as truth and the pin in
+                  gateTruth.test.ts retires with it. Until then the copy
+                  says only what is true today: a generated deed cannot be
+                  edited, so changes belong here, before the button. */}
               <p className="text-sm text-gray-500 mb-4">
-                The generated document is final and stored immutably. Need
-                changes? Generate a corrected deed — the record keeps both.
+                The generated document is final and stored immutably — it
+                cannot be edited afterwards, so make any changes now.
                 Resolve the items below first.
               </p>
 


### PR DESCRIPTION
The gate modal told officers:

> The generated document is final and stored immutably. **Need changes? Generate a corrected deed — the record keeps both.** Resolve the items below first.

Both halves sound true and the pair is not. Generating again *does* keep both rows — but nothing records that the second deed corrects the first. `deeds` has no lineage: no `superseded_by`, no status past `draft/completed/deleted`, no surface relating the pair. `document_authenticity` **has** the shape (`status` + `superseded_by` self-FK) and is written only by the partner-API lane, so no wizard deed has ever carried one.

The word "corrected" promised a recorded relationship — on the one screen where an officer is deciding whether it is safe to press the button.

Interim copy says only what is true today: the document cannot be edited afterwards, so changes belong here, before the button. The immutability warning stays; only the unrecorded promise goes.

## A pin required the removed sentence — changed deliberately

`U2.3 — immutability copy carries the correction path` asserted all three strings, including `Generate a corrected deed` and `the record keeps both`. Worth flagging because the pin was doing its job and was still wrong.

Its **intent** is right and survives intact: telling an officer a document is immutable without telling them what to do about it is a dead end. What U2.3 could not know is that the path it pinned did not exist.

So it asserts the intent now — a path forward is offered, stated in terms of what is true today — rather than the spelling of one particular promise. A second assertion keeps the false version from coming back by accident.

## Retirement is scheduled, not vague

The new block in `gateTruth.test.ts` says in its own docstring that it retires in T-5, in the same PR that mirrors `document_authenticity`'s shape onto `deeds`. When the lineage is real the sentence becomes true and should return — so the copy and the record change together, and neither can drift ahead of the other.

## Gates

| gate | result |
|---|---|
| jest | 429 passed, 32 suites |
| tsc | 94 — unchanged |

Backend untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_