### PR TITLE
T-6: the prelim types for her, and says so when it cannot read

### DIFF
--- a/backend/routers/deeds_crud.py
+++ b/backend/routers/deeds_crud.py
@@ -4,7 +4,7 @@ from datetime import timezone
 from time import time
 from typing import Dict, Optional, Union
 
-from fastapi import APIRouter, Depends, HTTPException, Response
+from fastapi import APIRouter, Depends, File, HTTPException, Response, UploadFile
 from psycopg2.extras import RealDictCursor
 from pydantic import BaseModel, Field
 
@@ -708,6 +708,34 @@ def lineage_endpoint(deed_id: int, user_id: int = Depends(get_current_user_id)):
         "supersedes": [shape(r) for r in supersedes],
         "current_version": shape(forward[-1])["id"] if forward else deed_id,
     }
+
+
+@router.post("/prelim/import")
+async def prelim_import_endpoint(file: UploadFile = File(...),
+                                 user_id: int = Depends(get_current_user_id)):
+    """T-6 — read a preliminary title report into CANDIDATES.
+
+    Nothing here reaches a deed. The response is a list of amber
+    candidates the officer confirms through the existing gate, exactly as
+    she confirms county-record data. This adds a source, not a lane.
+
+    A file we cannot read is a 422 with the reason in plain words — never
+    an empty success. An officer who thinks we read her prelim and found
+    little is worse off than one who knows we read nothing.
+    """
+    from services.prelim_import import PrelimUnreadable, import_prelim
+
+    raw = await file.read()
+    if len(raw) > 25 * 1024 * 1024:
+        raise HTTPException(status_code=413,
+                            detail="That file is larger than 25 MB.")
+    try:
+        return import_prelim(raw)
+    except PrelimUnreadable as e:
+        # 422, not 400: the request was well-formed and we understood it.
+        # What we could not do is READ THE DOCUMENT, and the message says
+        # which of the two reasons applies.
+        raise HTTPException(status_code=422, detail=str(e))
 
 
 @router.get("/deeds/{deed_id}/matter")

--- a/backend/services/prelim_import.py
+++ b/backend/services/prelim_import.py
@@ -1,0 +1,237 @@
+"""T-6 — reading a preliminary title report, and knowing when we can't.
+
+═══ THE HONESTY OF THIS FEATURE IS THE REFUSAL ═══
+
+A prelim arrives one of two ways. Some are generated digitally and carry
+a real text layer. Many are SCANNED — a photograph of paper, wrapped in a
+PDF, with no extractable text at all.
+
+Both open fine in a viewer. They look identical to a human. And a naive
+extractor handed the scanned one finds nothing, returns nothing, and
+reports success — which the officer reads as "this prelim had nothing
+useful in it" rather than "we cannot read this file."
+
+That is the whole failure mode, and it is the silent-zero disease in a
+new costume: an empty result presented as an answer. So the first thing
+this module does is ask whether there is a text layer at all, and refuse
+LOUDLY when there is not, naming the reason and what to do about it.
+
+═══ DETERMINISTIC ONLY, BY RULING ═══
+
+No LLM in v1. Every value below comes from a labelled pattern in the
+document — "APN:", "Legal Description:", "Title to said estate is vested
+in:". If a pattern does not match, the field is absent and the officer
+types it. Nothing is inferred, nothing is guessed, and nothing arrives
+already confirmed.
+
+`ai_suggested` exists as a FieldSource and is deliberately NOT used here.
+The machinery is ready for it; the ruling that would authorise it has not
+been made.
+
+═══ EVERYTHING ARRIVES AMBER ═══
+
+Extracted values are CANDIDATES. They flow through the existing
+confirmation gate untouched — the same gate, the same stamp, the same
+`confirmedAt` per field. This module adds a source; it does not add a
+lane, and it emphatically does not add a way to reach the deed without
+the officer's eyes.
+
+═══ TEMPLATE PROVENANCE — READ BEFORE TRUSTING ═══
+
+The per-underwriter patterns below are seeded from the LABEL CONVENTIONS
+these companies use, not from a corpus of their real reports. They are
+hypotheses. Each one needs verification against actual prelims from that
+underwriter before it can be called supported, and the generic template
+is what runs until then.
+
+That is stated here rather than discovered later: a template that matches
+the wrong line is worse than no template, because it produces a confident
+candidate instead of an absence.
+"""
+import io
+import re
+from typing import Any, Dict, List, NamedTuple, Optional
+
+
+class PrelimUnreadable(Exception):
+    """No text layer. The loud refusal — never a quiet empty result."""
+
+
+class Field(NamedTuple):
+    key: str
+    value: str
+    label: str
+
+
+class Template(NamedTuple):
+    underwriter: str
+    """A string that identifies whose report this is. Matched
+    case-insensitively against the first page."""
+    signature: str
+    patterns: Dict[str, str]
+
+
+# The five fields worth extracting — the ones an officer retypes from a
+# prelim every time. Anything beyond these is scope the ruling excluded.
+FIELD_LABELS = {
+    "apn": "APN",
+    "legal_description": "Legal description",
+    "vested_owner": "Vested owner",
+    "county": "County",
+    "property_address": "Property address",
+}
+
+_APN = r"(?:A\.?P\.?N\.?|Assessor'?s? Parcel (?:No\.?|Number))"
+
+# Where a legal description stops.
+#
+# NOT a blank line — that was the first attempt and it does not survive
+# extraction. PDF text layers do not reliably preserve vertical
+# whitespace: pdfplumber returns the paragraph after LEGAL DESCRIPTION and
+# the heading that follows it separated by a SINGLE newline, because the
+# blank line between them on the page is layout, not a character. A
+# pattern that waits for `\n\s*\n` waits forever and matches nothing.
+#
+# Nor an ALL-CAPS line, which was the second idea: legal descriptions are
+# full of them ("CITY OF SANTA MONICA, AS PER MAP RECORDED IN BOOK 128").
+#
+# So: the named sections that actually follow a legal description on a
+# preliminary report, plus a hard character ceiling.
+_LEGAL_END = (
+    r"(?=\n?\s*(?:AT THE DATE HEREOF|EXCEPTIONS|SCHEDULE B|END OF "
+    r"(?:LEGAL )?DESCRIPTION|NOTE\s*\d|Order No)|$)"
+)
+_VESTED = r"(?:Title to said estate or interest at the date hereof is vested in|Vested in|Owner(?:ship)?)"
+
+GENERIC = Template(
+    underwriter="unknown",
+    signature="",
+    patterns={
+        "apn": rf"{_APN}\s*[:#]?\s*([0-9]{{3,4}}[- ][0-9]{{3}}[- ][0-9]{{3}})",
+        "legal_description": (
+            r"(?:Legal Description|LEGAL DESCRIPTION)\s*[:\-]?\s*\n?\s*"
+            r"(.{20,900}?)" + _LEGAL_END
+        ),
+        "vested_owner": rf"{_VESTED}\s*[:\-]?\s*\n?\s*(.{{3,120}}?)(?:\n|$)",
+        "county": r"County of\s+([A-Z][A-Za-z ]{3,30}?)(?:\s*,|\s*\n|\s+State)",
+        "property_address": r"(?:Property Address|Situs Address|Address)\s*[:\-]?\s*([^\n]{8,120})",
+    },
+)
+
+# UNVERIFIED — see TEMPLATE PROVENANCE above. Each of these is a
+# hypothesis about one underwriter's layout and must be checked against
+# real reports before being relied on.
+TEMPLATES: List[Template] = [
+    Template("First American Title", "first american", dict(GENERIC.patterns)),
+    Template("Fidelity National Title", "fidelity national", dict(GENERIC.patterns)),
+    Template("Chicago Title", "chicago title", dict(GENERIC.patterns)),
+    Template("Old Republic Title", "old republic", dict(GENERIC.patterns)),
+    Template("Stewart Title", "stewart title", dict(GENERIC.patterns)),
+]
+
+
+def _text_of(pdf_bytes: bytes) -> str:
+    import pdfplumber
+
+    chunks: List[str] = []
+    with pdfplumber.open(io.BytesIO(pdf_bytes)) as pdf:
+        for page in pdf.pages:
+            chunks.append(page.extract_text() or "")
+    return "\n".join(chunks)
+
+
+# Below this many characters we treat the document as having no usable
+# text layer. Scanned PDFs frequently yield a handful of stray characters
+# from a header stamp or a fax banner rather than a clean zero, so a
+# `== 0` check would let exactly the documents this guard exists for slip
+# through and report "nothing found".
+MIN_TEXT_CHARS = 200
+
+
+def read_text_or_refuse(pdf_bytes: bytes) -> str:
+    """Extract the text layer, or refuse loudly.
+
+    THE watch-point of this ticket. A scanned prelim must never come back
+    as an empty-but-successful extraction.
+    """
+    try:
+        text = _text_of(pdf_bytes)
+    except Exception as e:
+        raise PrelimUnreadable(
+            f"This file could not be opened as a PDF ({type(e).__name__}). "
+            f"Please upload the preliminary report as a PDF."
+        )
+
+    if len(text.strip()) < MIN_TEXT_CHARS:
+        raise PrelimUnreadable(
+            "This looks like a scanned preliminary report — the pages are "
+            "images, so there is no text to read. Nothing was extracted. "
+            "Ask the title company for the digital (text) version, or enter "
+            "the details manually."
+        )
+    return text
+
+
+def pick_template(text: str) -> Template:
+    head = text[:4000].lower()
+    for t in TEMPLATES:
+        if t.signature and t.signature in head:
+            return t
+    return GENERIC
+
+
+def _clean(value: str) -> str:
+    return re.sub(r"\s+", " ", value).strip(" .,:;-")
+
+
+def extract_fields(text: str, template: Template) -> List[Field]:
+    found: List[Field] = []
+    for key, pattern in template.patterns.items():
+        m = re.search(pattern, text, re.IGNORECASE | re.DOTALL)
+        if not m:
+            continue
+        value = _clean(m.group(1))
+        if value:
+            found.append(Field(key=key, value=value, label=FIELD_LABELS[key]))
+    return found
+
+
+def import_prelim(pdf_bytes: bytes) -> Dict[str, Any]:
+    """Read a prelim and return CANDIDATES, never confirmed values.
+
+    Raises PrelimUnreadable when there is no text layer — the caller
+    surfaces that verbatim rather than rendering an empty result.
+    """
+    text = read_text_or_refuse(pdf_bytes)
+    template = pick_template(text)
+    fields = extract_fields(text, template)
+
+    if not fields:
+        # A readable document we could not parse is ALSO a refusal. An
+        # empty candidate list rendered as a result would tell the officer
+        # her prelim was empty, which is a different and untrue statement.
+        raise PrelimUnreadable(
+            "This PDF has readable text, but none of the fields we look for "
+            "were found — it may not be a preliminary title report, or its "
+            "layout is one we have not seen. Nothing was extracted."
+        )
+
+    return {
+        "underwriter": template.underwriter,
+        # Every value is a CANDIDATE. The gate is untouched: these arrive
+        # amber and the officer confirms them exactly as she confirms
+        # county-record data.
+        "candidates": [
+            {"key": f.key, "label": f.label, "value": f.value,
+             "source": "prelim", "status": "candidate"}
+            for f in fields
+        ],
+        "not_found": [
+            FIELD_LABELS[k] for k in template.patterns
+            if k not in {f.key for f in fields}
+        ],
+        "note": (
+            "Extracted from the report you uploaded and not yet confirmed. "
+            "Check each value against the document before generating."
+        ),
+    }

--- a/backend/tests/snapshots/openapi_routes.json
+++ b/backend/tests/snapshots/openapi_routes.json
@@ -421,6 +421,10 @@
  ],
  [
   "POST",
+  "/prelim/import"
+ ],
+ [
+  "POST",
   "/property/cache"
  ],
  [

--- a/backend/tests/test_prelim_import.py
+++ b/backend/tests/test_prelim_import.py
@@ -1,0 +1,208 @@
+"""T-6 — the prelim import, and the refusal that makes it honest.
+
+THE WATCH-POINT is `test_a_scanned_prelim_is_refused_loudly`. Everything
+else is ordinary coverage.
+
+A prelim arrives one of two ways: digitally generated with a real text
+layer, or SCANNED — a photograph of paper with no extractable text. Both
+open fine in a viewer and look identical to a human.
+
+A naive extractor handed the scanned one finds nothing, returns nothing,
+and reports success. The officer reads that as "this prelim had nothing
+useful in it" rather than "we cannot read this file" — the silent-zero
+disease wearing a new costume, an empty result presented as an answer.
+"""
+import io
+
+import pytest
+
+pytest.importorskip("pdfplumber")
+from pypdf import PdfWriter  # noqa: E402
+
+from services.prelim_import import (  # noqa: E402
+    FIELD_LABELS, GENERIC, MIN_TEXT_CHARS, PrelimUnreadable,
+    extract_fields, import_prelim, pick_template, read_text_or_refuse,
+)
+
+PRELIM_TEXT = """
+FIRST AMERICAN TITLE INSURANCE COMPANY
+PRELIMINARY REPORT
+
+Order No. 8827341-LA                    Dated as of August 1, 2026
+
+The form of policy of title insurance contemplated by this report is:
+CLTA Standard Coverage Policy.
+
+Title to said estate or interest at the date hereof is vested in:
+MARIA L. TORRES, a married woman as her sole and separate property
+
+The estate or interest in the land hereinafter described or referred to
+covered by this report is: A Fee.
+
+Property Address: 1420 OCEAN AVE, SANTA MONICA, CA 90401
+
+A.P.N.: 4291-013-027
+
+LEGAL DESCRIPTION
+Real property in the City of Santa Monica, County of Los Angeles, State
+of California, described as follows: LOT 7 OF TRACT NO. 9021, IN THE
+CITY OF SANTA MONICA, AS PER MAP RECORDED IN BOOK 128 PAGES 44 AND 45
+OF MAPS, IN THE OFFICE OF THE COUNTY RECORDER OF SAID COUNTY.
+
+AT THE DATE HEREOF EXCEPTIONS TO COVERAGE IN ADDITION TO THE PRINTED
+EXCEPTIONS AND EXCLUSIONS CONTAINED IN SAID POLICY WOULD BE AS FOLLOWS:
+1. General and special taxes and assessments for the fiscal year 2026-2027.
+"""
+
+
+def _text_pdf(body: str) -> bytes:
+    """A PDF with a real text layer, built through the engine this
+    product already ships (WeasyPrint) rather than a new dependency."""
+    from pdf_engine import render_pdf
+    esc = body.replace("&", "&amp;").replace("<", "&lt;")
+    return render_pdf(
+        f"<html><body><pre style='font-size:9pt'>{esc}</pre></body></html>")
+
+
+def _scanned_pdf() -> bytes:
+    """A PDF with NO text layer — pages that carry no extractable text,
+    which is what a scan of paper produces."""
+    w = PdfWriter()
+    for _ in range(3):
+        w.add_blank_page(width=612, height=792)
+    out = io.BytesIO()
+    w.write(out)
+    return out.getvalue()
+
+
+# ── THE WATCH-POINT ──────────────────────────────────────────────────
+
+def test_a_scanned_prelim_is_refused_loudly():
+    """No text layer means no extraction, and the officer is TOLD."""
+    with pytest.raises(PrelimUnreadable) as e:
+        import_prelim(_scanned_pdf())
+    msg = str(e.value)
+    assert "scanned" in msg.lower(), "the refusal must name the cause"
+    assert "nothing was extracted" in msg.lower(), (
+        "the refusal must say plainly that nothing came through — an "
+        "officer who thinks we read the file and found little is worse off "
+        "than one who knows we read nothing"
+    )
+    # And it tells her what to do next.
+    assert "manually" in msg.lower() or "digital" in msg.lower()
+
+
+def test_a_scanned_prelim_never_returns_an_empty_success():
+    """The specific shape of the bug: succeeding with nothing."""
+    try:
+        result = import_prelim(_scanned_pdf())
+    except PrelimUnreadable:
+        return  # correct
+    pytest.fail(
+        f"a scanned prelim returned a result instead of refusing: {result!r}")
+
+
+def test_a_readable_but_unparseable_pdf_is_also_a_refusal():
+    """A document we CAN read but do not recognise is a different
+    failure with the same rule: an empty candidate list rendered as a
+    result would tell the officer her prelim was empty."""
+    unrelated = _text_pdf("MINUTES OF THE BOARD MEETING\n" + ("lorem ipsum " * 200))
+    with pytest.raises(PrelimUnreadable) as e:
+        import_prelim(unrelated)
+    assert "nothing was extracted" in str(e.value).lower()
+
+
+def test_the_threshold_is_not_a_bare_zero():
+    """Scanned PDFs often yield a few stray characters from a fax banner
+    or header stamp rather than a clean zero. A `== 0` check would let
+    exactly the documents this guard exists for slip through."""
+    assert MIN_TEXT_CHARS > 0
+    nearly_empty = _text_pdf("SCANNED BY FAX 08/01/2026")
+    with pytest.raises(PrelimUnreadable):
+        read_text_or_refuse(nearly_empty)
+
+
+# ── Extraction ───────────────────────────────────────────────────────
+
+def test_the_five_fields_come_out_of_a_real_shaped_prelim():
+    result = import_prelim(_text_pdf(PRELIM_TEXT))
+    by_key = {c["key"]: c["value"] for c in result["candidates"]}
+    assert by_key["apn"] == "4291-013-027"
+    assert "MARIA L. TORRES" in by_key["vested_owner"]
+    assert "LOT 7 OF TRACT NO. 9021" in by_key["legal_description"]
+    assert by_key["county"] == "Los Angeles"
+    assert "1420 OCEAN AVE" in by_key["property_address"]
+
+
+def test_the_underwriter_is_identified():
+    assert import_prelim(_text_pdf(PRELIM_TEXT))["underwriter"] == "First American Title"
+
+
+def test_an_unknown_underwriter_falls_back_to_generic():
+    text = PRELIM_TEXT.replace("FIRST AMERICAN TITLE INSURANCE COMPANY",
+                               "SOME REGIONAL TITLE CO")
+    result = import_prelim(_text_pdf(text))
+    assert result["underwriter"] == "unknown"
+    # And still extracts, because the generic patterns are the real ones.
+    assert any(c["key"] == "apn" for c in result["candidates"])
+
+
+def test_fields_we_could_not_find_are_named():
+    """Absence stated, not implied. The officer sees which fields she
+    still has to type rather than wondering what she is missing."""
+    text = PRELIM_TEXT.replace("A.P.N.: 4291-013-027", "")
+    result = import_prelim(_text_pdf(text))
+    assert "APN" in result["not_found"]
+    assert not any(c["key"] == "apn" for c in result["candidates"])
+
+
+# ── Everything arrives amber, through the untouched gate ─────────────
+
+def test_every_extracted_value_is_a_candidate():
+    """Nothing from a machine arrives confirmed. This is the entire
+    reason the extraction is allowed to be imperfect."""
+    for c in import_prelim(_text_pdf(PRELIM_TEXT))["candidates"]:
+        assert c["status"] == "candidate", f"{c['key']} arrived pre-confirmed"
+        assert c["source"] == "prelim"
+
+
+def test_nothing_claims_to_be_ai_suggested():
+    """`ai_suggested` exists as a source and is deliberately unused here.
+    A deterministic label match is not a suggestion, and mislabelling it
+    would smuggle the LLM ruling that has not been made."""
+    for c in import_prelim(_text_pdf(PRELIM_TEXT))["candidates"]:
+        assert c["source"] != "ai_suggested"
+
+
+def test_no_llm_in_the_extraction_path():
+    from pathlib import Path
+    from tests.source_text import code_only
+
+    src = code_only(Path(__file__).resolve().parents[1] / "services/prelim_import.py")
+    for banned in ("openai", "anthropic", "claude", "gpt", "completion("):
+        assert banned not in src.lower(), f"an LLM call entered the v1 path: {banned}"
+
+
+def test_the_result_tells_the_officer_to_check_it():
+    assert "not yet confirmed" in import_prelim(_text_pdf(PRELIM_TEXT))["note"]
+
+
+# ── Scope ────────────────────────────────────────────────────────────
+
+def test_exactly_the_ruled_field_set():
+    """3-5 fields by ruling. Scope creep here is how a narrow v1 becomes
+    a parser nobody can verify."""
+    assert set(FIELD_LABELS) == {
+        "apn", "legal_description", "vested_owner", "county", "property_address"}
+    assert set(GENERIC.patterns) == set(FIELD_LABELS)
+
+
+def test_templates_are_marked_unverified():
+    """They are hypotheses about each underwriter's layout, seeded from
+    label conventions rather than from real reports. A template matching
+    the wrong line is worse than no template — it produces a confident
+    candidate instead of an absence."""
+    from pathlib import Path
+    src = (Path(__file__).resolve().parents[1] / "services/prelim_import.py").read_text()
+    assert "UNVERIFIED" in src
+    assert "TEMPLATE PROVENANCE" in src

--- a/frontend/src/features/builder/DeedBuilder.tsx
+++ b/frontend/src/features/builder/DeedBuilder.tsx
@@ -578,6 +578,10 @@ const SOURCE_LABELS: Record<string, string> = {
   sitex: 'From county records',
   google: 'From Google',
   titlepoint: 'From TitlePoint',
+  // T-6: read out of the uploaded preliminary title report. Labelled by
+  // where it came FROM, because that is what the officer needs in order
+  // to decide whether to trust it at a glance.
+  prelim: 'From the prelim',
   user: 'Entered by you',
 };
 

--- a/frontend/src/types/builder.ts
+++ b/frontend/src/types/builder.ts
@@ -5,7 +5,14 @@
  * confirms; we record the confirmation. AI/auto-fill never silently writes a
  * confirmed legal value.
  */
-export type FieldSource = 'sitex' | 'google' | 'user' | 'titlepoint' | 'ai_suggested';
+/**
+ * T-6 added 'prelim': a value read deterministically out of an uploaded
+ * preliminary title report. Deliberately NOT 'ai_suggested' — a labelled
+ * pattern match is not a suggestion, and mislabelling it would smuggle in
+ * the LLM ruling that has not been made.
+ */
+export type FieldSource =
+  | 'sitex' | 'google' | 'user' | 'titlepoint' | 'prelim' | 'ai_suggested';
 export type FieldStatus = 'candidate' | 'confirmed';
 
 /**


### PR DESCRIPTION
> **Stacked on #124.** Retargets to `main` when that merges.

A preliminary title report arrives one of two ways: generated digitally with a real text layer, or **scanned** — a photograph of paper wrapped in a PDF, with no extractable text. Both open fine in a viewer and look identical to a human.

## The honesty of this feature is the refusal — your watch-point

A naive extractor handed the scanned one finds nothing, returns nothing, and **reports success**. The officer reads that as *"this prelim had nothing useful in it"* rather than *"we cannot read this file."* That's the silent-zero disease in a new costume: an empty result presented as an answer.

So the first thing the module does is ask whether there's a text layer at all, and refuse **loudly** when there isn't — naming what happened, why, and what to do instead. Two tests hold it: one asserts the refusal names the cause *and* the next step, one asserts a scanned prelim **cannot return a result at all**.

**The threshold is not a bare zero.** Scanned PDFs routinely yield a handful of stray characters from a fax banner or header stamp, so `== 0` would let exactly the documents this guard exists for slip through. 200 characters, with a test that feeds it a near-empty page.

**A readable-but-unparseable file is also a refusal.** Returning an empty candidate list would tell the officer her prelim was empty — a different and untrue statement.

## Everything arrives amber, through the untouched gate

Extracted values are candidates carrying a new source, `prelim`. The gate is **not modified**: same confirmation, same per-field stamp. This adds a source, not a lane.

`prelim` is deliberately **not** `ai_suggested` — a labelled pattern match isn't a suggestion, and mislabelling it would smuggle in the LLM ruling that hasn't been made. One pin asserts no LLM call exists in the path; another asserts nothing claims that source.

## A real extraction finding, recorded where the next person will hit it

The legal-description pattern first terminated on a blank line. **It never matched.** PDF text layers don't preserve vertical whitespace — pdfplumber returns the description and the following heading separated by a *single* newline, because the blank line on the page is layout, not a character.

The second idea, terminating on an ALL-CAPS line, fails differently: legal descriptions are full of them (`CITY OF SANTA MONICA, AS PER MAP RECORDED IN BOOK 128`). It terminates on the named sections that actually follow a legal description — and both dead ends are written into the source, because the next person to touch this will reach for a blank line too.

## Template provenance — stated rather than discovered

The five per-underwriter templates are seeded from **label conventions**, not from a corpus of real reports. They're hypotheses, marked `UNVERIFIED` in the source and pinned as such. A template that matches the wrong line is worse than no template — it produces a confident candidate instead of an absence.

**Verifying them needs real prelims from each underwriter** — that's an owner-side input. Until then the generic patterns are what actually run, and they're the ones the tests exercise.

## Gates

| gate | result |
|---|---|
| backend pytest | 475 passed (+14) |
| jest | 486 passed, 34 suites |
| six-flow / API baselines | verify OK |
| tsc | 94 — unchanged |
| OpenAPI | one additive route |

Upload capped at 25 MB. Unreadable is **422, not 400** — the request was well-formed and understood; what failed was reading the document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_