### PR TITLE
T-2a: the rates are signed, and the tiers are flagged rather than priced

### DIFF
--- a/backend/routers/api_v1/router.py
+++ b/backend/routers/api_v1/router.py
@@ -745,7 +745,22 @@ async def calculate_transfer_tax(
 
     city_breakdown = None
     if request.city:
-        if city_rate is None and not dtt["city_rate_known"]:
+        if dtt.get("city_tier_measure"):
+            # T-2a: above the measure's threshold the city tax is tiered.
+            # We name the measure and state NO rate — the schedules move
+            # (Measure ULA's thresholds adjust annually) and a stale
+            # number that looks confident is the failure being avoided.
+            city_breakdown = {
+                "name": request.city,
+                "rate": None,
+                "amount": None,
+                "notes": (
+                    f"High-value transfer: a tiered city transfer tax applies "
+                    f"({dtt['city_tier_measure']}). Verify the current schedule — "
+                    f"no city amount is computed here."
+                ),
+            }
+        elif city_rate is None and not dtt["city_rate_known"]:
             # T-2: the third state, which used to be silently folded into
             # "levies none". We do not hold this place, so we do not know.
             # Saying "levies none" here was an invented $0 — the same class

--- a/backend/services/dtt_rates.py
+++ b/backend/services/dtt_rates.py
@@ -55,6 +55,9 @@ class DttBreakdown(TypedDict):
     # T-2: False when we do not KNOW the rate — distinct from knowing it
     # is zero. Callers must ask rather than print a number.
     city_rate_known: bool
+    # Set when a tiered high-value bracket applies. Names the measure and
+    # never a rate — flag over stale math.
+    city_tier_measure: Optional[str]
 
 
 def city_rate_per_1000(city: Optional[str]) -> Optional[float]:
@@ -80,12 +83,15 @@ def compute_dtt(taxable_value: float, city: Optional[str] = None,
     # A caller that supplies no city is not asking about an unknown place —
     # it is stating there is no city portion. Only a NAMED place we do not
     # hold is "unknown".
-    resolved = city_dtt_rate(city) if (apply_city_tax and city) else None
+    resolved = city_dtt_rate(city, value) if (apply_city_tax and city) else None
     rate = resolved.rate_per_1000 if resolved and resolved.state == "rated" else None
     city_tax = (value / 1000.0) * rate if rate else 0.0
     # Unknown is not zero. A city we have never rated must not be
     # reported as one that levies nothing.
-    known = resolved is None or resolved.state in ("rated", "none")
+    known = resolved is None or resolved.state in ("rated", "none", "tiered")
+    # T-2a: a high-value bracket applies and we deliberately computed NO
+    # city portion. The measure is named; no rate is stated.
+    tier = (resolved.measure if resolved and resolved.state == "tiered" else None)
 
     return {
         "county_tax": round(county_tax, 2),
@@ -95,4 +101,5 @@ def compute_dtt(taxable_value: float, city: Optional[str] = None,
         "city_rate_per_1000": rate,
         "city_levies_own_dtt": rate is not None,
         "city_rate_known": known,
+        "city_tier_measure": tier,
     }

--- a/backend/services/jurisdictions.py
+++ b/backend/services/jurisdictions.py
@@ -31,11 +31,22 @@ that review should fill — not omissions to be closed by guessing.
 from typing import Dict, List, NamedTuple, Optional
 
 
+class Tier(NamedTuple):
+    """A high-value bracket. FLAGGED, never computed — see the TS mirror:
+    tier schedules move (Measure ULA adjusts annually) and a compiled-in
+    rate goes stale while still producing confident numbers."""
+    amount: int
+    measure: str
+    boundaries: Optional[List[int]] = None
+
+
 class Place(NamedTuple):
     city: str
     county: str
     incorporated: bool
     dtt_rate_per_1000: Optional[float]
+    tiered_above: Optional[Tier] = None
+    source: Optional[str] = None
 
 
 class PcorRouting(NamedTuple):
@@ -59,41 +70,54 @@ PCOR_ROUTING: Dict[str, PcorRouting] = {
 # element by element, so a reordering here is a failure, not a style
 # choice.
 PLACES: List[Place] = [
-    Place("Los Angeles", "Los Angeles", True, 4.50),
-    Place("Culver City", "Los Angeles", True, 2.20),
-    Place("Santa Monica", "Los Angeles", True, 2.20),
-    Place("Redondo Beach", "Los Angeles", True, 2.20),
-    Place("Inglewood", "Los Angeles", True, 2.20),
-    Place("Long Beach", "Los Angeles", True, 2.20),
-    Place("Pasadena", "Los Angeles", True, 2.20),
-    Place("Pomona", "Los Angeles", True, 2.20),
-    Place("East Los Angeles", "Los Angeles", False, 0),
-    Place("Lake Los Angeles", "Los Angeles", False, 0),
-    Place("South Pasadena", "Los Angeles", True, None),
-    Place("South San Francisco", "San Mateo", True, None),
-    Place("West Sacramento", "Yolo", True, None),
-    Place("San Francisco", "San Francisco", True, 7.50),
-    Place("Oakland", "Alameda", True, 15.00),
-    Place("Berkeley", "Alameda", True, 2.20),
-    Place("San Jose", "Santa Clara", True, 2.20),
-    Place("Sacramento", "Sacramento", True, 2.20),
-    Place("Riverside", "Riverside", True, 2.20),
-    Place("Hercules", "Contra Costa", True, None),
-    Place("Hayward", "Alameda", True, None),
-    Place("Richmond", "Contra Costa", True, None),
-    Place("Alameda", "Alameda", True, None),
-    Place("Albany", "Alameda", True, None),
-    Place("Emeryville", "Alameda", True, None),
-    Place("Piedmont", "Alameda", True, None),
-    Place("San Leandro", "Alameda", True, None),
-    Place("San Pablo", "Contra Costa", True, None),
-    Place("Mountain View", "Santa Clara", True, None),
-    Place("Palo Alto", "Santa Clara", True, None),
-    Place("Petaluma", "Sonoma", True, None),
-    Place("Santa Rosa", "Sonoma", True, None),
-    Place("Sebastopol", "Sonoma", True, None),
-    Place("Cotati", "Sonoma", True, None),
-    Place("Cloverdale", "Sonoma", True, None),
+    Place("Los Angeles", "Los Angeles", True, 4.5, Tier(5000000, "Measure ULA", None), "PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04"),
+    Place("Santa Monica", "Los Angeles", True, 3.0, Tier(5000000, "Measure SM ($6.00 tier); Measure GS beyond", None), "PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04"),
+    Place("Culver City", "Los Angeles", True, 4.5, Tier(1500000, "Measure RE", [1500000, 3000000, 10000000]), "PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04"),
+    Place("Pomona", "Los Angeles", True, 2.2, None, "PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04"),
+    Place("Redondo Beach", "Los Angeles", True, 2.2, None, "PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04"),
+    Place("Long Beach", "Los Angeles", True, 0.0, None, "PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04"),
+    Place("Inglewood", "Los Angeles", True, 0.0, None, "PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04"),
+    Place("Pasadena", "Los Angeles", True, 0.0, None, "PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04"),
+    Place("Torrance", "Los Angeles", True, 0.0, None, "PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04"),
+    Place("Glendale", "Los Angeles", True, 0.0, None, "PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04"),
+    Place("Burbank", "Los Angeles", True, 0.0, None, "PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04"),
+    Place("Downey", "Los Angeles", True, 0.0, None, "PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04"),
+    Place("Norwalk", "Los Angeles", True, 0.0, None, "PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04"),
+    Place("Compton", "Los Angeles", True, 0.0, None, "PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04"),
+    Place("Carson", "Los Angeles", True, 0.0, None, "PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04"),
+    Place("Lakewood", "Los Angeles", True, 0.0, None, "PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04"),
+    Place("El Monte", "Los Angeles", True, 0.0, None, "PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04"),
+    Place("West Covina", "Los Angeles", True, 0.0, None, "PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04"),
+    Place("Whittier", "Los Angeles", True, 0.0, None, "PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04"),
+    Place("Lynwood", "Los Angeles", True, 0.0, None, "PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04"),
+    Place("Paramount", "Los Angeles", True, 0.0, None, "PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04"),
+    Place("South Pasadena", "Los Angeles", True, 0.0, None, "Derived from the closed-set ruling (owner, 2026-08-04)"),
+    Place("East Los Angeles", "Los Angeles", False, 0.0, None, "Unincorporated territory levies no municipal transfer tax (structural); closed-set ruling (owner, 2026-08-04)"),
+    Place("Lake Los Angeles", "Los Angeles", False, 0.0, None, "Unincorporated territory levies no municipal transfer tax (structural); closed-set ruling (owner, 2026-08-04)"),
+    Place("South San Francisco", "San Mateo", True, None, None, None),
+    Place("West Sacramento", "Yolo", True, None, None, None),
+    Place("San Francisco", "San Francisco", True, 7.5, None, None),
+    Place("Oakland", "Alameda", True, 15.0, None, None),
+    Place("Berkeley", "Alameda", True, 2.2, None, None),
+    Place("San Jose", "Santa Clara", True, 2.2, None, None),
+    Place("Sacramento", "Sacramento", True, 2.2, None, None),
+    Place("Riverside", "Riverside", True, 2.2, None, None),
+    Place("Hercules", "Contra Costa", True, None, None, None),
+    Place("Hayward", "Alameda", True, None, None, None),
+    Place("Richmond", "Contra Costa", True, None, None, None),
+    Place("Alameda", "Alameda", True, None, None, None),
+    Place("Albany", "Alameda", True, None, None, None),
+    Place("Emeryville", "Alameda", True, None, None, None),
+    Place("Piedmont", "Alameda", True, None, None, None),
+    Place("San Leandro", "Alameda", True, None, None, None),
+    Place("San Pablo", "Contra Costa", True, None, None, None),
+    Place("Mountain View", "Santa Clara", True, None, None, None),
+    Place("Palo Alto", "Santa Clara", True, None, None, None),
+    Place("Petaluma", "Sonoma", True, None, None, None),
+    Place("Santa Rosa", "Sonoma", True, None, None, None),
+    Place("Sebastopol", "Sonoma", True, None, None, None),
+    Place("Cotati", "Sonoma", True, None, None, None),
+    Place("Cloverdale", "Sonoma", True, None, None, None),
 ]
 
 _BY_NAME = {}
@@ -119,20 +143,30 @@ def lookup_place(city: Optional[str]) -> Optional[Place]:
 
 
 class CityRate(NamedTuple):
-    """Tri-state, deliberately. `state` is one of:
-    'rated' (levies its own, at rate), 'none' (affirmatively levies none),
-    'unknown' (we do not know — ask the officer)."""
+    """Four states, deliberately. `state` is one of:
+    'rated'   levies its own, at rate
+    'none'    affirmatively levies none
+    'tiered'  a high-value bracket applies — the measure is NAMED and no
+              rate is stated; the caller must not compute from the base
+    'unknown' we do not know — ask the officer"""
     state: str
     rate_per_1000: Optional[float] = None
     place: Optional[str] = None
+    measure: Optional[str] = None
+    threshold: Optional[int] = None
 
 
-def city_dtt_rate(city: Optional[str]) -> CityRate:
+def city_dtt_rate(city: Optional[str],
+                  consideration: Optional[float] = None) -> CityRate:
     place = lookup_place(city)
     if place is None:
         return CityRate("unknown", None, (city or "").strip())
     if place.dtt_rate_per_1000 is None:
         return CityRate("unknown", None, place.city)
+    if (place.tiered_above is not None and consideration is not None
+            and consideration >= place.tiered_above.amount):
+        return CityRate("tiered", None, place.city,
+                        place.tiered_above.measure, place.tiered_above.amount)
     if place.dtt_rate_per_1000 == 0:
         return CityRate("none")
     return CityRate("rated", place.dtt_rate_per_1000)

--- a/backend/tests/test_api_catalog_and_rates.py
+++ b/backend/tests/test_api_catalog_and_rates.py
@@ -152,15 +152,40 @@ def test_entity_slot_is_absent_for_ordinary_deeds():
 # ── One rates source ─────────────────────────────────────────────────
 
 def _registry_places():
-    """Parse the TS registry. T-2 moved the rates out of dttCalc.ts and
-    into lib/jurisdictions.ts, so the mirror reads the registry."""
+    """Parse the TS registry.
+
+    T-2a: entries became multi-line and gained `tieredAbove` and `source`,
+    so the flat one-line regex this used no longer matches. Walk each
+    object's braces instead of pattern-matching a formatting choice — the
+    pin is about the FACTS in the registry, not how prettier wrapped them.
+    """
     src = (BACKEND.parent / "frontend/src/lib/jurisdictions.ts").read_text(encoding="utf-8")
+    block = src[src.index("export const PLACES"):src.index("/**\n * Normalize for comparison")]
     out = []
-    for city, county, inc, rate in re.findall(
-            r"\{ city: '([^']+)', county: '([^']+)', incorporated: (true|false), "
-            r"dttRatePer1000: ([\d.]+|null) \}", src):
-        out.append((city, county, inc == "true",
-                    None if rate == "null" else float(rate)))
+    for m in re.finditer(r"city: '([^']+)'", block):
+        obj_start = block.rfind("{", 0, m.start())
+        depth, i = 0, obj_start
+        while i < len(block):
+            if block[i] == "{":
+                depth += 1
+            elif block[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    break
+            i += 1
+        txt = block[obj_start:i + 1]
+
+        def fld(name, pat):
+            mm = re.search(name + r":\s*" + pat, txt)
+            return mm.group(1) if mm else None
+
+        rate = fld("dttRatePer1000", r"([\d._]+|null)")
+        out.append((
+            m.group(1),
+            fld("county", r"'([^']+)'"),
+            fld("incorporated", r"(true|false)") == "true",
+            None if rate in (None, "null") else float(rate.replace("_", "")),
+        ))
     return out
 
 
@@ -169,13 +194,9 @@ def test_backend_rates_mirror_the_officer_facing_calculator():
     that differs between the wizard and the API is a number headed for a
     legal declaration under two different values.
 
-    T-2 REWROTE THIS PIN. It used to parse dttCalc.ts for a literal city
-    array, an if/else chain of `cityLower.includes(...)` branches, and a
-    trailing `else` default rate — i.e. it asserted the SHAPE of the old
-    substring matcher. That matcher is the defect this ticket removed (it
-    charged South San Francisco the City of San Francisco's rate), so a
-    pin shaped like it could not survive the fix. It compares the two
-    REGISTRIES now, which is the property it always meant to protect.
+    T-2 rewrote this pin (it used to assert the SHAPE of the substring
+    matcher that ticket removed). T-2a widened its parser when the rows
+    gained tier and source fields.
     """
     from services.jurisdictions import PLACES
 
@@ -183,6 +204,46 @@ def test_backend_rates_mirror_the_officer_facing_calculator():
     py = [(p.city, p.county, p.incorporated, p.dtt_rate_per_1000) for p in PLACES]
     assert py == ts, "the registries disagree — one surface would declare a different tax"
     assert COUNTY_RATE_PER_1000 == 1.10
+
+
+def test_the_la_county_set_is_closed_at_five():
+    """T-2a owner sign-off. Every LA County row is an affirmative fact —
+    a rate or a verified zero — never an unknown, because 'not among the
+    five' is knowledge about this county rather than a gap in it."""
+    from services.jurisdictions import PLACES, city_dtt_rate
+
+    la = [p for p in PLACES if p.county == "Los Angeles"]
+    rated = sorted(p.city for p in la
+                   if p.dtt_rate_per_1000 is not None and p.dtt_rate_per_1000 > 0)
+    assert rated == sorted([
+        "Culver City", "Los Angeles", "Pomona", "Redondo Beach", "Santa Monica"])
+    assert all(p.dtt_rate_per_1000 is not None for p in la), \
+        "an LA County row went back to unknown — the set is closed"
+    # And the three that were wrongly rated $2.20 levy nothing.
+    for city in ("Long Beach", "Inglewood", "Pasadena"):
+        assert city_dtt_rate(city).state == "none"
+
+
+def test_tiers_are_flagged_and_never_priced():
+    """RULED: name the measure, state no rate. Measure ULA's thresholds
+    adjust annually — a compiled-in rate goes stale while still printing a
+    confident number, and understating a City of LA transfer by ULA's
+    margin is the failure being avoided."""
+    from services.jurisdictions import city_dtt_rate as rate_of
+
+    low = rate_of("Los Angeles", 1_000_000)
+    assert low.state == "rated" and low.rate_per_1000 == 4.50
+
+    high = rate_of("Los Angeles", 6_000_000)
+    assert high.state == "tiered"
+    assert high.measure == "Measure ULA"
+    assert high.rate_per_1000 is None, "the flag must never carry a rate"
+
+    d = compute_dtt(6_000_000, "Los Angeles")
+    assert d["city_tax"] == 0.0, "no city portion may be computed above the tier"
+    assert d["city_tier_measure"] == "Measure ULA"
+    # The county portion does not tier and is still computed.
+    assert d["county_tax"] == 6600.0
 
 
 def test_there_is_no_generic_fallback_city_rate():
@@ -254,6 +315,10 @@ def test_known_city_rates():
     assert city_rate_per_1000("Los Angeles") == 4.50
     assert city_rate_per_1000("San Francisco") == 7.50
     assert city_rate_per_1000("Oakland") == 15.00
-    assert city_rate_per_1000("Pasadena") == 2.20
+    # T-2a: Pasadena was $2.20 here and levies NOTHING (owner sign-off,
+    # PCT chart). Pomona is the surviving $2.20 city.
+    assert city_rate_per_1000("Pasadena") is None
+    assert city_rate_per_1000("Pomona") == 2.20
+    assert city_rate_per_1000("Santa Monica") == 3.00
     # County portion alone on a $500k transfer.
     assert compute_dtt(500_000, None)["total_tax"] == 550.0

--- a/frontend/src/__tests__/dttRatesMirror.test.ts
+++ b/frontend/src/__tests__/dttRatesMirror.test.ts
@@ -65,9 +65,12 @@ describe('DTT rates — one source across the wire', () => {
       path.join(__dirname, '..', '..', '..', 'backend', 'services', 'jurisdictions.py'),
       'utf8'
     );
+    // T-2a: Place() gained tier + source fields, so match the first four
+    // positional args and stop — the pin is about rates, not arity.
     const pyRated = [...pyReg.matchAll(
-      /Place\("([^"]+)",\s*"[^"]+",\s*(?:True|False),\s*([\d.]+)\)/g
-    )].filter((m) => parseFloat(m[2]) > 0).map((m) => m[1].toLowerCase());
+      /Place\("([^"]+)",\s*"[^"]+",\s*(?:True|False),\s*([\d.]+|None),/g
+    )].filter((m) => m[2] !== 'None' && parseFloat(m[2]) > 0)
+      .map((m) => m[1].toLowerCase());
     expect(pyRated.sort()).toEqual([...CITIES_WITH_OWN_DTT].sort());
   });
 
@@ -86,9 +89,11 @@ describe('DTT rates — one source across the wire', () => {
     // dict literal that no longer exists.
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     const { cityDttRate } = require('@/lib/jurisdictions');
+    // T-2a corrected two of these and zeroed a third. Pasadena was $2.20
+    // here and levies nothing; Santa Monica and Culver City moved.
     for (const [city, rate] of [
       ['Los Angeles', 4.5], ['San Francisco', 7.5], ['Oakland', 15.0],
-      ['Pasadena', 2.2],
+      ['Santa Monica', 3.0], ['Culver City', 4.5], ['Pomona', 2.2],
     ] as Array<[string, number]>) {
       const r = cityDttRate(city);
       expect(r.state).toBe('rated');
@@ -137,7 +142,7 @@ describe('T-2 — the jurisdictions registry is mirrored element for element', (
   const { PLACES } = require('@/lib/jurisdictions');
 
   const pyPlaces = [...pyReg.matchAll(
-    /Place\("([^"]+)",\s*"([^"]+)",\s*(True|False),\s*([\d.]+|None)\)/g
+    /Place\("([^"]+)",\s*"([^"]+)",\s*(True|False),\s*([\d.]+|None),/g
   )].map((m) => ({
     city: m[1],
     county: m[2],
@@ -171,6 +176,11 @@ describe('T-2 — the jurisdictions registry is mirrored element for element', (
     expect(unknowns.length).toBeGreaterThan(0);
     expect(zeros).toContain('East Los Angeles');
     expect(unknowns).not.toContain('East Los Angeles');
+    // T-2a: the sign-off moved LA County rows from unknown to affirmative
+    // zero. Non-LA rows must NOT have crossed with them.
+    expect(zeros).toContain('Long Beach');
+    expect(unknowns).toContain('South San Francisco');
+    expect(unknowns).toContain('Palo Alto');
   });
 
   it('the backend refuses to guess for a place it does not hold', () => {

--- a/frontend/src/__tests__/jurisdictions.test.ts
+++ b/frontend/src/__tests__/jurisdictions.test.ts
@@ -34,17 +34,19 @@ describe('T-2 — substring collisions cannot happen', () => {
   ];
 
   for (const [place, contained] of COLLISIONS) {
-    it(`"${place}" is never charged "${contained}"'s rate`, () => {
+    it(`"${place}" resolves independently of "${contained}"`, () => {
       const victim = cityDttRate(place);
       const container = cityDttRate(contained);
-      expect(container.state).toBe('rated');
-      // Whatever the victim resolves to, it is NOT the containing city's rate.
-      if (victim.state === 'rated') {
-        expect(victim.ratePer1000).not.toBe(
-          container.state === 'rated' ? container.ratePer1000 : null);
-      } else {
-        expect(['unknown', 'none']).toContain(victim.state);
+      // T-2a: Pasadena is now a verified ZERO (owner sign-off closed the
+      // LA set at five cities), so this pair no longer has a positive
+      // rate to inherit. The pin stays anyway — it guards the MECHANISM,
+      // and a future rate change to any container must not leak sideways.
+      if (container.state === 'rated') {
+        expect(victim.state === 'rated'
+          && victim.ratePer1000 === container.ratePer1000).toBe(false);
       }
+      // Each is resolved from its own row, never by containment.
+      expect(['unknown', 'none', 'rated', 'tiered']).toContain(victim.state);
     });
   }
 
@@ -107,9 +109,12 @@ describe('T-2 — unknown is never rendered as a rate', () => {
 describe('T-2 — incorporation and taxation are separate facts', () => {
   it('an incorporated city may levy no DTT', () => {
     // The pre-T-2 code called Glendale "unincorporated" because that
-    // produced the right tax by accident.
+    // produced the right tax by accident. Glendale is now an explicit
+    // row: incorporated, and verified to levy nothing.
+    expect(isIncorporated('Glendale')).toBe(true);
+    expect(cityDttRate('Glendale').state).toBe('none');
     expect(isIncorporated('South Pasadena')).toBe(true);
-    expect(cityDttRate('South Pasadena').state).toBe('unknown');
+    expect(cityDttRate('South Pasadena').state).toBe('none');
   });
 
   it('an unknown place asserts neither', () => {
@@ -140,5 +145,89 @@ describe('T-2 — the registry is the only list', () => {
       // A literal array of quoted city names is the shape of a fork.
       expect(src).not.toMatch(/=\s*\[\s*\n?\s*["']los angeles["']/i);
     }
+  });
+});
+
+/**
+ * T-2a — OWNER SIGN-OFF. Rates verified against the PCT published chart
+ * and an escrow professional's desk experience, 2026-08-04.
+ */
+describe('T-2a — the verified LA County set', () => {
+  const FIVE = ['Los Angeles', 'Santa Monica', 'Culver City', 'Pomona', 'Redondo Beach'];
+
+  it('exactly five LA County cities levy their own DTT', () => {
+    const laRated = PLACES
+      .filter((p) => p.county === 'Los Angeles'
+        && p.dttRatePer1000 !== null && p.dttRatePer1000 > 0)
+      .map((p) => p.city);
+    expect(laRated.sort()).toEqual([...FIVE].sort());
+  });
+
+  it('the corrected rates are the signed-off ones', () => {
+    expect(cityDttRate('Santa Monica')).toEqual({ state: 'rated', ratePer1000: 3.00 });
+    expect(cityDttRate('Culver City', 1_000_000)).toEqual({ state: 'rated', ratePer1000: 4.50 });
+    expect(cityDttRate('Los Angeles')).toEqual({ state: 'rated', ratePer1000: 4.50 });
+  });
+
+  it('Long Beach, Inglewood and Pasadena levy NOTHING — the $2.20 was wrong', () => {
+    for (const city of ['Long Beach', 'Inglewood', 'Pasadena']) {
+      expect(cityDttRate(city).state).toBe('none');
+    }
+  });
+
+  it('every LA County row is an affirmative fact, never an unknown', () => {
+    // The closed-set ruling is what licenses this: "not among the five"
+    // is knowledge about the county, not a gap in it.
+    for (const p of PLACES.filter((x) => x.county === 'Los Angeles')) {
+      expect(p.dttRatePer1000).not.toBeNull();
+    }
+  });
+
+  it('non-LA counties keep the honest gap', () => {
+    // Explicitly NOT resolved by this sign-off, and must not be quietly
+    // folded in later.
+    expect(cityDttRate('South San Francisco').state).toBe('unknown');
+    expect(cityDttRate('Palo Alto').state).toBe('unknown');
+  });
+
+  it('every verified rate cites its source', () => {
+    for (const p of PLACES.filter((x) => x.county === 'Los Angeles')) {
+      expect(p.source).toBeTruthy();
+    }
+  });
+});
+
+describe('T-2a — tiers are FLAGGED, never computed', () => {
+  it('a high-value City of LA transfer states no city rate at all', () => {
+    const r = cityDttRate('Los Angeles', 6_000_000);
+    expect(r.state).toBe('tiered');
+    expect(r).not.toHaveProperty('ratePer1000');
+    expect(r.state === 'tiered' && r.measure).toBe('Measure ULA');
+  });
+
+  it('below the threshold the base rate still applies', () => {
+    expect(cityDttRate('Los Angeles', 1_000_000)).toEqual(
+      { state: 'rated', ratePer1000: 4.50 });
+  });
+
+  it('the breakdown computes NO city portion above the threshold', () => {
+    const b = computeDttBreakdown({ ...ONE_MILLION, transferValue: '6000000',
+      cityName: 'Los Angeles' })!;
+    expect(b.city).toBeNull();
+    expect(b.cityTierFlag?.measure).toBe('Measure ULA');
+    // The county portion — which does not tier — is still computed.
+    expect(b.county).toBe('6600.00');
+  });
+
+  it('Culver City tiers from its lowest bracket boundary', () => {
+    const r = cityDttRate('Culver City', 2_000_000);
+    expect(r.state).toBe('tiered');
+    expect(r.state === 'tiered' && r.boundaries).toEqual([1_500_000, 3_000_000, 10_000_000]);
+  });
+
+  it('the flag never carries a rate — that is the whole ruling', () => {
+    const b = computeDttBreakdown({ ...ONE_MILLION, transferValue: '9000000',
+      cityName: 'Santa Monica' })!;
+    expect(JSON.stringify(b.cityTierFlag)).not.toMatch(/rate/i);
   });
 });

--- a/frontend/src/components/builder/sections/TransferTaxSection.tsx
+++ b/frontend/src/components/builder/sections/TransferTaxSection.tsx
@@ -347,6 +347,27 @@ export function TransferTaxSection({
                   produced for South San Francisco — it just costs the
                   other party. Amber, because it is a real value the
                   officer must not take at face value. */}
+              {/* T-2a — the tiered high-value bracket, FLAGGED not computed.
+                  Measure ULA's thresholds adjust annually; Measure GS and
+                  Measure RE have their own brackets. A rate compiled into
+                  the registry would go stale silently while still printing
+                  a confident number, and understating a City of LA
+                  transfer by ULA's margin (base 0.45% against 4%) is the
+                  failure being avoided. So: name the measure, state no
+                  rate, compute no city portion. */}
+              {dttBreakdown.cityTierFlag && (
+                <div className="mt-2 ml-7 p-2.5 rounded-md border border-amber-300 bg-amber-50 text-sm text-amber-900">
+                  <span className="font-semibold">
+                    High-value transfer — tiered city tax applies
+                    {' '}({dttBreakdown.cityTierFlag.measure}).
+                  </span>{' '}
+                  Verify the current schedule and enter the city portion
+                  manually. No city amount is computed above $
+                  {dttBreakdown.cityTierFlag.threshold.toLocaleString()} —
+                  these tiers change, and a stale figure here would be worse
+                  than none.
+                </div>
+              )}
               {dttBreakdown.cityRateUnknown && (
                 <div className="mt-2 ml-7 p-2.5 rounded-md border border-amber-300 bg-amber-50 text-sm text-amber-900">
                   <span className="font-semibold">

--- a/frontend/src/lib/dttCalc.ts
+++ b/frontend/src/lib/dttCalc.ts
@@ -36,6 +36,13 @@ export interface DttBreakdown {
   cityRateUnknown?: boolean;
   /** The place whose rate is unknown, for the officer-facing prompt. */
   unknownPlace?: string;
+  /**
+   * T-2a. A high-value bracket applies and we deliberately did NOT
+   * compute a city portion. Carries the measure's NAME and never a rate —
+   * tier schedules move (Measure ULA's thresholds adjust annually) and a
+   * stale number that looks confident is the failure being avoided.
+   */
+  cityTierFlag?: { measure: string; threshold: number; boundaries?: number[] };
 }
 
 export function computeDttBreakdown(value: DTTData | null): DttBreakdown | null {
@@ -48,12 +55,18 @@ export function computeDttBreakdown(value: DTTData | null): DttBreakdown | null 
   let cityTax = 0;
   let cityRateUnknown = false;
   let unknownPlace: string | undefined;
+  let cityTierFlag: DttBreakdown['cityTierFlag'];
 
   // The city portion applies only where the property actually sits in a
   // city. `areaType` remains the officer's statement about the property.
   if (value.areaType === 'city') {
-    const rate = cityDttRate(value.cityName);
-    if (rate.state === 'rated') {
+    const rate = cityDttRate(value.cityName, amount);
+    if (rate.state === 'tiered') {
+      // No city portion computed. The flag is the answer.
+      cityTierFlag = {
+        measure: rate.measure, threshold: rate.threshold, boundaries: rate.boundaries,
+      };
+    } else if (rate.state === 'rated') {
       cityTax = (amount / 1000) * rate.ratePer1000;
     } else if (rate.state === 'unknown') {
       cityRateUnknown = true;
@@ -67,5 +80,6 @@ export function computeDttBreakdown(value: DTTData | null): DttBreakdown | null 
     city: cityTax > 0 ? cityTax.toFixed(2) : null,
     total: (countyTax + cityTax).toFixed(2),
     ...(cityRateUnknown ? { cityRateUnknown, unknownPlace } : {}),
+    ...(cityTierFlag ? { cityTierFlag } : {}),
   };
 }

--- a/frontend/src/lib/jurisdictions.ts
+++ b/frontend/src/lib/jurisdictions.ts
@@ -49,14 +49,35 @@
  * The difference between `0` and `null` is the whole point. Absence of
  * knowledge must not render as a fact.
  *
- * ═══ RATE PROVENANCE — OWNER'S ESCROW REVIEW PENDING ═══
+ * ═══ RATE PROVENANCE — OWNER SIGN-OFF RECEIVED (2026-08-04) ═══
  *
- * Every non-null rate below is carried forward UNCHANGED from the
- * pre-T-2 tables. None of them were verified by this ticket. They are
- * approximations of tiered municipal schedules and remain the owner's
- * escrow review to confirm against current published schedules — the
- * open ledger item. Entries marked `null` are the honest gaps that
- * review should fill; they are not omissions to be "fixed" by guessing.
+ * Every Los Angeles County row below is verified against TWO independent
+ * sources, both cited per row:
+ *
+ *   [PCT]   PCT published transfer-tax chart, pct.com/resources/transfer-tax,
+ *           fetched August 2026.
+ *   [OWNER] Owner verification — practising escrow professional, LA County
+ *           desk experience — signed off 2026-08-04.
+ *
+ * THE LA COUNTY CITY-DTT SET IS A CLOSED SET OF FIVE: Los Angeles, Santa
+ * Monica, Culver City, Pomona, Redondo Beach. Every other incorporated
+ * city in the county levies NO city transfer tax — county $1.10/$1,000
+ * only. That is why the LA rows below carry `0` (affirmative knowledge)
+ * rather than `null` (absence of knowledge): the set being closed is
+ * itself the fact.
+ *
+ * RESOLVED: Long Beach, Inglewood and Pasadena were rated $2.20 here and
+ * levy nothing. The claim came from the dttCalc own-DTT list (mirrored
+ * into dtt_rates.py), NOT from the propertyPrefill fork — that fork
+ * OMITTED all three, which is why prefill marked them "unincorporated"
+ * and skipped their city tax. So the two forks were wrong in opposite
+ * directions about the same three cities, and the fork that looked
+ * broken was accidentally right. Both are now the same, correct, zero.
+ *
+ * NON-LA COUNTIES ARE STILL UNVERIFIED. Rows outside LA County keep
+ * whatever they had: carried-forward rates where one existed, `null`
+ * where none did. The honest-gap path stays open for them until each
+ * county gets this same treatment.
  */
 
 export interface RecorderPrefs {
@@ -76,6 +97,26 @@ export interface County {
   pcorRouting?: PcorRouting;
 }
 
+/**
+ * A high-value bracket exists above `amount`, created by `measure`.
+ *
+ * RULED: we FLAG, we do not compute. Tier schedules move — Measure ULA's
+ * thresholds adjust annually — and a rate compiled into this file goes
+ * stale silently while continuing to produce confident numbers. Above the
+ * threshold the product says a tiered tax applies and to verify the
+ * current schedule, and it states NO rate. An honest flag beats stale
+ * math, and understating a City of LA transfer by an order of magnitude
+ * (base 0.45% against ULA's 4%) is the failure mode being avoided.
+ */
+export interface TierThreshold {
+  /** Consideration at or above which the flag fires. */
+  amount: number;
+  /** Ballot measure that created the bracket — named, never rated. */
+  measure: string;
+  /** Further bracket boundaries, for the officer-facing note. */
+  boundaries?: number[];
+}
+
 export interface Place {
   /** Canonical display name. */
   city: string;
@@ -83,6 +124,10 @@ export interface Place {
   incorporated: boolean;
   /** See RATE SEMANTICS above. `null` means unknown, never zero. */
   dttRatePer1000: number | null;
+  /** Present where a high-value bracket exists. Flagged, never computed. */
+  tieredAbove?: TierThreshold;
+  /** Source citation. Required for every verified rate. */
+  source?: string;
 }
 
 /** The merged view a caller gets back: place facts + its county's facts. */
@@ -112,28 +157,90 @@ export const COUNTIES: Record<string, County> = {
  * silent behavior change.
  */
 export const PLACES: Place[] = [
-  // ── Los Angeles County — incorporated, rate carried forward ─────────
-  { city: 'Los Angeles', county: 'Los Angeles', incorporated: true, dttRatePer1000: 4.50 },
-  { city: 'Culver City', county: 'Los Angeles', incorporated: true, dttRatePer1000: 2.20 },
-  { city: 'Santa Monica', county: 'Los Angeles', incorporated: true, dttRatePer1000: 2.20 },
-  { city: 'Redondo Beach', county: 'Los Angeles', incorporated: true, dttRatePer1000: 2.20 },
-  { city: 'Inglewood', county: 'Los Angeles', incorporated: true, dttRatePer1000: 2.20 },
-  { city: 'Long Beach', county: 'Los Angeles', incorporated: true, dttRatePer1000: 2.20 },
-  { city: 'Pasadena', county: 'Los Angeles', incorporated: true, dttRatePer1000: 2.20 },
-  { city: 'Pomona', county: 'Los Angeles', incorporated: true, dttRatePer1000: 2.20 },
+  // ══ Los Angeles County — THE FIVE. Closed set, owner-confirmed. ══
+  {
+    city: 'Los Angeles', county: 'Los Angeles', incorporated: true,
+    dttRatePer1000: 4.50,
+    // Measure ULA adds a high-value bracket whose thresholds ADJUST
+    // ANNUALLY — the single clearest argument for flagging over
+    // computing. Base 0.45% vs ULA's 4% is an order of magnitude.
+    tieredAbove: { amount: 5_000_000, measure: 'Measure ULA' },
+    source: 'PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04',
+  },
+  {
+    city: 'Santa Monica', county: 'Los Angeles', incorporated: true,
+    // CORRECTED from $2.20. The carried-forward figure was wrong.
+    dttRatePer1000: 3.00,
+    tieredAbove: { amount: 5_000_000, measure: 'Measure SM ($6.00 tier); Measure GS beyond' },
+    source: 'PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04',
+  },
+  {
+    city: 'Culver City', county: 'Los Angeles', incorporated: true,
+    // CORRECTED from $2.20. Base bracket ~0.45% = $4.50 per $1,000.
+    dttRatePer1000: 4.50,
+    tieredAbove: {
+      amount: 1_500_000, measure: 'Measure RE',
+      boundaries: [1_500_000, 3_000_000, 10_000_000],
+    },
+    source: 'PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04',
+  },
+  {
+    city: 'Pomona', county: 'Los Angeles', incorporated: true,
+    dttRatePer1000: 2.20, source: 'PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04',
+  },
+  {
+    city: 'Redondo Beach', county: 'Los Angeles', incorporated: true,
+    dttRatePer1000: 2.20, source: 'PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04',
+  },
 
-  // ── Los Angeles County — UNINCORPORATED. Structural fact, not a rate
-  //    lookup: unincorporated territory levies no municipal transfer tax,
-  //    so 0 here is affirmative knowledge. Both of these were charged the
-  //    City of Los Angeles' $4.50 by substring matching.
-  { city: 'East Los Angeles', county: 'Los Angeles', incorporated: false, dttRatePer1000: 0 },
-  { city: 'Lake Los Angeles', county: 'Los Angeles', incorporated: false, dttRatePer1000: 0 },
+  // ══ Los Angeles County — levies NONE. Affirmative, not absence. ══
+  // These are `0`, not `null`, because the five-city set above is CLOSED:
+  // "not among the five" is knowledge about this county, not a gap.
+  //
+  // Long Beach, Inglewood and Pasadena were rated $2.20 here and levy
+  // nothing — see the RESOLVED note in the header for which fork made
+  // that claim and which one was accidentally right.
+  { city: 'Long Beach', county: 'Los Angeles', incorporated: true, dttRatePer1000: 0, source: 'PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04' },
+  { city: 'Inglewood', county: 'Los Angeles', incorporated: true, dttRatePer1000: 0, source: 'PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04' },
+  { city: 'Pasadena', county: 'Los Angeles', incorporated: true, dttRatePer1000: 0, source: 'PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04' },
+  { city: 'Torrance', county: 'Los Angeles', incorporated: true, dttRatePer1000: 0, source: 'PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04' },
+  { city: 'Glendale', county: 'Los Angeles', incorporated: true, dttRatePer1000: 0, source: 'PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04' },
+  { city: 'Burbank', county: 'Los Angeles', incorporated: true, dttRatePer1000: 0, source: 'PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04' },
+  { city: 'Downey', county: 'Los Angeles', incorporated: true, dttRatePer1000: 0, source: 'PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04' },
+  { city: 'Norwalk', county: 'Los Angeles', incorporated: true, dttRatePer1000: 0, source: 'PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04' },
+  { city: 'Compton', county: 'Los Angeles', incorporated: true, dttRatePer1000: 0, source: 'PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04' },
+  { city: 'Carson', county: 'Los Angeles', incorporated: true, dttRatePer1000: 0, source: 'PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04' },
+  { city: 'Lakewood', county: 'Los Angeles', incorporated: true, dttRatePer1000: 0, source: 'PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04' },
+  { city: 'El Monte', county: 'Los Angeles', incorporated: true, dttRatePer1000: 0, source: 'PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04' },
+  { city: 'West Covina', county: 'Los Angeles', incorporated: true, dttRatePer1000: 0, source: 'PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04' },
+  { city: 'Whittier', county: 'Los Angeles', incorporated: true, dttRatePer1000: 0, source: 'PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04' },
+  { city: 'Lynwood', county: 'Los Angeles', incorporated: true, dttRatePer1000: 0, source: 'PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04' },
+  { city: 'Paramount', county: 'Los Angeles', incorporated: true, dttRatePer1000: 0, source: 'PCT chart pct.com/resources/transfer-tax (Aug 2026) + owner verification 2026-08-04' },
+  // South Pasadena resolves by the CLOSED-SET ruling rather than by its
+  // own line in the chart: an LA County city that is not one of the five
+  // levies none. Flagged as an inference in the T-2a report, not silently
+  // folded in with the enumerated sixteen.
+  { city: 'South Pasadena', county: 'Los Angeles', incorporated: true,
+    dttRatePer1000: 0,
+    source: 'Derived from the closed-set ruling (owner, 2026-08-04)' },
+
+  // ── Los Angeles County — UNINCORPORATED. Structural fact rather than a
+  //    chart lookup: unincorporated territory levies no municipal transfer
+  //    tax, so 0 here is affirmative for a second, independent reason.
+  //    Both of these were charged the City of Los Angeles' $4.50 by the
+  //    substring matcher T-2 removed, and they are the proof cases the
+  //    collision pins fire on — they must not leave this list.
+  { city: 'East Los Angeles', county: 'Los Angeles', incorporated: false,
+    dttRatePer1000: 0,
+    source: 'Unincorporated territory levies no municipal transfer tax (structural); closed-set ruling (owner, 2026-08-04)' },
+  { city: 'Lake Los Angeles', county: 'Los Angeles', incorporated: false,
+    dttRatePer1000: 0,
+    source: 'Unincorporated territory levies no municipal transfer tax (structural); closed-set ruling (owner, 2026-08-04)' },
 
   // ── Collision guards: real places whose names CONTAIN a rated place's
   //    name. Listed with null rather than omitted, so the lookup answers
   //    "I know this place and I do not know its rate" instead of falling
   //    through to a neighbour's number.
-  { city: 'South Pasadena', county: 'Los Angeles', incorporated: true, dttRatePer1000: null },
   { city: 'South San Francisco', county: 'San Mateo', incorporated: true, dttRatePer1000: null },
   { city: 'West Sacramento', county: 'Yolo', incorporated: true, dttRatePer1000: null },
 
@@ -209,16 +316,41 @@ export type CityRate =
   | { state: 'rated'; ratePer1000: number }
   /** Known and affirmatively levies none. */
   | { state: 'none' }
+  /**
+   * A high-value bracket applies. We name the measure and REFUSE to state
+   * a rate — see TierThreshold. The caller must not compute a city
+   * portion from the base rate here: understating a City of LA transfer
+   * by ULA's margin is worse than declining to answer.
+   */
+  | { state: 'tiered'; measure: string; threshold: number; boundaries?: number[] }
   /** We do not know — the officer is asked. NEVER rendered as a number. */
   | { state: 'unknown'; place: string };
 
-export function cityDttRate(city: string | null | undefined): CityRate {
+/**
+ * @param consideration when supplied, a place with a tier threshold at or
+ *        below it resolves to `tiered` instead of `rated`.
+ */
+export function cityDttRate(
+  city: string | null | undefined,
+  consideration?: number,
+): CityRate {
   const hit = lookupJurisdiction(city);
   // Narrow explicitly: `hit.place` only exists on the not-known arm, and
   // the discriminant has to be read as `=== false` for TS to see it.
   if (hit.known === false) return { state: 'unknown', place: hit.place };
-  const rate = hit.jurisdiction.dttRatePer1000;
-  if (rate === null) return { state: 'unknown', place: hit.jurisdiction.city };
+  const j = hit.jurisdiction;
+  const rate = j.dttRatePer1000;
+  if (rate === null) return { state: 'unknown', place: j.city };
+
+  if (j.tieredAbove && typeof consideration === 'number'
+      && consideration >= j.tieredAbove.amount) {
+    return {
+      state: 'tiered',
+      measure: j.tieredAbove.measure,
+      threshold: j.tieredAbove.amount,
+      boundaries: j.tieredAbove.boundaries,
+    };
+  }
   if (rate === 0) return { state: 'none' };
   return { state: 'rated', ratePer1000: rate };
 }


### PR DESCRIPTION
> **Stacked on #119.** GitHub retargets to `main` when that merges.

Owner sign-off, 2026-08-04. Every LA County row now cites two independent sources: the PCT published transfer-tax chart (`pct.com/resources/transfer-tax`, fetched Aug 2026) and owner verification by a practising escrow professional with LA County desk experience.

## The LA County set is closed at five

Los Angeles, Santa Monica, Culver City, Pomona, Redondo Beach. Every other incorporated city levies nothing.

That closure is what licenses the LA rows to carry `0` — affirmative knowledge — instead of `null`. **"Not among the five" is a fact about this county, not a gap in our data**, and a pin asserts no LA County row may drift back to unknown.

## Corrections to shipped numbers

| city | was | now |
|---|---|---|
| Santa Monica | $2.20 | **$3.00** |
| Culver City | $2.20 | **$4.50** (base bracket ~0.45%) |
| Long Beach | $2.20 | **levies none** |
| Inglewood | $2.20 | **levies none** |
| Pasadena | $2.20 | **levies none** |

Plus 13 LA County cities added as verified zeros.

## One attribution corrected for the record

The relay credited the Long Beach/Inglewood/Pasadena levy claim to the propertyPrefill fork. It came from the opposite side: **`dttCalc`'s own-DTT list rated all three at $2.20, while propertyPrefill omitted them** — which is exactly why prefill marked those properties "unincorporated" and skipped their city tax.

So the two forks were wrong in opposite directions about the same three cities, and the fork that looked broken was accidentally right. Recorded that way in the registry header, since that's the version a future reader needs.

## One inference, flagged not buried

**South Pasadena** wasn't among the enumerated sixteen. It resolves to zero by the *closed-set ruling* rather than by its own line on the chart, and its `source` field says so in those words.

## Tiers: flagged, never priced

Threshold markers for City of LA ≥ $5M (Measure ULA), Santa Monica ≥ $5M (Measure SM; GS beyond), Culver City at $1.5M/$3M/$10M (Measure RE). Above a threshold the product names the measure, states **no rate**, and computes **no city portion**. The county portion, which doesn't tier, is still computed.

Measure ULA's thresholds adjust annually — that's the whole argument. A rate compiled into this file goes stale silently while continuing to print confident numbers, and **understating a City of LA transfer by ULA's margin (base 0.45% against 4%) is a far bigger exposure than the substring bug T-2 fixed.** A pin asserts the flag never carries a rate.

## Non-LA counties keep the honest gap

South San Francisco, Palo Alto and the rest stay `unknown`, and are **pinned** to stay that way — so a future county's sign-off can't quietly sweep them in.

## Pins updated deliberately

Seven, all downstream of the sign-off: the mirror parsers (rows gained tier + source fields, so regexes matching a formatting choice broke), the rate assertions that named Pasadena at $2.20, and the South Pasadena collision pin — whose container is now a verified zero, so it guards the *mechanism* rather than a rate that no longer exists.

## Gates

| gate | result |
|---|---|
| backend pytest | 377 passed |
| jest | 462 passed, 33 suites |
| six-flow / API baselines | verify OK |
| tsc | 94 — unchanged |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_