### PR TITLE
RED-H1.2: connections close on every exit, and the public path is capped

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -1,7 +1,10 @@
 import json
 import os
+from contextlib import contextmanager
+
 import psycopg2
 from dotenv import load_dotenv
+from fastapi import HTTPException
 
 from db_rows import ROW_FACTORY
 
@@ -27,6 +30,52 @@ def get_db_connection():
     except Exception as e:
         print(f"Database connection error: {e}")
         return None
+
+
+@contextmanager
+def db_connection(unavailable_detail="Database unavailable"):
+    """A connection that closes on EVERY path out. RED-H1.2.
+
+    ═══ WHY THIS EXISTS ═══
+
+    `get_db_connection()` opens a real socket. Every caller was then
+    responsible for closing it — and callers raise. `api_key_requests`
+    opened four connections and closed each one on exactly one of its
+    three exits; `admin_api_v2` opened eighteen and closed two.
+
+    A leaked connection is not garbage-collected in any useful sense:
+    Postgres holds the backend process open until the client goes away or
+    a timeout fires, and the instance has a hard `max_connections`. Leak
+    enough and the database stops accepting new work — for everyone, not
+    just the leaking endpoint.
+
+    The worst instance was on the PUBLIC, unauthenticated inquiry
+    endpoint, where the leaking path was the cheapest one to hit: send a
+    whitespace-only company name, get a 400, leak a connection. No
+    account, no rate limit, a few hundred requests to take the product
+    down. That is a denial of service reachable by anyone with curl, and
+    it was a missing `finally`.
+
+    So this replaces the discipline with a mechanism. `with
+    db_connection() as conn:` closes on return, on raise, on
+    HTTPException, on anything — because the fix for "everyone must
+    remember" is never "remind everyone."
+
+    The 503 is raised INSIDE the manager rather than returning None, so
+    `if not conn` checks cannot be forgotten either.
+    """
+    conn = get_db_connection()
+    if not conn:
+        raise HTTPException(status_code=503, detail=unavailable_detail)
+    try:
+        yield conn
+    finally:
+        try:
+            conn.close()
+        except Exception as e:
+            # A close that fails is worth a line, never an exception: it
+            # would mask whatever the caller was actually raising.
+            print(f"[db_connection] close failed: {e}")
 
 def create_tables():
     conn = get_db_connection()

--- a/backend/routers/admin_api_v2.py
+++ b/backend/routers/admin_api_v2.py
@@ -10,14 +10,19 @@ except Exception:
     # If project uses package style imports
     from backend.auth import get_current_admin  # type: ignore
 
+# RED-H1.2: this module opened EIGHTEEN connections and closed TWO. Every
+# admin page view leaked Postgres backends until the instance hit
+# max_connections. All seventeen call sites now take `db_connection()`,
+# which closes on every exit — including the `raise HTTPException(404)`
+# paths, which is where most of them were escaping.
 try:
-    from database import get_db_connection
+    from database import db_connection
 except Exception:
-    from backend.database import get_db_connection  # type: ignore
+    from backend.database import db_connection  # type: ignore
 
 router = APIRouter(prefix="/admin", tags=["Admin v2"])
 
-# Note: get_db_connection() uses RealDictCursor, so fetchall() already returns dicts
+# Note: connections use RealDictCursor, so fetchall() already returns dicts
 # No need for a _dictify helper function
 
 # ── Sort whitelists (ADMIN1.5 frictions) ─────────────────────────────
@@ -74,8 +79,7 @@ def admin_users_search(
     """
     order_sql = _order_by(USER_SORTS, sort)
     offset = (page - 1) * limit
-    conn = get_db_connection()
-    with conn.cursor() as cur:
+    with db_connection() as conn, conn.cursor() as cur:
         where = []
         params: List[Any] = []
         if search:
@@ -114,8 +118,7 @@ def admin_user_detail(user_id: int, admin=Depends(get_current_admin)):
     `activity_log`) and is deleted, so the honest one takes the plain
     path and sits alongside the PUT and DELETE already there.
     """
-    conn = get_db_connection()
-    with conn.cursor() as cur:
+    with db_connection() as conn, conn.cursor() as cur:
         cur.execute("""
             SELECT id, email, full_name, COALESCE(role,'') as role, plan, company_name, company_type,
                    phone, state, verified, stripe_customer_id, last_login, created_at, is_active
@@ -156,8 +159,7 @@ def admin_deeds_search(
     """
     order_sql = _order_by(DEED_SORTS, sort)
     offset = (page - 1) * limit
-    conn = get_db_connection()
-    with conn.cursor() as cur:
+    with db_connection() as conn, conn.cursor() as cur:
         where = []
         params: List[Any] = []
         if search:
@@ -196,8 +198,7 @@ def admin_deeds_search(
 
 @router.get("/deeds/{deed_id}")
 def admin_deed_detail(deed_id: int, admin=Depends(get_current_admin)):
-    conn = get_db_connection()
-    with conn.cursor() as cur:
+    with db_connection() as conn, conn.cursor() as cur:
         cur.execute("""
             SELECT d.*, u.email as user_email
             FROM deeds d
@@ -211,10 +212,9 @@ def admin_deed_detail(deed_id: int, admin=Depends(get_current_admin)):
 
 @router.get("/export/users.csv")
 def export_users_csv(admin=Depends(get_current_admin)):
-    conn = get_db_connection()
     output = io.StringIO()
     writer = csv.writer(output)
-    with conn.cursor() as cur:
+    with db_connection() as conn, conn.cursor() as cur:
         cur.execute("""
             SELECT id, email, full_name, role, plan, created_at, last_login, is_active
             FROM users ORDER BY created_at DESC
@@ -227,10 +227,9 @@ def export_users_csv(admin=Depends(get_current_admin)):
 
 @router.get("/export/deeds.csv")
 def export_deeds_csv(admin=Depends(get_current_admin)):
-    conn = get_db_connection()
     output = io.StringIO()
     writer = csv.writer(output)
-    with conn.cursor() as cur:
+    with db_connection() as conn, conn.cursor() as cur:
         cur.execute("""
             SELECT d.id, d.deed_type, d.status, d.property_address, d.apn, d.county, d.created_at, d.updated_at, u.email
             FROM deeds d LEFT JOIN users u ON u.id = d.user_id
@@ -271,37 +270,33 @@ def admin_email_log(
     """Every send attempt we managed to record, newest first."""
     order_sql = _order_by(EMAIL_SORTS, sort)
     offset = (page - 1) * limit
-    conn = get_db_connection()
-    try:
-        with conn.cursor() as cur:
-            where, params = [], []
-            if status:
-                if status.lower() not in ("sent", "failed"):
-                    raise HTTPException(status_code=400, detail="status must be sent or failed")
-                where.append("status = %s")
-                params.append(status.lower())
-            if template:
-                where.append("template = %s")
-                params.append(template)
-            if search:
-                where.append("LOWER(recipient) LIKE %s")
-                params.append(f"%{search.lower()}%")
-            where_sql = f"WHERE {' AND '.join(where)}" if where else ""
+    with db_connection() as conn, conn.cursor() as cur:
+        where, params = [], []
+        if status:
+            if status.lower() not in ("sent", "failed"):
+                raise HTTPException(status_code=400, detail="status must be sent or failed")
+            where.append("status = %s")
+            params.append(status.lower())
+        if template:
+            where.append("template = %s")
+            params.append(template)
+        if search:
+            where.append("LOWER(recipient) LIKE %s")
+            params.append(f"%{search.lower()}%")
+        where_sql = f"WHERE {' AND '.join(where)}" if where else ""
 
-            cur.execute(f"SELECT COUNT(*) AS count FROM email_log {where_sql}", params)
-            total = cur.fetchone()["count"]
+        cur.execute(f"SELECT COUNT(*) AS count FROM email_log {where_sql}", params)
+        total = cur.fetchone()["count"]
 
-            cur.execute(f"""
-                SELECT id, template, recipient, subject, status, reason,
-                       user_id, context, created_at
-                FROM email_log
-                {where_sql}
-                ORDER BY {order_sql}
-                LIMIT %s OFFSET %s
-            """, params + [limit, offset])
-            rows = cur.fetchall()
-    finally:
-        conn.close()
+        cur.execute(f"""
+            SELECT id, template, recipient, subject, status, reason,
+                   user_id, context, created_at
+            FROM email_log
+            {where_sql}
+            ORDER BY {order_sql}
+            LIMIT %s OFFSET %s
+        """, params + [limit, offset])
+        rows = cur.fetchall()
 
     return {"page": page, "limit": limit, "total": total,
             "sort": (sort or DEFAULT_SORT).lower(), "items": rows}
@@ -317,48 +312,44 @@ def admin_email_stats(days: int = Query(7, ge=1, le=90),
     tells them it is an unverified sender identity, which is a fix
     rather than an investigation.
     """
-    conn = get_db_connection()
-    try:
-        with conn.cursor() as cur:
-            cur.execute("""
-                SELECT COUNT(*) FILTER (WHERE status = 'sent')   AS sent,
-                       COUNT(*) FILTER (WHERE status = 'failed') AS failed,
-                       COUNT(*)                                  AS total,
-                       MIN(created_at)                           AS first_recorded
-                FROM email_log
-                WHERE created_at >= NOW() - (%s || ' days')::interval
-            """, (days,))
-            totals = cur.fetchone()
+    with db_connection() as conn, conn.cursor() as cur:
+        cur.execute("""
+            SELECT COUNT(*) FILTER (WHERE status = 'sent')   AS sent,
+                   COUNT(*) FILTER (WHERE status = 'failed') AS failed,
+                   COUNT(*)                                  AS total,
+                   MIN(created_at)                           AS first_recorded
+            FROM email_log
+            WHERE created_at >= NOW() - (%s || ' days')::interval
+        """, (days,))
+        totals = cur.fetchone()
 
-            cur.execute("""
-                SELECT template,
-                       COUNT(*) FILTER (WHERE status = 'sent')   AS sent,
-                       COUNT(*) FILTER (WHERE status = 'failed') AS failed
-                FROM email_log
-                WHERE created_at >= NOW() - (%s || ' days')::interval
-                GROUP BY template
-                ORDER BY COUNT(*) DESC
-            """, (days,))
-            by_template = cur.fetchall()
+        cur.execute("""
+            SELECT template,
+                   COUNT(*) FILTER (WHERE status = 'sent')   AS sent,
+                   COUNT(*) FILTER (WHERE status = 'failed') AS failed
+            FROM email_log
+            WHERE created_at >= NOW() - (%s || ' days')::interval
+            GROUP BY template
+            ORDER BY COUNT(*) DESC
+        """, (days,))
+        by_template = cur.fetchall()
 
-            cur.execute("""
-                SELECT reason, COUNT(*) AS count
-                FROM email_log
-                WHERE status = 'failed' AND reason IS NOT NULL
-                  AND created_at >= NOW() - (%s || ' days')::interval
-                GROUP BY reason
-                ORDER BY COUNT(*) DESC
-                LIMIT 10
-            """, (days,))
-            failures_by_reason = cur.fetchall()
+        cur.execute("""
+            SELECT reason, COUNT(*) AS count
+            FROM email_log
+            WHERE status = 'failed' AND reason IS NOT NULL
+              AND created_at >= NOW() - (%s || ' days')::interval
+            GROUP BY reason
+            ORDER BY COUNT(*) DESC
+            LIMIT 10
+        """, (days,))
+        failures_by_reason = cur.fetchall()
 
-            # The window's oldest row overall — so the UI can say "we
-            # have only been recording since X" instead of letting a
-            # young table read as a quiet one.
-            cur.execute("SELECT MIN(created_at) AS since FROM email_log")
-            since = cur.fetchone()["since"]
-    finally:
-        conn.close()
+        # The window's oldest row overall — so the UI can say "we
+        # have only been recording since X" instead of letting a
+        # young table read as a quiet one.
+        cur.execute("SELECT MIN(created_at) AS since FROM email_log")
+        since = cur.fetchone()["since"]
 
     return {
         "window_days": days,
@@ -382,8 +373,7 @@ def admin_update_user(
     admin=Depends(get_current_admin)
 ):
     """Update user fields - Phase 12-3"""
-    conn = get_db_connection()
-    with conn.cursor() as cur:
+    with db_connection() as conn, conn.cursor() as cur:
         # Build dynamic UPDATE query
         set_clauses = []
         params = []
@@ -411,8 +401,7 @@ def admin_update_user(
 @router.delete("/users/{user_id}")
 def admin_delete_user(user_id: int, admin=Depends(get_current_admin)):
     """Soft delete user (set is_active = false) - Phase 12-3"""
-    conn = get_db_connection()
-    with conn.cursor() as cur:
+    with db_connection() as conn, conn.cursor() as cur:
         # Check if user exists
         cur.execute("SELECT id FROM users WHERE id = %s", (user_id,))
         if not cur.fetchone():
@@ -430,8 +419,7 @@ def admin_delete_user(user_id: int, admin=Depends(get_current_admin)):
 @router.delete("/deeds/{deed_id}")
 def admin_delete_deed(deed_id: int, admin=Depends(get_current_admin)):
     """Soft delete a deed (set status to 'deleted') - Phase 5B"""
-    conn = get_db_connection()
-    with conn.cursor() as cur:
+    with db_connection() as conn, conn.cursor() as cur:
         # Check if deed exists
         cur.execute("SELECT id, status FROM deeds WHERE id = %s", (deed_id,))
         row = cur.fetchone()
@@ -458,8 +446,7 @@ def admin_get_deed_pdf(deed_id: int, admin=Depends(get_current_admin)):
     
     Returns the stored PDF URL or regenerates the PDF if needed.
     """
-    conn = get_db_connection()
-    with conn.cursor() as cur:
+    with db_connection() as conn, conn.cursor() as cur:
         # Get deed with PDF info
         cur.execute("""
             SELECT id, deed_type, status, pdf_url, property_address, 
@@ -505,8 +492,7 @@ def list_api_keys(
 ):
     """List all API keys with usage statistics."""
     offset = (page - 1) * limit
-    conn = get_db_connection()
-    with conn.cursor() as cur:
+    with db_connection() as conn, conn.cursor() as cur:
         # Get total count
         cur.execute("SELECT COUNT(*) as count FROM api_keys")
         total = cur.fetchone()['count']
@@ -549,8 +535,7 @@ def create_api_key(
     
     full_key, key_prefix, key_hash = gen_key(is_test=is_test)
     
-    conn = get_db_connection()
-    with conn.cursor() as cur:
+    with db_connection() as conn, conn.cursor() as cur:
         # Use gen_random_uuid() for UUID id
         cur.execute("""
             INSERT INTO api_keys (id, key_prefix, key_hash, name, is_test, rate_limit_hour, rate_limit_day, created_by_email, is_active, created_at)
@@ -583,8 +568,7 @@ def get_api_key(
     admin=Depends(get_current_admin)
 ):
     """Get API key details and usage statistics."""
-    conn = get_db_connection()
-    with conn.cursor() as cur:
+    with db_connection() as conn, conn.cursor() as cur:
         cur.execute("""
             SELECT id, key_prefix, name, is_active, is_test,
                    rate_limit_hour, rate_limit_day, created_at, last_used_at, created_by_email
@@ -644,8 +628,7 @@ def update_api_key(
     admin=Depends(get_current_admin)
 ):
     """Update API key settings."""
-    conn = get_db_connection()
-    with conn.cursor() as cur:
+    with db_connection() as conn, conn.cursor() as cur:
         # Build update query dynamically
         updates = []
         params = []
@@ -691,8 +674,7 @@ def delete_api_key(
     admin=Depends(get_current_admin)
 ):
     """Deactivate (soft delete) an API key."""
-    conn = get_db_connection()
-    with conn.cursor() as cur:
+    with db_connection() as conn, conn.cursor() as cur:
         cur.execute("""
             UPDATE api_keys SET is_active = false
             WHERE id = %s

--- a/backend/routers/api_key_requests.py
+++ b/backend/routers/api_key_requests.py
@@ -15,7 +15,7 @@ is recorded on the row rather than swallowed.
 import os
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, EmailStr, Field
 
 from auth import get_current_admin, get_current_user_id
@@ -26,8 +26,15 @@ from auth import get_current_admin, get_current_user_id
 # exactly the defect that made every partner API key 401 for months
 # (A1). This module reads rows as dicts, so it uses database's, which
 # also gives a fresh per-request connection rather than the shared one.
-from database import clean_profile_text, get_db_connection
+#
+# RED-H1.2: every endpoint here now takes its connection through
+# `db_connection()`, which closes on every exit including the raising
+# ones. Before, each of the four opened a connection and closed it on
+# exactly one of its three exits — see database.db_connection for what
+# that cost on the public path.
+from database import clean_profile_text, db_connection
 from utils.notifications import notify_api_key_request
+from utils.throttle import ThrottleExceeded, client_key, throttle
 
 router = APIRouter(tags=["API Access Requests"])
 
@@ -55,79 +62,68 @@ def create_api_key_request(payload: ApiKeyRequestIn,
     way, and the response says so plainly. The user is told what actually
     happens next: a conversation, not an automatic provisioning.
     """
-    conn = get_db_connection()
-    if not conn:
-        raise HTTPException(status_code=503,
-                            detail="Unable to record the request right now — please try again.")
-
     company = clean_profile_text(payload.company_name)
     if not company:
         raise HTTPException(status_code=400, detail="Company name is required")
 
-    try:
-        with conn.cursor() as cur:
-            cur.execute("""
-                INSERT INTO api_key_requests (
-                    user_id, company_name, business_type, contact_name, email, phone,
-                    use_case, expected_volume, integration_timeline, current_software,
-                    additional_info, status
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, 'new')
-                RETURNING id, created_at
-            """, (
-                user_id, company, payload.business_type,
-                clean_profile_text(payload.contact_name), payload.email.lower(),
-                clean_profile_text(payload.phone), payload.use_case,
-                payload.expected_volume, payload.integration_timeline,
-                payload.current_software, payload.additional_info,
-            ))
-            row = cur.fetchone()
-            conn.commit()
-    except Exception as e:
+    with db_connection("Unable to record the request right now — please try again.") as conn:
         try:
-            conn.rollback()
-        except Exception:
-            pass
-        print(f"[api-key-request] store failed: {e}")
-        raise HTTPException(status_code=500,
-                            detail="Could not record the request — please try again.")
+            with conn.cursor() as cur:
+                cur.execute("""
+                    INSERT INTO api_key_requests (
+                        user_id, company_name, business_type, contact_name, email, phone,
+                        use_case, expected_volume, integration_timeline, current_software,
+                        additional_info, status
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, 'new')
+                    RETURNING id, created_at
+                """, (
+                    user_id, company, payload.business_type,
+                    clean_profile_text(payload.contact_name), payload.email.lower(),
+                    clean_profile_text(payload.phone), payload.use_case,
+                    payload.expected_volume, payload.integration_timeline,
+                    payload.current_software, payload.additional_info,
+                ))
+                row = cur.fetchone()
+                conn.commit()
+        except Exception as e:
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            print(f"[api-key-request] store failed: {e}")
+            raise HTTPException(status_code=500,
+                                detail="Could not record the request — please try again.")
 
-    request_id = row["id"] if isinstance(row, dict) else row[0]
-    # The connection stays open only long enough to record the send
-    # result below; closed in the finally that follows.
+        request_id = row["id"] if isinstance(row, dict) else row[0]
 
-    admin_email = os.getenv("ADMIN_EMAIL", "admin@deedpro.com")
-    notified, notify_error = notify_api_key_request(
-        admin_email=admin_email,
-        company_name=company,
-        contact_email=payload.email.lower(),
-        business_type=payload.business_type or "—",
-        expected_volume=payload.expected_volume or "—",
-        use_case=payload.use_case or "",
-        request_id=request_id,
-    )
+        admin_email = os.getenv("ADMIN_EMAIL", "admin@deedpro.com")
+        notified, notify_error = notify_api_key_request(
+            admin_email=admin_email,
+            company_name=company,
+            contact_email=payload.email.lower(),
+            business_type=payload.business_type or "—",
+            expected_volume=payload.expected_volume or "—",
+            use_case=payload.use_case or "",
+            request_id=request_id,
+        )
 
-    # The row carries whether its own ping landed. A failed email must
-    # not lose a sales lead — the admin queue still shows it, flagged.
-    try:
-        with conn.cursor() as cur:
-            cur.execute("""
-                UPDATE api_key_requests
-                SET notified_at = CASE WHEN %s THEN NOW() ELSE NULL END,
-                    notify_error = %s
-                WHERE id = %s
-            """, (notified, None if notified else (notify_error or "unknown")[:500], request_id))
-            conn.commit()
-    except Exception as e:
+        # The row carries whether its own ping landed. A failed email must
+        # not lose a sales lead — the admin queue still shows it, flagged.
         try:
-            conn.rollback()
-        except Exception:
-            pass
-        print(f"[api-key-request] could not record notification state: {e}")
-    finally:
-        try:
-            conn.close()
-        except Exception:
-            pass
+            with conn.cursor() as cur:
+                cur.execute("""
+                    UPDATE api_key_requests
+                    SET notified_at = CASE WHEN %s THEN NOW() ELSE NULL END,
+                        notify_error = %s
+                    WHERE id = %s
+                """, (notified, None if notified else (notify_error or "unknown")[:500], request_id))
+                conn.commit()
+        except Exception as e:
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            print(f"[api-key-request] could not record notification state: {e}")
 
     if not notified:
         print(f"[api-key-request] request #{request_id} stored but not emailed: {notify_error}")
@@ -156,8 +152,14 @@ class ApiKeyInquiryIn(BaseModel):
     use_case: str = Field(..., min_length=1, max_length=2000)
 
 
+# Sized for the human, not the script. A person filling in this form once
+# is nowhere near five in an hour; a loop hits it on request six.
+INQUIRY_LIMIT = 5
+INQUIRY_WINDOW_SECONDS = 3600
+
+
 @router.post("/api-key-inquiries")
-def create_api_key_inquiry(payload: ApiKeyInquiryIn):
+def create_api_key_inquiry(payload: ApiKeyInquiryIn, request: Request):
     """Public — deliberately no auth dependency.
 
     Same store and same transport as the authenticated form, so the
@@ -165,69 +167,94 @@ def create_api_key_inquiry(payload: ApiKeyInquiryIn):
     before sending matters more here, not less — an anonymous inquiry has
     no account we could trace it back to if the email were lost.
 
-    Abuse posture (ruled): no captcha today; length caps and the email
-    validator are the whole defence, and the fallback if spam becomes
-    real is a plain mailto: link rather than more machinery.
+    ═══ ABUSE POSTURE, CORRECTED (RED-H1.2) ═══
+
+    The prior ruling was that length caps and the email validator were
+    the whole defence, with a plain mailto: as the fallback if spam
+    became real. That reasoning was about SPAM, and on spam it was
+    defensible. It missed two things this endpoint also does per request:
+
+      1. It held a database connection that was NOT closed on either
+         early-exit path. A whitespace-only company name returned 400 and
+         leaked the connection. A few hundred of those exhaust
+         `max_connections` and the entire product stops serving — an
+         unauthenticated denial of service, reachable with curl, costing
+         an attacker nothing. That is now structurally impossible: the
+         connection comes from `db_connection()`, which closes on every
+         exit including the raising ones.
+
+      2. It sends an email through the company's SendGrid account.
+         Attacker-controlled volume against our own sender reputation is
+         the damage that does not heal by itself.
+
+    So the throttle below is not anti-spam machinery — it is the cap on
+    those two amplifiers. It is in-process and therefore only as good as
+    the deployment is single-instance; see utils/throttle.py, which says
+    so plainly. Real edge limiting is RED-S3.
     """
-    conn = get_db_connection()
-    if not conn:
-        raise HTTPException(status_code=503,
-                            detail="Unable to record the request right now — please try again.")
+    try:
+        throttle(f"inquiry:{client_key(request)}",
+                 limit=INQUIRY_LIMIT, window_seconds=INQUIRY_WINDOW_SECONDS)
+    except ThrottleExceeded as e:
+        # 429 with Retry-After, and a message that tells a real person
+        # what to do instead of implying they did something wrong.
+        raise HTTPException(
+            status_code=429,
+            detail="Too many inquiries from this address. Please try again "
+                   "later, or email us directly.",
+            headers={"Retry-After": str(e.retry_after)},
+        )
 
     company = clean_profile_text(payload.company_name)
     if not company:
         raise HTTPException(status_code=400, detail="Company name is required")
 
-    try:
-        with conn.cursor() as cur:
-            cur.execute("""
-                INSERT INTO api_key_requests (
-                    user_id, company_name, email, use_case, status
-                ) VALUES (NULL, %s, %s, %s, 'new')
-                RETURNING id
-            """, (company, payload.email.lower(), payload.use_case))
-            request_id = cur.fetchone()[0]
-            conn.commit()
-    except Exception as e:
+    with db_connection("Unable to record the request right now — please try again.") as conn:
         try:
-            conn.rollback()
-        except Exception:
-            pass
-        print(f"[api-key-inquiry] store failed: {e}")
-        raise HTTPException(status_code=500,
-                            detail="Could not record the request — please try again.")
+            with conn.cursor() as cur:
+                cur.execute("""
+                    INSERT INTO api_key_requests (
+                        user_id, company_name, email, use_case, status
+                    ) VALUES (NULL, %s, %s, %s, 'new')
+                    RETURNING id
+                """, (company, payload.email.lower(), payload.use_case))
+                request_id = cur.fetchone()[0]
+                conn.commit()
+        except Exception as e:
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            print(f"[api-key-inquiry] store failed: {e}")
+            raise HTTPException(status_code=500,
+                                detail="Could not record the request — please try again.")
 
-    admin_email = os.getenv("ADMIN_EMAIL", "admin@deedpro.com")
-    notified, notify_error = notify_api_key_request(
-        admin_email=admin_email,
-        company_name=company,
-        contact_email=payload.email.lower(),
-        business_type="—",
-        expected_volume="—",
-        use_case=payload.use_case,
-        request_id=request_id,
-    )
+        admin_email = os.getenv("ADMIN_EMAIL", "admin@deedpro.com")
+        notified, notify_error = notify_api_key_request(
+            admin_email=admin_email,
+            company_name=company,
+            contact_email=payload.email.lower(),
+            business_type="—",
+            expected_volume="—",
+            use_case=payload.use_case,
+            request_id=request_id,
+        )
 
-    try:
-        with conn.cursor() as cur:
-            cur.execute("""
-                UPDATE api_key_requests
-                SET notified_at = CASE WHEN %s THEN NOW() ELSE NULL END,
-                    notify_error = %s
-                WHERE id = %s
-            """, (notified, None if notified else (notify_error or "unknown")[:500], request_id))
-            conn.commit()
-    except Exception as e:
         try:
-            conn.rollback()
-        except Exception:
-            pass
-        print(f"[api-key-inquiry] could not record notification state: {e}")
-    finally:
-        try:
-            conn.close()
-        except Exception:
-            pass
+            with conn.cursor() as cur:
+                cur.execute("""
+                    UPDATE api_key_requests
+                    SET notified_at = CASE WHEN %s THEN NOW() ELSE NULL END,
+                        notify_error = %s
+                    WHERE id = %s
+                """, (notified, None if notified else (notify_error or "unknown")[:500], request_id))
+                conn.commit()
+        except Exception as e:
+            try:
+                conn.rollback()
+            except Exception:
+                pass
+            print(f"[api-key-inquiry] could not record notification state: {e}")
 
     if not notified:
         print(f"[api-key-inquiry] inquiry #{request_id} stored but not emailed: {notify_error}")
@@ -245,10 +272,7 @@ def create_api_key_inquiry(payload: ApiKeyInquiryIn):
 def list_api_key_requests(status: Optional[str] = None,
                           admin=Depends(get_current_admin)):
     """The queue behind the manual-issuance ruling."""
-    conn = get_db_connection()
-    if not conn:
-        raise HTTPException(status_code=503, detail="Database unavailable")
-    with conn.cursor() as cur:
+    with db_connection() as conn, conn.cursor() as cur:
         if status:
             cur.execute("""
                 SELECT id, company_name, business_type, contact_name, email, phone,
@@ -266,7 +290,6 @@ def list_api_key_requests(status: Optional[str] = None,
                 ORDER BY created_at DESC LIMIT 100
             """)
         items = [dict(r) for r in cur.fetchall()]
-    conn.close()
     return {"items": items, "total": len(items)}
 
 
@@ -281,19 +304,17 @@ def update_api_key_request(request_id: int, payload: RequestStatusIn,
     if payload.status not in allowed:
         raise HTTPException(status_code=400,
                             detail=f"status must be one of {sorted(allowed)}")
-    conn = get_db_connection()
-    if not conn:
-        raise HTTPException(status_code=503, detail="Database unavailable")
-    with conn.cursor() as cur:
+    with db_connection() as conn, conn.cursor() as cur:
         cur.execute("""
             UPDATE api_key_requests SET status = %s WHERE id = %s
             RETURNING id, company_name, status
         """, (payload.status, request_id))
         row = cur.fetchone()
         if not row:
-            conn.close()
+            # No explicit close before raising any more — the manager has
+            # it. This line used to be the ONLY reason the 404 path did
+            # not leak, and it was one edit away from not being there.
             raise HTTPException(status_code=404, detail="Request not found")
         conn.commit()
-    result = dict(row)
-    conn.close()
+        result = dict(row)
     return {"success": True, "request": result}

--- a/backend/routers/auth_extra.py
+++ b/backend/routers/auth_extra.py
@@ -10,7 +10,13 @@ from jose import jwt, JWTError
 
 try:
     # Project-local utilities
-    from database import get_db_connection
+    # RED-H1.2: db_connection() closes on every exit. All four
+    # endpoints in this module are UNAUTHENTICATED (forgot-password,
+    # reset-password, both verify-email routes) and none of them
+    # closed its connection — four more anonymous leak vectors of the
+    # same class as the inquiry endpoint, and forgot-password sends
+    # an email too, so it carried both amplifiers.
+    from database import db_connection
     from auth import create_access_token, get_password_hash, AuthUtils, ALGORITHM, SECRET_KEY
     from utils.email import email_configured  # Phase 7.5: Relative import first
     from utils.notifications import (
@@ -20,7 +26,7 @@ try:
     )
 except Exception as e:
     # Fallback names if modules are under different paths; adjust as needed in your repo
-    from backend.database import get_db_connection  # type: ignore
+    from backend.database import db_connection  # type: ignore
     from backend.auth import create_access_token, get_password_hash, AuthUtils, ALGORITHM, SECRET_KEY  # type: ignore
     from backend.utils.email import email_configured  # Phase 7.5: Absolute fallback
     from backend.utils.notifications import (  # type: ignore
@@ -69,8 +75,7 @@ def forgot_password(payload: ForgotPasswordRequest):
         )
     email = payload.email.lower()
     try:
-        conn = get_db_connection()
-        with conn.cursor() as cur:
+        with db_connection() as conn, conn.cursor() as cur:
             cur.execute("SELECT id, full_name FROM users WHERE email = %s", (email,))
             row = cur.fetchone()
         if not row:
@@ -116,8 +121,7 @@ def reset_password(payload: ResetPasswordRequest):
 
     hashed = get_password_hash(payload.new_password)
     try:
-        conn = get_db_connection()
-        with conn.cursor() as cur:
+        with db_connection() as conn, conn.cursor() as cur:
             cur.execute("UPDATE users SET password_hash = %s, updated_at = CURRENT_TIMESTAMP WHERE id = %s RETURNING email, full_name", (hashed, user_id))
             updated = cur.fetchone()
             conn.commit()
@@ -140,8 +144,7 @@ def reset_password(payload: ResetPasswordRequest):
 def request_verify_email(payload: VerifyEmailRequest):
     email = payload.email.lower()
     try:
-        conn = get_db_connection()
-        with conn.cursor() as cur:
+        with db_connection() as conn, conn.cursor() as cur:
             cur.execute("SELECT id, full_name, verified FROM users WHERE email = %s", (email,))
             row = cur.fetchone()
         if not row:
@@ -172,8 +175,7 @@ def verify_email(token: str):
         raise HTTPException(status_code=400, detail="Invalid or expired token")
 
     try:
-        conn = get_db_connection()
-        with conn.cursor() as cur:
+        with db_connection() as conn, conn.cursor() as cur:
             cur.execute("UPDATE users SET verified = TRUE, updated_at = CURRENT_TIMESTAMP WHERE id = %s", (user_id,))
             conn.commit()
         return {"message": "Email verified"}

--- a/backend/routers/notifications.py
+++ b/backend/routers/notifications.py
@@ -4,7 +4,8 @@ from pydantic import BaseModel
 from typing import List, Optional, Dict, Any
 import os, json
 from auth import get_current_user_id  # Phase 7.5: Absolute import for Render compatibility
-from database import get_db_connection  # Phase 7.5: Absolute import for Render compatibility
+# RED-H1.2: was get_db_connection with three opens and zero closes.
+from database import db_connection
 
 router = APIRouter()
 
@@ -25,8 +26,7 @@ def feature_enabled() -> bool:
 def list_notifications(user_id: int = Depends(get_current_user_id)):
     if not feature_enabled():
         return []
-    conn = get_db_connection()
-    with conn.cursor() as cur:
+    with db_connection() as conn, conn.cursor() as cur:
         cur.execute(
             """
             SELECT n.id, n.type, n.title, n.message, n.severity, n.payload, n.created_at,
@@ -65,8 +65,7 @@ def mark_read(body: MarkReadIn, user_id: int = Depends(get_current_user_id)):
         return {"success": False, "message": "Notifications disabled"}
     if not body.ids:
         return {"success": True}
-    conn = get_db_connection()
-    with conn.cursor() as cur:
+    with db_connection() as conn, conn.cursor() as cur:
         cur.execute(
             """
             UPDATE user_notifications
@@ -83,8 +82,7 @@ def mark_read(body: MarkReadIn, user_id: int = Depends(get_current_user_id)):
 def unread_count(user_id: int = Depends(get_current_user_id)):
     if not feature_enabled():
         return {"count": 0}
-    conn = get_db_connection()
-    with conn.cursor() as cur:
+    with db_connection() as conn, conn.cursor() as cur:
         cur.execute(
             """
             SELECT COUNT(*) as count

--- a/backend/tests/test_red_h1_connection_lifecycle.py
+++ b/backend/tests/test_red_h1_connection_lifecycle.py
@@ -1,0 +1,207 @@
+"""RED-H1.2 — connections close on every exit, and the public path is capped.
+
+═══ WHAT THIS PINS, AND WHY IT IS NOT A STYLE TEST ═══
+
+`get_db_connection()` opens a real socket. Postgres holds a backend
+process open per connection and the instance has a hard
+`max_connections`. A leaked connection is therefore not "untidy" — it is
+a consumed unit of a small, shared, exhaustible resource, and when they
+run out the database stops serving EVERY caller, not just the leaking
+endpoint.
+
+The census before this ticket:
+
+    api_key_requests.py    4 opens, closed on 1 of 3 exits each
+    admin_api_v2.py       18 opens, 2 closes
+    auth_extra.py          4 opens, 0 closes   ← ALL UNAUTHENTICATED
+    notifications.py       3 opens, 0 closes
+
+The cheapest path to the worst outcome was the public inquiry form: a
+whitespace-only company name returns 400 from a `raise` that sits above
+any `finally`, so the connection leaks and the attacker spends one
+request. A few hundred of those and the product is down — unauthenticated
+denial of service, with curl.
+
+`auth_extra` then turned out to be the same defect on FOUR more
+unauthenticated routes, forgot-password among them.
+
+The fix is a context manager rather than four hundred careful `finally`
+blocks, because the failure mode of "everyone must remember" is that
+someone eventually does not — which is exactly the history above.
+"""
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+BACKEND = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(BACKEND))
+
+import database  # noqa: E402
+from tests.source_text import code_only  # noqa: E402
+from utils import throttle as throttle_mod  # noqa: E402
+
+
+# ── The manager itself ────────────────────────────────────────────────
+
+
+def test_connection_closes_on_the_happy_path():
+    fake = MagicMock()
+    with patch.object(database, "get_db_connection", return_value=fake):
+        with database.db_connection() as conn:
+            assert conn is fake
+    fake.close.assert_called_once()
+
+
+def test_connection_closes_when_the_body_raises_httpexception():
+    """THE case. Every leak in the census was a `raise HTTPException`
+    sitting above the close — a 400 for a bad field, a 404 for a missing
+    row. The manager has to survive the exception that used to escape."""
+    fake = MagicMock()
+    with patch.object(database, "get_db_connection", return_value=fake):
+        with pytest.raises(HTTPException):
+            with database.db_connection() as conn:
+                raise HTTPException(status_code=400, detail="bad field")
+    fake.close.assert_called_once()
+
+
+def test_connection_closes_when_the_body_raises_anything_else():
+    fake = MagicMock()
+    with patch.object(database, "get_db_connection", return_value=fake):
+        with pytest.raises(ValueError):
+            with database.db_connection() as conn:
+                raise ValueError("boom")
+    fake.close.assert_called_once()
+
+
+def test_unavailable_database_raises_503_and_never_yields():
+    """Returning None made every caller responsible for an `if not conn`
+    check, which is one more thing to forget."""
+    with patch.object(database, "get_db_connection", return_value=None):
+        with pytest.raises(HTTPException) as exc:
+            with database.db_connection("custom detail"):
+                pytest.fail("body must not run without a connection")
+    assert exc.value.status_code == 503
+    assert exc.value.detail == "custom detail"
+
+
+def test_a_failing_close_does_not_mask_the_real_error():
+    """If close() raises while the body is already raising, the caller
+    must still see the body's exception — not a confusing close error."""
+    fake = MagicMock()
+    fake.close.side_effect = RuntimeError("socket already gone")
+    with patch.object(database, "get_db_connection", return_value=fake):
+        with pytest.raises(ValueError, match="the real problem"):
+            with database.db_connection():
+                raise ValueError("the real problem")
+
+
+# ── No raw opens left where the leaks were ────────────────────────────
+
+
+LEAKY_MODULES = [
+    "routers/api_key_requests.py",
+    "routers/admin_api_v2.py",
+    "routers/auth_extra.py",
+    "routers/notifications.py",
+]
+
+
+@pytest.mark.parametrize("rel", LEAKY_MODULES)
+def test_no_module_that_leaked_still_opens_a_bare_connection(rel):
+    src = code_only((BACKEND / rel).read_text(encoding="utf-8"))
+    assert "get_db_connection()" not in src, (
+        f"{rel} still opens a connection it must remember to close")
+
+
+@pytest.mark.parametrize("rel", LEAKY_MODULES)
+def test_no_module_that_leaked_still_closes_by_hand(rel):
+    """A manual close alongside the manager means someone re-introduced
+    the pattern; the manager is the only thing that should close."""
+    src = code_only((BACKEND / rel).read_text(encoding="utf-8"))
+    assert "conn.close()" not in src, f"{rel} closes by hand again"
+
+
+def test_the_four_unauthenticated_auth_routes_use_the_manager():
+    """auth_extra's endpoints take no auth dependency, so their leak was
+    reachable by anyone — the same severity as the inquiry endpoint and
+    four times the surface."""
+    src = code_only((BACKEND / "routers" / "auth_extra.py").read_text(encoding="utf-8"))
+    assert src.count("with db_connection() as conn") == 4
+
+
+# ── The public endpoint is capped ─────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _clean_throttle():
+    throttle_mod.reset()
+    yield
+    throttle_mod.reset()
+
+
+def test_the_limit_allows_the_human_and_stops_the_loop():
+    for _ in range(5):
+        throttle_mod.throttle("k", limit=5, window_seconds=3600)
+    with pytest.raises(throttle_mod.ThrottleExceeded):
+        throttle_mod.throttle("k", limit=5, window_seconds=3600)
+
+
+def test_callers_are_counted_separately():
+    for _ in range(5):
+        throttle_mod.throttle("a", limit=5, window_seconds=3600)
+    throttle_mod.throttle("b", limit=5, window_seconds=3600)  # must not raise
+
+
+def test_the_window_slides_rather_than_resetting_on_a_boundary():
+    """A fixed window lets a caller send `limit` at 0:59 and `limit`
+    again at 1:01 — double the intended rate at the worst moment."""
+    with patch.object(throttle_mod.time, "monotonic", side_effect=[
+        0, 1, 2,          # three hits at t≈0
+        61, 61,           # a fourth at t=61: the first three are still
+    ]):                   # inside a 120s window, so this is hit four
+        for _ in range(3):
+            throttle_mod.throttle("slide", limit=3, window_seconds=120)
+        with pytest.raises(throttle_mod.ThrottleExceeded):
+            throttle_mod.throttle("slide", limit=3, window_seconds=120)
+
+
+def test_the_refusal_says_when_to_come_back():
+    for _ in range(2):
+        throttle_mod.throttle("r", limit=2, window_seconds=60)
+    with pytest.raises(throttle_mod.ThrottleExceeded) as exc:
+        throttle_mod.throttle("r", limit=2, window_seconds=60)
+    assert 0 < exc.value.retry_after <= 61
+
+
+def test_the_limiter_is_not_itself_a_memory_leak():
+    """An attacker rotating source addresses must not grow the map
+    without bound — the naive dict-keyed-by-IP is its own DoS."""
+    for i in range(throttle_mod.MAX_TRACKED_KEYS + 500):
+        throttle_mod.throttle(f"ip-{i}", limit=5, window_seconds=1)
+    assert len(throttle_mod._buckets) <= throttle_mod.MAX_TRACKED_KEYS
+
+
+def test_forwarded_for_takes_the_first_hop():
+    req = MagicMock()
+    req.headers = {"x-forwarded-for": "203.0.113.9, 10.0.0.1, 10.0.0.2"}
+    assert throttle_mod.client_key(req) == "203.0.113.9"
+
+
+def test_the_public_endpoint_actually_wires_the_throttle():
+    src = code_only((BACKEND / "routers" / "api_key_requests.py").read_text(encoding="utf-8"))
+    assert "throttle(" in src and "client_key(request)" in src
+    assert "status_code=429" in src
+    # Retry-After, so a legitimate caller is told when rather than just no.
+    assert "Retry-After" in src
+
+
+def test_the_throttle_is_honest_about_being_in_process():
+    """The module must keep saying what it cannot do. An in-process
+    limiter across two workers enforces double the stated limit, and a
+    limiter that implies otherwise is worse than none."""
+    doc = (BACKEND / "utils" / "throttle.py").read_text(encoding="utf-8")
+    assert "in-process" in doc.lower()
+    assert "single-instance" in doc.lower()

--- a/backend/utils/throttle.py
+++ b/backend/utils/throttle.py
@@ -1,0 +1,121 @@
+"""RED-H1.2 — a per-caller rate limit, and an honest account of its reach.
+
+═══ WHAT THIS IS FOR ═══
+
+One endpoint in this product accepts writes from anyone: the public
+API-access inquiry form. No account, three fields. Every request stores a
+row AND sends an email through the company's SendGrid account.
+
+That is two amplifiers pointed outward. Unthrottled, a loop turns into a
+filled table and a burned sender reputation, and the sender reputation is
+the one that does not recover on its own — deliverability damage outlasts
+whatever you do about the traffic.
+
+The prior ruling on this endpoint said length caps and the email
+validator were the whole defence, with a plain mailto: as the fallback if
+spam became real. That reasoning considered SPAM. It did not consider
+that each request also holds a database connection and an SMTP send.
+
+═══ WHAT THIS IS NOT ═══
+
+NOT the answer to rate limiting generally. This is in-process memory: it
+counts requests inside ONE python process, so it is exactly as good as
+the deployment is single-instance. The moment the app runs two workers,
+each keeps its own counter and the effective limit doubles.
+
+That is stated here rather than discovered later. RED-S3 carries real
+edge rate limiting; this is the specific hole plugged specifically,
+sized so that a legitimate human filling in a form never meets it and a
+script does so immediately.
+
+It is also memory-bounded on purpose. A naive dict keyed by IP is itself
+a denial-of-service surface — an attacker rotating source addresses grows
+it without limit. Expired buckets are swept on write, and the map is
+capped; past the cap the oldest buckets are dropped.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from collections import OrderedDict
+from typing import Optional
+
+from fastapi import Request
+
+
+class ThrottleExceeded(Exception):
+    """Raised when a caller exceeds its window. Carries the retry hint."""
+
+    def __init__(self, retry_after: int):
+        self.retry_after = retry_after
+        super().__init__(f"Rate limit exceeded; retry in {retry_after}s")
+
+
+# Past this many tracked keys, the oldest are evicted. Chosen so the map
+# stays trivially small in memory while being far above any plausible
+# count of real simultaneous form-fillers.
+MAX_TRACKED_KEYS = 10_000
+
+_buckets: "OrderedDict[str, list[float]]" = OrderedDict()
+_lock = threading.Lock()
+
+
+def client_key(request: Optional[Request]) -> str:
+    """Best-effort caller identity.
+
+    Behind Render's proxy the socket peer is the proxy, so the real
+    client is the FIRST entry of X-Forwarded-For. That header is
+    caller-supplied and trivially spoofed — which is precisely why this
+    module does not pretend to be a security boundary. It raises the cost
+    of casual abuse; it does not stop a determined attacker, and an
+    honest limiter says so rather than implying otherwise.
+    """
+    if request is None:
+        return "unknown"
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
+def throttle(key: str, *, limit: int, window_seconds: int) -> None:
+    """Allow `limit` events per `window_seconds` for `key`, else raise.
+
+    A sliding window rather than a fixed one: fixed windows let a caller
+    send `limit` at 0:59 and `limit` again at 1:01, which is double the
+    intended rate at the moment it matters most.
+    """
+    now = time.monotonic()
+    cutoff = now - window_seconds
+
+    with _lock:
+        hits = _buckets.get(key)
+        if hits is None:
+            hits = []
+        else:
+            hits = [t for t in hits if t > cutoff]
+
+        if len(hits) >= limit:
+            retry_after = max(1, int(window_seconds - (now - hits[0])) + 1)
+            _buckets[key] = hits
+            _buckets.move_to_end(key)
+            raise ThrottleExceeded(retry_after)
+
+        hits.append(now)
+        _buckets[key] = hits
+        _buckets.move_to_end(key)
+
+        # Sweep on write: drop keys whose windows have fully expired,
+        # then hard-cap. Without both, the limiter becomes the leak.
+        if len(_buckets) > MAX_TRACKED_KEYS:
+            for stale in [k for k, v in list(_buckets.items())
+                          if not v or v[-1] <= cutoff]:
+                _buckets.pop(stale, None)
+            while len(_buckets) > MAX_TRACKED_KEYS:
+                _buckets.popitem(last=False)
+
+
+def reset() -> None:
+    """Test hook — the module is process-global by design."""
+    with _lock:
+        _buckets.clear()


### PR DESCRIPTION
Second of the RED-H1 wave.

## The census, finished

RED0 named two modules. The sweep found four.

| module | opens | closes | auth |
|---|---|---|---|
| `api_key_requests.py` | 4 | 1 of 3 exits each | mixed (**1 public**) |
| `admin_api_v2.py` | 18 | 2 | admin |
| **`auth_extra.py`** | **4** | **0** | **all four UNAUTHENTICATED** |
| `notifications.py` | 3 | 0 | authenticated |

**`auth_extra.py` is the worse find.** `POST /users/forgot-password`, `POST /users/reset-password`, `POST /users/verify-email/request` and `GET /users/verify-email` take no auth dependency, and none of them closed its connection. That is **four more anonymous leak vectors**, and forgot-password sends an email too — so it carried both amplifiers the inquiry endpoint has. RED0 found one unauthenticated leak; there were five.

## Why a leak is severity, not tidiness

Postgres holds a backend process per connection against a hard `max_connections`. The cheapest path to the worst outcome was a whitespace-only company name on the public form: 400 from a `raise` sitting above any `finally`, one connection gone, one attacker request spent. A few hundred and the database stops serving **everyone**, not just the leaking endpoint.

## The fix is a mechanism, not discipline

`database.db_connection()` — closes on return, on raise, on `HTTPException`, on anything. It raises the 503 itself, so the `if not conn` check can't be forgotten either.

**All 29 sites converted.** Zero bare opens and zero hand-written closes remain in the four modules, both pinned.

The alternative was 29 careful `finally` blocks. The failure mode of *"everyone must remember"* is that someone eventually doesn't — which is the entire table above.

## The throttle

`POST /api-key-inquiries`: **5/hour per caller**, sliding window, 429 with `Retry-After`.

Sliding rather than fixed, because a fixed window allows `limit` at 0:59 and `limit` again at 1:01 — double the intended rate at the moment it matters. Pinned.

It is **in-process**, and `utils/throttle.py` says so in its own docstring — across two workers it enforces double the stated limit, and a limiter that implies otherwise is worse than none. A test pins that the honesty stays in the file. Real edge limiting is RED-S3.

The limiter is memory-capped and swept on write, because a dict keyed by attacker-controlled IP is its own denial of service. Pinned with 10,500 rotating keys.

## Correcting the record

The prior abuse-posture ruling on this endpoint — *"length caps and the email validator are the whole defence"* — reasoned about **spam**, and on spam it was defensible. It missed that each request also holds a database connection and sends mail. That's now written into the endpoint's docstring where the next person will read it.

## Gates

| gate | result |
|---|---|
| backend pytest | **523 passed** (+22) |
| jest | 487, 34 suites |
| tsc | 94 — unchanged |
| six-flow | ✔ verify |
| API baseline | ✔ verify |
| banned-claims | ✔ clean |

The two baselines matter here — this touched login, register, share and admin request paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_