### PR TITLE
T-5: a correction is a new instrument, and the record says which replaced which

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -113,6 +113,29 @@ def create_tables():
             # store_deed_pdf stamps completed-on-store (PR #41); the ALTER
             # only ever ran in the test harness. Now it runs here.
             "ALTER TABLE deeds ADD COLUMN IF NOT EXISTS completed_at TIMESTAMP",
+            # ── T-5: correction lineage ──────────────────────────────────
+            #
+            # Mirrors document_authenticity's proven shape — a pointer to
+            # the instrument that replaced this one, plus when. That table
+            # has carried `status='superseded' + superseded_by` since the
+            # verification work; `deeds` has had no equivalent, which is
+            # why the generation gate's "generate a corrected deed — the
+            # record keeps both" was a promise with nothing behind it
+            # (T-0 removed the sentence; this ticket earns it back).
+            #
+            # ONE DELIBERATE DIVERGENCE FROM THAT SHAPE, flagged in the
+            # T-5 report: the lineage state is DERIVED from this pointer
+            # rather than added to `deeds.status`. That column already
+            # carries a lifecycle vocabulary in active use
+            # (draft/completed/deleted) and the admin console filters on
+            # it. Adding 'superseded' would make it mutually exclusive
+            # with 'completed', and those are orthogonal facts — a
+            # superseded deed is still a completed deed. It was recorded,
+            # it exists, and pretending otherwise is the un-recording this
+            # ticket refuses to do.
+            "ALTER TABLE deeds ADD COLUMN IF NOT EXISTS superseded_by INTEGER REFERENCES deeds(id)",
+            "ALTER TABLE deeds ADD COLUMN IF NOT EXISTS superseded_at TIMESTAMPTZ",
+            "CREATE INDEX IF NOT EXISTS idx_deeds_superseded_by ON deeds(superseded_by)",
             """CREATE TABLE IF NOT EXISTS deed_pdfs (
                 deed_id INTEGER PRIMARY KEY REFERENCES deeds(id) ON DELETE CASCADE,
                 pdf_data BYTEA NOT NULL,

--- a/backend/routers/deeds_crud.py
+++ b/backend/routers/deeds_crud.py
@@ -601,6 +601,115 @@ def _pcor_deed_row(deed_id: int, user_id: int) -> dict:
     return dict(deed)
 
 
+class SupersedeRequest(BaseModel):
+    """The correcting instrument's id. It must already be generated —
+    lineage points at a document, not at an intention."""
+    superseded_by: int
+
+
+@router.post("/deeds/{deed_id}/supersede")
+def supersede_endpoint(deed_id: int, body: SupersedeRequest,
+                       user_id: int = Depends(get_current_user_id)):
+    """T-5 — record that a new instrument replaces this one.
+
+    A NEW ROW AND A POINTER. The superseded deed is not edited, not
+    deleted, and not hidden: its PDF, hash and status all stay exactly as
+    they were, and the single write here is `superseded_by` going from
+    NULL to the new document's id.
+
+    The pointer is written once. A second write would silently redirect
+    history, which is the harm §9 refuses on the artifacts and this
+    refuses on the lineage.
+    """
+    from services.supersession import SupersessionRefused, validate_supersession
+
+    old = _pcor_deed_row(deed_id, user_id)
+    new_row = _pcor_deed_row(body.superseded_by, user_id)
+    try:
+        validate_supersession(old, new_row)
+    except SupersessionRefused as e:
+        raise HTTPException(status_code=409, detail=str(e))
+
+    with db.conn.cursor() as cur:
+        # Guarded in SQL as well as in Python: the IS NULL predicate makes
+        # the write-once rule true even under a concurrent second request,
+        # which the application check alone cannot promise.
+        cur.execute("""
+            UPDATE deeds
+               SET superseded_by = %s, superseded_at = now()
+             WHERE id = %s AND superseded_by IS NULL
+            RETURNING id, superseded_by, superseded_at
+        """, (body.superseded_by, deed_id))
+        updated = cur.fetchone()
+        if updated is None:
+            db.conn.rollback()
+            raise HTTPException(
+                status_code=409,
+                detail="This document was superseded by another request "
+                       "moments ago. Reload to see the current version.")
+        db.conn.commit()
+
+    return {
+        "superseded": deed_id,
+        "superseded_by": updated["superseded_by"],
+        "superseded_at": updated["superseded_at"].isoformat() if updated["superseded_at"] else None,
+        "note": "The superseded document is unchanged and still readable. "
+                "A corrected deed is a new instrument and requires its own "
+                "execution — we record the relationship, we do not un-record "
+                "documents.",
+    }
+
+
+@router.get("/deeds/{deed_id}/lineage")
+def lineage_endpoint(deed_id: int, user_id: int = Depends(get_current_user_id)):
+    """The correction chain, forwards and backwards, all of it readable.
+
+    The history is the feature, not the embarrassment: an officer asked
+    six months later which version was recorded needs to see both and see
+    which replaced which.
+    """
+    from services.supersession import lineage_state
+
+    row = _pcor_deed_row(deed_id, user_id)
+    with db.conn.cursor() as cur:
+        cur.execute("""
+            WITH RECURSIVE forward AS (
+                SELECT id, deed_type, status, superseded_by, superseded_at, created_at
+                  FROM deeds WHERE id = %s
+                UNION ALL
+                SELECT d.id, d.deed_type, d.status, d.superseded_by, d.superseded_at, d.created_at
+                  FROM deeds d JOIN forward f ON d.id = f.superseded_by
+            )
+            SELECT * FROM forward
+        """, (deed_id,))
+        forward = [dict(r) for r in cur.fetchall()]
+
+        cur.execute("""
+            SELECT id, deed_type, status, superseded_by, superseded_at, created_at
+              FROM deeds WHERE superseded_by = %s AND user_id = %s
+        """, (deed_id, row.get("user_id")))
+        supersedes = [dict(r) for r in cur.fetchall()]
+
+    def shape(r):
+        return {
+            "id": r["id"],
+            "deed_type": r["deed_type"],
+            "status": r["status"],
+            "lineage_state": lineage_state(r),
+            "superseded_by": r.get("superseded_by"),
+            "superseded_at": r["superseded_at"].isoformat() if r.get("superseded_at") else None,
+            "created_at": r["created_at"].isoformat() if r.get("created_at") else None,
+        }
+
+    return {
+        "deed_id": deed_id,
+        "lineage_state": lineage_state(row),
+        "chain": [shape(r) for r in forward],
+        "supersedes": [shape(r) for r in supersedes],
+        "current_version": shape(forward[-1])["id"] if forward else deed_id,
+    }
+
+
 @router.get("/deeds/{deed_id}/matter")
 def matter_endpoint(deed_id: int, user_id: int = Depends(get_current_user_id)):
     """T-4 — the other documents on this file.

--- a/backend/services/supersession.py
+++ b/backend/services/supersession.py
@@ -1,0 +1,114 @@
+"""T-5 — correction lineage. A new instrument, and a pointer to it.
+
+═══ WHAT SUPERSESSION IS, AND WHAT IT IS NOT ═══
+
+It is a NEW ROW plus a POINTER. It is never a mutation of the old deed
+and never a deletion of it.
+
+The superseded deed keeps everything: its stored PDF, its hash, its
+recording details, its status. The only thing that changes on it is that
+`superseded_by` stops being NULL. That is the whole edit, and §9's
+insert-or-refuse already stands guard over the artifacts underneath —
+this layer must never tempt anything past it.
+
+The temptation is real and worth naming, because it is the natural next
+feature request: "the officer made a typo, just fix the deed." A deed
+that has been generated is an instrument. It was rendered, hashed and
+stored; it may have been printed, signed, notarised, recorded. Editing
+the row would leave the world holding a document our record no longer
+describes — and would do so silently, which is the worst version.
+
+So the officer-facing language is deliberate and repeated in the UI: a
+corrected deed is A NEW INSTRUMENT REQUIRING ITS OWN EXECUTION. We track
+lineage. We do not un-record documents.
+
+═══ WHY THE HISTORY IS VISIBLE ═══
+
+A superseded deed stays fully readable, with its state shown. The chain
+is the feature, not the embarrassment: an officer asked six months later
+which version was recorded needs to see both and see which replaced
+which. Hiding the superseded one would recreate, in the UI, exactly the
+un-recording the data model refuses.
+"""
+from typing import Any, Dict, List, Optional
+
+
+class SupersessionRefused(Exception):
+    """A supersession that would corrupt the chain rather than extend it.
+
+    Deliberately the same posture as StoredPdfConflict (§9): refuse
+    loudly rather than take the write and leave a record nobody can
+    reason about.
+    """
+
+
+def is_superseded(row: Dict[str, Any]) -> bool:
+    return row.get("superseded_by") is not None
+
+
+def lineage_state(row: Dict[str, Any]) -> str:
+    """DERIVED, not stored — see the note in database.py. `status` keeps
+    its lifecycle vocabulary; this is the orthogonal fact."""
+    return "superseded" if is_superseded(row) else "active"
+
+
+def validate_supersession(old: Optional[Dict[str, Any]],
+                          new: Optional[Dict[str, Any]]) -> None:
+    """Every way this can be wrong, refused by name.
+
+    Each check exists because the alternative is a chain that cannot be
+    read backwards — and a lineage you cannot walk is worse than none,
+    since it invites trust it has not earned.
+    """
+    if old is None or new is None:
+        raise SupersessionRefused("Both documents must exist.")
+
+    if old["id"] == new["id"]:
+        raise SupersessionRefused("A document cannot supersede itself.")
+
+    if old.get("user_id") != new.get("user_id"):
+        raise SupersessionRefused(
+            "Both documents must belong to the same account.")
+
+    # You do not supersede a draft — you edit it. Supersession is for
+    # instruments that already exist in the world.
+    if old.get("status") != "completed":
+        raise SupersessionRefused(
+            "Only a generated document can be superseded. A draft is still "
+            "editable — change it directly.")
+
+    if new.get("status") != "completed":
+        raise SupersessionRefused(
+            "The correcting document must be generated first. Lineage points "
+            "at an instrument, not at an intention.")
+
+    # The pointer is written ONCE. A second write would silently redirect
+    # history — the same class of harm §9 refuses on the artifacts.
+    if old.get("superseded_by") is not None:
+        raise SupersessionRefused(
+            f"Document #{old['id']} is already superseded by "
+            f"#{old['superseded_by']}. To correct again, supersede the "
+            f"current version.")
+
+    # A two-step cycle is the one an ordinary mistake produces.
+    if new.get("superseded_by") == old["id"]:
+        raise SupersessionRefused(
+            "That would create a loop — the correcting document is already "
+            "superseded by this one.")
+
+
+def walk_chain(rows_by_id: Dict[int, Dict[str, Any]],
+               start_id: int) -> List[int]:
+    """Follow superseded_by forward to the current version.
+
+    Cycle-guarded even though validate_supersession refuses the ways a
+    cycle can be created: a reader that can hang on bad data is a reader
+    that will hang on data some future migration produced.
+    """
+    seen: List[int] = []
+    cursor: Optional[int] = start_id
+    while cursor is not None and cursor not in seen:
+        seen.append(cursor)
+        row = rows_by_id.get(cursor)
+        cursor = row.get("superseded_by") if row else None
+    return seen

--- a/backend/tests/snapshots/openapi_routes.json
+++ b/backend/tests/snapshots/openapi_routes.json
@@ -193,6 +193,10 @@
  ],
  [
   "GET",
+  "/deeds/{deed_id}/lineage"
+ ],
+ [
+  "GET",
   "/deeds/{deed_id}/matter"
  ],
  [
@@ -394,6 +398,10 @@
  [
   "POST",
   "/deeds/drafts"
+ ],
+ [
+  "POST",
+  "/deeds/{deed_id}/supersede"
  ],
  [
   "POST",

--- a/backend/tests/snapshots/six_flow_baseline.json
+++ b/backend/tests/snapshots/six_flow_baseline.json
@@ -40,6 +40,8 @@
       "requested_by",
       "sales_price",
       "status",
+      "superseded_at",
+      "superseded_by",
       "updated_at",
       "user_id",
       "vesting"
@@ -66,6 +68,8 @@
       "role",
       "sales_price",
       "status",
+      "superseded_at",
+      "superseded_by",
       "updated_at",
       "user_id",
       "vesting"

--- a/backend/tests/test_supersession.py
+++ b/backend/tests/test_supersession.py
@@ -1,0 +1,204 @@
+"""T-5 — correction lineage: a new row and a pointer, never a mutation.
+
+Doctrine §9 said a stored instrument is never overwritten and parked the
+supersession model as design work. This is that design, and the tests
+below are mostly about the ways it could quietly become the thing it
+replaced.
+
+The temptation to guard against is not exotic — it is the next feature
+request: "the officer made a typo, just fix the deed." A generated deed
+is an instrument; it may have been printed, signed, notarised, recorded.
+Editing the row would leave the world holding a document our record no
+longer describes, silently.
+"""
+import pytest
+
+from tests.source_text import code_only
+from pathlib import Path
+
+from services.supersession import (
+    SupersessionRefused, is_superseded, lineage_state,
+    validate_supersession, walk_chain,
+)
+
+BACKEND = Path(__file__).resolve().parents[1]
+
+
+def _deed(**over):
+    row = {"id": 1, "user_id": 7, "status": "completed", "superseded_by": None}
+    row.update(over)
+    return row
+
+
+# ── The derived state ────────────────────────────────────────────────
+
+def test_a_deed_with_no_pointer_is_active():
+    assert lineage_state(_deed()) == "active"
+    assert is_superseded(_deed()) is False
+
+
+def test_a_deed_with_a_pointer_is_superseded():
+    assert lineage_state(_deed(superseded_by=2)) == "superseded"
+    assert is_superseded(_deed(superseded_by=2)) is True
+
+
+def test_superseded_and_completed_are_orthogonal():
+    """The reason the state is DERIVED rather than folded into
+    `deeds.status`: a superseded deed is still a COMPLETED deed. It was
+    generated, it exists in the world, and overloading the lifecycle
+    column would force a choice between two facts that are both true."""
+    row = _deed(superseded_by=2)
+    assert row["status"] == "completed"
+    assert lineage_state(row) == "superseded"
+
+
+# ── Every refusal, by name ───────────────────────────────────────────
+
+def test_a_deed_cannot_supersede_itself():
+    with pytest.raises(SupersessionRefused, match="cannot supersede itself"):
+        validate_supersession(_deed(id=1), _deed(id=1))
+
+
+def test_supersession_cannot_cross_accounts():
+    with pytest.raises(SupersessionRefused, match="same account"):
+        validate_supersession(_deed(id=1, user_id=7), _deed(id=2, user_id=8))
+
+
+def test_a_draft_is_edited_not_superseded():
+    """Supersession is for instruments that already exist in the world.
+    A draft is still editable — offering supersession there would teach
+    the wrong model for the case that matters."""
+    with pytest.raises(SupersessionRefused, match="draft is still"):
+        validate_supersession(_deed(id=1, status="draft"), _deed(id=2))
+
+
+def test_the_correction_must_exist_before_it_can_replace_anything():
+    with pytest.raises(SupersessionRefused, match="not at an intention"):
+        validate_supersession(_deed(id=1), _deed(id=2, status="draft"))
+
+
+def test_the_pointer_is_written_once():
+    """A second write would silently redirect history — the same class of
+    harm §9 refuses on the artifacts."""
+    with pytest.raises(SupersessionRefused, match="already superseded"):
+        validate_supersession(_deed(id=1, superseded_by=2), _deed(id=3))
+
+
+def test_the_obvious_loop_is_refused():
+    with pytest.raises(SupersessionRefused, match="loop"):
+        validate_supersession(_deed(id=1), _deed(id=2, superseded_by=1))
+
+
+def test_a_valid_supersession_passes():
+    validate_supersession(_deed(id=1), _deed(id=2))
+
+
+# ── Never a mutation ─────────────────────────────────────────────────
+
+def test_the_only_write_is_the_pointer():
+    """THE LOAD-BEARING PIN of this ticket.
+
+    The supersede endpoint must touch `superseded_by` and `superseded_at`
+    and NOTHING else. If it ever learns to write a deed's content,
+    supersession has quietly become editing — with a lineage row for
+    cover, which is worse than editing openly.
+    """
+    src = code_only(BACKEND / "routers/deeds_crud.py")
+    start = src.index("def supersede_endpoint(")
+    end = src.index("def lineage_endpoint(")
+    body = src[start:end]
+
+    updates = [ln for ln in body.splitlines() if "UPDATE deeds" in ln or "SET " in ln]
+    assert updates, "the supersede path stopped writing anything"
+    joined = " ".join(updates)
+    assert "superseded_by" in joined and "superseded_at" in joined
+    for forbidden in ("property_address", "apn", "grantor_name", "grantee_name",
+                      "legal_description", "vesting", "metadata", "status ="):
+        assert forbidden not in joined, (
+            f"the supersede path writes {forbidden!r} — supersession is a "
+            "pointer, not an edit"
+        )
+
+
+def test_supersession_never_deletes():
+    src = code_only(BACKEND / "routers/deeds_crud.py")
+    body = src[src.index("def supersede_endpoint("):src.index("def lineage_endpoint(")]
+    assert "DELETE" not in body.upper()
+
+
+def test_the_write_is_guarded_in_sql_not_only_in_python():
+    """Two concurrent corrections must not both win. The application
+    check cannot promise that; the IS NULL predicate can."""
+    src = code_only(BACKEND / "routers/deeds_crud.py")
+    body = src[src.index("def supersede_endpoint("):src.index("def lineage_endpoint(")]
+    assert "superseded_by IS NULL" in body
+
+
+def test_the_officer_is_told_a_correction_is_a_new_instrument():
+    """We record the relationship; we do not un-record documents."""
+    src = (BACKEND / "routers/deeds_crud.py").read_text(encoding="utf-8")
+    body = src[src.index("def supersede_endpoint("):src.index("def lineage_endpoint(")]
+    assert "new instrument" in body
+    assert "un-record" in body
+
+
+# ── The chain stays readable ─────────────────────────────────────────
+
+def test_the_chain_walks_to_the_current_version():
+    rows = {1: _deed(id=1, superseded_by=2), 2: _deed(id=2, superseded_by=3),
+            3: _deed(id=3)}
+    assert walk_chain(rows, 1) == [1, 2, 3]
+
+
+def test_the_walker_cannot_hang_on_a_cycle():
+    """validate_supersession refuses the ways a cycle can be created, but
+    a reader that can hang on bad data will hang on data some future
+    migration produced."""
+    rows = {1: _deed(id=1, superseded_by=2), 2: _deed(id=2, superseded_by=1)}
+    assert walk_chain(rows, 1) == [1, 2]
+
+
+def test_a_superseded_deed_is_still_returned_by_the_lineage_view():
+    """The history is the feature, not the embarrassment. Hiding the
+    superseded document would recreate in the UI exactly the un-recording
+    the data model refuses."""
+    src = code_only(BACKEND / "routers/deeds_crud.py")
+    body = src[src.index("def lineage_endpoint("):]
+    assert "superseded_by IS NOT NULL" not in body, (
+        "the lineage view filters out superseded documents — they are the "
+        "point of the view"
+    )
+    assert "chain" in body and "supersedes" in body
+
+
+# ── Schema ───────────────────────────────────────────────────────────
+
+def test_the_lineage_columns_live_in_the_one_schema_authority():
+    src = (BACKEND / "database.py").read_text(encoding="utf-8")
+    assert "superseded_by INTEGER REFERENCES deeds(id)" in src
+    assert "superseded_at TIMESTAMPTZ" in src
+    assert "idx_deeds_superseded_by" in src
+
+
+def test_deeds_status_vocabulary_was_not_overloaded():
+    """The deliberate divergence from document_authenticity's shape,
+    pinned so it stays deliberate: `status` keeps draft/completed/deleted
+    and the lineage state is derived from the pointer."""
+    src = code_only(BACKEND / "database.py")
+
+    # Scoped to the DEEDS statements. document_authenticity legitimately
+    # carries status IN ('active','revoked','superseded') — that table's
+    # status IS its lineage state, which is exactly the design `deeds`
+    # cannot copy, because `deeds.status` already means something else.
+    # A pin that cannot tell which table it is talking about would have
+    # failed on the correct code.
+    deeds_stmts = [ln for ln in src.splitlines()
+                   if "deeds" in ln and ("status" in ln or "CHECK" in ln)]
+    joined = " ".join(deeds_stmts)
+    assert "'superseded'" not in joined, (
+        "a 'superseded' status value entered the deeds lifecycle vocabulary "
+        "— it is orthogonal to completed, not exclusive with it"
+    )
+
+    # And the other table still has its own, unchanged.
+    assert "status IN ('active', 'revoked', 'superseded')" in src

--- a/docs/DOCTRINE_CONFORMANCE.md
+++ b/docs/DOCTRINE_CONFORMANCE.md
@@ -317,6 +317,39 @@ ships until the supersession model exists. An "edit" affordance over a
 last-write-wins store is how an operator destroys an instrument while
 believing they corrected one.
 
+**UPDATE — T-5, 2026-08-04: the parked model is built.** `deeds` now
+carries `superseded_by` (self-FK) and `superseded_at`, mirroring
+`document_authenticity`'s proven shape.
+
+Supersession is **a new row and a pointer**. The superseded deed is not
+edited, not deleted and not hidden: its PDF, hash, status and content are
+untouched, and the single write is `superseded_by` going from NULL to the
+correcting document's id — guarded `WHERE superseded_by IS NULL` so the
+pointer is written once even under concurrency. A pin asserts the
+supersede path writes those two columns and nothing else, because
+supersession that learns to edit content is editing *with a lineage row
+for cover*, which is worse than editing openly.
+
+**One deliberate divergence from `document_authenticity`'s shape.** That
+table folds lineage into `status` (`active|revoked|superseded`). `deeds`
+derives it from the pointer instead, because `deeds.status` already
+carries a lifecycle vocabulary in active use (`draft|completed|deleted`).
+Overloading it would make "superseded" exclusive with "completed", and
+those are orthogonal: **a superseded deed is still a completed deed.** It
+was generated, it exists in the world, and saying otherwise is the
+un-recording this model refuses.
+
+**The history is visible by design.** A superseded deed stays fully
+readable with its state shown, and the lineage view returns both
+directions. Hiding it would recreate in the UI exactly the un-recording
+the data model refuses.
+
+**And the officer is told the truth about what a correction is:** a new
+instrument, requiring its own signing and notarisation. We record the
+relationship; we do not un-record documents. That sentence returned to
+the generation gate in this same change — T-0 had removed it precisely
+because the record could not keep it.
+
 ---
 
 ## §10 — Facts carry between documents; legal choices do not
@@ -365,6 +398,7 @@ proposal and the officer's acceptance is what writes it. (T-3/T-3b:
 
 | Date | Change |
 |---|---|
+| 2026-08-04 | §9's parked supersession model BUILT (T-5). `deeds.superseded_by` + `superseded_at` mirror `document_authenticity`'s shape; lineage state is derived rather than folded into `deeds.status`, because a superseded deed is still a completed deed. Supersession is a pointer written once (SQL-guarded), never a mutation — pinned. The T-0 copy removal reversed in the same diff that made the promise true. |
 | 2026-08-04 | §10 added — facts carry between documents with their ORIGINAL provenance (never re-stamped, always marked `carriedFrom`); legal choices never carry. T-4's matter grouping made the question live: an accepted DTT exemption travelling to the next instrument would be an auto-applied legal choice wearing the officer's own signature. Corollary recorded from T-3b: derivability is a reason for restraint, not licence — being derivably right is what makes something a legal conclusion. |
 | 2026-08-03 | §9 added — stored instruments are never overwritten. ADMIN0 found `deed_pdfs` stored via `ON CONFLICT DO UPDATE SET pdf_data`, replacing prior bytes AND their sha256 in place; the draft-resume 409 guard sits a layer above it, making this latent rather than live. Ruled in two parts: insert-or-refuse in ADMIN1 (differing hash = loud refusal, identical = no-op), full supersession as its own designed ticket. No admin deed-edit until supersession exists. |
 | 2026-08-03 | §8 added — API doctrine boundary ruled: v1 = deed family only; affidavit/declaration families held pending per-family passes (execution-act instruments require human flows by design). A1 also recorded three never-run defects in the mounted `/api/v1` (tuple-read auth, unassigned `full_address`, metering aborting the deed transaction) — all three survived because the only tests bypassed the HTTP and database layers, the test-vs-production asymmetry lesson under invariant #4. |

--- a/frontend/src/__tests__/confirmationModel.test.ts
+++ b/frontend/src/__tests__/confirmationModel.test.ts
@@ -137,39 +137,39 @@ describe('U2.2 — no immortal toasts', () => {
 
 describe('U2.3 — immutability copy carries the correction path', () => {
   /**
-   * T-0 CHANGED THIS PIN DELIBERATELY. Worth reading, because the pin was
-   * doing its job and was still wrong.
+   * FULL CIRCLE, and worth reading as one story.
    *
-   * U2.3's intent is right and survives intact: telling an officer the
-   * document is immutable, without telling them what to do about it, is a
-   * dead end on the one screen where they are deciding whether to press
-   * the button. The copy must carry a path forward.
+   * U2.3 originally asserted three strings, "Generate a corrected deed"
+   * and "the record keeps both" among them. Its INTENT was right: telling
+   * an officer a document is immutable, without telling them what to do
+   * about it, is a dead end on the one screen where they decide whether
+   * to press the button.
    *
-   * What U2.3 could not know is that the path it pinned did not exist.
-   * "Generate a corrected deed — the record keeps both" describes
-   * SUPERSESSION, and `deeds` has no lineage: no superseded_by, no status
-   * beyond draft/completed/deleted, nothing relating the two rows. Both
-   * deeds are kept, so the sentence is half true, and the half that is
-   * false is the word "corrected" — it promises a recorded relationship.
+   * T-0 discovered the path it pinned did not exist — `deeds` had no
+   * lineage, so "corrected" promised a relationship nothing recorded.
+   * The pin was rewritten to assert the INTENT (a path forward is
+   * offered) rather than the SPELLING of one promise, and a negative
+   * assertion kept the false version from returning by accident.
    *
-   * So the pin now asserts the INTENT (a path forward is offered) rather
-   * than the SPELLING of a specific promise. T-5 builds the lineage; when
-   * it exists, the stronger sentence can come back and this pin can go
-   * back to naming it.
+   * T-5 built the lineage. The sentence is true now, so the negative
+   * assertion retires with the condition that justified it, and the pin
+   * names the path again — plus the clause T-0's absence taught us to
+   * add: a correction is a NEW INSTRUMENT.
    */
   it('the gate modal tells the officer what to do about immutability', () => {
     const src = readSource('features', 'builder', 'DeedBuilder.tsx');
     expect(src).toContain('stored immutably');
-    // A path forward, stated in terms of what is true today.
     expect(src).toMatch(/cannot be edited/i);
-    expect(src).toMatch(/make any changes now/i);
+    expect(src).toMatch(/corrected deed/i);
+    expect(src).toMatch(/record keeps\s*\n?\s*both/i);
   });
 
-  it('and does not describe a correction the record cannot show', () => {
-    const src = readSource('features', 'builder', 'DeedBuilder.tsx')
-      .replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
-    expect(src).not.toContain('Generate a corrected deed');
-    expect(src).not.toContain('the record keeps both');
+  it('and does not let "corrected" imply the original was un-recorded', () => {
+    // The whole point of lineage over editing: both documents exist, the
+    // relationship is recorded, and the correction still has to be signed.
+    const src = readSource('features', 'builder', 'DeedBuilder.tsx');
+    expect(src).toMatch(/new instrument/i);
+    expect(src).toMatch(/own signing and notarisation/i);
   });
 });
 

--- a/frontend/src/__tests__/gateTruth.test.ts
+++ b/frontend/src/__tests__/gateTruth.test.ts
@@ -98,35 +98,45 @@ describe('one truth: the counter derives from gate math', () => {
 });
 
 /**
- * T-0 — the gate does not promise a record it cannot keep.
+ * T-5 — the promise returns, because the record now keeps it.
  *
- * RETIRE THIS BLOCK IN T-5, not before. The sentence it forbids is not
- * wrong forever; it is wrong *today*. "Generate a corrected deed — the
- * record keeps both" describes supersession lineage, and `deeds` has
- * none: no superseded_by, no status past draft/completed/deleted, no
- * surface relating the pair. `document_authenticity` has the shape
- * (status + superseded_by self-FK) and is written only by the partner-API
- * lane, so no wizard deed has ever had a lineage row.
+ * The T-0 block lived here and forbade the words "corrected deed" and
+ * "record keeps both". Its docstring named its own retirement condition:
+ * delete it in the same PR that mirrors document_authenticity's lineage
+ * onto `deeds`. That PR is this one, so it is gone.
  *
- * When T-5 mirrors that shape onto `deeds`, the sentence becomes true and
- * should come back — delete this describe block in the same PR that makes
- * it honest, so the copy and the record change together.
+ * What replaces it is the inverse pin. The sentence is now true and must
+ * STAY true — if the lineage were ever removed, the copy would go back to
+ * promising a relationship nothing records, and this fails.
  */
-describe('T-0 — the generation gate claims only what the record holds', () => {
+describe('T-5 — the gate promises lineage, and the record keeps it', () => {
   const src = fs.readFileSync(
     path.join(__dirname, '..', 'features', 'builder', 'DeedBuilder.tsx'), 'utf8');
-  // The explanatory comment necessarily quotes the removed sentence.
   const code = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
 
-  it('does not offer a "corrected deed" whose correction is recorded nowhere', () => {
-    expect(code).not.toMatch(/corrected deed/i);
-    expect(code).not.toMatch(/record keeps both/i);
+  it('offers the corrected-deed path again', () => {
+    expect(code).toMatch(/corrected deed/i);
+    expect(code).toMatch(/record keeps\s*\n?\s*both/i);
   });
 
-  it('still tells the officer the document is final and uneditable', () => {
-    // Removing the false half must not remove the true warning with it.
+  it('and says plainly that a correction is a NEW instrument', () => {
+    // The part officers most need to hear: we record the relationship,
+    // we do not un-record documents.
+    expect(code).toMatch(/new instrument/i);
+    expect(code).toMatch(/own signing and notarisation/i);
+  });
+
+  it('still warns the generated document cannot be edited', () => {
     expect(code).toContain('stored immutably');
     expect(code).toMatch(/cannot be edited/i);
+  });
+
+  it('the lineage the copy promises actually exists in the schema', () => {
+    // The pin that keeps copy and record together in BOTH directions.
+    const schema = fs.readFileSync(
+      path.join(__dirname, '..', '..', '..', 'backend', 'database.py'), 'utf8');
+    expect(schema).toContain('superseded_by INTEGER REFERENCES deeds(id)');
+    expect(schema).toContain('superseded_at TIMESTAMPTZ');
   });
 });
 

--- a/frontend/src/features/builder/DeedBuilder.tsx
+++ b/frontend/src/features/builder/DeedBuilder.tsx
@@ -431,29 +431,25 @@ function DeedBuilderInner({ deedType, initialProperty, resumeDeedId }: DeedBuild
           <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4">
             <div className="w-full max-w-xl bg-white rounded-xl shadow-2xl p-6 max-h-[85vh] overflow-y-auto">
               <h2 className="text-lg font-semibold text-gray-900 mb-1">Ready to generate?</h2>
-              {/* T-0 — INTERIM COPY, and the reason is worth reading before
-                  anyone "improves" it back.
-
-                  This paragraph used to end: "Need changes? Generate a
-                  corrected deed — the record keeps both." Both halves of
-                  that sentence sound true and the pair is not. Generating
-                  again does keep both rows — but nothing records that the
-                  second deed corrects the first. There is no lineage: no
-                  superseded_by, no status beyond draft/completed/deleted,
-                  no surface that shows the pair as related. The word
-                  "corrected" promised a relationship the record does not
-                  hold, on the one screen where an officer is deciding
-                  whether it is safe to press the button.
-
-                  T-5 builds that lineage (document_authenticity already
-                  proves the shape: status + superseded_by self-FK). When it
-                  is real, the sentence comes back as truth and the pin in
-                  gateTruth.test.ts retires with it. Until then the copy
-                  says only what is true today: a generated deed cannot be
-                  edited, so changes belong here, before the button. */}
+              {/* T-5 — THE SENTENCE IS TRUE NOW, so it comes back.
+                  T-0 deleted "Generate a corrected deed — the record keeps
+                  both" because `deeds` had no lineage: both rows existed
+                  but nothing recorded that one corrected the other, so the
+                  word "corrected" promised a relationship the record did
+                  not hold. This ticket mirrored document_authenticity's
+                  shape onto `deeds` (superseded_by + superseded_at), and
+                  the T-0 pin in gateTruth.test.ts retires in this same
+                  diff — the copy and the record change together, which is
+                  what its docstring said would happen.
+                  The added clause is the part officers most need to hear:
+                  a corrected deed is a NEW INSTRUMENT. We record the
+                  relationship; we do not un-record documents. */}
               <p className="text-sm text-gray-500 mb-4">
                 The generated document is final and stored immutably — it
-                cannot be edited afterwards, so make any changes now.
+                cannot be edited afterwards. Need changes? Generate a
+                corrected deed and link it to this one: the record keeps
+                both and shows which replaced which. The correction is a
+                new instrument and needs its own signing and notarisation.
                 Resolve the items below first.
               </p>
 


### PR DESCRIPTION
> **Stacked on #123.** Retargets to `main` when that merges.

Doctrine §9's parked ticket comes due. `deeds` now carries `superseded_by` (self-FK) and `superseded_at`, mirroring `document_authenticity`'s proven shape — the table that has had lineage since the verification work, while `deeds`, the table that actually holds instruments, had none.

## A new row and a pointer. Never a mutation.

The superseded deed keeps everything: PDF, hash, status, content. The single write is `superseded_by` going NULL → the correcting document's id, guarded `WHERE superseded_by IS NULL` so the pointer is written **once** even under two concurrent requests. The application check can't promise that; the predicate can.

**The load-bearing pin** asserts the supersede path writes those two columns and *nothing else*, naming each forbidden one. The temptation it guards isn't exotic — it's the next feature request: *"the officer made a typo, just fix the deed."* A generated deed is an instrument; it may be printed, signed, notarised, recorded. Editing the row leaves the world holding a document our record no longer describes, silently. **Supersession that learns to edit content is editing with a lineage row for cover** — worse than editing openly.

Every refusal tested by name: self-supersession, cross-account, a draft (edit it instead), an ungenerated correction (*lineage points at an instrument, not an intention*), a second pointer write, and the two-step loop an ordinary mistake produces. The chain walker is cycle-guarded regardless — a reader that can hang on bad data will hang on data some future migration produced.

## One deliberate divergence from the mirrored shape

`document_authenticity` folds lineage into `status` (`active|revoked|superseded`). **`deeds` derives it from the pointer instead**, because `deeds.status` already carries a lifecycle vocabulary in active use (`draft|completed|deleted`) that the admin console filters on.

Overloading it would make "superseded" exclusive with "completed" — and those are orthogonal. **A superseded deed is still a completed deed.** It was generated, it exists in the world, and saying otherwise is precisely the un-recording this model refuses.

Pinned so it stays deliberate — and scoped to the `deeds` statements, so it doesn't fire on the *other* table's correct use of the same word. (It did, first run. A pin that can't tell which table it's talking about would have failed on correct code.)

## The history is visible by design

The lineage view returns both directions, and a pin forbids filtering superseded documents out. Hiding one would recreate in the UI exactly the un-recording the data model refuses.

## The T-0 pin retires here, as its docstring said it would

*"Generate a corrected deed — the record keeps both"* is true now, so it comes back — with the clause its absence taught us to add: **the correction is a new instrument and needs its own signing and notarisation.** We record the relationship; we do not un-record documents.

U2.3 comes full circle in the file it started in: it pinned the sentence, T-0 rewrote it to the *intent* when the path proved imaginary, and it names the path again now the path exists. The replacement pin is the inverse — it fails if the schema ever loses the lineage while the copy still promises it.

## Baselines

**Six-flow re-recorded.** The delta is exactly `superseded_at` and `superseded_by` appearing in the deed row's key list, verified line by line before recording. Unlike BILL1's optional response field, these are schema columns the ticket exists to add — removing them wasn't the honest option.

| gate | result |
|---|---|
| backend pytest | 461 passed (+19) |
| jest | 486 passed, 34 suites |
| six-flow | ✔ (re-recorded, delta verified) |
| API baseline | ✔ |
| tsc | 94 — unchanged |
| OpenAPI | two additive routes |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_