### PR TITLE
T-4: the escrow number becomes a thread, and legal choices stay put

### DIFF
--- a/backend/routers/deeds_crud.py
+++ b/backend/routers/deeds_crud.py
@@ -601,6 +601,51 @@ def _pcor_deed_row(deed_id: int, user_id: int) -> dict:
     return dict(deed)
 
 
+@router.get("/deeds/{deed_id}/matter")
+def matter_endpoint(deed_id: int, user_id: int = Depends(get_current_user_id)):
+    """T-4 — the other documents on this file.
+
+    v1 threads by escrow number (then title order), which the builder has
+    collected and persisted since T2 and nothing has ever grouped by. No
+    schema change: the proper `matters` table waits until this proves the
+    workflow.
+    """
+    from services.matters import carry_forward, matter_key, party_names
+
+    row = _pcor_deed_row(deed_id, user_id)
+    key = matter_key(row)
+    if key is None:
+        return {"grouped": False,
+                "reason": "This document has no escrow or title order number, "
+                          "so there is nothing to group it by."}
+
+    kind, value = key
+    with db.conn.cursor() as cur:
+        cur.execute(f"""
+            SELECT id, deed_type, status, property_address, apn,
+                   grantor_name, grantee_name, parties, created_at
+            FROM deeds
+            WHERE user_id = %s AND id <> %s AND status <> 'deleted'
+              AND metadata->>%s = %s
+            ORDER BY created_at DESC
+        """, (row.get("user_id"), deed_id, kind, value))
+        siblings = [dict(r) for r in cur.fetchall()]
+
+    return {
+        "grouped": True,
+        "key": {"kind": kind, "value": value},
+        "documents": [{
+            "id": s_["id"],
+            "deed_type": s_["deed_type"],
+            "status": s_["status"],
+            "property_address": s_["property_address"],
+            "created_at": s_["created_at"].isoformat() if s_.get("created_at") else None,
+            "parties": party_names(s_),
+        } for s_ in siblings],
+        "carry_forward": carry_forward(row),
+    }
+
+
 @router.get("/deeds/{deed_id}/death-statement")
 def death_statement_status_endpoint(deed_id: int, user_id: int = Depends(get_current_user_id)):
     """T-3b — the BOE-502-D's availability and remaining asks.

--- a/backend/services/matters.py
+++ b/backend/services/matters.py
@@ -1,0 +1,142 @@
+"""T-4 — the file concept, v1: a matter is an escrow number.
+
+═══ NO SCHEMA CHANGE, DELIBERATELY ═══
+
+The grouping key already existed as data. `metadata.escrow_no` and
+`metadata.title_order_no` have been collected by the builder and
+persisted on every deed since T2, and nothing ever grouped by them. So v1
+groups by what is already there and proves the workflow before asking for
+a `matters` table — the proper model is deferred until the officer's use
+of this tells us what it should look like.
+
+═══ WHAT CARRIES, AND WHAT MUST NOT ═══
+
+FACTS CARRY. The APN is the APN; the legal description is the legal
+description. When the officer already confirmed one on the grant deed,
+re-asking on the affidavit an hour later is the busywork this ticket
+exists to kill.
+
+They carry WITH THEIR ORIGINAL PROVENANCE — the source and the ORIGINAL
+`confirmedAt`, never a fresh stamp. A confirmation is a record of a
+moment a human looked at a value and said yes. Re-stamping it on copy
+would forge a second look that never happened, and the record would claim
+the officer confirmed the APN twice when they confirmed it once. Each
+carried field is additionally marked `carriedFrom`, so the UI can say
+where it came from rather than presenting inherited data as freshly
+entered.
+
+LEGAL CHOICES NEVER CARRY. Ruled, and it is the sharper half.
+
+The documentary-transfer-tax treatment, an exemption claim, the
+characterisation of how title passed — these are decisions ABOUT AN
+INSTRUMENT, not facts about a property. The DTT exemption that was
+correct on an interspousal transfer is not thereby correct on the
+quitclaim that follows it, and the officer who accepted R&T 11927 on
+Monday accepted it for Monday's document. Carrying it forward would
+auto-apply a legal choice to a document nobody has read yet, which is
+exactly what doctrine §1 forbids — and it would do so while wearing the
+officer's own recorded acceptance, which makes it worse than an
+auto-apply, not better.
+
+So: `LEGAL_CHOICE_KEYS` never appear in a carry-forward payload, and a
+test asserts each one by name.
+"""
+from typing import Any, Dict, List, Optional, Tuple
+
+# Facts about the PROPERTY and the parties, safe to carry.
+CARRYABLE_ROW_FIELDS = [
+    "property_address", "apn", "county", "legal_description",
+]
+CARRYABLE_META_FIELDS = [
+    "property_city", "property_state", "property_zip", "current_owner",
+    "title_order_no", "escrow_no", "requested_by_address", "return_to",
+]
+
+# NEVER carried. Each is a decision about a particular instrument.
+LEGAL_CHOICE_KEYS = [
+    "dtt",           # transfer-tax treatment, incl. any exemption claim
+    "dttDecision",   # the officer's recorded acceptance of one
+    "provenance",    # re-derived per document from the carried fields
+    "affidavit",     # facts sworn to in a specific affidavit
+]
+
+
+def matter_key(row: Dict[str, Any]) -> Optional[Tuple[str, str]]:
+    """The thread. Escrow number first — it is the officer's own file
+    number and the one they say out loud — then the title order.
+
+    Returns (kind, value) or None when the deed carries neither, which is
+    common and is not an error: a matter is opt-in, created by the
+    officer having typed a number they already use.
+    """
+    meta = row.get("metadata") or {}
+    for kind in ("escrow_no", "title_order_no"):
+        value = (meta.get(kind) or "").strip() if isinstance(meta.get(kind), str) else meta.get(kind)
+        if value:
+            return kind, str(value)
+    return None
+
+
+def party_names(row: Dict[str, Any]) -> List[str]:
+    """Both shapes.
+
+    Two-party instruments keep authoritative `grantor_name`/`grantee_name`
+    COLUMNS; single-party families (the declaration/affidavit shapes) carry
+    their people in the `parties` JSONB instead, per the parties migration.
+    A reader that knows only one shape silently misses half the library —
+    and the half it misses is the affidavit family, which is precisely
+    what an officer wants grouped with a deed.
+    """
+    names: List[str] = []
+    for col in ("grantor_name", "grantee_name"):
+        v = row.get(col)
+        if v and str(v).strip():
+            names.append(str(v).strip())
+    parties = row.get("parties")
+    if isinstance(parties, dict):
+        for v in parties.values():
+            if v and str(v).strip():
+                names.append(str(v).strip())
+    return names
+
+
+def carry_forward(row: Dict[str, Any]) -> Dict[str, Any]:
+    """Build the payload for "start a related document" from a deed.
+
+    Provenance is copied VERBATIM — original source, original
+    confirmedAt — and annotated with `carriedFrom`. Nothing is re-stamped.
+    """
+    meta = row.get("metadata") or {}
+    carried: Dict[str, Any] = {}
+    for f in CARRYABLE_ROW_FIELDS:
+        if row.get(f):
+            carried[f] = row[f]
+    for f in CARRYABLE_META_FIELDS:
+        if meta.get(f):
+            carried[f] = meta[f]
+
+    # The officer's earlier confirmations, preserved exactly.
+    source_prov = meta.get("provenance") or {}
+    provenance: Dict[str, Any] = {}
+    for field, stamp in source_prov.items():
+        if not isinstance(stamp, dict):
+            continue
+        provenance[field] = {
+            **stamp,
+            # The marker that keeps this honest on screen: inherited data
+            # is never presented as freshly entered.
+            "carriedFrom": row.get("id"),
+        }
+
+    return {
+        "from_deed_id": row.get("id"),
+        "carried": carried,
+        "provenance": provenance,
+        # Named, so the UI can say WHY the transfer-tax section is empty
+        # rather than looking like it forgot.
+        "not_carried": [
+            "Transfer-tax treatment and any exemption — a legal choice, "
+            "decided fresh for each instrument",
+            "Affidavit facts — sworn to in a specific document",
+        ],
+    }

--- a/backend/tests/snapshots/openapi_routes.json
+++ b/backend/tests/snapshots/openapi_routes.json
@@ -193,6 +193,10 @@
  ],
  [
   "GET",
+  "/deeds/{deed_id}/matter"
+ ],
+ [
+  "GET",
   "/deeds/{deed_id}/pcor"
  ],
  [

--- a/backend/tests/test_matter_grouping.py
+++ b/backend/tests/test_matter_grouping.py
@@ -1,0 +1,182 @@
+"""T-4 — the file concept, and the two things it must never do.
+
+The workflow this kills: an officer finishes a grant deed, then starts
+the affidavit for the same property an hour later and retypes the APN,
+the legal description, the address and the escrow number she already
+confirmed once.
+
+The two failure modes it must not introduce:
+
+1. RE-STAMPING A CONFIRMATION. A `confirmedAt` is the record of a moment
+   a human looked at a value and said yes. Copying it forward with a
+   FRESH timestamp forges a second look that never happened.
+
+2. CARRYING A LEGAL CHOICE. The DTT exemption accepted on Monday's
+   interspousal transfer is not thereby correct on Tuesday's quitclaim.
+   Carrying it would auto-apply a legal choice to a document nobody has
+   read — while wearing the officer's own recorded acceptance, which
+   makes it worse than an auto-apply rather than better.
+"""
+import pytest
+
+from services.matters import (
+    CARRYABLE_ROW_FIELDS, LEGAL_CHOICE_KEYS,
+    carry_forward, matter_key, party_names,
+)
+
+
+def _row(**over):
+    row = {
+        "id": 501,
+        "user_id": 9,
+        "property_address": "1420 OCEAN AVE",
+        "apn": "4291-013-027",
+        "county": "Los Angeles",
+        "legal_description": "LOT 7, BLOCK B",
+        "grantor_name": "JAMES R. OKONKWO",
+        "grantee_name": "MARIA L. TORRES",
+        "metadata": {
+            "escrow_no": "ESC-88214",
+            "title_order_no": "TO-99",
+            "property_city": "SANTA MONICA",
+            "provenance": {
+                "apn": {"value": "4291-013-027", "source": "sitex",
+                        "status": "confirmed", "confirmedAt": "2026-08-01T10:00:00Z"},
+            },
+            "dtt": {"isExempt": True, "exemptReason": "R&T 11927",
+                    "basis": "full_value"},
+            "dttDecision": {"source": "ai_suggested", "status": "confirmed",
+                            "confirmedAt": "2026-08-01T10:05:00Z",
+                            "codeSection": "R&T 11927"},
+            "affidavit": {"decedentName": "SOMEBODY"},
+        },
+    }
+    row.update(over)
+    return row
+
+
+# ── The thread ───────────────────────────────────────────────────────
+
+def test_escrow_number_is_the_thread():
+    assert matter_key(_row()) == ("escrow_no", "ESC-88214")
+
+
+def test_title_order_is_the_fallback():
+    r = _row()
+    r["metadata"] = {**r["metadata"], "escrow_no": ""}
+    assert matter_key(r) == ("title_order_no", "TO-99")
+
+
+def test_no_number_is_not_an_error():
+    """A matter is opt-in — created by the officer having typed a number
+    they already use. A deed without one simply is not grouped."""
+    r = _row(metadata={})
+    assert matter_key(r) is None
+
+
+def test_whitespace_only_is_not_a_key():
+    r = _row()
+    r["metadata"] = {**r["metadata"], "escrow_no": "   ", "title_order_no": "  "}
+    assert matter_key(r) is None
+
+
+# ── Both party shapes ────────────────────────────────────────────────
+
+def test_two_party_instruments_read_from_the_columns():
+    assert party_names(_row()) == ["JAMES R. OKONKWO", "MARIA L. TORRES"]
+
+
+def test_single_party_instruments_read_from_the_jsonb():
+    """The declaration and affidavit families carry their people in
+    `parties`, per the parties migration. A reader that knows only the
+    columns misses the affidavit family entirely — which is exactly the
+    half an officer wants grouped WITH a deed."""
+    r = _row(grantor_name=None, grantee_name=None,
+             parties={"declarant": "ELENA V. MARQUEZ"})
+    assert party_names(r) == ["ELENA V. MARQUEZ"]
+
+
+def test_both_shapes_at_once():
+    r = _row(parties={"trustee": "FIRST TRUST CO"})
+    assert set(party_names(r)) == {
+        "JAMES R. OKONKWO", "MARIA L. TORRES", "FIRST TRUST CO"}
+
+
+def test_empty_party_values_are_skipped():
+    r = _row(grantor_name="", grantee_name=None, parties={"declarant": "  "})
+    assert party_names(r) == []
+
+
+# ── Facts carry ──────────────────────────────────────────────────────
+
+def test_property_facts_carry():
+    carried = carry_forward(_row())["carried"]
+    for f in CARRYABLE_ROW_FIELDS:
+        assert f in carried
+    assert carried["apn"] == "4291-013-027"
+    assert carried["property_city"] == "SANTA MONICA"
+    assert carried["escrow_no"] == "ESC-88214"
+
+
+# ── ...with the ORIGINAL confirmation, never a fresh one ─────────────
+
+def test_a_carried_confirmation_keeps_its_original_timestamp():
+    """The heart of it. A fresh stamp would forge a second look."""
+    prov = carry_forward(_row())["provenance"]
+    assert prov["apn"]["confirmedAt"] == "2026-08-01T10:00:00Z"
+    assert prov["apn"]["source"] == "sitex"
+    assert prov["apn"]["status"] == "confirmed"
+
+
+def test_a_carried_field_is_visibly_marked_as_carried():
+    """Inherited data must never present itself as freshly entered."""
+    prov = carry_forward(_row())["provenance"]
+    assert prov["apn"]["carriedFrom"] == 501
+
+
+def test_nothing_in_the_payload_is_stamped_now():
+    """No key anywhere may hold a timestamp minted during the carry."""
+    import datetime
+    today = datetime.date.today().isoformat()
+    payload = carry_forward(_row())
+    assert today not in repr(payload), (
+        "a fresh timestamp appeared in a carry-forward payload — the only "
+        "timestamps here may be the ORIGINAL confirmations"
+    )
+
+
+# ── Legal choices never carry ────────────────────────────────────────
+
+@pytest.mark.parametrize("key", LEGAL_CHOICE_KEYS)
+def test_no_legal_choice_key_survives_the_carry(key):
+    """Occurrence pin, one per key by name — the T-3b lesson: a group
+    assertion shrugs where a per-element one fails."""
+    payload = carry_forward(_row())
+    assert key not in payload["carried"]
+    assert key not in payload.get("provenance", {})
+
+
+def test_the_dtt_exemption_does_not_reach_the_next_document():
+    """Concretely: R&T 11927 was accepted for an interspousal transfer.
+    The quitclaim that follows it is a different instrument and a
+    different decision."""
+    payload = carry_forward(_row())
+    assert "11927" not in repr(payload), (
+        "an accepted exemption travelled to the next document — that is an "
+        "auto-applied legal choice wearing the officer's own signature"
+    )
+
+
+def test_the_officer_is_told_what_did_not_carry():
+    """A silently empty transfer-tax section looks like a bug. Naming the
+    omission is the difference between deliberate and forgotten."""
+    not_carried = carry_forward(_row())["not_carried"]
+    joined = " ".join(not_carried).lower()
+    assert "legal choice" in joined
+    assert "transfer-tax" in joined or "transfer tax" in joined
+
+
+def test_affidavit_facts_do_not_carry_between_instruments():
+    """Sworn in a specific document, about a specific death."""
+    payload = carry_forward(_row())
+    assert "SOMEBODY" not in repr(payload)

--- a/docs/DOCTRINE_CONFORMANCE.md
+++ b/docs/DOCTRINE_CONFORMANCE.md
@@ -319,10 +319,53 @@ believing they corrected one.
 
 ---
 
+## §10 — Facts carry between documents; legal choices do not
+
+**Ruled T-4, 2026-08-04.**
+
+An officer working one escrow file produces several instruments about
+the same property. Re-asking her for the APN she confirmed an hour ago
+is busywork, so **facts carry forward** when she starts a related
+document.
+
+They carry with their **original provenance** — the original source and
+the original `confirmedAt`, never a fresh stamp. A confirmation records
+a moment a human looked at a value and said yes; re-stamping it on copy
+would forge a second look that never happened, and the record would
+claim two confirmations where there was one. Every carried field is
+additionally marked `carriedFrom`, because inherited data must never
+present itself on screen as freshly entered.
+
+**Legal choices never carry**, and this is the sharper half. The
+documentary-transfer-tax treatment, an exemption claim, the
+characterisation of how title passed — each is a decision *about an
+instrument*, not a fact about a property. R&T 11927 accepted on Monday's
+interspousal transfer is not thereby correct on Tuesday's quitclaim.
+
+Carrying one would auto-apply a legal choice to a document nobody has
+read yet — §1's exact prohibition — and it would do so **wearing the
+officer's own recorded acceptance**, which makes it worse than a plain
+auto-apply rather than better: the record would show a human decision
+where none occurred.
+
+The keys are enumerated in `services/matters.LEGAL_CHOICE_KEYS` and
+pinned one test per key by name.
+
+**Corollary — derivability is a reason for restraint, not licence.**
+The affidavit variant tells us how title passed. The temptation is to
+pre-check the succession box on the BOE-502-D because we are so
+obviously right. But being *derivably* right is what makes it a legal
+conclusion rather than an observation — so it arrives as a violet
+proposal and the officer's acceptance is what writes it. (T-3/T-3b:
+`check_fields` empty and pinned empty on both county forms.)
+
+---
+
 ## Change log
 
 | Date | Change |
 |---|---|
+| 2026-08-04 | §10 added — facts carry between documents with their ORIGINAL provenance (never re-stamped, always marked `carriedFrom`); legal choices never carry. T-4's matter grouping made the question live: an accepted DTT exemption travelling to the next instrument would be an auto-applied legal choice wearing the officer's own signature. Corollary recorded from T-3b: derivability is a reason for restraint, not licence — being derivably right is what makes something a legal conclusion. |
 | 2026-08-03 | §9 added — stored instruments are never overwritten. ADMIN0 found `deed_pdfs` stored via `ON CONFLICT DO UPDATE SET pdf_data`, replacing prior bytes AND their sha256 in place; the draft-resume 409 guard sits a layer above it, making this latent rather than live. Ruled in two parts: insert-or-refuse in ADMIN1 (differing hash = loud refusal, identical = no-op), full supersession as its own designed ticket. No admin deed-edit until supersession exists. |
 | 2026-08-03 | §8 added — API doctrine boundary ruled: v1 = deed family only; affidavit/declaration families held pending per-family passes (execution-act instruments require human flows by design). A1 also recorded three never-run defects in the mounted `/api/v1` (tuple-read auth, unassigned `full_address`, metering aborting the deed transaction) — all three survived because the only tests bypassed the HTTP and database layers, the test-vs-production asymmetry lesson under invariant #4. |
 | 2026-07-28 | Initial sweep: partner-API chassis fix, AI-chat proxy honesty fix, proxy source-scan test, partner-render tests. Draft pending owner decisions on §7. |

--- a/frontend/src/__tests__/pcorPackage.test.ts
+++ b/frontend/src/__tests__/pcorPackage.test.ts
@@ -87,3 +87,31 @@ describe('T-3b — the BOE-502-D offer', () => {
     expect(code).toMatch(/stays fillable/);
   });
 });
+
+describe('T-4 — the file, and what it refuses to carry', () => {
+  it('threads documents by the officer\'s own escrow number', () => {
+    expect(code).toContain('matter?.grouped');
+    expect(code).toMatch(/File \{matter\.key\?\.value\}/);
+  });
+
+  it('offers "start related document"', () => {
+    expect(code).toContain('Start related document');
+    expect(code).toContain('carryFrom=');
+  });
+
+  it('says the carried facts keep their ORIGINAL confirmation times', () => {
+    // Doctrine §10: a re-stamped confirmation forges a second look.
+    expect(code).toMatch(/original confirmation times/i);
+  });
+
+  it('names what did not carry rather than leaving a silent gap', () => {
+    // A blank transfer-tax section looks like a bug; naming the omission
+    // is the difference between deliberate and forgotten.
+    expect(code).toContain('not_carried');
+    expect(code).toMatch(/Not carried:/);
+  });
+
+  it('does not present a first document as an error', () => {
+    expect(code).toMatch(/first document on this file/);
+  });
+});

--- a/frontend/src/app/deed-builder/[type]/success/success-content.tsx
+++ b/frontend/src/app/deed-builder/[type]/success/success-content.tsx
@@ -64,6 +64,16 @@ export function SuccessContent() {
     available: boolean; county?: string; form_code?: string;
     still_needed?: string[];
   } | null>(null);
+  // T-4 — the file. The escrow number the officer already typed becomes
+  // the thread between her deed, her affidavit and their state forms.
+  const [matter, setMatter] = useState<{
+    grouped: boolean;
+    key?: { kind: string; value: string };
+    documents?: Array<{ id: number; deed_type: string; status: string;
+                        property_address?: string; created_at?: string;
+                        parties: string[] }>;
+    carry_forward?: { not_carried?: string[] };
+  } | null>(null);
 
   useEffect(() => {
     if (!deedId) return;
@@ -71,12 +81,14 @@ export function SuccessContent() {
       try {
         const api = process.env.NEXT_PUBLIC_API_URL || 'https://deedpro-main-api.onrender.com';
         const token = localStorage.getItem('access_token') || localStorage.getItem('token');
-        const [pcorRes, dsRes] = await Promise.all([
+        const [pcorRes, dsRes, matterRes] = await Promise.all([
           fetch(`${api}/deeds/${deedId}/pcor`, { headers: { 'Authorization': `Bearer ${token}` } }),
           fetch(`${api}/deeds/${deedId}/death-statement`, { headers: { 'Authorization': `Bearer ${token}` } }),
+          fetch(`${api}/deeds/${deedId}/matter`, { headers: { 'Authorization': `Bearer ${token}` } }),
         ]);
         if (pcorRes.ok) setPcor(await pcorRes.json());
         if (dsRes.ok) setDeathStatement(await dsRes.json());
+        if (matterRes.ok) setMatter(await matterRes.json());
       } catch {
         // Passive: a failed check hides the offer rather than inventing one.
       }
@@ -312,6 +324,68 @@ export function SuccessContent() {
 
             {/* FORMS flag-4 ruling: companion-filing guidance — passive,
                 links the state form, never a block and never form-fill. */}
+            {/* T-4 — the file. Same property, next document: the
+                officer's own escrow number is the thread, and starting a
+                related instrument carries the facts she already
+                confirmed — with their ORIGINAL confirmation timestamps,
+                marked as carried. What does NOT carry is named out loud
+                (doctrine §10): a transfer-tax treatment is a decision
+                about an instrument, not a fact about a property, and an
+                exemption travelling forward would be an auto-applied
+                legal choice wearing her own signature. */}
+            {matter?.grouped && (
+              <div className="mb-6 rounded-xl border border-slate-200 bg-slate-50 p-5">
+                <div className="flex items-start justify-between gap-4 flex-wrap">
+                  <div className="min-w-0">
+                    <p className="font-semibold text-slate-800">
+                      File {matter.key?.value}
+                    </p>
+                    <p className="text-sm text-slate-600 mt-0.5">
+                      {matter.documents?.length
+                        ? `${matter.documents.length} other document${matter.documents.length === 1 ? '' : 's'} on this file.`
+                        : 'This is the first document on this file.'}
+                    </p>
+                  </div>
+                  <button
+                    onClick={() => router.push(
+                      `/create-deed?carryFrom=${deedId}`)}
+                    className="shrink-0 inline-flex items-center gap-2 border-2 border-[#7C4DFF] text-[#7C4DFF] hover:bg-[#7C4DFF]/5 font-semibold px-4 py-2.5 rounded-lg transition-colors"
+                  >
+                    Start related document
+                  </button>
+                </div>
+
+                {!!matter.documents?.length && (
+                  <ul className="mt-4 pt-4 border-t border-slate-200 space-y-2">
+                    {matter.documents.map((d) => (
+                      <li key={d.id} className="text-sm text-slate-700 flex items-baseline gap-2 flex-wrap">
+                        <button
+                          onClick={() => router.push(`/past-deeds?highlight=${d.id}`)}
+                          className="font-medium text-[#7C4DFF] hover:underline"
+                        >
+                          #{d.id} {d.deed_type?.replace(/[-_]/g, ' ')}
+                        </button>
+                        <span className="text-slate-500">{d.status}</span>
+                        {!!d.parties.length && (
+                          <span className="text-slate-500 truncate">
+                            · {d.parties.join(', ')}
+                          </span>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+
+                {!!matter.carry_forward?.not_carried?.length && (
+                  <p className="mt-4 text-xs text-slate-500">
+                    Carried forward: the property facts you already confirmed,
+                    with their original confirmation times. Not carried:{' '}
+                    {matter.carry_forward.not_carried.join('; ')}.
+                  </p>
+                )}
+              </div>
+            )}
+
             {/* T-3b — the notice cashes its check.
                 The FORMS flag-4 ruling made this passive guidance because
                 form-fill was Tier B and deferred: "counties commonly


### PR DESCRIPTION
An officer finishes a grant deed, then starts the affidavit for the same property an hour later and retypes the APN, the legal description, the address and the escrow number she already confirmed once. That's the Tuesday pain this closes.

## No schema change — the key was already there

`metadata.escrow_no` and `metadata.title_order_no` have been collected by the builder and persisted on every deed since T2, and **nothing has ever grouped by them**. v1 threads by what already exists and proves the workflow before asking for a `matters` table; the proper model waits until the officer's use of this says what it should look like.

A matter is opt-in. A deed without a number simply isn't grouped — that isn't an error state and isn't rendered as one.

## Both party shapes, because half the library lives in the other one

Two-party instruments keep the authoritative `grantor_name`/`grantee_name` **columns**; the declaration and affidavit families carry their people in the `parties` **JSONB** per the parties migration. A reader that knows only the columns misses the affidavit family entirely — which is precisely the half an officer wants grouped *with* a deed.

## Facts carry, with the original confirmation

Provenance is copied verbatim: original source, **original `confirmedAt`**. A confirmation records a moment a human looked at a value and said yes; re-stamping it on copy would forge a second look that never happened, and the record would claim two confirmations where there was one.

A pin asserts that **no timestamp minted during the carry appears anywhere in the payload**. Every carried field is marked `carriedFrom`, so inherited data never presents itself on screen as freshly entered.

## Legal choices never carry — the sharper half

The DTT treatment, an exemption claim, affidavit facts: each is a decision *about an instrument*, not a fact about a property. **R&T 11927 accepted on Monday's interspousal transfer is not thereby correct on Tuesday's quitclaim.**

Carrying one would auto-apply a legal choice to a document nobody has read — §1's exact prohibition — and would do it **wearing the officer's own recorded acceptance**, which makes it worse than a plain auto-apply rather than better: the record would show a human decision where none occurred.

`LEGAL_CHOICE_KEYS` is enumerated and pinned one test per key by name — the T-3b lesson, that a group assertion shrugs where a per-element one fails — plus a concrete pin that `11927` cannot appear anywhere in a payload.

And the officer is **told** what didn't carry. A silently empty transfer-tax section looks like a bug; naming the omission is the difference between deliberate and forgotten.

## Doctrine §10 recorded

Facts carry with original provenance; legal choices don't. With the T-3b corollary written in: **derivability is a reason for restraint, not licence** — being derivably right is what makes something a legal conclusion rather than an observation.

## Gates

| gate | result |
|---|---|
| backend pytest | 442 passed (+19) |
| jest | 484 passed, 34 suites |
| six-flow / API baselines | verify OK |
| tsc | 94 — unchanged |
| OpenAPI | re-recorded — one additive route |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_