### PR TITLE
refactor(tests): one source-text helper per language, and a meta-pin that keeps it that way

### DIFF
--- a/backend/tests/source_text.py
+++ b/backend/tests/source_text.py
@@ -2,7 +2,7 @@
 
 ═══ WHY THIS FILE EXISTS ═══
 
-Six times now, a forbidden-pattern pin has failed on the comment
+EIGHT times now, a forbidden-pattern pin has failed on the comment
 EXPLAINING the removal it was guarding. The shape is always the same:
 
     # This used to apply a generic $2.20 to any city at all.
@@ -11,48 +11,134 @@ EXPLAINING the removal it was guarding. The shape is always the same:
 
 The pin is right, the code is right, and the test fails because prose
 that describes a defect necessarily quotes it. Every occurrence got its
-own local `code_only()`/AST-strip, and by T-2 there were four of them in
-this directory with slightly different behaviour — one stripped comments
-but not docstrings, which is exactly how the sixth trip happened.
+own local strip, and by T-2 there were four of them in this directory
+with slightly different behaviour — one stripped comments but not
+docstrings, which is exactly how the sixth trip happened.
 
-Owner-ruled into T-3. One helper, one behaviour: docstrings AND comments
-removed, code preserved verbatim.
+T-3 consolidated the Python side. The eighth trip (RED-H1.4, on a
+comment recording an `OPENAI_AVAILABLE` removal) cost one import instead
+of a debugging session, which is the argument for this file.
+
+═══ WHAT CHANGED, AND WHY THE OLD VERSION WAS NOT ENOUGH ═══
+
+The first implementation did:
+
+    for node in ast.walk(tree):
+        doc = ast.get_docstring(node)
+        if doc:
+            src = src.replace(doc, "")     # <- text replace
+
+That is a substring replace over the WHOLE FILE. Two consequences:
+
+  1. If a docstring's text also appears in code — a SQL fragment, an
+     error message, a status literal — the replace deletes it THERE too,
+     and a pin then passes because the thing it was guarding vanished
+     from the text it searched. A pin that passes for the wrong reason is
+     worse than one that fails.
+  2. It removed the docstring's CONTENT but left its quotes, and took the
+     newlines with it, so every line number below shifted and a failure
+     message pointed at the wrong line.
+
+It also only stripped comments on lines that START with `#`, so a
+trailing `x = 1  # ...` survived and could trip a pin.
+
+This version tokenizes. `tokenize` knows which `#` is a comment and which
+is inside a string, and it reports exact positions, so comments and
+docstrings are blanked IN PLACE. Line and column numbers survive.
+
+Same lesson as everywhere else in this project, in its narrowest form:
+match STATEMENTS, not strings. A tokenizer knows what a comment is; a
+pattern only knows what one looks like.
 
 ═══ WHAT IT DOES NOT DO ═══
 
-It does not strip string literals. A pin searching for a value that
-legitimately appears in a STRING (an error message, a SQL fragment) is
-asking a different question and should say so at the call site.
+It does not strip ordinary string literals. A pin searching for a value
+that legitimately appears in a STRING (an error message, a SQL fragment)
+is asking a different question and should say so at the call site.
 """
-import ast
+import io
+import tokenize
 from pathlib import Path
 from typing import Union
 
 
-def code_only(source: Union[str, Path]) -> str:
-    """Return `source` with docstrings and `#` comments removed.
+def _blank_span(lines, start, end):
+    """Replace the source between two (row, col) points with spaces,
+    keeping newlines so every later position stays where it was."""
+    srow, scol = start
+    erow, ecol = end
+    if srow == erow:
+        line = lines[srow - 1]
+        lines[srow - 1] = line[:scol] + " " * (ecol - scol) + line[ecol:]
+        return
+    first = lines[srow - 1]
+    lines[srow - 1] = first[:scol] + " " * (len(first) - scol)
+    for row in range(srow + 1, erow):
+        lines[row - 1] = " " * len(lines[row - 1])
+    last = lines[erow - 1]
+    lines[erow - 1] = " " * ecol + last[ecol:]
 
-    Accepts a path or the source text itself. Line structure is
-    preserved for comments (the line becomes empty rather than
-    disappearing), so a failure message's line numbers stay usable.
+
+def code_only(source: Union[str, Path]) -> str:
+    """Return `source` with docstrings and `#` comments blanked out.
+
+    Accepts a path or the source text itself. Positions are preserved:
+    a comment becomes spaces, not nothing, so `line N` in a failure
+    message still refers to line N of the real file.
+
+    Falls back to the raw text if the source does not tokenize — a test
+    helper must never turn a syntax error into a confusing assertion
+    failure somewhere else.
     """
     src = Path(source).read_text(encoding="utf-8") if isinstance(source, Path) else source
 
-    # Docstrings first: they are the half that the pre-T-3 comment-only
-    # variants missed.
-    try:
-        tree = ast.parse(src)
-    except SyntaxError:
-        tree = None
-    if tree is not None:
-        for node in ast.walk(tree):
-            if isinstance(node, (ast.Module, ast.FunctionDef,
-                                 ast.AsyncFunctionDef, ast.ClassDef)):
-                doc = ast.get_docstring(node, clean=False)
-                if doc:
-                    src = src.replace(doc, "")
+    # keepends so column offsets line up with the original exactly.
+    lines = src.splitlines(keepends=True)
+    if not lines:
+        return src
 
-    return "\n".join(
-        "" if line.lstrip().startswith("#") else line
-        for line in src.splitlines()
-    )
+    try:
+        tokens = list(tokenize.generate_tokens(io.StringIO(src).readline))
+    except (tokenize.TokenError, IndentationError, SyntaxError):
+        return src
+
+    # A STRING token is a docstring when it is the first meaningful token
+    # of a logical line — which covers module, class and function
+    # docstrings AND the bare string-expression case, without ast's
+    # node walk or its whole-file text replace.
+    at_statement_start = True
+    spans = []
+    for tok in tokens:
+        if tok.type == tokenize.COMMENT:
+            spans.append((tok.start, tok.end))
+            continue
+        if tok.type in (tokenize.NL, tokenize.NEWLINE, tokenize.INDENT,
+                        tokenize.DEDENT, tokenize.ENCODING):
+            # ONLY the logical NEWLINE starts a new statement. NL is the
+            # non-logical newline tokenize emits INSIDE brackets, and
+            # treating it as a statement boundary was a real bug caught
+            # by the existing suite: in
+            #
+            #     for stmt in [
+            #         \"\"\"CREATE TABLE ...\"\"\",
+            #
+            # the SQL follows `[` + NL, so resetting here marked it a
+            # docstring and blanked the entire schema out of database.py.
+            # Ten pins failed at once — the over-stripping direction,
+            # which is the one that makes pins pass for the wrong reason.
+            if tok.type == tokenize.NEWLINE:
+                at_statement_start = True
+            continue
+        if tok.type == tokenize.STRING and at_statement_start:
+            spans.append((tok.start, tok.end))
+        at_statement_start = False
+
+    for start, end in reversed(spans):
+        _blank_span(lines, start, end)
+
+    return "".join(lines)
+
+
+def read_code(*segments: str) -> str:
+    """Read a file relative to `backend/` and return it as code only."""
+    return code_only(Path(__file__).resolve().parent.parent.joinpath(*segments))

--- a/backend/tests/test_admin_serializer_contract.py
+++ b/backend/tests/test_admin_serializer_contract.py
@@ -31,6 +31,7 @@ import json
 import os
 
 import pytest
+from tests.source_text import code_only
 
 LIVE_DB = os.getenv("DATABASE_URL")
 pytestmark = pytest.mark.skipif(not LIVE_DB, reason="live test DB required")
@@ -156,7 +157,7 @@ def test_the_mock_half_of_the_split_is_deleted():
     """The deleted endpoints emitted a per-user monthly_revenue from
     hardcoded prices, `shared_deeds: 0`, and an empty `activity_log`."""
     from pathlib import Path
-    src = (Path(__file__).resolve().parents[1] / "routers/admin_inline.py").read_text()
+    src = code_only(Path(__file__).resolve().parents[1] / "routers/admin_inline.py")
     assert "TODO: Implement activity tracking table" not in src
     assert "TODO: Implement when shared_deeds table exists" not in src
 

--- a/backend/tests/test_api_key_requests.py
+++ b/backend/tests/test_api_key_requests.py
@@ -14,6 +14,7 @@ import os
 from unittest.mock import patch
 
 import pytest
+from tests.source_text import code_only
 
 LIVE_DB = os.getenv("DATABASE_URL")
 
@@ -58,7 +59,7 @@ def test_admin_queue_requires_admin():
 
 def test_request_table_is_in_the_schema_authority():
     from pathlib import Path
-    schema = (Path(__file__).resolve().parents[1] / "database.py").read_text(encoding="utf-8")
+    schema = code_only(Path(__file__).resolve().parents[1] / "database.py")
     assert "CREATE TABLE IF NOT EXISTS api_key_requests" in schema
 
 

--- a/backend/tests/test_api_v1_structure.py
+++ b/backend/tests/test_api_v1_structure.py
@@ -8,12 +8,13 @@ everywhere.
 import inspect
 import re
 from pathlib import Path
+from tests.source_text import code_only
 
 BACKEND = Path(__file__).resolve().parents[1]
 
 
 def _router_src():
-    return (BACKEND / "routers/api_v1/router.py").read_text(encoding="utf-8")
+    return code_only(BACKEND / "routers/api_v1/router.py")
 
 
 # ── The two defects that shipped and never ran ───────────────────────
@@ -61,7 +62,7 @@ def test_create_accepts_and_replays_idempotency_key():
     src = _router_src()
     assert 'alias="Idempotency-Key"' in src
     assert "WHERE api_key_id = %s AND idempotency_key = %s" in src
-    schema = (BACKEND / "database.py").read_text(encoding="utf-8")
+    schema = code_only(BACKEND / "database.py")
     assert "uq_api_deeds_idempotency" in schema, "replay needs the unique index"
 
 
@@ -70,7 +71,7 @@ def test_create_accepts_and_replays_idempotency_key():
 def test_api_tables_live_in_the_schema_authority():
     """The mounted /api/v1 depended on tables that existed only in
     hand-run migration files. H1: create_tables is the one authority."""
-    schema = (BACKEND / "database.py").read_text(encoding="utf-8")
+    schema = code_only(BACKEND / "database.py")
     for table in ["api_keys", "api_deeds", "api_usage_log", "api_rate_limits",
                   "document_authenticity", "notifications", "user_notifications"]:
         assert f"CREATE TABLE IF NOT EXISTS {table}" in schema, table
@@ -80,7 +81,7 @@ def test_lock_taking_ddl_is_guarded():
     """Schema convergence runs in a daemon thread while the app serves
     traffic. Unguarded ALTERs on FK-referenced tables take ACCESS
     EXCLUSIVE and deadlock against in-flight requests."""
-    schema = (BACKEND / "database.py").read_text(encoding="utf-8")
+    schema = code_only(BACKEND / "database.py")
     assert "ALTER TABLE api_keys ALTER COLUMN company DROP NOT NULL;" in schema
     assert "is_nullable = 'NO'" in schema, "the DROP NOT NULL must stay guarded"
 

--- a/backend/tests/test_db_row_contract.py
+++ b/backend/tests/test_db_row_contract.py
@@ -22,6 +22,7 @@ import re
 from pathlib import Path
 
 import pytest
+from tests.source_text import code_only
 
 BACKEND = Path(__file__).resolve().parents[1]
 SKIP_DIRS = {"tests", "migrations", "scripts", "__pycache__"}
@@ -41,7 +42,7 @@ def test_exactly_one_row_factory_is_declared():
     for path in _source_files():
         if path.name == "db_rows.py":
             continue
-        src = path.read_text(encoding="utf-8", errors="ignore")
+        src = code_only(path.read_text(encoding="utf-8", errors="ignore"))
         if "cursor_factory=" in src and "ROW_FACTORY" not in src:
             offenders.append(str(path.relative_to(BACKEND)))
         if re.search(r"cursor_factory\s*=\s*RealDictCursor", src):
@@ -69,7 +70,7 @@ def test_no_third_connection_helper():
     for path in _source_files():
         if path.name in {"database.py", "db.py"}:
             continue
-        src = path.read_text(encoding="utf-8", errors="ignore")
+        src = code_only(path.read_text(encoding="utf-8", errors="ignore"))
         if re.search(r"^def get_db_connection\(", src, re.M):
             definers.append(str(path.relative_to(BACKEND)))
     assert definers == [], f"additional connection helpers: {definers}"
@@ -162,7 +163,7 @@ def test_rows_are_never_returned_raw_from_an_endpoint():
     that the original pattern list missed."""
     offenders = []
     for path in (BACKEND / "routers").rglob("*.py"):
-        src = path.read_text(encoding="utf-8", errors="ignore")
+        src = code_only(path.read_text(encoding="utf-8", errors="ignore"))
         for pattern in [r"return\s+cur(?:sor)?\.fetch(?:one|all)\(\)",
                         r"return\s+\[?\s*dict\(r\)\s+for", ]:
             if re.search(pattern, src):

--- a/backend/tests/test_email_system.py
+++ b/backend/tests/test_email_system.py
@@ -40,6 +40,7 @@ from pathlib import Path
 import pytest
 
 from utils import email_templates
+from tests.source_text import code_only
 
 BACKEND = Path(__file__).resolve().parents[1]
 SNAP_DIR = Path(__file__).resolve().parent / "snapshots" / "emails"
@@ -136,7 +137,7 @@ def test_forbidden_strings_not_in_sender_source():
     for rel in ["utils/email_templates.py", "utils/notifications.py",
                 "utils/email.py", "routers/sharing.py", "routers/auth_extra.py",
                 "routers/deeds_crud.py", "routers/users_auth.py"]:
-        src = (BACKEND / rel).read_text(encoding="utf-8").lower()
+        src = code_only(BACKEND / rel).lower()
         for phrase in FORBIDDEN:
             assert phrase.lower() not in src, f"{rel} contains removed-for-cause copy: {phrase!r}"
 
@@ -172,7 +173,7 @@ def test_bodies_never_carry_full_address_or_legal_description():
     for name, (subject, html, text) in _samples().items():
         for part in (html, text):
             assert "Los Angeles, CA 90001" not in part, f"{name}: full address in body"
-    src = (BACKEND / "utils/email_templates.py").read_text(encoding="utf-8")
+    src = code_only(BACKEND / "utils/email_templates.py")
     assert "legal_description" not in src, "templates must never touch legal descriptions"
 
 
@@ -190,7 +191,7 @@ def test_sendgrid_client_touched_only_by_the_one_transport():
     for path in BACKEND.rglob("*.py"):
         if "tests" in path.parts or path.name == "email.py":
             continue
-        if "SendGridAPIClient" in path.read_text(encoding="utf-8", errors="ignore"):
+        if "SendGridAPIClient" in code_only(path.read_text(encoding="utf-8", errors="ignore")):
             offenders.append(str(path.relative_to(BACKEND)))
     assert offenders == [], f"second transport detected: {offenders}"
 

--- a/backend/tests/test_source_text_helper.py
+++ b/backend/tests/test_source_text_helper.py
@@ -1,0 +1,169 @@
+"""The source-text helper, pinned — including the bugs it replaces.
+
+A helper that every forbidden-pattern pin depends on is load-bearing in
+an unusual way: if it strips too much, pins pass for the wrong reason
+and the thing they guard can walk out of the codebase unnoticed. That
+failure is silent, which is why the over-stripping cases below matter
+more than the under-stripping ones.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+BACKEND = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(BACKEND))
+
+from tests.source_text import code_only, read_code  # noqa: E402
+
+
+# ── It removes prose ──────────────────────────────────────────────────
+
+
+def test_a_line_comment_goes():
+    assert "2.20" not in code_only('# a generic $2.20 rate\nx = 1\n')
+
+
+def test_a_TRAILING_comment_goes():
+    """The old version only handled comments that START a line."""
+    assert "2.20" not in code_only('x = 1  # the old $2.20 fallback\n')
+
+
+def test_a_module_docstring_goes():
+    assert "SOC 2" not in code_only('"""We used to claim SOC 2."""\nx = 1\n')
+
+
+def test_a_function_docstring_goes():
+    src = 'def f():\n    """The old $2.20 default lived here."""\n    return 1\n'
+    assert "2.20" not in code_only(src)
+
+
+def test_a_class_docstring_goes():
+    src = 'class C:\n    """Removed: SOC 2 Compliant."""\n    x = 1\n'
+    assert "SOC 2" not in code_only(src)
+
+
+# ── ...and nothing else. These are the dangerous direction. ───────────
+
+
+def test_code_survives_verbatim():
+    src = 'RATE = 2.20\nURL = "https://api.example.com/v1"\n'
+    assert code_only(src) == src
+
+
+def test_a_hash_inside_a_string_is_not_a_comment():
+    src = 'anchor = "#integrations"\n'
+    assert code_only(src) == src
+
+
+def test_a_docstring_whose_text_also_appears_in_code_does_not_delete_the_code():
+    """THE bug in the previous implementation.
+
+    `src.replace(doc, "")` is a whole-file substring replace, so a
+    docstring mentioning a value scrubbed that value out of the CODE
+    too — and the pin guarding it then passed with nothing left to
+    guard."""
+    src = (
+        'def f():\n'
+        '    """Status is superseded."""\n'
+        '    return "superseded"\n'
+    )
+    out = code_only(src)
+    assert 'return "superseded"' in out, "the real statement was deleted"
+    assert out.count("superseded") == 1, "only the docstring should go"
+
+
+def test_a_multiline_string_inside_a_list_is_not_a_docstring():
+    """The over-strip this helper shipped with for exactly one run.
+
+    `tokenize` emits NL (not NEWLINE) for newlines INSIDE brackets, and
+    treating NL as a statement boundary made every multi-line string in
+    a list literal look like a docstring — which blanked the entire
+    schema out of database.py and failed ten pins at once.
+
+    Ten LOUD failures were lucky. The same bug over a file whose pins
+    only assert absence would have passed silently, with nothing left to
+    guard.
+    """
+    src = (
+        'STATEMENTS = [\n'
+        '    """CREATE TABLE deeds (id SERIAL)""",\n'
+        '    "ALTER TABLE deeds ADD COLUMN superseded_by INTEGER",\n'
+        ']\n'
+    )
+    out = code_only(src)
+    assert "CREATE TABLE deeds" in out
+    assert "superseded_by" in out
+
+
+def test_a_multiline_string_passed_to_a_call_is_not_a_docstring():
+    src = 'cur.execute("""\n    SELECT pdf_data FROM deed_pdfs\n""")\n'
+    assert "deed_pdfs" in code_only(src)
+
+
+def test_line_numbers_do_not_move():
+    src = 'a = 1\n\n\n# a comment\n"""doc"""\nb = 2\n'
+    out = code_only(src)
+    assert len(out.splitlines()) == len(src.splitlines())
+    assert out.splitlines()[5] == "b = 2"
+
+
+def test_unparseable_source_is_returned_unchanged():
+    src = "def broken(:\n"
+    assert code_only(src) == src
+
+
+def test_it_accepts_a_path_as_well_as_text():
+    assert "import" in read_code("tests", "source_text.py") or True
+    out = code_only(BACKEND / "tests" / "source_text.py")
+    # Its own docstring is prose and must be gone from its own output.
+    assert "EIGHT times now" not in out
+    assert "def code_only" in out
+
+
+# ── The meta-pin ──────────────────────────────────────────────────────
+
+SUITE = BACKEND / "tests"
+
+# Files that legitimately read RAW text, each with a reason. A pin about
+# ENCODING or about a comment's presence is asking about the bytes, not
+# about the code, and must not be forced through the helper.
+RAW_TEXT_ALLOWED = {
+    "test_red_h1_requirements.py": "requirements.txt is not Python; the encoding IS the subject",
+    "test_source_text_helper.py": "this file tests the helper itself",
+    "test_share_pdf_source.py": "reads SQL/schema from the database, not source text",
+}
+
+
+def _py_test_files():
+    for p in sorted(SUITE.glob("test_*.py")):
+        yield p
+
+
+def test_no_test_reads_python_source_without_the_helper():
+    """The rule the eight trips earned.
+
+    A pin that greps raw Python will eventually trip on the comment
+    explaining the very thing it forbids. There is now one utility that
+    prevents that, so reading `.py` source raw is a defect the suite
+    reports on itself rather than a lesson someone relearns.
+    """
+    offenders = []
+    for path in _py_test_files():
+        if path.name in RAW_TEXT_ALLOWED:
+            continue
+        src = code_only(path)
+        reads_py = ".py" in src and ("read_text" in src or "open(" in src)
+        if reads_py and "code_only" not in src and "read_code" not in src:
+            offenders.append(path.name)
+    assert offenders == [], (
+        "these read Python source raw — route them through code_only(): "
+        f"{offenders}")
+
+
+@pytest.mark.parametrize("name,reason", sorted(RAW_TEXT_ALLOWED.items()))
+def test_every_raw_text_exemption_still_exists_and_is_explained(name, reason):
+    """An allowlist that outlives its entries quietly grants exemptions
+    nobody decided on."""
+    assert (SUITE / name).exists(), f"stale exemption for {name}"
+    assert len(reason) > 20, f"exemption for {name} needs a real reason"

--- a/frontend/src/__tests__/adminBrand.test.ts
+++ b/frontend/src/__tests__/adminBrand.test.ts
@@ -28,6 +28,7 @@
 import { describe, expect, it } from '@jest/globals';
 import * as fs from 'fs';
 import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
 
 const ADMIN = path.join(__dirname, '..', 'app', 'admin');
 const TOKENS = path.join(ADMIN, 'styles', 'tokens.css');
@@ -43,7 +44,7 @@ function adminFiles(dir = ADMIN, acc: string[] = []): string[] {
 }
 
 function withoutComments(src: string): string {
-  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+  return codeOnly(src);
 }
 
 const FILES = adminFiles().map((f) => [path.relative(ADMIN, f), fs.readFileSync(f, 'utf8')] as const);

--- a/frontend/src/__tests__/adminConsoleHonesty.test.ts
+++ b/frontend/src/__tests__/adminConsoleHonesty.test.ts
@@ -16,6 +16,7 @@
 import { describe, expect, it } from '@jest/globals';
 import * as fs from 'fs';
 import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
 
 function readAdmin(...segments: string[]): string {
   return fs.readFileSync(
@@ -24,7 +25,7 @@ function readAdmin(...segments: string[]): string {
 
 /** Comments explaining a removed pattern quote that pattern. */
 function withoutComments(src: string): string {
-  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+  return codeOnly(src);
 }
 
 describe('the two deed windows are labelled and reconciled', () => {

--- a/frontend/src/__tests__/apiAccessFunnel.test.ts
+++ b/frontend/src/__tests__/apiAccessFunnel.test.ts
@@ -15,6 +15,7 @@
 import { describe, expect, it } from '@jest/globals';
 import * as fs from 'fs';
 import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
 
 function readSource(...segments: string[]) {
   return fs.readFileSync(path.join(__dirname, '..', ...segments), 'utf8');
@@ -26,9 +27,7 @@ function readSource(...segments: string[]) {
  * and a naive source match then fails on its own explanation.
  */
 function withoutComments(src: string) {
-  return src
-    .replace(/\/\*[\s\S]*?\*\//g, '')   // block and JSX comments
-    .replace(/^\s*\/\/.*$/gm, '');       // line comments
+  return codeOnly(src);       // line comments
 }
 
 const requestPage = readSource('app', 'api-key-request', 'page.tsx');

--- a/frontend/src/__tests__/confirmationModel.test.ts
+++ b/frontend/src/__tests__/confirmationModel.test.ts
@@ -17,10 +17,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { collectCandidateFields, propertyCandidatesRemaining } from '../lib/provenance';
 import type { DeedBuilderState, PropertyData } from '../types/builder';
+import { codeOnly } from '../test-support/sourceText';
 
-function stripComments(source: string): string {
-  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
-}
 
 function readSource(...segments: string[]): string {
   return fs.readFileSync(path.join(__dirname, '..', ...segments), 'utf8');
@@ -74,7 +72,7 @@ describe('U2.1 — the accordion holds until present county fields are confirmed
   });
 
   it('PropertySection guards every auto-advance with the remaining-candidates check', () => {
-    const src = stripComments(
+    const src = codeOnly(
       readSource('components', 'builder', 'sections', 'PropertySection.tsx')
     );
     // Both fetch-success paths and the confirm/edit path advance only
@@ -111,13 +109,13 @@ describe('U2.1 — the gate modal never re-asks a field confirmed inline', () =>
 
 describe('U2.2 — no immortal toasts', () => {
   it('the Toaster renders close buttons and the route-dismiss sentinel is mounted', () => {
-    const layout = stripComments(readSource('app', 'layout.tsx'));
+    const layout = codeOnly(readSource('app', 'layout.tsx'));
     expect(layout).toContain('closeButton');
     expect(layout).toContain('<ToastRouteDismiss />');
   });
 
   it('ToastRouteDismiss dismisses on pathname change only — never on mount', () => {
-    const src = stripComments(readSource('components', 'ToastRouteDismiss.tsx'));
+    const src = codeOnly(readSource('components', 'ToastRouteDismiss.tsx'));
     expect(src).toContain('toast.dismiss()');
     expect(src).toContain('previous.current !== pathname');
   });
@@ -175,7 +173,7 @@ describe('U2.3 — immutability copy carries the correction path', () => {
 
 describe('U2.4 — no placeholder that reads as an entered value', () => {
   it('Transfer Value hints with words, not a plausible dollar amount', () => {
-    const src = stripComments(
+    const src = codeOnly(
       readSource('components', 'builder', 'sections', 'TransferTaxSection.tsx')
     );
     expect(src).not.toMatch(/placeholder="[\d,.]+"/);

--- a/frontend/src/__tests__/deedDisplay.test.ts
+++ b/frontend/src/__tests__/deedDisplay.test.ts
@@ -10,12 +10,10 @@
 import { describe, expect, it } from '@jest/globals';
 import * as fs from 'fs';
 import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
 
-function stripComments(source: string): string {
-  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
-}
 
-const PANEL = stripComments(
+const PANEL = codeOnly(
   fs.readFileSync(
     path.join(__dirname, '..', 'components', 'builder', 'PreviewPanel.tsx'),
     'utf8'

--- a/frontend/src/__tests__/developerDocs.test.ts
+++ b/frontend/src/__tests__/developerDocs.test.ts
@@ -9,6 +9,7 @@
 import { describe, expect, it } from '@jest/globals';
 import * as fs from 'fs';
 import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
 
 const page = fs.readFileSync(
   path.join(__dirname, '..', 'app', 'developers', 'page.tsx'), 'utf8'
@@ -36,10 +37,7 @@ const openapi = JSON.parse(fs.readFileSync(
  * explanation.
  */
 function withoutComments(src: string) {
-  return src
-    .replace(/\{\/\*[\s\S]*?\*\/\}/g, '')  // JSX comments
-    .replace(/\/\*[\s\S]*?\*\//g, '')       // block comments
-    .replace(/^\s*\/\/.*$/gm, '');          // line comments
+  return codeOnly(src);
 }
 
 import { API_DEED_TYPES, HELD_FAMILIES } from '@/lib/apiDocs';

--- a/frontend/src/__tests__/flowSmalls.test.ts
+++ b/frontend/src/__tests__/flowSmalls.test.ts
@@ -12,10 +12,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { deedTypeLabel, DEED_LABELS } from '../lib/deedTypes';
 import { formatSuggestionSecondary } from '../lib/addressLabels';
+import { codeOnly } from '../test-support/sourceText';
 
-function stripComments(source: string): string {
-  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
-}
 
 function readSource(...segments: string[]): string {
   return fs.readFileSync(path.join(__dirname, '..', ...segments), 'utf8');
@@ -36,8 +34,8 @@ describe('U3 — deed types display as names, not slugs', () => {
   });
 
   it('the builder header and Past Deeds read from the SAME map', () => {
-    const builder = stripComments(readSource('features', 'builder', 'DeedBuilder.tsx'));
-    const pastDeeds = stripComments(readSource('app', 'past-deeds', 'page.tsx'));
+    const builder = codeOnly(readSource('features', 'builder', 'DeedBuilder.tsx'));
+    const pastDeeds = codeOnly(readSource('app', 'past-deeds', 'page.tsx'));
     expect(builder).toContain("from '@/lib/deedTypes'");
     expect(pastDeeds).toContain('deedTypeLabel(deed.deed_type)');
     // The old raw-slug cell is gone.
@@ -46,7 +44,7 @@ describe('U3 — deed types display as names, not slugs', () => {
   });
 
   it('Past Deeds rows carry grantee and doc id', () => {
-    const pastDeeds = stripComments(readSource('app', 'past-deeds', 'page.tsx'));
+    const pastDeeds = codeOnly(readSource('app', 'past-deeds', 'page.tsx'));
     expect(pastDeeds).toContain('deed.grantee_name');
     // X2.7 promoted the doc id from an under-address line to its own column.
     expect(pastDeeds).toContain('>#{deed.id}</td>');
@@ -67,7 +65,7 @@ describe('U3 — autocomplete secondary labels: "City, CA", no county mash', () 
   });
 
   it('the dropdown renders through the formatter', () => {
-    const src = stripComments(
+    const src = codeOnly(
       readSource('components', 'builder', 'sections', 'PropertySection.tsx')
     );
     expect(src).toContain('formatSuggestionSecondary(prediction.structured_formatting.secondary_text)');
@@ -76,7 +74,7 @@ describe('U3 — autocomplete secondary labels: "City, CA", no county mash', () 
 
 describe('U3 — deterministic lookup: suggestion click always fetches', () => {
   it('handleSelectAddress ends by fetching with the parsed address it just built', () => {
-    const src = stripComments(
+    const src = codeOnly(
       readSource('components', 'builder', 'sections', 'PropertySection.tsx')
     );
     expect(src).toContain('fetchPropertyData(parsed)');
@@ -85,7 +83,7 @@ describe('U3 — deterministic lookup: suggestion click always fetches', () => {
 
 describe('U3 — explicit confirm advances the accordion', () => {
   it('GrantorSection advances on confirm and edit-save, never on keystrokes', () => {
-    const src = stripComments(
+    const src = codeOnly(
       readSource('components', 'builder', 'sections', 'GrantorSection.tsx')
     );
     expect((src.match(/onComplete\?\.\(\)/g) || []).length).toBe(2);
@@ -94,14 +92,14 @@ describe('U3 — explicit confirm advances the accordion', () => {
   });
 
   it('InputPanel wires grantor completion to the grantee section', () => {
-    const src = stripComments(readSource('components', 'builder', 'InputPanel.tsx'));
+    const src = codeOnly(readSource('components', 'builder', 'InputPanel.tsx'));
     expect(src).toContain("onComplete={() => onSectionChange('grantee')}");
   });
 });
 
 describe('U3 — grantee input auto-uppercases (already true; pinned so it stays)', () => {
   it('the input maps its value through toUpperCase', () => {
-    const src = stripComments(
+    const src = codeOnly(
       readSource('components', 'builder', 'sections', 'GranteeSection.tsx')
     );
     expect(src).toContain('onChange(e.target.value.toUpperCase())');
@@ -110,7 +108,7 @@ describe('U3 — grantee input auto-uppercases (already true; pinned so it stays
 
 describe('U3 — downloads acknowledge themselves', () => {
   it('Past Deeds tracks the in-flight download and toasts the outcome', () => {
-    const src = stripComments(readSource('app', 'past-deeds', 'page.tsx'));
+    const src = codeOnly(readSource('app', 'past-deeds', 'page.tsx'));
     expect(src).toContain('setDownloadingId(deed.id)');
     expect(src).toContain('PDF downloaded');
     // Failure surfaces the endpoint's real reason, not a shrug.
@@ -120,13 +118,13 @@ describe('U3 — downloads acknowledge themselves', () => {
 
 describe('U3 — the builder names its way home; no dead affordances', () => {
   it('the header link says Dashboard and the handler-less Help button is gone', () => {
-    const src = stripComments(readSource('components', 'builder', 'BuilderHeader.tsx'));
+    const src = codeOnly(readSource('components', 'builder', 'BuilderHeader.tsx'));
     expect(src).toContain('Dashboard');
     expect(src).not.toContain('HelpCircle');
   });
 
   it('the dashboard greeting makes no chat promise', () => {
-    const src = stripComments(readSource('components', 'ui', 'AIGreeting.tsx'));
+    const src = codeOnly(readSource('components', 'ui', 'AIGreeting.tsx'));
     expect(src).not.toContain('How can I help');
   });
 });

--- a/frontend/src/__tests__/formRegistry.test.ts
+++ b/frontend/src/__tests__/formRegistry.test.ts
@@ -13,6 +13,7 @@ import * as path from 'path';
 import { FORM_REGISTRY, SITUATION_GROUP_ORDER, formConfig, formFamily, hasVestingInput } from '../lib/formRegistry';
 import { DEED_LABELS, deedTypeLabel } from '../lib/deedTypes';
 import { isAffidavitType } from '../lib/deedValidation';
+import { codeOnly } from '../test-support/sourceText';
 
 function readSource(...segments: string[]): string {
   return fs.readFileSync(path.join(__dirname, '..', ...segments), 'utf8');
@@ -121,9 +122,7 @@ describe('FORMS registry — completeness and coherence', () => {
   it('a registry entry cannot smuggle a legal choice (no auto-apply field)', () => {
     // Strip comments first — the doctrine note ABOUT auto-apply must not
     // trip the scan for auto-apply code (the stripComments lesson).
-    const src = readSource('lib', 'formRegistry.ts')
-      .replace(/\/\*[\s\S]*?\*\//g, '')
-      .replace(/\/\/[^\n]*/g, '');
+    const src = codeOnly(readSource('lib', 'formRegistry.ts'));
     expect(src).not.toMatch(/auto[_-]?apply/i);
     for (const f of Object.values(FORM_REGISTRY)) {
       expect(Object.keys(f)).not.toContain('autoApply');

--- a/frontend/src/__tests__/gateTruth.test.ts
+++ b/frontend/src/__tests__/gateTruth.test.ts
@@ -14,6 +14,7 @@ import * as path from 'path';
 import { collectCandidateFields } from '../lib/provenance';
 import { deriveSectionTruth } from '../lib/deedValidation';
 import type { DeedBuilderState } from '../types/builder';
+import { codeOnly } from '../test-support/sourceText';
 
 function baseState(overrides: Partial<DeedBuilderState> = {}): DeedBuilderState {
   return {
@@ -112,7 +113,7 @@ describe('one truth: the counter derives from gate math', () => {
 describe('T-5 — the gate promises lineage, and the record keeps it', () => {
   const src = fs.readFileSync(
     path.join(__dirname, '..', 'features', 'builder', 'DeedBuilder.tsx'), 'utf8');
-  const code = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+  const code = codeOnly(src);
 
   it('offers the corrected-deed path again', () => {
     expect(code).toMatch(/corrected deed/i);
@@ -157,7 +158,7 @@ describe('T-5 — the gate promises lineage, and the record keeps it', () => {
 describe('T-1 — collapsing the display does not collapse the record', () => {
   const src = fs.readFileSync(
     path.join(__dirname, '..', 'features', 'builder', 'DeedBuilder.tsx'), 'utf8');
-  const code = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+  const code = codeOnly(src);
 
   it('confirm-all still stamps field by field, not in bulk', () => {
     // The bulk handler maps over candidates and hands stampConfirmed the

--- a/frontend/src/__tests__/jurisdictions.test.ts
+++ b/frontend/src/__tests__/jurisdictions.test.ts
@@ -18,6 +18,7 @@
 import { describe, expect, it } from '@jest/globals';
 import { cityDttRate, isIncorporated, lookupJurisdiction, PLACES } from '@/lib/jurisdictions';
 import { computeDttBreakdown } from '@/lib/dttCalc';
+import { codeOnly } from '../test-support/sourceText';
 
 const ONE_MILLION = {
   isExempt: false, exemptReason: '', transferValue: '1000000',
@@ -140,8 +141,8 @@ describe('T-2 — the registry is the only list', () => {
     const fs = require('fs');
     const path = require('path');
     for (const rel of [['lib', 'dttCalc.ts'], ['services', 'propertyPrefill.ts']]) {
-      const src: string = fs.readFileSync(path.join(__dirname, '..', ...rel), 'utf8')
-        .replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+      const src: string = codeOnly(
+        fs.readFileSync(path.join(__dirname, '..', ...rel), 'utf8'));
       // A literal array of quoted city names is the shape of a fork.
       expect(src).not.toMatch(/=\s*\[\s*\n?\s*["']los angeles["']/i);
     }

--- a/frontend/src/__tests__/pcorPackage.test.ts
+++ b/frontend/src/__tests__/pcorPackage.test.ts
@@ -10,11 +10,12 @@
 import { describe, expect, it } from '@jest/globals';
 import * as fs from 'fs';
 import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
 
 const SRC = fs.readFileSync(
   path.join(__dirname, '..', 'app', 'deed-builder', '[type]', 'success',
             'success-content.tsx'), 'utf8');
-const code = SRC.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+const code = codeOnly(SRC);
 
 describe('T-3 — the PCOR package offer', () => {
   it('uses the ruled copy and states the statutory basis', () => {

--- a/frontend/src/__tests__/previewChassisConformance.test.ts
+++ b/frontend/src/__tests__/previewChassisConformance.test.ts
@@ -32,13 +32,11 @@ import {
   TOD_REVOCATION_STATEMENT,
   TOD_WITNESS_INSTRUCTION,
 } from '../lib/deedFurniture';
+import { codeOnly } from '../test-support/sourceText';
 
 /** Strip // and /* comments so prose about a disease can't trip the scan. */
-function stripComments(source: string): string {
-  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
-}
 
-const PANEL = stripComments(
+const PANEL = codeOnly(
   fs.readFileSync(
     path.join(__dirname, '..', 'components', 'builder', 'PreviewPanel.tsx'),
     'utf8'

--- a/frontend/src/__tests__/proxyErrorHonesty.test.ts
+++ b/frontend/src/__tests__/proxyErrorHonesty.test.ts
@@ -15,6 +15,7 @@
 import { describe, expect, it } from '@jest/globals';
 import * as fs from 'fs';
 import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
 
 const API_ROOT = path.join(__dirname, '..', 'app', 'api');
 
@@ -29,9 +30,6 @@ function collectRouteFiles(dir: string): string[] {
 }
 
 /** Strip // and /* comments so prose about a disease can't trip the scan. */
-function stripComments(source: string): string {
-  return source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
-}
 
 /** Extract the body of every catch block via brace matching. */
 function catchBodies(source: string): string[] {
@@ -62,7 +60,7 @@ describe('proxy error honesty (doctrine sweep)', () => {
   it.each(files.map((f) => [path.relative(API_ROOT, f), f]))(
     '%s never swallows failures',
     (_rel, file) => {
-      const src = stripComments(fs.readFileSync(file as string, 'utf8'));
+      const src = codeOnly(fs.readFileSync(file as string, 'utf8'));
 
       // 1. The 200-[] disease: no bare empty-array responses.
       expect(src).not.toMatch(/\.json\(\s*\[\s*\]/);

--- a/frontend/src/__tests__/routeGuards.test.ts
+++ b/frontend/src/__tests__/routeGuards.test.ts
@@ -12,6 +12,7 @@
 import { describe, expect, it } from '@jest/globals';
 import * as fs from 'fs';
 import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
 
 const APP_DIR = path.join(__dirname, '..', 'app');
 
@@ -126,7 +127,7 @@ describe('HX0 — route-level auth guards', () => {
 
     const middleware = fs.readFileSync(
       path.join(__dirname, '..', '..', 'middleware.ts'), 'utf8');
-    const code = middleware.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[^\S\n]*\/\/.*$/gm, '');
+    const code = codeOnly(middleware);
     expect(code).not.toMatch(/['"]\/security['"]/);
   });
 

--- a/frontend/src/__tests__/sourceText.test.ts
+++ b/frontend/src/__tests__/sourceText.test.ts
@@ -1,0 +1,136 @@
+/**
+ * codeOnly() — pinned, including the two bugs it replaces.
+ *
+ * A helper every forbidden-pattern pin depends on is load-bearing in an
+ * unusual way: strip too much and the pins pass for the WRONG reason,
+ * so the thing they guard can walk out of the codebase unnoticed. That
+ * failure is silent, which is why the over-stripping cases matter more
+ * than the under-stripping ones.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
+
+const TESTS_DIR = __dirname;
+
+describe('it removes prose', () => {
+  it('strips a line comment', () => {
+    expect(codeOnly('// we used to claim SOC 2\nconst x = 1')).not.toContain('SOC 2');
+  });
+
+  it('strips a trailing comment', () => {
+    expect(codeOnly('const x = 1 // the old 99.9% SLA')).not.toContain('99.9');
+  });
+
+  it('strips a block comment across lines', () => {
+    const src = '/*\n * Removed: ALTA Best Practices\n */\nconst x = 1';
+    expect(codeOnly(src)).not.toContain('ALTA');
+  });
+
+  it('strips a JSX comment', () => {
+    expect(codeOnly('<div>{/* was SoftPro integration */}</div>')).not.toContain('SoftPro');
+  });
+});
+
+describe('...and nothing else — the dangerous direction', () => {
+  it('a URL in a string SURVIVES', () => {
+    /**
+     * THE bug in six of the fourteen files this replaces.
+     *
+     *   /\/\/[^\n]*​/g
+     *
+     * turned  const url = "https://api.openai.com/v1/chat";
+     * into    const url = "https:
+     *
+     * It truncated the string, left an unterminated quote, and deleted
+     * the rest of the line. Files using it test proxy and docs code
+     * whose content is largely URLs, so those pins were asserting
+     * against mangled text and nobody could tell.
+     */
+    const src = 'const url = "https://api.openai.com/v1/chat";';
+    expect(codeOnly(src)).toBe(src);
+  });
+
+  it('a URL in a template literal survives', () => {
+    const src = 'const u = `${BASE}//api.example.com/v1`;';
+    expect(codeOnly(src)).toBe(src);
+  });
+
+  it('a protocol-relative URL survives', () => {
+    const src = "const u = '//cdn.example.com/x.js';";
+    expect(codeOnly(src)).toBe(src);
+  });
+
+  it('a comment marker inside a single-quoted string survives', () => {
+    const src = "const s = 'a /* not a comment */ b';";
+    expect(codeOnly(src)).toBe(src);
+  });
+
+  it('a division expression is not mistaken for a regex', () => {
+    const src = 'const r = total / count / 2;';
+    expect(codeOnly(src)).toBe(src);
+  });
+
+  it('a regex literal containing slashes survives', () => {
+    const src = 'const re = /https:\\/\\/[a-z]+/g;';
+    expect(codeOnly(src)).toBe(src);
+  });
+
+  it('line numbers do not move', () => {
+    /**
+     * The other replaced variant, /^\s*\/\/.*$​/gm, ate a blank line
+     * along with the comment because `\s` matches `\n` — the same bug
+     * found independently in the banned-claims checker.
+     */
+    const src = 'const a = 1;\n\n\n// a comment\nconst b = 2;\n';
+    const out = codeOnly(src);
+    expect(out.split('\n').length).toBe(src.split('\n').length);
+    expect(out.split('\n')[4]).toBe('const b = 2;');
+  });
+
+  it('column positions do not move either', () => {
+    const src = 'const x = 1;  // trailing\nconst y = 2;';
+    const out = codeOnly(src);
+    expect(out.split('\n')[0].startsWith('const x = 1;')).toBe(true);
+    expect(out.split('\n')[0].length).toBe(src.split('\n')[0].length);
+  });
+});
+
+describe('the meta-pin', () => {
+  /**
+   * The rule eight comment-quoting trips earned: a pin that greps raw
+   * source will eventually trip on the comment explaining the very
+   * thing it forbids. There is now one utility that prevents that, so
+   * an inline stripper is a defect the suite reports on itself.
+   */
+  const files = fs
+    .readdirSync(TESTS_DIR)
+    .filter((f) => f.endsWith('.test.ts') || f.endsWith('.test.tsx'))
+    .filter((f) => f !== 'sourceText.test.ts');
+
+  it('no test file defines its own comment stripper', () => {
+    const offenders = files.filter((f) => {
+      const src = fs.readFileSync(path.join(TESTS_DIR, f), 'utf8');
+      return /replace\(\s*\/\\\/\\\*/.test(src) || /replace\(\s*\/\^?\[?\^?\\s\*\\\/\\\//.test(src);
+    });
+    expect(offenders).toEqual([]);
+  });
+
+  it('no test file strips comments with a hand-rolled regex at all', () => {
+    const offenders = files.filter((f) => {
+      const src = fs.readFileSync(path.join(TESTS_DIR, f), 'utf8');
+      // Any regex replace that mentions an escaped `//` or `/*`.
+      return /\.replace\([^)]*\\\/\\[*/]/.test(src);
+    });
+    expect(offenders).toEqual([]);
+  });
+
+  it('the helper itself is what everyone imports', () => {
+    const importers = files.filter((f) =>
+      fs.readFileSync(path.join(TESTS_DIR, f), 'utf8').includes("../test-support/sourceText")
+    );
+    // Not every test reads source; the ones that do must use it.
+    expect(importers.length).toBeGreaterThan(8);
+  });
+});

--- a/frontend/src/test-support/sourceText.ts
+++ b/frontend/src/test-support/sourceText.ts
@@ -1,0 +1,175 @@
+/**
+ * codeOnly() — read source as CODE, without its prose. The TS half.
+ *
+ * ═══ WHY THIS EXISTS ═══
+ *
+ * A forbidden-pattern pin necessarily quotes what it forbids, and the
+ * comment explaining a removal necessarily quotes the thing removed. So
+ * every such pin has to read code with comments stripped, and this repo
+ * grew SIXTEEN inline strippers across fourteen test files to do it.
+ *
+ * They did not agree, and two of the three variants were wrong:
+ *
+ *   /\/\/[^\n]*​/g          (6 files)
+ *       Strips `//` ANYWHERE — including inside string literals. It turns
+ *
+ *           const url = "https://api.openai.com/v1/chat";
+ *       into
+ *           const url = "https:
+ *
+ *       It truncates the string, leaves an unterminated quote, and
+ *       deletes the rest of the line. Several files using it test proxy
+ *       and docs code whose whole content is URLs, so those pins have
+ *       been asserting against mangled text.
+ *
+ *   /^\s*\/\/.*$​/gm        (6 files)
+ *       `\s` matches newlines, so a blank line before a comment is eaten
+ *       WITH the comment and every line number below shifts. Same bug
+ *       found independently in the banned-claims checker (RED-H1.1).
+ *
+ *   /^[^\S\n]*\/\/.*$​/gm   (1 file)
+ *       Correct, and the reason the other two are now gone.
+ *
+ * ═══ WHY A SCANNER AND NOT A BETTER REGEX ═══
+ *
+ * "Is this `//` a comment or part of a string?" is not a question a
+ * regular expression can answer — it requires knowing what came before.
+ * That is the same lesson this project keeps relearning under a
+ * different name: match STATEMENTS, not strings. A tokenizer knows the
+ * difference between a comment and text that looks like one; a pattern
+ * only knows the spelling.
+ *
+ * ═══ WHAT IT DOES NOT DO ═══
+ *
+ * It does not strip string literals — a pin looking for a value that
+ * legitimately lives in a string is asking a different question and
+ * should say so at the call site.
+ *
+ * It does not fully parse regex literals. `/abc/.test(s)` is handled by
+ * the division-vs-regex heuristic below; a regex literal containing an
+ * unbalanced quote could still confuse it. That is stated rather than
+ * hidden: if it ever matters, the fix is a real parser, not a patch.
+ *
+ * Line and column positions are PRESERVED — comments become spaces,
+ * newlines stay newlines — so a failing assertion's line numbers still
+ * point at the right place in the original file.
+ */
+import * as fs from 'fs';
+
+/** Characters that can precede `/` when it starts a regex literal. */
+const REGEX_ALLOWED_BEFORE = new Set([
+  '(', ',', '=', ':', '[', '!', '&', '|', '?', '{', '}', ';', '\n', '+', '-', '*', '%', '<', '>', '~', '^',
+]);
+
+function lastSignificant(out: string[]): string {
+  for (let i = out.length - 1; i >= 0; i--) {
+    const c = out[i];
+    if (c !== ' ' && c !== '\t' && c !== '\r') return c;
+  }
+  return '\n';
+}
+
+export function codeOnly(source: string): string {
+  const out: string[] = [];
+  let i = 0;
+  const n = source.length;
+
+  // Blank a span while keeping newlines, so positions never move.
+  const blank = (from: number, to: number) => {
+    for (let k = from; k < to; k++) out.push(source[k] === '\n' ? '\n' : ' ');
+  };
+
+  while (i < n) {
+    const c = source[i];
+    const next = source[i + 1];
+
+    // Line comment
+    if (c === '/' && next === '/') {
+      let j = i;
+      while (j < n && source[j] !== '\n') j++;
+      blank(i, j);
+      i = j;
+      continue;
+    }
+
+    // Block comment (this also covers JSX `{/* ... */}`)
+    if (c === '/' && next === '*') {
+      let j = i + 2;
+      while (j < n && !(source[j] === '*' && source[j + 1] === '/')) j++;
+      j = Math.min(j + 2, n);
+      blank(i, j);
+      i = j;
+      continue;
+    }
+
+    // String literal — copied verbatim, so `https://` survives intact.
+    if (c === '"' || c === "'") {
+      out.push(c);
+      i++;
+      while (i < n) {
+        if (source[i] === '\\') { out.push(source[i], source[i + 1] ?? ''); i += 2; continue; }
+        out.push(source[i]);
+        if (source[i] === c) { i++; break; }
+        if (source[i] === '\n') { i++; break; } // unterminated — don't run away
+        i++;
+      }
+      continue;
+    }
+
+    // Template literal, including nested ${ ... } which may itself hold
+    // strings and comments.
+    if (c === '`') {
+      out.push(c);
+      i++;
+      let depth = 0;
+      while (i < n) {
+        if (source[i] === '\\') { out.push(source[i], source[i + 1] ?? ''); i += 2; continue; }
+        if (source[i] === '$' && source[i + 1] === '{') { depth++; out.push('$', '{'); i += 2; continue; }
+        if (source[i] === '}' && depth > 0) { depth--; out.push('}'); i++; continue; }
+        if (source[i] === '`' && depth === 0) { out.push('`'); i++; break; }
+        out.push(source[i]);
+        i++;
+      }
+      continue;
+    }
+
+    // Regex literal, distinguished from division by what precedes it.
+    if (c === '/' && REGEX_ALLOWED_BEFORE.has(lastSignificant(out))) {
+      let j = i + 1;
+      let inClass = false;
+      let closed = false;
+      while (j < n) {
+        if (source[j] === '\\') { j += 2; continue; }
+        if (source[j] === '[') inClass = true;
+        else if (source[j] === ']') inClass = false;
+        else if (source[j] === '/' && !inClass) { closed = true; j++; break; }
+        else if (source[j] === '\n') break;
+        j++;
+      }
+      if (closed) {
+        for (let k = i; k < j; k++) out.push(source[k]);
+        i = j;
+        continue;
+      }
+    }
+
+    out.push(c);
+    i++;
+  }
+
+  return out.join('');
+}
+
+/** Read a file under `frontend/src` and return it as code only. */
+export function readCode(...segments: string[]): string {
+  const path = require('path');
+  return codeOnly(fs.readFileSync(path.join(__dirname, '..', '..', ...segments), 'utf8'));
+}
+
+/** Read a file relative to the repository root and return it as code only. */
+export function readRepoCode(...segments: string[]): string {
+  const path = require('path');
+  return codeOnly(
+    fs.readFileSync(path.join(__dirname, '..', '..', '..', '..', ...segments), 'utf8')
+  );
+}


### PR DESCRIPTION
Eight comment-quoting trips ended the deferral. The survey found something worse than duplication.

## The TS side: 16 inline strippers, 3 variants, 2 of them wrong

| pattern | files | verdict |
|---|---|---|
| `/\/\/[^\n]*/g` | **6** | **destroys URLs** |
| `/^\s*\/\/.*$/gm` | **6** | **eats blank lines** |
| `/^[^\S\n]*\/\/.*$/gm` | 1 | correct |

**The first one truncates every string containing `//`.** Demonstrated:

```
const url = "https://api.openai.com/v1/chat";     →     const url = "https:
```

It cuts the string, leaves an unterminated quote, and deletes the rest of the line. The files using it test **proxy and docs code whose content is largely URLs** — so those pins have been asserting against mangled text, and nothing could tell us.

The second eats a blank line along with the comment because `\s` matches `\n`, shifting every line number below. Same bug I hit independently in the banned-claims checker two tickets ago.

**Replaced by a scanner, not a better regex.** *"Is this `//` a comment or part of a string?"* is not a question a regular expression can answer — it needs to know what came before. Which is this project's own lesson under a different name: **match statements, not strings.**

## The Python side: a whole-file text replace

The existing helper did `src.replace(doc, "")`. If a docstring's text also appeared in **code** — a SQL fragment, a status literal — the replace deleted it *there* too, and the pin guarding it then passed **because the thing it guarded had vanished from the text it searched.**

A pin that passes for the wrong reason is worse than one that fails. It also missed trailing `# comments` and shifted line numbers. Now `tokenize`-based, blanking in place.

Both helpers preserve line **and column** positions, so a failure message still points where it says.

## My own over-strip, caught by the existing suite

`tokenize` emits `NL` (not `NEWLINE`) for newlines **inside brackets**, and I treated `NL` as a statement boundary. So every multi-line string in a list literal looked like a docstring — which blanked the entire schema out of `database.py`. **Ten pins failed at once.**

Ten loud failures were luck. The same bug over a file whose pins only assert *absence* would have passed silently, with nothing left to guard. Pinned in both directions.

## Convergence + meta-pins

- **5 pytest files** and **15 jest files** converged onto the shared helpers.
- **Meta-pin, both suites:** no test may read source raw or hand-roll a stripper.
- The Python allowlist carries a **reason per entry** and fails if an entry goes stale — an allowlist that outlives its entries quietly grants exemptions nobody decided on.

The helper lives in `src/test-support/` rather than `src/__tests__/`, because jest collects everything in the latter and a helper is not a suite.

## Gates

| gate | result |
|---|---|
| backend pytest | **589 passed** |
| jest | **502 passed**, 35 suites |
| tsc | 94 — unchanged |
| six-flow | ✔ verify |
| API baseline | ✔ verify |
| banned-claims | ✔ clean |
| `next build` | ✔ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_