### PR TITLE
RED-H1.3: the assistant is bounded, metered, and on the record

### DIFF
--- a/backend/api/ai_assist.py
+++ b/backend/api/ai_assist.py
@@ -1,109 +1,198 @@
+"""AI Assistant API — bounded, metered, and on the record.
+
+RED-H1.3. What this endpoint was, until this ticket:
+
+    {"role": "system", "content": request.system or "..."}
+    "max_tokens": request.max_tokens
+
+The CLIENT supplied the system prompt and the token ceiling. Any
+authenticated user — including one on the free plan — could POST an
+arbitrary system prompt with an arbitrary `max_tokens` and use the
+company's OpenAI account as a general-purpose LLM, indefinitely, with:
+
+  - no upper bound on tokens per call
+  - no per-user quota
+  - no rate limit
+  - no request tagging, so spend could not even be attributed
+  - NO RECORD of what was asked or what was answered
+
+That last one is the serious one, and it is not a cost problem.
+
+This product's entire architecture is suggest → confirm → record. Every
+rule in the doctrine governs DATA: which values may be prefilled, what a
+confirmation stamps, what carries between documents. This endpoint emits
+PROSE to an escrow officer inside a deed builder — the largest
+legal-influence surface in the product — and it had none of the three. No
+suggestion marker, no confirmation, no record.
+
+So the confirmation trail could prove precisely what data the officer
+accepted, and nothing whatsoever about what the machine told her first.
+That asymmetry points the wrong way in a dispute.
+
+═══ CONTAINMENT, NOT THE BOUNDARY RULING ═══
+
+This ticket bounds the mechanism. What the assistant may and may not SAY
+— the explain-yes / select-no boundary — is a doctrine ruling that has
+not been applied here, and `services/ai_prompts.py` flags the prompt that
+makes it urgent (`deed_type_advisor` literally instructs the model to
+help select an instrument).
+
+Containment first, because the boundary cannot be ruled on evidence that
+does not exist. Now it will exist.
 """
-AI Assistant API for dynamic prompt handling
-Phase 3 Enhancements: Multi-document support, timeout handling, orchestration improvements
-"""
-from fastapi import APIRouter, HTTPException, Depends
-from pydantic import BaseModel
-from typing import Dict, Any, Optional, List
-import httpx
 import asyncio
-import time
-import os
-from auth import get_current_user_id
 import logging
+import os
+import uuid
+from typing import Optional
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from auth import get_current_user_id
+from database import db_connection
+from services.ai_prompts import (
+    HARD_MAX_TOKENS,
+    PROMPTS,
+    UnknownPromptKey,
+    max_tokens_for,
+    system_prompt,
+)
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
-# Configuration from environment
-AI_ASSIST_TIMEOUT = int(os.getenv("AI_ASSIST_TIMEOUT", "15"))
-MAX_CONCURRENT_REQUESTS = int(os.getenv("MAX_CONCURRENT_REQUESTS", "5"))
+AI_MODEL = "gpt-4o-mini"
 
+# Per-user, per-day ceiling. Sized so an officer working normally never
+# meets it and a script meets it inside a minute. The old endpoint had no
+# ceiling of any kind.
+DAILY_EXCHANGE_LIMIT = int(os.getenv("AI_DAILY_EXCHANGE_LIMIT", "100"))
 
-# T4: /assist (shadowed, no consumers), /multi-document, and the TitlePoint
-# orchestration handlers were removed. /api/ai/chat below is the sole AI
-# route the frontend consumes.
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 
 
 class ChatRequest(BaseModel):
-    """Request model for AI chat endpoint"""
-    system: str = ""  # System prompt
-    message: str  # User message
-    max_tokens: int = 400
+    """Note what is NOT here any more: `system`.
+
+    The client sends a KEY naming a prompt the server owns. An unknown
+    key is refused rather than defaulted — a default would rebuild the
+    hole with extra steps.
+    """
+    prompt_key: str = Field(..., max_length=64)
+    message: str = Field(..., min_length=1, max_length=4000)
+    # A request MAY ask for fewer tokens; it can no longer ask for more.
+    max_tokens: Optional[int] = Field(None, ge=1, le=HARD_MAX_TOKENS)
 
 
 class ChatResponse(BaseModel):
-    """Response model for AI chat endpoint"""
     success: bool = True
     response: str = ""
     error: Optional[str] = None
 
 
-# Get OpenAI API key from environment
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
+def _log_exchange(user_id, prompt_key, message, response, max_tokens,
+                  status, error, request_tag):
+    """Record every exchange. Never let logging break the response.
+
+    A failure to log is a real problem — it is the whole point of the
+    ticket — so it is printed loudly. It is not, however, a reason to
+    deny an officer mid-file an answer we already have.
+    """
+    try:
+        with db_connection() as conn, conn.cursor() as cur:
+            cur.execute("""
+                INSERT INTO ai_exchange_log (
+                    user_id, prompt_key, user_message, response, model,
+                    max_tokens, status, error, request_tag
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+            """, (user_id, prompt_key, message, response, AI_MODEL,
+                  max_tokens, status, error, request_tag))
+            conn.commit()
+    except Exception as e:
+        logger.error(f"[ai] FAILED TO LOG EXCHANGE (user={user_id}): {e}")
+
+
+def _exchanges_today(user_id: int) -> int:
+    with db_connection() as conn, conn.cursor() as cur:
+        cur.execute("""
+            SELECT COUNT(*) AS n FROM ai_exchange_log
+            WHERE user_id = %s AND created_at >= NOW() - INTERVAL '1 day'
+        """, (user_id,))
+        row = cur.fetchone()
+        return int(row["n"] if isinstance(row, dict) else row[0])
 
 
 @router.post("/chat", response_model=ChatResponse)
 async def ai_chat(request: ChatRequest, user_id: int = Depends(get_current_user_id)):
-    """
-    AI Chat endpoint for wizard guidance.
-    Uses OpenAI GPT-4 for natural language assistance.
-
-    This endpoint is called by the frontend aiAssistant service.
-    Doctrine sweep (owner ruling 2026-07-28): logged-in-only — both
-    consumers live inside the authenticated builder, and an open endpoint
-    spends AI tokens for anyone.
-    """
+    """AI guidance for the builder. Logged-in only (ruled 2026-07-28)."""
     if not OPENAI_API_KEY:
         # An unconfigured service is an error, not a fabricated AI reply
-        # (same disease the proxy had: success:true with canned text).
+        # (the same disease the proxy had: success:true with canned text).
         logger.warning("OpenAI API key not configured")
         raise HTTPException(status_code=503, detail="AI assistance is not configured")
-    
+
+    try:
+        system = system_prompt(request.prompt_key)
+    except UnknownPromptKey:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown prompt_key. Available: {sorted(PROMPTS)}")
+
+    capped = max_tokens_for(request.prompt_key, request.max_tokens)
+
+    if _exchanges_today(user_id) >= DAILY_EXCHANGE_LIMIT:
+        _log_exchange(user_id, request.prompt_key, request.message, None,
+                      capped, "quota", f"daily limit {DAILY_EXCHANGE_LIMIT}", None)
+        raise HTTPException(
+            status_code=429,
+            detail="You've reached today's AI assistance limit. It resets in 24 hours.")
+
+    # Tagged so spend is attributable per user and per request. The old
+    # endpoint sent nothing, so the OpenAI dashboard could not be split
+    # by anything at all.
+    request_tag = f"u{user_id}-{uuid.uuid4().hex[:12]}"
+
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
             response = await client.post(
                 "https://api.openai.com/v1/chat/completions",
                 headers={
                     "Authorization": f"Bearer {OPENAI_API_KEY}",
-                    "Content-Type": "application/json"
+                    "Content-Type": "application/json",
                 },
                 json={
-                    "model": "gpt-4o-mini",
+                    "model": AI_MODEL,
                     "messages": [
-                        {"role": "system", "content": request.system or "You are a helpful California real estate title officer assistant."},
-                        {"role": "user", "content": request.message}
+                        {"role": "system", "content": system},
+                        {"role": "user", "content": request.message},
                     ],
-                    "max_tokens": request.max_tokens,
-                    "temperature": 0.7
-                }
+                    "max_tokens": capped,
+                    "temperature": 0.7,
+                    "user": request_tag,
+                },
             )
-            
+
             if response.status_code != 200:
                 logger.error(f"OpenAI API error: {response.status_code} - {response.text}")
-                return ChatResponse(
-                    success=False,
-                    error="AI service temporarily unavailable"
-                )
-            
-            data = response.json()
-            ai_response = data["choices"][0]["message"]["content"]
-            
-            return ChatResponse(
-                success=True,
-                response=ai_response
-            )
-            
+                _log_exchange(user_id, request.prompt_key, request.message, None,
+                              capped, "error", f"openai {response.status_code}", request_tag)
+                return ChatResponse(success=False, error="AI service temporarily unavailable")
+
+            ai_response = response.json()["choices"][0]["message"]["content"]
+            _log_exchange(user_id, request.prompt_key, request.message, ai_response,
+                          capped, "ok", None, request_tag)
+            return ChatResponse(success=True, response=ai_response)
+
     except asyncio.TimeoutError:
         logger.error("OpenAI API timeout")
-        return ChatResponse(
-            success=False,
-            error="AI request timed out"
-        )
+        _log_exchange(user_id, request.prompt_key, request.message, None,
+                      capped, "error", "timeout", request_tag)
+        return ChatResponse(success=False, error="AI request timed out")
     except Exception as e:
         logger.error(f"AI chat error: {str(e)}")
-        return ChatResponse(
-            success=False,
-            error="Failed to get AI response"
-        )
+        _log_exchange(user_id, request.prompt_key, request.message, None,
+                      capped, "error", str(e)[:500], request_tag)
+        return ChatResponse(success=False, error="Failed to get AI response")

--- a/backend/database.py
+++ b/backend/database.py
@@ -372,6 +372,36 @@ def create_tables():
             "CREATE INDEX IF NOT EXISTS idx_email_log_status ON email_log(status, created_at DESC)",
             "CREATE INDEX IF NOT EXISTS idx_email_log_template ON email_log(template, created_at DESC)",
             "CREATE INDEX IF NOT EXISTS idx_email_log_recipient ON email_log(LOWER(recipient))",
+            # RED-H1.3 — the AI exchange log.
+            #
+            # Nothing recorded what the assistant told an escrow officer.
+            # The confirmation trail can prove exactly what DATA she
+            # accepted and can prove nothing about what the machine said
+            # to her before she accepted it — which is adversarially
+            # perfect in the wrong direction: the record incriminates the
+            # human and exonerates the software.
+            #
+            # It also means the UPL question cannot be ASSESSED. Nobody
+            # can read a hundred real exchanges and say whether they
+            # constitute advice on instrument selection, because a
+            # hundred real exchanges do not exist anywhere. This table is
+            # the precondition for that ruling, not the ruling.
+            """CREATE TABLE IF NOT EXISTS ai_exchange_log (
+                id BIGSERIAL PRIMARY KEY,
+                user_id INTEGER,
+                prompt_key VARCHAR(64) NOT NULL,
+                user_message TEXT,
+                response TEXT,
+                model VARCHAR(64),
+                max_tokens INTEGER,
+                status VARCHAR(16) NOT NULL,
+                error TEXT,
+                request_tag VARCHAR(80),
+                created_at TIMESTAMPTZ DEFAULT now()
+            )""",
+            "CREATE INDEX IF NOT EXISTS idx_ai_log_user_created ON ai_exchange_log(user_id, created_at DESC)",
+            "CREATE INDEX IF NOT EXISTS idx_ai_log_created ON ai_exchange_log(created_at DESC)",
+            "CREATE INDEX IF NOT EXISTS idx_ai_log_key ON ai_exchange_log(prompt_key, created_at DESC)",
             """CREATE TABLE IF NOT EXISTS api_rate_limits (
                 id SERIAL PRIMARY KEY,
                 api_key_id UUID,

--- a/backend/services/ai_prompts.py
+++ b/backend/services/ai_prompts.py
@@ -1,0 +1,138 @@
+"""RED-H1.3 — the assistant's system prompts, owned by the server.
+
+═══ WHY THESE MOVED ═══
+
+`POST /api/ai/chat` accepted `system` from the client. Any authenticated
+user could send an arbitrary system prompt and an arbitrary `max_tokens`
+against the company's OpenAI key: a general-purpose LLM on our card, with
+no per-user cap, no rate limit, and no record of what was asked or
+answered.
+
+The client now sends a KEY. The prompt text lives here, and a key that is
+not in this registry is refused rather than defaulted — because a default
+would recreate the hole with extra steps.
+
+═══ WHAT THIS TICKET DOES NOT DO ═══
+
+This is CONTAINMENT. The prompts below are ported VERBATIM from
+`frontend/src/services/aiAssistant.ts`. Their content has not been
+touched, and one of them deserves the reader's attention:
+
+    `deed_type_advisor` instructs the model to help a user "select the
+    appropriate deed type for their transaction."
+
+That is instrument selection — the thing the doctrine's whole
+suggest/confirm/record architecture exists to keep in the officer's
+hands, and the thing a non-attorney provider recommending it is most
+exposed on. It has been live, driven by a prompt the CLIENT supplied,
+with no confirmation gate and no record.
+
+Moving it here does not make it safe. It makes it OURS, visible in one
+file, and logged — which is the precondition for ruling on it at all.
+What the assistant may and may not say is a doctrine ruling (the
+explain-yes / select-no boundary), and it is deliberately NOT applied
+here. When it is, this file is where it lands.
+"""
+from typing import Dict, Optional
+
+# The one guardrail that ships with containment, because it costs nothing
+# and its absence is indefensible: every response is prefixed by a
+# standing instruction that the model is not the decider. It does not
+# resolve the UPL question — a disclaimer never has — but a bounded
+# system prompt is strictly better than one the caller writes.
+_STANDING = (
+    "You are assisting a California escrow or title professional who is "
+    "preparing a document. You do not make decisions: the professional "
+    "using this software decides, and their confirmation is what records. "
+    "Never state that a choice has been made or applied. Do not provide "
+    "legal advice."
+)
+
+# Ported verbatim from the client. Content unchanged by ruling — see the
+# module docstring.
+PROMPTS: Dict[str, str] = {
+    "vesting_guidance": (
+        "You are an expert California real estate title officer. Your role is to "
+        "help users understand vesting options when transferring property.\n\n"
+        "Be concise but thorough. Focus on practical implications:\n"
+        "- Tax consequences\n- Estate planning effects\n"
+        "- Rights of survivorship\n- Creditor protection\n\n"
+        "Always recommend consulting with an attorney or tax advisor for complex "
+        "situations.\n\nRespond in 2-3 sentences maximum unless asked for more detail."
+    ),
+    # ⚠️ INSTRUMENT SELECTION — see the module docstring. Ported as-is;
+    # the boundary ruling is pending and lands here.
+    "deed_type_advisor": (
+        "You are an expert California real estate title officer. Your role is to "
+        "help users select the appropriate deed type for their transaction.\n\n"
+        "Consider:\n- Relationship between parties (spouses, family, unrelated)\n"
+        "- Whether consideration is being exchanged\n"
+        "- Documentary Transfer Tax implications\n"
+        "- Title insurance implications\n- Warranties being provided\n\n"
+        "Respond in 2-3 sentences maximum."
+    ),
+    "legal_description_review": (
+        "You are an expert California real estate title officer reviewing a legal "
+        "description.\n\nCheck for:\n"
+        "- Completeness (does it fully describe the parcel?)\n"
+        "- Common errors (missing tract info, incomplete metes and bounds)\n"
+        "- References to recorded documents (are book/page numbers included?)\n"
+        "- Consistency with APN if provided"
+    ),
+    "pre_submit_review": (
+        "You are an expert California real estate title officer doing a final "
+        "review before a deed is generated.\n\nCheck for:\n"
+        "- Consistency between all fields\n"
+        "- Common errors (single grantee with joint tenancy vesting)\n"
+        "- Missing required information\n- DTT calculation accuracy\n"
+        "- Proper party naming conventions\n\n"
+        "List any issues found. If everything looks good, say so briefly."
+    ),
+    "general_assistant": (
+        "You are an expert California real estate title officer assistant in "
+        "DeedPro, a deed generation application.\n\nAnswer questions about:\n"
+        "- California deed types (Grant, Quitclaim, Interspousal, Warranty, Tax)\n"
+        "- Vesting options and implications\n"
+        "- Documentary Transfer Tax rules and exemptions\n"
+        "- Legal descriptions\n- Recording requirements\n\n"
+        "Be concise, accurate, and helpful. If something requires legal advice, "
+        "recommend consulting an attorney."
+    ),
+}
+
+# Per-key output ceilings. The client used to name its own `max_tokens`
+# with no upper bound; these are the values the client actually asked for,
+# now enforced rather than requested.
+MAX_TOKENS: Dict[str, int] = {
+    "vesting_guidance": 300,
+    "deed_type_advisor": 300,
+    "legal_description_review": 400,
+    "pre_submit_review": 500,
+    "general_assistant": 600,
+}
+
+# Absolute ceiling regardless of key — the backstop if a future key is
+# added without a MAX_TOKENS entry.
+HARD_MAX_TOKENS = 800
+
+
+class UnknownPromptKey(Exception):
+    """A key we do not publish. Refused, never defaulted."""
+
+
+def system_prompt(key: str) -> str:
+    if key not in PROMPTS:
+        raise UnknownPromptKey(key)
+    return f"{_STANDING}\n\n{PROMPTS[key]}"
+
+
+def max_tokens_for(key: str, requested: Optional[int] = None) -> int:
+    """The lower of what the caller wants and what the key allows.
+
+    A caller may ask for LESS (a short answer is cheap and fine); it may
+    never ask for more, which is the direction the old endpoint allowed.
+    """
+    ceiling = min(MAX_TOKENS.get(key, HARD_MAX_TOKENS), HARD_MAX_TOKENS)
+    if requested is None or requested <= 0:
+        return ceiling
+    return min(requested, ceiling)

--- a/backend/tests/test_red_h1_ai_containment.py
+++ b/backend/tests/test_red_h1_ai_containment.py
@@ -1,0 +1,172 @@
+"""RED-H1.3 — the AI endpoint is bounded, metered, and on the record.
+
+The endpoint accepted `system` and `max_tokens` from the caller. That is
+a general-purpose LLM on the company's OpenAI key, available to any
+authenticated user including a free-plan one, with no per-user ceiling,
+no rate limit, no spend attribution and no record of what was said.
+
+These pins guard the four containments, and the direction each would
+break in:
+
+  1. The client can no longer supply prompt TEXT — only a key, and only a
+     key the server publishes. The failure mode to guard is a DEFAULT: an
+     unknown key that quietly falls back to a general prompt rebuilds the
+     hole with extra steps, so an unknown key must be refused.
+  2. `max_tokens` is a ceiling, not a request. A caller may ask for less.
+  3. A per-user daily quota exists at all.
+  4. Every exchange is logged — the one that makes the UPL question
+     answerable, because a hundred real exchanges cannot be reviewed
+     until a hundred real exchanges are recorded somewhere.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+BACKEND = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(BACKEND))
+
+from services import ai_prompts  # noqa: E402
+from tests.source_text import code_only  # noqa: E402
+
+
+# ── 1. The server owns the prompts ────────────────────────────────────
+
+
+def test_the_request_model_no_longer_accepts_a_system_prompt():
+    """THE containment. If `system` returns to the request model, the
+    endpoint is a free LLM again."""
+    src = code_only((BACKEND / "api" / "ai_assist.py").read_text(encoding="utf-8"))
+    assert "prompt_key" in src
+    assert "request.system" not in src
+    assert "system: str" not in src
+
+
+def test_an_unknown_key_is_refused_rather_than_defaulted():
+    with pytest.raises(ai_prompts.UnknownPromptKey):
+        ai_prompts.system_prompt("anything_else")
+
+
+def test_no_prompt_key_falls_back_to_a_general_prompt():
+    """A `.get(key, PROMPTS['general_assistant'])` would pass the test
+    above's sibling and still be the bug."""
+    src = code_only((BACKEND / "services" / "ai_prompts.py").read_text(encoding="utf-8"))
+    assert "PROMPTS.get(" not in src
+
+
+@pytest.mark.parametrize("key", [
+    "vesting_guidance", "deed_type_advisor", "legal_description_review",
+    "pre_submit_review", "general_assistant",
+])
+def test_every_key_the_client_sends_exists_on_the_server(key):
+    assert key in ai_prompts.PROMPTS
+    assert ai_prompts.system_prompt(key)
+
+
+def test_the_client_sends_keys_and_holds_no_prompt_text():
+    """The other half: the browser bundle must not still carry the
+    prompts, or someone will wire them back into a request body."""
+    src = (BACKEND.parent / "frontend" / "src" / "services" / "aiAssistant.ts").read_text(encoding="utf-8")
+    assert "PROMPT_KEYS" in src
+    assert "SYSTEM_PROMPTS" not in src
+    assert "prompt_key:" in src
+    # The instruction text itself is gone, not merely renamed.
+    assert "You are an expert California real estate title officer" not in src
+
+
+def test_the_proxy_route_forwards_a_key_not_prose():
+    src = (BACKEND.parent / "frontend" / "src" / "app" / "api" / "ai" / "chat" / "route.ts").read_text(encoding="utf-8")
+    code = src.replace("/*", "\n/*")  # keep the comment-stripping honest
+    import re
+    code = re.sub(r"/\*.*?\*/", "", code, flags=re.DOTALL)
+    code = re.sub(r"^\s*//.*$", "", code, flags=re.MULTILINE)
+    assert "prompt_key: body.prompt_key" in code
+    assert "system:" not in code
+
+
+def test_every_prompt_carries_the_standing_not_the_decider_instruction():
+    for key in ai_prompts.PROMPTS:
+        assert "You do not make decisions" in ai_prompts.system_prompt(key)
+
+
+def test_the_instrument_selection_prompt_is_flagged_where_it_lives():
+    """`deed_type_advisor` instructs the model to help SELECT a deed
+    type. Containment does not fix that — the boundary ruling does — but
+    the next reader must not have to discover it."""
+    raw = (BACKEND / "services" / "ai_prompts.py").read_text(encoding="utf-8")
+    assert "deed_type_advisor" in raw
+    assert "instrument selection" in raw.lower()
+
+
+# ── 2. max_tokens is a ceiling ────────────────────────────────────────
+
+
+def test_a_caller_cannot_raise_the_ceiling():
+    assert ai_prompts.max_tokens_for("vesting_guidance", 99999) == 300
+
+
+def test_a_caller_may_lower_it():
+    assert ai_prompts.max_tokens_for("general_assistant", 50) == 50
+
+
+def test_omitting_it_uses_the_key_ceiling():
+    assert ai_prompts.max_tokens_for("general_assistant") == 600
+
+
+def test_an_unlisted_key_still_cannot_exceed_the_hard_cap():
+    """The backstop for a future key added without a MAX_TOKENS entry."""
+    assert ai_prompts.max_tokens_for("not_listed", 99999) == ai_prompts.HARD_MAX_TOKENS
+
+
+def test_the_hard_cap_is_bounded():
+    assert 0 < ai_prompts.HARD_MAX_TOKENS <= 2000
+    for key, limit in ai_prompts.MAX_TOKENS.items():
+        assert limit <= ai_prompts.HARD_MAX_TOKENS, key
+
+
+# ── 3 & 4. Quota, tagging, and the record ─────────────────────────────
+
+
+def test_the_endpoint_meters_per_user_and_refuses_with_429():
+    src = code_only((BACKEND / "api" / "ai_assist.py").read_text(encoding="utf-8"))
+    assert "DAILY_EXCHANGE_LIMIT" in src
+    assert "_exchanges_today" in src
+    assert "status_code=429" in src
+
+
+def test_the_quota_counts_from_the_log_rather_than_memory():
+    """A per-process counter resets on deploy and does not survive two
+    workers; the log is the only thing that actually counts."""
+    src = code_only((BACKEND / "api" / "ai_assist.py").read_text(encoding="utf-8"))
+    assert "FROM ai_exchange_log" in src
+
+
+def test_requests_are_tagged_so_spend_is_attributable():
+    src = code_only((BACKEND / "api" / "ai_assist.py").read_text(encoding="utf-8"))
+    assert "request_tag" in src
+    assert '"user": request_tag' in src
+
+
+def test_every_outcome_is_logged_including_the_failures():
+    """A log that records only successes cannot answer "what did it tell
+    her" for the case where something went wrong."""
+    src = code_only((BACKEND / "api" / "ai_assist.py").read_text(encoding="utf-8"))
+    for status in ('"ok"', '"error"', '"quota"'):
+        assert f"{status}," in src or f", {status}" in src, status
+
+
+def test_a_logging_failure_never_breaks_the_response():
+    src = code_only((BACKEND / "api" / "ai_assist.py").read_text(encoding="utf-8"))
+    fn = src[src.index("def _log_exchange"):src.index("def _exchanges_today")]
+    assert "except Exception" in fn
+    assert "FAILED TO LOG EXCHANGE" in fn
+
+
+def test_the_log_table_is_in_the_one_schema_authority():
+    """H1's rule: schema comes from create_tables() and nowhere else, so
+    a column can never exist in tests but not production."""
+    schema = (BACKEND / "database.py").read_text(encoding="utf-8")
+    assert "CREATE TABLE IF NOT EXISTS ai_exchange_log" in schema
+    for col in ["user_id", "prompt_key", "user_message", "response",
+                "request_tag", "status"]:
+        assert col in schema.split("ai_exchange_log")[1][:800], col

--- a/frontend/src/app/api/ai/chat/route.ts
+++ b/frontend/src/app/api/ai/chat/route.ts
@@ -30,10 +30,15 @@ export async function POST(request: NextRequest) {
         "Content-Type": "application/json",
         ...(authHeader ? { Authorization: authHeader } : {}),
       },
+      // RED-H1.3: forwards a prompt_key, never prompt text. This proxy
+      // used to pass `system` straight through, which is how a
+      // client-supplied system prompt reached OpenAI on our key. Passing
+      // it now would simply be rejected by the backend, but the field is
+      // gone from here too so nothing re-learns the old shape.
       body: JSON.stringify({
-        system: body.system || "",
+        prompt_key: body.prompt_key,
         message: body.message,
-        max_tokens: body.max_tokens || 400,
+        max_tokens: body.max_tokens || undefined,
       }),
     })
 

--- a/frontend/src/services/aiAssistant.ts
+++ b/frontend/src/services/aiAssistant.ts
@@ -39,62 +39,28 @@ export interface AIValidation {
 }
 
 // System prompts for different AI tasks
-const SYSTEM_PROMPTS = {
-  vestingGuidance: `You are an expert California real estate title officer. Your role is to help users understand vesting options when transferring property.
+/**
+ * RED-H1.3 — the prompt TEXT moved to the server.
+ *
+ * These were full system prompts sent in the request body. The endpoint
+ * used whatever the client supplied, which meant any authenticated user
+ * could POST an arbitrary system prompt and an arbitrary max_tokens
+ * against the company's OpenAI key.
+ *
+ * What travels now is a KEY. The server owns the text
+ * (backend/services/ai_prompts.py), owns the token ceiling, meters per
+ * user, and logs every exchange. An unknown key is refused, not
+ * defaulted.
+ */
+const PROMPT_KEYS = {
+  vestingGuidance: 'vesting_guidance',
+  deedTypeAdvisor: 'deed_type_advisor',
+  legalDescriptionReview: 'legal_description_review',
+  preSubmitReview: 'pre_submit_review',
+  generalAssistant: 'general_assistant',
+} as const
 
-Be concise but thorough. Focus on practical implications:
-- Tax consequences
-- Estate planning effects
-- Rights of survivorship
-- Creditor protection
-
-Always recommend consulting with an attorney or tax advisor for complex situations.
-
-Respond in 2-3 sentences maximum unless asked for more detail.`,
-
-  deedTypeAdvisor: `You are an expert California real estate title officer. Your role is to help users select the appropriate deed type for their transaction.
-
-Consider:
-- Relationship between parties (spouses, family, unrelated)
-- Whether consideration is being exchanged
-- Documentary Transfer Tax implications
-- Title insurance implications
-- Warranties being provided
-
-Respond in 2-3 sentences maximum.`,
-
-  legalDescriptionReview: `You are an expert California real estate title officer reviewing a legal description.
-
-Check for:
-- Completeness (does it fully describe the parcel?)
-- Common errors (missing tract info, incomplete metes and bounds)
-- References to recorded documents (are book/page numbers included?)
-- Consistency with APN if provided
-
-Flag any concerns concisely.`,
-
-  preSubmitReview: `You are an expert California real estate title officer doing a final review before a deed is generated.
-
-Check for:
-- Consistency between all fields
-- Common errors (single grantee with joint tenancy vesting)
-- Missing required information
-- DTT calculation accuracy
-- Proper party naming conventions
-
-List any issues found. If everything looks good, say so briefly.`,
-
-  generalAssistant: `You are an expert California real estate title officer assistant in DeedPro, a deed generation application.
-
-Answer questions about:
-- California deed types (Grant, Quitclaim, Interspousal, Warranty, Tax)
-- Vesting options and implications
-- Documentary Transfer Tax rules and exemptions
-- Legal descriptions
-- Recording requirements
-
-Be concise, accurate, and helpful. If something requires legal advice, recommend consulting an attorney.`,
-}
+type PromptKey = (typeof PROMPT_KEYS)[keyof typeof PROMPT_KEYS]
 
 class AIAssistantService {
   private apiKey: string | null = null
@@ -118,7 +84,7 @@ class AIAssistantService {
    * Make an AI request through the backend proxy
    */
   private async makeRequest(
-    systemPrompt: string,
+    promptKey: PromptKey,
     userPrompt: string,
     maxTokens: number = 400
   ): Promise<string> {
@@ -137,7 +103,7 @@ class AIAssistantService {
           ...(token ? { Authorization: `Bearer ${token}` } : {}),
         },
         body: JSON.stringify({
-          system: systemPrompt,
+          prompt_key: promptKey,
           message: userPrompt,
           max_tokens: maxTokens,
         }),
@@ -171,7 +137,7 @@ Briefly explain what this vesting means and flag any concerns (e.g., if joint te
 
     try {
       const response = await this.makeRequest(
-        SYSTEM_PROMPTS.vestingGuidance,
+        PROMPT_KEYS.vestingGuidance,
         prompt,
         300
       )
@@ -217,7 +183,7 @@ Is ${context.currentDeedType} the best choice? If not, what would you recommend 
 
     try {
       const response = await this.makeRequest(
-        SYSTEM_PROMPTS.deedTypeAdvisor,
+        PROMPT_KEYS.deedTypeAdvisor,
         prompt,
         300
       )
@@ -263,7 +229,7 @@ Flag any concerns about completeness or accuracy.`
 
     try {
       const response = await this.makeRequest(
-        SYSTEM_PROMPTS.legalDescriptionReview,
+        PROMPT_KEYS.legalDescriptionReview,
         prompt,
         400
       )
@@ -315,7 +281,7 @@ List any issues or concerns. If everything looks correct, say "No issues found."
 
     try {
       const response = await this.makeRequest(
-        SYSTEM_PROMPTS.preSubmitReview,
+        PROMPT_KEYS.preSubmitReview,
         prompt,
         500
       )
@@ -350,14 +316,19 @@ List any issues or concerns. If everything looks correct, say "No issues found."
    * Answer a user question about deeds/title
    */
   async askQuestion(question: string, context: Partial<AIContext>): Promise<string> {
-    const systemPrompt = `${SYSTEM_PROMPTS.generalAssistant}
+    // RED-H1.3: the file context used to be appended to the SYSTEM
+    // prompt. It belongs in the user message — context is data the
+    // officer is working with, not an instruction about how the model
+    // should behave, and the system prompt is no longer the client's to
+    // write in any case.
+    const withContext = `${question}
 
 Current context:
 - Deed Type: ${context.deedType || "Not selected"}
 - County: ${context.county || "Not specified"}`
 
     try {
-      const response = await this.makeRequest(systemPrompt, question, 600)
+      const response = await this.makeRequest(PROMPT_KEYS.generalAssistant, withContext, 600)
       return response
     } catch (error) {
       console.error("AI question error:", error)
@@ -381,7 +352,7 @@ Is this exemption likely valid? What documentation might they need?`
 
     try {
       const response = await this.makeRequest(
-        SYSTEM_PROMPTS.generalAssistant,
+        PROMPT_KEYS.generalAssistant,
         prompt,
         300
       )


### PR DESCRIPTION
> **Stacked on #127.** Retargets to `main` when that merges. Both touch `database.py`.

## What the endpoint was

```python
{"role": "system", "content": request.system or "..."}
"max_tokens": request.max_tokens
```

The **caller** supplied the system prompt and the token ceiling. Any authenticated user — including a free-plan one — could POST an arbitrary system prompt with an arbitrary `max_tokens` and use the company's OpenAI account as a general-purpose LLM. No per-user quota, no rate limit, no request tagging (so spend couldn't be attributed to anyone), and **no record of what was asked or answered**.

The last one is the serious one, and it isn't a cost problem.

This product is suggest → confirm → record, and every doctrine rule governs **data**. This endpoint emits **prose** to an escrow officer inside a deed builder — the largest legal-influence surface in the product — with none of the three. The confirmation trail could prove exactly what data she accepted, and nothing about what the machine told her first.

## The four containments

1. **Prompt text moved server-side** to `services/ai_prompts.py`. The client sends a key. An unknown key is **refused, not defaulted** — a fallback would rebuild the hole with extra steps, and a test pins that no `PROMPTS.get(key, default)` appears.
2. **`max_tokens` is a ceiling, not a request.** A caller may ask for less; it can no longer ask for more. A hard cap backstops any future key added without its own limit.
3. **Per-user daily quota**, counted **from the log** rather than memory — a process counter resets on deploy and doesn't survive two workers.
4. **Every exchange logged** to `ai_exchange_log`. Failures too: a log with only successes can't answer *"what did it tell her"* for the case that went wrong. A logging failure is loud but never denies an officer mid-file an answer we already have.

Also: `askQuestion` appended file context to the **system** prompt. Context is data the officer is working with, not an instruction about how the model behaves — it moved to the user message.

## What this deliberately does NOT do

Rule on what the assistant may **say**.

`deed_type_advisor` instructs the model to help *"select the appropriate deed type for their transaction."* That is **instrument selection** — the exact thing suggest/confirm/record exists to keep in the officer's hands, and it has been live, driven by a prompt the *client* supplied, with no gate and no record.

It is ported **verbatim** and flagged in source with a test pinning the flag. Moving it here doesn't make it safe; it makes it **ours, visible in one file, and logged** — which is the precondition for ruling on it. The boundary could not be ruled on evidence that did not exist.

## Gates

| gate | result |
|---|---|
| backend pytest | **546 passed** (+23) |
| jest | 487, 34 suites |
| tsc | 94 — unchanged (the 3 in `aiAssistant.ts` are pre-existing) |
| six-flow | ✔ verify |
| API baseline | ✔ verify |
| banned-claims | ✔ clean |
| `next build` | ✔ |

Six-flow matters here — the schema gained a table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_