### PR TITLE
T-2: place becomes an identity the system looks up, not a string it matches

### DIFF
--- a/backend/routers/api_v1/router.py
+++ b/backend/routers/api_v1/router.py
@@ -745,9 +745,25 @@ async def calculate_transfer_tax(
 
     city_breakdown = None
     if request.city:
-        if city_rate is None:
-            # Honest silence beats an invented number: cities absent from
-            # the own-DTT list levy no municipal transfer tax.
+        if city_rate is None and not dtt["city_rate_known"]:
+            # T-2: the third state, which used to be silently folded into
+            # "levies none". We do not hold this place, so we do not know.
+            # Saying "levies none" here was an invented $0 — the same class
+            # of error as the invented $7,500 substring matching produced
+            # for South San Francisco, just costing the other party.
+            city_breakdown = {
+                "name": request.city,
+                "rate": None,
+                "amount": 0.0,
+                "notes": (
+                    "No verified transfer-tax rate on file for this city. "
+                    "The county portion above is complete; confirm any city "
+                    "portion against the city's current schedule."
+                ),
+            }
+        elif city_rate is None:
+            # Honest silence beats an invented number: this place is on
+            # file and affirmatively levies no municipal transfer tax.
             city_breakdown = {
                 "name": request.city,
                 "rate": None,

--- a/backend/services/dtt_rates.py
+++ b/backend/services/dtt_rates.py
@@ -24,34 +24,26 @@ any city at all, which invented tax for cities that levy none.
 """
 from typing import Optional, TypedDict
 
+from services.jurisdictions import PLACES as _PLACES, city_dtt_rate
+
 COUNTY_RATE_PER_1000 = 1.10
 
-# Cities with their own documentary transfer tax (order mirrors dttCalc.ts).
+# T-2: the city table and its matching moved to services/jurisdictions.py.
+# This module computes; the registry knows places. What lived here was a
+# flat name list matched with `if known in lowered` — substring matching,
+# which charged South San Francisco the City of San Francisco's rate.
+#
+# Kept as DERIVED back-compat exports so nothing hand-maintains a second
+# list beside the registry. That is precisely how the A2 fork survived in
+# a third file until T-2 found it.
 CITIES_WITH_OWN_DTT = [
-    "los angeles",
-    "san francisco",
-    "oakland",
-    "berkeley",
-    "san jose",
-    "sacramento",
-    "riverside",
-    "pomona",
-    "culver city",
-    "santa monica",
-    "redondo beach",
-    "inglewood",
-    "long beach",
-    "pasadena",
+    p.city.lower() for p in _PLACES
+    if p.dtt_rate_per_1000 is not None and p.dtt_rate_per_1000 > 0
 ]
-
-# Cities whose rate differs from the $2.20 default.
 CITY_RATES_PER_1000 = {
-    "los angeles": 4.50,
-    "san francisco": 7.50,
-    "oakland": 15.00,
+    p.city.lower(): p.dtt_rate_per_1000 for p in _PLACES
+    if p.dtt_rate_per_1000 is not None and p.dtt_rate_per_1000 > 0
 }
-DEFAULT_CITY_RATE_PER_1000 = 2.20
-
 
 class DttBreakdown(TypedDict):
     county_tax: float
@@ -60,20 +52,22 @@ class DttBreakdown(TypedDict):
     county_rate_per_1000: float
     city_rate_per_1000: Optional[float]
     city_levies_own_dtt: bool
+    # T-2: False when we do not KNOW the rate — distinct from knowing it
+    # is zero. Callers must ask rather than print a number.
+    city_rate_known: bool
 
 
 def city_rate_per_1000(city: Optional[str]) -> Optional[float]:
-    """None when the city levies no transfer tax of its own — distinct
-    from 0.0, which would read as 'levies one, and it is zero'."""
-    if not city:
-        return None
-    lowered = city.strip().lower()
-    if not any(known in lowered for known in CITIES_WITH_OWN_DTT):
-        return None
-    for known, rate in CITY_RATES_PER_1000.items():
-        if known in lowered:
-            return rate
-    return DEFAULT_CITY_RATE_PER_1000
+    """The rate, or None when no city portion applies.
+
+    T-2 NOTE: None is now ambiguous by necessity of the old signature — it
+    covers both "levies none" and "we do not know". Callers that need to
+    tell those apart must use `city_dtt_rate` from services.jurisdictions
+    (or read `city_rate_known` off compute_dtt). This wrapper survives for
+    the existing pins; the tri-state is the real contract.
+    """
+    rate = city_dtt_rate(city)
+    return rate.rate_per_1000 if rate.state == "rated" else None
 
 
 def compute_dtt(taxable_value: float, city: Optional[str] = None,
@@ -83,8 +77,15 @@ def compute_dtt(taxable_value: float, city: Optional[str] = None,
     value = max(0.0, float(taxable_value or 0))
     county_tax = (value / 1000.0) * COUNTY_RATE_PER_1000
 
-    rate = city_rate_per_1000(city) if apply_city_tax else None
+    # A caller that supplies no city is not asking about an unknown place —
+    # it is stating there is no city portion. Only a NAMED place we do not
+    # hold is "unknown".
+    resolved = city_dtt_rate(city) if (apply_city_tax and city) else None
+    rate = resolved.rate_per_1000 if resolved and resolved.state == "rated" else None
     city_tax = (value / 1000.0) * rate if rate else 0.0
+    # Unknown is not zero. A city we have never rated must not be
+    # reported as one that levies nothing.
+    known = resolved is None or resolved.state in ("rated", "none")
 
     return {
         "county_tax": round(county_tax, 2),
@@ -93,4 +94,5 @@ def compute_dtt(taxable_value: float, city: Optional[str] = None,
         "county_rate_per_1000": COUNTY_RATE_PER_1000,
         "city_rate_per_1000": rate,
         "city_levies_own_dtt": rate is not None,
+        "city_rate_known": known,
     }

--- a/backend/services/jurisdictions.py
+++ b/backend/services/jurisdictions.py
@@ -1,0 +1,146 @@
+"""T-2 — the jurisdictions registry, backend mirror.
+
+Mirror of frontend/src/lib/jurisdictions.ts. Read that file for the full
+account of why this exists; the short version is that "place" used to be
+a STRING the code pattern-matched rather than an IDENTITY it looked up,
+and substring matching charged South San Francisco the City of San
+Francisco's $7.50 per $1,000 while charging unincorporated East Los
+Angeles the City of LA's $4.50.
+
+A jest pin (dttRatesMirror.test.ts) reads this file and holds the two in
+sync — the same arrangement form_families.py has with formRegistry.ts —
+because a rate that differs between the wizard and the partner API is a
+number headed for a legal declaration under two different values. That is
+not hypothetical: A2 found exactly that fork and killed it in two files
+while a third copy survived in propertyPrefill.ts until T-2.
+
+RATE SEMANTICS — the distinction the whole ticket turns on:
+
+    rate > 0     levies its own DTT at this rate
+    rate == 0    AFFIRMATIVE: we know it levies none
+    rate is None we do not know. Callers must ASK, never assume.
+
+A zero we invented is the same class of error as a $7,500 we invented; it
+just costs the other party. Absence of knowledge must not render as fact.
+
+RATE PROVENANCE: every non-None rate is carried forward unchanged from
+the pre-T-2 table and remains the owner's escrow review to confirm
+against current published schedules. The `None` rows are the honest gaps
+that review should fill — not omissions to be closed by guessing.
+"""
+from typing import Dict, List, NamedTuple, Optional
+
+
+class Place(NamedTuple):
+    city: str
+    county: str
+    incorporated: bool
+    dtt_rate_per_1000: Optional[float]
+
+
+class PcorRouting(NamedTuple):
+    office: str
+    notes: str
+
+
+# County-level knowledge. LA's PCOR routing is the registry's first datum:
+# the form is filed with the Registrar-Recorder/County Clerk alongside the
+# deed, not sent separately to the Assessor — which is why the county
+# publishes it at lavote.gov and why officers new to LA look in the wrong
+# place for it.
+PCOR_ROUTING: Dict[str, PcorRouting] = {
+    "los angeles": PcorRouting(
+        office="Los Angeles County Registrar-Recorder/County Clerk",
+        notes="Filed concurrently with the deed at the recorder, not sent separately to the Assessor.",
+    ),
+}
+
+# Order mirrors PLACES in jurisdictions.ts exactly — the pin compares them
+# element by element, so a reordering here is a failure, not a style
+# choice.
+PLACES: List[Place] = [
+    Place("Los Angeles", "Los Angeles", True, 4.50),
+    Place("Culver City", "Los Angeles", True, 2.20),
+    Place("Santa Monica", "Los Angeles", True, 2.20),
+    Place("Redondo Beach", "Los Angeles", True, 2.20),
+    Place("Inglewood", "Los Angeles", True, 2.20),
+    Place("Long Beach", "Los Angeles", True, 2.20),
+    Place("Pasadena", "Los Angeles", True, 2.20),
+    Place("Pomona", "Los Angeles", True, 2.20),
+    Place("East Los Angeles", "Los Angeles", False, 0),
+    Place("Lake Los Angeles", "Los Angeles", False, 0),
+    Place("South Pasadena", "Los Angeles", True, None),
+    Place("South San Francisco", "San Mateo", True, None),
+    Place("West Sacramento", "Yolo", True, None),
+    Place("San Francisco", "San Francisco", True, 7.50),
+    Place("Oakland", "Alameda", True, 15.00),
+    Place("Berkeley", "Alameda", True, 2.20),
+    Place("San Jose", "Santa Clara", True, 2.20),
+    Place("Sacramento", "Sacramento", True, 2.20),
+    Place("Riverside", "Riverside", True, 2.20),
+    Place("Hercules", "Contra Costa", True, None),
+    Place("Hayward", "Alameda", True, None),
+    Place("Richmond", "Contra Costa", True, None),
+    Place("Alameda", "Alameda", True, None),
+    Place("Albany", "Alameda", True, None),
+    Place("Emeryville", "Alameda", True, None),
+    Place("Piedmont", "Alameda", True, None),
+    Place("San Leandro", "Alameda", True, None),
+    Place("San Pablo", "Contra Costa", True, None),
+    Place("Mountain View", "Santa Clara", True, None),
+    Place("Palo Alto", "Santa Clara", True, None),
+    Place("Petaluma", "Sonoma", True, None),
+    Place("Santa Rosa", "Sonoma", True, None),
+    Place("Sebastopol", "Sonoma", True, None),
+    Place("Cotati", "Sonoma", True, None),
+    Place("Cloverdale", "Sonoma", True, None),
+]
+
+_BY_NAME = {}
+
+
+def normalize_place(name: Optional[str]) -> str:
+    """Comparison only, never display. Case and whitespace collapse and
+    nothing else — direction words ("South", "West") are NOT stripped,
+    because they are the entire difference between two different cities in
+    two different counties."""
+    return " ".join((name or "").strip().lower().split())
+
+
+for _p in PLACES:
+    _BY_NAME[normalize_place(_p.city)] = _p
+
+
+def lookup_place(city: Optional[str]) -> Optional[Place]:
+    """EXACT lookup. None means we do not hold this place — which the
+    caller must surface as a question, never resolve as a zero."""
+    key = normalize_place(city)
+    return _BY_NAME.get(key) if key else None
+
+
+class CityRate(NamedTuple):
+    """Tri-state, deliberately. `state` is one of:
+    'rated' (levies its own, at rate), 'none' (affirmatively levies none),
+    'unknown' (we do not know — ask the officer)."""
+    state: str
+    rate_per_1000: Optional[float] = None
+    place: Optional[str] = None
+
+
+def city_dtt_rate(city: Optional[str]) -> CityRate:
+    place = lookup_place(city)
+    if place is None:
+        return CityRate("unknown", None, (city or "").strip())
+    if place.dtt_rate_per_1000 is None:
+        return CityRate("unknown", None, place.city)
+    if place.dtt_rate_per_1000 == 0:
+        return CityRate("none")
+    return CityRate("rated", place.dtt_rate_per_1000)
+
+
+def is_incorporated(city: Optional[str]) -> Optional[bool]:
+    """Its OWN fact — not "does it tax". The pre-T-2 code conflated the
+    two and labelled Glendale unincorporated because that produced the
+    right tax by accident."""
+    place = lookup_place(city)
+    return place.incorporated if place else None

--- a/backend/tests/test_api_catalog_and_rates.py
+++ b/backend/tests/test_api_catalog_and_rates.py
@@ -25,7 +25,7 @@ from services.api_catalog import (
 from services.deed_pdf import TEMPLATE_BY_DEED_TYPE
 from services.dtt_rates import (
     CITIES_WITH_OWN_DTT, CITY_RATES_PER_1000, COUNTY_RATE_PER_1000,
-    DEFAULT_CITY_RATE_PER_1000, city_rate_per_1000, compute_dtt,
+    city_rate_per_1000, compute_dtt,
 )
 from services.form_families import FAMILY_BY_DEED_TYPE
 
@@ -151,29 +151,66 @@ def test_entity_slot_is_absent_for_ordinary_deeds():
 
 # ── One rates source ─────────────────────────────────────────────────
 
-def _ts_rates():
-    """Parse the officer-facing calculator's rates out of dttCalc.ts."""
-    src = DTT_CALC_TS.read_text(encoding="utf-8")
-    cities = re.search(r"CITIES_WITH_OWN_DTT\s*=\s*\[(.*?)\]", src, re.S).group(1)
-    city_list = re.findall(r"'([^']+)'", cities)
-    county = float(re.search(r"\(amount / 1000\) \* ([\d.]+)", src).group(1))
-    specials = {}
-    for city, rate in re.findall(
-            r"cityLower\.includes\('([^']+)'\)\)\s*\{\s*cityTax = \(amount / 1000\) \* ([\d.]+)", src):
-        specials[city] = float(rate)
-    default = float(re.findall(r"else \{\s*cityTax = \(amount / 1000\) \* ([\d.]+)", src)[0])
-    return city_list, county, specials, default
+def _registry_places():
+    """Parse the TS registry. T-2 moved the rates out of dttCalc.ts and
+    into lib/jurisdictions.ts, so the mirror reads the registry."""
+    src = (BACKEND.parent / "frontend/src/lib/jurisdictions.ts").read_text(encoding="utf-8")
+    out = []
+    for city, county, inc, rate in re.findall(
+            r"\{ city: '([^']+)', county: '([^']+)', incorporated: (true|false), "
+            r"dttRatePer1000: ([\d.]+|null) \}", src):
+        out.append((city, county, inc == "true",
+                    None if rate == "null" else float(rate)))
+    return out
 
 
 def test_backend_rates_mirror_the_officer_facing_calculator():
     """Same arrangement form_families.py has with formRegistry.ts: a rate
     that differs between the wizard and the API is a number headed for a
-    legal declaration under two different values."""
-    city_list, county, specials, default = _ts_rates()
-    assert CITIES_WITH_OWN_DTT == city_list
-    assert COUNTY_RATE_PER_1000 == county
-    assert CITY_RATES_PER_1000 == specials
-    assert DEFAULT_CITY_RATE_PER_1000 == default
+    legal declaration under two different values.
+
+    T-2 REWROTE THIS PIN. It used to parse dttCalc.ts for a literal city
+    array, an if/else chain of `cityLower.includes(...)` branches, and a
+    trailing `else` default rate — i.e. it asserted the SHAPE of the old
+    substring matcher. That matcher is the defect this ticket removed (it
+    charged South San Francisco the City of San Francisco's rate), so a
+    pin shaped like it could not survive the fix. It compares the two
+    REGISTRIES now, which is the property it always meant to protect.
+    """
+    from services.jurisdictions import PLACES
+
+    ts = _registry_places()
+    py = [(p.city, p.county, p.incorporated, p.dtt_rate_per_1000) for p in PLACES]
+    assert py == ts, "the registries disagree — one surface would declare a different tax"
+    assert COUNTY_RATE_PER_1000 == 1.10
+
+
+def test_there_is_no_generic_fallback_city_rate():
+    """DEFAULT_CITY_RATE_PER_1000 is deliberately gone.
+
+    A single fallback rate applied to "any city we don't have" is the
+    pre-X2.3 disease in a nicer coat: it invents a number for a place we
+    know nothing about. Every rate is per-place now, and a place we do
+    not hold resolves to UNKNOWN rather than to a default.
+    """
+    import ast
+
+    import services.dtt_rates as rates
+    assert not hasattr(rates, "DEFAULT_CITY_RATE_PER_1000")
+
+    # Strip DOCSTRINGS as well as comments. The module docstring recounts
+    # the rate history and necessarily quotes the old fallback figure —
+    # the sixth time in this codebase that a forbidden-pattern pin has
+    # tripped on the prose explaining the removal.
+    src = (BACKEND / "services/dtt_rates.py").read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            doc = ast.get_docstring(node, clean=False)
+            if doc:
+                src = src.replace(doc, "")
+    code = "\n".join(l for l in src.splitlines() if not l.strip().startswith("#"))
+    assert "2.20" not in code, "a fallback rate reappeared in code"
 
 
 def test_the_api_no_longer_carries_its_own_rate_table():
@@ -188,18 +225,35 @@ def test_the_api_no_longer_carries_its_own_rate_table():
     assert not re.search(r"/ 1000\)?\s*\*\s*[\d.]+", code), "rate math back in the router"
 
 
-def test_cities_without_their_own_dtt_are_charged_nothing():
-    """The pre-X2.3 disease: applying a generic city rate to any city at
-    all invented tax for cities that levy none."""
+def test_an_unheld_city_is_unknown_rather_than_free():
+    """T-2 sharpened X2.3. That fix stopped INVENTING a generic rate for
+    every city; this one stops inventing a ZERO for cities we have never
+    rated. Fresno contributed $0 and the total read as complete — but we
+    hold no Fresno rate, so the $0 was invented too. It just cost the
+    other party."""
     assert city_rate_per_1000("Fresno") is None
     assert compute_dtt(500_000, "Fresno")["city_tax"] == 0.0
-    assert compute_dtt(500_000, "Fresno")["city_levies_own_dtt"] is False
+    assert compute_dtt(500_000, "Fresno")["city_rate_known"] is False
+
+    # An affirmative zero is distinguishable from an unknown: East Los
+    # Angeles is unincorporated, so "levies none" is knowledge.
+    assert compute_dtt(500_000, "East Los Angeles")["city_rate_known"] is True
+    assert compute_dtt(500_000, "East Los Angeles")["city_tax"] == 0.0
+
+
+def test_substring_collisions_cannot_charge_a_neighbours_rate():
+    """The live defect, on the backend side of the wire."""
+    assert compute_dtt(1_000_000, "San Francisco")["city_tax"] == 7500.0
+    assert compute_dtt(1_000_000, "South San Francisco")["city_tax"] == 0.0
+    assert compute_dtt(1_000_000, "South San Francisco")["city_rate_known"] is False
+    assert compute_dtt(1_000_000, "Los Angeles")["city_tax"] == 4500.0
+    assert compute_dtt(1_000_000, "East Los Angeles")["city_tax"] == 0.0
 
 
 def test_known_city_rates():
     assert city_rate_per_1000("Los Angeles") == 4.50
     assert city_rate_per_1000("San Francisco") == 7.50
     assert city_rate_per_1000("Oakland") == 15.00
-    assert city_rate_per_1000("Pasadena") == DEFAULT_CITY_RATE_PER_1000
+    assert city_rate_per_1000("Pasadena") == 2.20
     # County portion alone on a $500k transfer.
     assert compute_dtt(500_000, None)["total_tax"] == 550.0

--- a/frontend/src/__tests__/dttRatesMirror.test.ts
+++ b/frontend/src/__tests__/dttRatesMirror.test.ts
@@ -22,17 +22,53 @@ const py = fs.readFileSync(
 );
 
 describe('DTT rates — one source across the wire', () => {
-  it('every city with its own DTT appears in the backend mirror', () => {
+  /**
+   * T-2 REWROTE FOUR OF THESE PINS DELIBERATELY, and the reason is the
+   * lesson this codebase keeps relearning: they guarded a SPELLING.
+   *
+   * They matched literal text in dtt_rates.py — `CITIES_WITH_OWN_DTT = [`
+   * followed by quoted names, `"los angeles": 4.50`, and a docstring
+   * sentence. All four broke when the rates moved into the jurisdictions
+   * registry and dtt_rates.py began DERIVING its lists from it, even
+   * though the property they existed to protect — the two sides declare
+   * the same tax — became strictly better guarded (the registry mirror
+   * below compares city, county, incorporation AND rate, element for
+   * element, and distinguishes null from zero).
+   *
+   * Worse, the old shape could not have caught the fork that actually
+   * existed. It compared the two files it knew about while a third list
+   * lived in propertyPrefill.ts, disagreeing with both, deciding whether
+   * a Long Beach property was charged city tax at all.
+   *
+   * So these assert the property through the computation itself: same
+   * input, same declared tax, on both sides of the wire.
+   */
+  it('every rated city agrees on both sides of the wire', () => {
+    // Derived from the registry on the TS side; parsed from the mirrored
+    // registry on the Python side. No literal list on either.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { PLACES } = require('@/lib/jurisdictions');
+    const pyReg = fs.readFileSync(
+      path.join(__dirname, '..', '..', '..', 'backend', 'services', 'jurisdictions.py'),
+      'utf8'
+    );
     for (const city of CITIES_WITH_OWN_DTT) {
-      expect(py).toContain(`"${city}"`);
+      const entry = PLACES.find(
+        (p: { city: string }) => p.city.toLowerCase() === city);
+      expect(entry).toBeDefined();
+      expect(pyReg).toContain(`Place("${entry.city}"`);
     }
   });
 
-  it('the backend list has no cities this one lacks', () => {
-    const block = py.match(/CITIES_WITH_OWN_DTT = \[([\s\S]*?)\]/);
-    expect(block).not.toBeNull();
-    const backendCities = [...block![1].matchAll(/"([^"]+)"/g)].map((m) => m[1]);
-    expect(backendCities).toEqual(CITIES_WITH_OWN_DTT);
+  it('the backend rates no city this one does not', () => {
+    const pyReg = fs.readFileSync(
+      path.join(__dirname, '..', '..', '..', 'backend', 'services', 'jurisdictions.py'),
+      'utf8'
+    );
+    const pyRated = [...pyReg.matchAll(
+      /Place\("([^"]+)",\s*"[^"]+",\s*(?:True|False),\s*([\d.]+)\)/g
+    )].filter((m) => parseFloat(m[2]) > 0).map((m) => m[1].toLowerCase());
+    expect(pyRated.sort()).toEqual([...CITIES_WITH_OWN_DTT].sort());
   });
 
   it('the county rate matches', () => {
@@ -45,21 +81,100 @@ describe('DTT rates — one source across the wire', () => {
     expect(breakdown?.county).toBe('550.00');
   });
 
-  it('the city rates that differ from the default match', () => {
-    expect(py).toContain('"los angeles": 4.50');
-    expect(py).toContain('"san francisco": 7.50');
-    expect(py).toContain('"oakland": 15.00');
-    expect(py).toContain('DEFAULT_CITY_RATE_PER_1000 = 2.20');
+  it('the distinctive city rates still compute identically on both sides', () => {
+    // Rates asserted through the registry rather than through a hardcoded
+    // dict literal that no longer exists.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { cityDttRate } = require('@/lib/jurisdictions');
+    for (const [city, rate] of [
+      ['Los Angeles', 4.5], ['San Francisco', 7.5], ['Oakland', 15.0],
+      ['Pasadena', 2.2],
+    ] as Array<[string, number]>) {
+      const r = cityDttRate(city);
+      expect(r.state).toBe('rated');
+      expect(r.ratePer1000).toBe(rate);
+    }
   });
 
-  it('a city with no DTT of its own is charged nothing on both sides', () => {
+  it('an UNRATED city is surfaced, not silently charged nothing', () => {
+    // T-2 changed this behaviour deliberately. Fresno used to contribute
+    // $0 and read as complete; we have never held a Fresno rate, so the
+    // $0 was invented. It is now an explicit unknown on both sides.
     const breakdown = computeDttBreakdown({
       transferValue: '500000', isExempt: false, areaType: 'city',
       cityName: 'Fresno', basis: 'full_value', exemptionReason: '', calculatedAmount: '',
     } as never);
     expect(breakdown?.city).toBeNull();
-    // The backend returns None for the same reason, not 0.0 — "levies
-    // none" and "levies one, and it is zero" are different claims.
-    expect(py).toContain('None when the city levies no transfer tax of its own');
+    expect(breakdown?.cityRateUnknown).toBe(true);
+    const pyReg = fs.readFileSync(
+      path.join(__dirname, '..', '..', '..', 'backend', 'services', 'jurisdictions.py'),
+      'utf8'
+    );
+    expect(pyReg).toContain('we do not know. Callers must ASK, never assume');
+  });
+});
+
+/**
+ * T-2 — the mirror widens to the REGISTRY, because that is where the
+ * rates moved and because the old pin could not have caught the fork that
+ * actually existed.
+ *
+ * A2 pinned dttCalc.ts against dtt_rates.py and declared the fork dead.
+ * It was not: services/propertyPrefill.ts kept a THIRD list, with a
+ * different 27 cities, and nothing compared it to anything. The pin
+ * guarded the two files it knew about. So this block asserts the property
+ * that actually matters — one registry, mirrored element for element —
+ * and jurisdictions.test.ts separately forbids any file from growing its
+ * own city array again.
+ */
+describe('T-2 — the jurisdictions registry is mirrored element for element', () => {
+  const pyReg = fs.readFileSync(
+    path.join(__dirname, '..', '..', '..', 'backend', 'services', 'jurisdictions.py'),
+    'utf8'
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { PLACES } = require('@/lib/jurisdictions');
+
+  const pyPlaces = [...pyReg.matchAll(
+    /Place\("([^"]+)",\s*"([^"]+)",\s*(True|False),\s*([\d.]+|None)\)/g
+  )].map((m) => ({
+    city: m[1],
+    county: m[2],
+    incorporated: m[3] === 'True',
+    dttRatePer1000: m[4] === 'None' ? null : parseFloat(m[4]),
+  }));
+
+  it('both registries hold the same places in the same order', () => {
+    expect(pyPlaces.map((p) => p.city)).toEqual(
+      PLACES.map((p: { city: string }) => p.city));
+  });
+
+  it('every place agrees on county, incorporation AND rate', () => {
+    // Rate is the one that reaches a legal declaration; county and
+    // incorporation are what make the rate lookup correct in the first
+    // place, so all three are pinned.
+    expect(pyPlaces).toEqual(PLACES.map((p: Record<string, unknown>) => ({
+      city: p.city,
+      county: p.county,
+      incorporated: p.incorporated,
+      dttRatePer1000: p.dttRatePer1000,
+    })));
+  });
+
+  it('null-vs-zero survives the crossing', () => {
+    // The distinction the whole ticket turns on. If the mirror flattened
+    // `null` to `0` on either side, an unknown rate would silently become
+    // "this city levies nothing" on that surface only.
+    const unknowns = pyPlaces.filter((p) => p.dttRatePer1000 === null).map((p) => p.city);
+    const zeros = pyPlaces.filter((p) => p.dttRatePer1000 === 0).map((p) => p.city);
+    expect(unknowns.length).toBeGreaterThan(0);
+    expect(zeros).toContain('East Los Angeles');
+    expect(unknowns).not.toContain('East Los Angeles');
+  });
+
+  it('the backend refuses to guess for a place it does not hold', () => {
+    expect(pyReg).toContain('def city_dtt_rate');
+    expect(pyReg).toMatch(/CityRate\("unknown"/);
   });
 });

--- a/frontend/src/__tests__/jurisdictions.test.ts
+++ b/frontend/src/__tests__/jurisdictions.test.ts
@@ -1,0 +1,144 @@
+/**
+ * T-2 — the substring defect, killed and pinned.
+ *
+ * These are the collision pairs that were live in production. Each is a
+ * real California place whose name CONTAINS a rated place's name, and
+ * each was charged the containing place's rate by
+ * `cityLower.includes(known)`:
+ *
+ *   South San Francisco  → San Francisco's $7.50/$1,000  (different county)
+ *   East Los Angeles     → City of LA's  $4.50/$1,000    (UNINCORPORATED)
+ *   Lake Los Angeles     → City of LA's  $4.50/$1,000    (UNINCORPORATED)
+ *   West Sacramento      → Sacramento's rate             (different county)
+ *   South Pasadena       → Pasadena's rate
+ *
+ * On a $1,000,000 transfer, South San Francisco alone was $7,500 of
+ * invented tax on a legal declaration.
+ */
+import { describe, expect, it } from '@jest/globals';
+import { cityDttRate, isIncorporated, lookupJurisdiction, PLACES } from '@/lib/jurisdictions';
+import { computeDttBreakdown } from '@/lib/dttCalc';
+
+const ONE_MILLION = {
+  isExempt: false, exemptReason: '', transferValue: '1000000',
+  calculatedAmount: '', basis: 'full_value' as const, areaType: 'city' as const,
+};
+
+describe('T-2 — substring collisions cannot happen', () => {
+  const COLLISIONS: Array<[string, string]> = [
+    ['South San Francisco', 'San Francisco'],
+    ['East Los Angeles', 'Los Angeles'],
+    ['Lake Los Angeles', 'Los Angeles'],
+    ['West Sacramento', 'Sacramento'],
+    ['South Pasadena', 'Pasadena'],
+  ];
+
+  for (const [place, contained] of COLLISIONS) {
+    it(`"${place}" is never charged "${contained}"'s rate`, () => {
+      const victim = cityDttRate(place);
+      const container = cityDttRate(contained);
+      expect(container.state).toBe('rated');
+      // Whatever the victim resolves to, it is NOT the containing city's rate.
+      if (victim.state === 'rated') {
+        expect(victim.ratePer1000).not.toBe(
+          container.state === 'rated' ? container.ratePer1000 : null);
+      } else {
+        expect(['unknown', 'none']).toContain(victim.state);
+      }
+    });
+  }
+
+  it('South San Francisco no longer produces $7,500 of city tax on $1M', () => {
+    const b = computeDttBreakdown({ ...ONE_MILLION, cityName: 'South San Francisco' })!;
+    expect(b.city).toBeNull();
+    expect(b.cityRateUnknown).toBe(true);
+    expect(b.unknownPlace).toBe('South San Francisco');
+    // And the county portion — the part we DO know — is unaffected.
+    expect(b.county).toBe('1100.00');
+  });
+
+  it('the City of San Francisco still is charged $7,500 on $1M', () => {
+    // The fix must not have been "stop charging anyone".
+    const b = computeDttBreakdown({ ...ONE_MILLION, cityName: 'San Francisco' })!;
+    expect(b.city).toBe('7500.00');
+  });
+
+  it('unincorporated East Los Angeles is a MEASURED zero, not an unknown', () => {
+    const b = computeDttBreakdown({ ...ONE_MILLION, cityName: 'East Los Angeles' })!;
+    expect(b.city).toBeNull();
+    expect(b.cityRateUnknown).toBeUndefined();
+    expect(isIncorporated('East Los Angeles')).toBe(false);
+  });
+});
+
+describe('T-2 — unknown is never rendered as a rate', () => {
+  it('a place we do not hold comes back unknown, not zero', () => {
+    const r = cityDttRate('Fresno');
+    expect(r.state).toBe('unknown');
+  });
+
+  it('an unknown place surfaces to the officer instead of computing', () => {
+    const b = computeDttBreakdown({ ...ONE_MILLION, cityName: 'Fresno' })!;
+    expect(b.cityRateUnknown).toBe(true);
+    expect(b.city).toBeNull();
+  });
+
+  it('a known-zero and an unknown are distinguishable', () => {
+    expect(cityDttRate('East Los Angeles').state).toBe('none');
+    expect(cityDttRate('Fresno').state).toBe('unknown');
+  });
+
+  it('matching is exact — no leading/trailing or case tricks', () => {
+    expect(cityDttRate('  los ANGELES ').state).toBe('rated');
+    expect(cityDttRate('Los Angeles City').state).toBe('unknown');
+    expect(cityDttRate('LosAngeles').state).toBe('unknown');
+  });
+
+  it('normalization never strips direction words', () => {
+    // "South"/"West" ARE the difference between two different cities.
+    expect(lookupJurisdiction('South San Francisco').known).toBe(true);
+    const a = lookupJurisdiction('South San Francisco');
+    const b = lookupJurisdiction('San Francisco');
+    expect(a.known && b.known && a.jurisdiction.county).not.toBe(
+      b.known ? b.jurisdiction.county : null);
+  });
+});
+
+describe('T-2 — incorporation and taxation are separate facts', () => {
+  it('an incorporated city may levy no DTT', () => {
+    // The pre-T-2 code called Glendale "unincorporated" because that
+    // produced the right tax by accident.
+    expect(isIncorporated('South Pasadena')).toBe(true);
+    expect(cityDttRate('South Pasadena').state).toBe('unknown');
+  });
+
+  it('an unknown place asserts neither', () => {
+    expect(isIncorporated('Nowhere Township')).toBeNull();
+  });
+});
+
+describe('T-2 — the registry is the only list', () => {
+  it('every rated place carries a positive rate; zeros are affirmative', () => {
+    for (const p of PLACES) {
+      if (p.dttRatePer1000 !== null) expect(p.dttRatePer1000).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('LA County carries the PCOR routing datum', () => {
+    const la = lookupJurisdiction('Los Angeles');
+    expect(la.known).toBe(true);
+    expect(la.known && la.jurisdiction.pcorRouting?.office)
+      .toContain('Registrar-Recorder');
+  });
+
+  it('no source file keeps its own city list any more', () => {
+    const fs = require('fs');
+    const path = require('path');
+    for (const rel of [['lib', 'dttCalc.ts'], ['services', 'propertyPrefill.ts']]) {
+      const src: string = fs.readFileSync(path.join(__dirname, '..', ...rel), 'utf8')
+        .replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+      // A literal array of quoted city names is the shape of a fork.
+      expect(src).not.toMatch(/=\s*\[\s*\n?\s*["']los angeles["']/i);
+    }
+  });
+});

--- a/frontend/src/components/builder/sections/TransferTaxSection.tsx
+++ b/frontend/src/components/builder/sections/TransferTaxSection.tsx
@@ -339,6 +339,24 @@ export function TransferTaxSection({
                   <> · City of {value.cityName}: ${dttBreakdown.city}</>
                 )}
               </div>
+              {/* T-2 — the unknown state, said out loud.
+                  This used to be indistinguishable from "levies none":
+                  a city we had never rated simply contributed $0 and the
+                  total read as complete. An invented $0 is the same class
+                  of error as the invented $7,500 substring matching
+                  produced for South San Francisco — it just costs the
+                  other party. Amber, because it is a real value the
+                  officer must not take at face value. */}
+              {dttBreakdown.cityRateUnknown && (
+                <div className="mt-2 ml-7 p-2.5 rounded-md border border-amber-300 bg-amber-50 text-sm text-amber-900">
+                  <span className="font-semibold">
+                    No rate on file for {dttBreakdown.unknownPlace || 'this city'}.
+                  </span>{' '}
+                  The county portion above is complete. Any city transfer tax
+                  must be confirmed against that city&apos;s current schedule
+                  and entered manually — it is not included in the total.
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/frontend/src/lib/dttCalc.ts
+++ b/frontend/src/lib/dttCalc.ts
@@ -1,42 +1,41 @@
 /**
  * X2.3 — documentary transfer tax breakdown (county + city portions).
  *
- * One opaque total hid what was being declared. And the old inline math
- * fabricated a generic $2.20/$1,000 "city tax" for ANY city — including
- * cities with no municipal transfer tax at all — a wrong number headed
- * for a legal declaration. City portion now applies only to cities on
- * the own-DTT list.
+ * T-2: the city table and its matching moved to lib/jurisdictions.ts.
+ * This file computes; the registry knows places. The old matcher here was
+ * `cityLower.includes(known)`, which charged South San Francisco the City
+ * of San Francisco's $7.50 and charged unincorporated East Los Angeles
+ * the City of LA's $4.50 — read jurisdictions.ts for the full account.
  *
- * RATE PROVENANCE (owner/legal to verify against current schedules):
- * county $1.10/$1,000 (R&T §11911). City rates are APPROXIMATIONS of
- * tiered schedules: LA $4.50, SF $7.50, Oakland $15.00, other listed
- * cities $2.20 per $1,000.
+ * RATE PROVENANCE moved with the rates. County $1.10/$1,000 (R&T §11911)
+ * stays here because it is statewide, not a place fact — and it too is
+ * the owner's escrow review to confirm.
  */
 import type { DTTData } from '@/types/builder';
+import { cityDttRate, PLACES } from '@/lib/jurisdictions';
 
-// Cities with their own documentary transfer tax.
-export const CITIES_WITH_OWN_DTT = [
-  'los angeles',
-  'san francisco',
-  'oakland',
-  'berkeley',
-  'san jose',
-  'sacramento',
-  'riverside',
-  'pomona',
-  'culver city',
-  'santa monica',
-  'redondo beach',
-  'inglewood',
-  'long beach',
-  'pasadena',
-];
+/**
+ * Back-compat export: the names of places that levy their own DTT,
+ * DERIVED from the registry rather than maintained beside it. A second
+ * hand-kept list is exactly how the A2 fork survived in a third file.
+ */
+export const CITIES_WITH_OWN_DTT: string[] = PLACES
+  .filter((p) => p.dttRatePer1000 !== null && p.dttRatePer1000 > 0)
+  .map((p) => p.city.toLowerCase());
 
 export interface DttBreakdown {
   county: string;
   /** null when the city levies no transfer tax of its own. */
   city: string | null;
   total: string;
+  /**
+   * T-2. Set when we do not KNOW the city's rate — distinct from knowing
+   * it is zero. The UI must ask rather than render a number; a $0 we
+   * invented is the same class of error as a $7,500 we invented.
+   */
+  cityRateUnknown?: boolean;
+  /** The place whose rate is unknown, for the officer-facing prompt. */
+  unknownPlace?: string;
 }
 
 export function computeDttBreakdown(value: DTTData | null): DttBreakdown | null {
@@ -46,25 +45,27 @@ export function computeDttBreakdown(value: DTTData | null): DttBreakdown | null 
   if (isNaN(amount) || amount <= 0) return null;
 
   const countyTax = (amount / 1000) * 1.1;
-
   let cityTax = 0;
-  const cityLower = (value.cityName || '').toLowerCase();
-  const hasOwnDtt = CITIES_WITH_OWN_DTT.some((c) => cityLower.includes(c));
-  if (value.areaType === 'city' && hasOwnDtt) {
-    if (cityLower.includes('los angeles')) {
-      cityTax = (amount / 1000) * 4.5;
-    } else if (cityLower.includes('san francisco')) {
-      cityTax = (amount / 1000) * 7.5;
-    } else if (cityLower.includes('oakland')) {
-      cityTax = (amount / 1000) * 15.0;
-    } else {
-      cityTax = (amount / 1000) * 2.2;
+  let cityRateUnknown = false;
+  let unknownPlace: string | undefined;
+
+  // The city portion applies only where the property actually sits in a
+  // city. `areaType` remains the officer's statement about the property.
+  if (value.areaType === 'city') {
+    const rate = cityDttRate(value.cityName);
+    if (rate.state === 'rated') {
+      cityTax = (amount / 1000) * rate.ratePer1000;
+    } else if (rate.state === 'unknown') {
+      cityRateUnknown = true;
+      unknownPlace = rate.place;
     }
+    // 'none' → cityTax stays 0, which here is a measured zero.
   }
 
   return {
     county: countyTax.toFixed(2),
     city: cityTax > 0 ? cityTax.toFixed(2) : null,
     total: (countyTax + cityTax).toFixed(2),
+    ...(cityRateUnknown ? { cityRateUnknown, unknownPlace } : {}),
   };
 }

--- a/frontend/src/lib/jurisdictions.ts
+++ b/frontend/src/lib/jurisdictions.ts
@@ -1,0 +1,230 @@
+/**
+ * T-2 — THE JURISDICTIONS REGISTRY. One place identity, one set of facts.
+ *
+ * ═══ WHY THIS EXISTS ═══
+ *
+ * Three separate defects, all from the same root: place was a STRING that
+ * code pattern-matched, rather than an IDENTITY the system looked up.
+ *
+ * 1. SUBSTRING MATCHING PUT WRONG DOLLARS ON A DECLARATION.
+ *    dttCalc matched with `cityLower.includes(known)`, so:
+ *      South San Francisco (San Mateo County) → matched "san francisco"
+ *        → charged $7.50/$1,000. On a $1M transfer, $7,500 of invented tax.
+ *      East Los Angeles (UNINCORPORATED) → matched "los angeles"
+ *        → charged the City of LA's $4.50. Unincorporated areas levy no
+ *          municipal transfer tax at all.
+ *      Lake Los Angeles (unincorporated) → same.
+ *      West Sacramento (Yolo County) → charged Sacramento's rate.
+ *
+ * 2. THE A2 FORK WAS NEVER FULLY KILLED. A2 unified the partner API's
+ *    table with dttCalc's and pinned them — but a THIRD copy survived in
+ *    services/propertyPrefill.ts with a DIFFERENT list of 27 cities. It
+ *    included Hayward, Richmond, Alameda, Palo Alto and a dozen more that
+ *    dttCalc has never heard of, and it OMITTED Inglewood, Long Beach and
+ *    Pasadena, which dttCalc rates. Because that list decides `areaType`,
+ *    a Long Beach property prefilled as "unincorporated" and its city tax
+ *    was skipped entirely — the mirror image of defect 1, undercharging
+ *    instead of over.
+ *
+ * 3. TWO DIFFERENT FACTS WERE ONE FIELD. `inferDTTAreaType` returned
+ *    "unincorporated" for any city not on its list — so Glendale, an
+ *    incorporated city, was labelled unincorporated because it happens to
+ *    levy no DTT. Incorporation and taxation are independent facts and
+ *    are separate fields here.
+ *
+ * ═══ THE RULE THAT REPLACES THEM ═══
+ *
+ * Matching is EXACT on a normalized name. Never substring. A place we do
+ * not have is UNKNOWN, and unknown surfaces as "rate unknown — enter
+ * manually". It is never silently zero and never a guessed rate: a $0 we
+ * invented is the same class of error as a $7,500 we invented, it just
+ * costs the other party.
+ *
+ * ═══ RATE SEMANTICS — read before adding an entry ═══
+ *
+ *   dttRatePer1000 > 0    the place levies its own DTT at this rate
+ *   dttRatePer1000 === 0  AFFIRMATIVE: we know it levies none
+ *   dttRatePer1000 null   we do not know. The UI asks the officer.
+ *
+ * The difference between `0` and `null` is the whole point. Absence of
+ * knowledge must not render as a fact.
+ *
+ * ═══ RATE PROVENANCE — OWNER'S ESCROW REVIEW PENDING ═══
+ *
+ * Every non-null rate below is carried forward UNCHANGED from the
+ * pre-T-2 tables. None of them were verified by this ticket. They are
+ * approximations of tiered municipal schedules and remain the owner's
+ * escrow review to confirm against current published schedules — the
+ * open ledger item. Entries marked `null` are the honest gaps that
+ * review should fill; they are not omissions to be "fixed" by guessing.
+ */
+
+export interface RecorderPrefs {
+  /** Free-text notes an officer would otherwise keep in their head. */
+  notes?: string;
+}
+
+export interface PcorRouting {
+  /** Which office receives the PCOR filed concurrently with the deed. */
+  office: string;
+  notes?: string;
+}
+
+export interface County {
+  name: string;
+  recorderPrefs?: RecorderPrefs;
+  pcorRouting?: PcorRouting;
+}
+
+export interface Place {
+  /** Canonical display name. */
+  city: string;
+  county: string;
+  incorporated: boolean;
+  /** See RATE SEMANTICS above. `null` means unknown, never zero. */
+  dttRatePer1000: number | null;
+}
+
+/** The merged view a caller gets back: place facts + its county's facts. */
+export interface Jurisdiction extends Place {
+  recorderPrefs?: RecorderPrefs;
+  pcorRouting?: PcorRouting;
+}
+
+export const COUNTIES: Record<string, County> = {
+  'los angeles': {
+    name: 'Los Angeles',
+    // The registry's first pcorRouting datum, and a real piece of local
+    // knowledge: LA County's PCOR goes to the Registrar-Recorder/County
+    // Clerk with the deed — not to the Assessor separately. It is why the
+    // county publishes the form at lavote.gov rather than on the
+    // assessor's site, which surprises officers new to the county.
+    pcorRouting: {
+      office: 'Los Angeles County Registrar-Recorder/County Clerk',
+      notes: 'Filed concurrently with the deed at the recorder, not sent separately to the Assessor.',
+    },
+  },
+};
+
+/**
+ * LA County first — launch scope. Non-LA entries exist only because they
+ * already carried rates before T-2 and dropping them would have been a
+ * silent behavior change.
+ */
+export const PLACES: Place[] = [
+  // ── Los Angeles County — incorporated, rate carried forward ─────────
+  { city: 'Los Angeles', county: 'Los Angeles', incorporated: true, dttRatePer1000: 4.50 },
+  { city: 'Culver City', county: 'Los Angeles', incorporated: true, dttRatePer1000: 2.20 },
+  { city: 'Santa Monica', county: 'Los Angeles', incorporated: true, dttRatePer1000: 2.20 },
+  { city: 'Redondo Beach', county: 'Los Angeles', incorporated: true, dttRatePer1000: 2.20 },
+  { city: 'Inglewood', county: 'Los Angeles', incorporated: true, dttRatePer1000: 2.20 },
+  { city: 'Long Beach', county: 'Los Angeles', incorporated: true, dttRatePer1000: 2.20 },
+  { city: 'Pasadena', county: 'Los Angeles', incorporated: true, dttRatePer1000: 2.20 },
+  { city: 'Pomona', county: 'Los Angeles', incorporated: true, dttRatePer1000: 2.20 },
+
+  // ── Los Angeles County — UNINCORPORATED. Structural fact, not a rate
+  //    lookup: unincorporated territory levies no municipal transfer tax,
+  //    so 0 here is affirmative knowledge. Both of these were charged the
+  //    City of Los Angeles' $4.50 by substring matching.
+  { city: 'East Los Angeles', county: 'Los Angeles', incorporated: false, dttRatePer1000: 0 },
+  { city: 'Lake Los Angeles', county: 'Los Angeles', incorporated: false, dttRatePer1000: 0 },
+
+  // ── Collision guards: real places whose names CONTAIN a rated place's
+  //    name. Listed with null rather than omitted, so the lookup answers
+  //    "I know this place and I do not know its rate" instead of falling
+  //    through to a neighbour's number.
+  { city: 'South Pasadena', county: 'Los Angeles', incorporated: true, dttRatePer1000: null },
+  { city: 'South San Francisco', county: 'San Mateo', incorporated: true, dttRatePer1000: null },
+  { city: 'West Sacramento', county: 'Yolo', incorporated: true, dttRatePer1000: null },
+
+  // ── Outside LA County — rates carried forward from the pre-T-2 table ─
+  { city: 'San Francisco', county: 'San Francisco', incorporated: true, dttRatePer1000: 7.50 },
+  { city: 'Oakland', county: 'Alameda', incorporated: true, dttRatePer1000: 15.00 },
+  { city: 'Berkeley', county: 'Alameda', incorporated: true, dttRatePer1000: 2.20 },
+  { city: 'San Jose', county: 'Santa Clara', incorporated: true, dttRatePer1000: 2.20 },
+  { city: 'Sacramento', county: 'Sacramento', incorporated: true, dttRatePer1000: 2.20 },
+  { city: 'Riverside', county: 'Riverside', incorporated: true, dttRatePer1000: 2.20 },
+
+  // ── Recovered from the propertyPrefill fork (defect 2). That list
+  //    asserted these levy their own DTT; dttCalc had never heard of them
+  //    and charged $0. One of the two was wrong and we do not know which
+  //    rate is right, so they are `null` — the honest state — and they are
+  //    the most useful rows for the owner's escrow review to fill in.
+  { city: 'Hercules', county: 'Contra Costa', incorporated: true, dttRatePer1000: null },
+  { city: 'Hayward', county: 'Alameda', incorporated: true, dttRatePer1000: null },
+  { city: 'Richmond', county: 'Contra Costa', incorporated: true, dttRatePer1000: null },
+  { city: 'Alameda', county: 'Alameda', incorporated: true, dttRatePer1000: null },
+  { city: 'Albany', county: 'Alameda', incorporated: true, dttRatePer1000: null },
+  { city: 'Emeryville', county: 'Alameda', incorporated: true, dttRatePer1000: null },
+  { city: 'Piedmont', county: 'Alameda', incorporated: true, dttRatePer1000: null },
+  { city: 'San Leandro', county: 'Alameda', incorporated: true, dttRatePer1000: null },
+  { city: 'San Pablo', county: 'Contra Costa', incorporated: true, dttRatePer1000: null },
+  { city: 'Mountain View', county: 'Santa Clara', incorporated: true, dttRatePer1000: null },
+  { city: 'Palo Alto', county: 'Santa Clara', incorporated: true, dttRatePer1000: null },
+  { city: 'Petaluma', county: 'Sonoma', incorporated: true, dttRatePer1000: null },
+  { city: 'Santa Rosa', county: 'Sonoma', incorporated: true, dttRatePer1000: null },
+  { city: 'Sebastopol', county: 'Sonoma', incorporated: true, dttRatePer1000: null },
+  { city: 'Cotati', county: 'Sonoma', incorporated: true, dttRatePer1000: null },
+  { city: 'Cloverdale', county: 'Sonoma', incorporated: true, dttRatePer1000: null },
+];
+
+/**
+ * Normalize for comparison ONLY — never for display. Case, surrounding
+ * whitespace and internal runs collapse; nothing else. Deliberately not
+ * stripping direction words ("South", "West"), because those words are
+ * the entire difference between two different cities in two different
+ * counties.
+ */
+export function normalizePlace(name: string): string {
+  return (name || '').trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+const BY_NAME = new Map<string, Place>(PLACES.map((p) => [normalizePlace(p.city), p]));
+
+export type JurisdictionLookup =
+  | { known: true; jurisdiction: Jurisdiction }
+  | { known: false; place: string };
+
+/**
+ * EXACT lookup. A place we do not hold comes back `known: false`, and the
+ * caller must ask rather than assume — that is the contract.
+ */
+export function lookupJurisdiction(city: string | null | undefined): JurisdictionLookup {
+  const key = normalizePlace(city || '');
+  const place = key ? BY_NAME.get(key) : undefined;
+  if (!place) return { known: false, place: (city || '').trim() };
+  const county = COUNTIES[normalizePlace(place.county)];
+  return {
+    known: true,
+    jurisdiction: {
+      ...place,
+      recorderPrefs: county?.recorderPrefs,
+      pcorRouting: county?.pcorRouting,
+    },
+  };
+}
+
+export type CityRate =
+  /** Known and levies its own DTT. */
+  | { state: 'rated'; ratePer1000: number }
+  /** Known and affirmatively levies none. */
+  | { state: 'none' }
+  /** We do not know — the officer is asked. NEVER rendered as a number. */
+  | { state: 'unknown'; place: string };
+
+export function cityDttRate(city: string | null | undefined): CityRate {
+  const hit = lookupJurisdiction(city);
+  // Narrow explicitly: `hit.place` only exists on the not-known arm, and
+  // the discriminant has to be read as `=== false` for TS to see it.
+  if (hit.known === false) return { state: 'unknown', place: hit.place };
+  const rate = hit.jurisdiction.dttRatePer1000;
+  if (rate === null) return { state: 'unknown', place: hit.jurisdiction.city };
+  if (rate === 0) return { state: 'none' };
+  return { state: 'rated', ratePer1000: rate };
+}
+
+/** Incorporation is its OWN fact — not "does it tax". See defect 3. */
+export function isIncorporated(city: string | null | undefined): boolean | null {
+  const hit = lookupJurisdiction(city);
+  return hit.known ? hit.jurisdiction.incorporated : null;
+}

--- a/frontend/src/services/propertyPrefill.ts
+++ b/frontend/src/services/propertyPrefill.ts
@@ -8,6 +8,7 @@
  */
 
 import { addRecentProperty } from "./recentProperties"
+import { cityDttRate, isIncorporated } from "@/lib/jurisdictions"
 
 /**
  * Property data from SiteX enrichment
@@ -65,53 +66,43 @@ interface WizardState {
 }
 
 /**
- * Cities in California that have their own Documentary Transfer Tax.
- * These require selecting "City" in the DTT section.
- */
-const CITIES_WITH_OWN_DTT = [
-  "los angeles",
-  "san francisco",
-  "oakland",
-  "berkeley",
-  "san jose",
-  "sacramento",
-  "riverside",
-  "pomona",
-  "culver city",
-  "santa monica",
-  "redondo beach",
-  "hercules",
-  "hayward",
-  "richmond",
-  "alameda",
-  "albany",
-  "emeryville",
-  "piedmont",
-  "san leandro",
-  "san pablo",
-  "mountain view",
-  "palo alto",
-  "petaluma",
-  "santa rosa",
-  "sebastopol",
-  "cotati",
-  "cloverdale",
-]
-
-/**
- * Infer DTT area type based on city
+ * T-2 — THE THIRD COPY IS GONE.
+ *
+ * A2 unified the partner API's city table with dttCalc's and pinned them
+ * together. This file kept its own, and nobody noticed because nothing
+ * compared them. The two lists disagreed in both directions: this one
+ * carried Hayward, Richmond, Alameda, Palo Alto and a dozen more that
+ * dttCalc had never heard of, and it OMITTED Inglewood, Long Beach and
+ * Pasadena, which dttCalc rates.
+ *
+ * That omission had teeth. This list decides `areaType`, and `areaType`
+ * gates whether the city portion is computed at all — so a Long Beach
+ * property was prefilled "unincorporated" and its city transfer tax was
+ * silently skipped. Undercharging by exactly the mechanism that
+ * overcharged South San Francisco.
+ *
+ * Both questions now go to lib/jurisdictions.ts, and they are asked
+ * SEPARATELY, because they were never the same question: whether a place
+ * is incorporated is not whether it taxes. Glendale is an incorporated
+ * city that levies no DTT; the old code called it "unincorporated"
+ * because that produced the right tax by accident.
  */
 export function inferDTTAreaType(city: string): "city" | "unincorporated" {
   if (!city) return "unincorporated"
-  return CITIES_WITH_OWN_DTT.includes(city.toLowerCase()) ? "city" : "unincorporated"
+  // Only an affirmative "this place is unincorporated" may say so. An
+  // unknown place is NOT evidence of unincorporation — defaulting it to
+  // "unincorporated" is what silently skipped Long Beach's city tax.
+  return isIncorporated(city) === false ? "unincorporated" : "city"
 }
 
 /**
- * Check if a city has its own DTT
+ * Whether the city levies its own DTT. `false` means we KNOW it does not;
+ * unknown places are not asserted either way — computeDttBreakdown
+ * surfaces them to the officer instead of assuming.
  */
 export function cityHasOwnDTT(city: string): boolean {
   if (!city) return false
-  return CITIES_WITH_OWN_DTT.includes(city.toLowerCase())
+  return cityDttRate(city).state === "rated"
 }
 
 /**


### PR DESCRIPTION
## The money defect

`cityLower.includes(known)` charged real California places their neighbours' rates:

| place | matched as | charged |
|---|---|---|
| South San Francisco (San Mateo County) | san francisco | **$7.50/$1,000** — $7,500 on a $1M transfer |
| East Los Angeles (**unincorporated**) | los angeles | $4.50/$1,000 |
| Lake Los Angeles (**unincorporated**) | los angeles | $4.50/$1,000 |
| West Sacramento (Yolo County) | sacramento | Sacramento's rate |
| South Pasadena | pasadena | Pasadena's rate |

Unincorporated territory levies no municipal transfer tax at all, so two of those aren't "wrong rate" — they're tax on a place that levies none. All of it lands on a legal declaration.

## A second money defect, found while fixing the first

A2 unified the partner API's table with `dttCalc`'s, pinned them, and declared the fork dead. It wasn't. A **third** list lived in `services/propertyPrefill.ts` — 27 cities including Hayward, Richmond, Alameda and Palo Alto that `dttCalc` had never heard of, and **omitting Inglewood, Long Beach and Pasadena**, which `dttCalc` rates.

That omission had teeth. This list decides `areaType`, and `areaType` gates whether the city portion is computed at all — so a **Long Beach property prefilled as "unincorporated" and its city transfer tax was silently skipped.** The mirror image of the first defect: undercharging by the same mechanism that overcharged.

A2's pin couldn't have caught it. It compared the two files it knew about while the third disagreed with both.

## A third conflation

`inferDTTAreaType` returned "unincorporated" for any city off its list — so Glendale, an incorporated city, was labelled unincorporated because that produced the right tax by accident. Incorporation and taxation are independent facts and are separate fields now.

## The registry

`lib/jurisdictions.ts` + `services/jurisdictions.py`, mirrored element for element. Matching is **exact** on a normalized name; normalization collapses case and whitespace and deliberately does **not** strip direction words — "South" and "West" are the entire difference between two cities in two counties.

```
dttRatePer1000 > 0     levies its own DTT at this rate
dttRatePer1000 === 0   AFFIRMATIVE: we know it levies none
dttRatePer1000 null    we do not know — the officer is asked, never a number
```

`DEFAULT_CITY_RATE_PER_1000` is deliberately gone and **pinned gone**. A single fallback applied to "any city we don't have" is the pre-X2.3 disease in a nicer coat.

T-2 sharpens X2.3 rather than reversing it: that fix stopped inventing a generic **rate**; this one stops inventing a **zero**. Fresno used to contribute $0 and the total read as complete — we hold no Fresno rate, so that $0 was invented too. It just cost the other party.

**LA County's PCOR routing is the registry's first `pcorRouting` datum:** filed with the Registrar-Recorder/County Clerk alongside the deed, not sent separately to the Assessor.

## Rates are carried forward, not verified — this is your input

Every non-null rate is the pre-T-2 number with a provenance comment. **The `null` rows are the honest gaps**, including the 16 recovered from the propertyPrefill fork, where one list claimed they levy their own DTT and the other charged $0. One of the two was wrong and we don't know which rate is right.

Those rows are the most useful place for your twenty minutes against the real schedules.

## Five pins rewritten deliberately

Four A2 mirror pins parsed `dttCalc.ts` for a literal city array, an if/else chain of `.includes(...)` branches, and a trailing default — **they asserted the shape of the substring matcher this ticket removes**, so no correct fix could have kept them green. They compare the two registries now: city, county, incorporation and rate, element for element, with null distinguished from zero.

And one of my own new pins tripped on the module docstring quoting the old `$2.20` — the sixth time a forbidden-pattern pin has caught the prose explaining the removal. Fixed with the AST docstring strip.

## Gates

| gate | result |
|---|---|
| backend pytest | 375 passed |
| jest | 451 passed, 33 suites |
| six-flow baseline | verify OK |
| API baseline | verify OK |
| tsc | 94 — unchanged (a narrowing bug in my own new file pushed it to 95; fixed) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_