### PR TITLE
RED-S1: one connection per request, from a pool — the shared connection is gone

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -1,90 +1,266 @@
-"""Single DB module (T8 split).
+"""One connection per request, from a pool. RED-S1.
 
-Owns the module-level psycopg2 connection and the auto-reconnect helper.
+═══ WHAT THIS REPLACES, AND WHY IT WAS A CORRECTNESS BUG ═══
 
-CRITICAL BINDING RULE: ``conn`` is a global that get_db_connection() rebinds
-on reconnect. Consumers must ``import db`` and reference ``db.conn`` —
-never ``from db import conn`` (that snapshot goes stale after a reconnect).
+This module used to own ONE module-level psycopg2 connection, referenced
+as `db.conn` from 103 call sites. Nearly every endpoint in this codebase
+is a sync `def`, which FastAPI runs in an anyio threadpool — up to 40
+workers.
+
+Forty threads. One connection. One transaction.
+
+psycopg2 makes a connection thread-safe for CURSOR creation. It cannot
+make the TRANSACTION per-thread, because there is exactly one transaction
+per connection. So:
+
+  - Request A executes an UPDATE and has not committed.
+  - Request B, on another thread, calls `db.conn.commit()` — and commits
+    A's uncommitted write, mid-flight, unreviewed.
+  - Request C errors and calls `db.conn.rollback()` — and discards A's
+    and B's uncommitted work.
+
+None of that is theoretical. The production outage of 2026-08-01 was one
+failed query on this connection, never rolled back, leaving the
+transaction aborted — after which Postgres refuses EVERY later query on
+it and the whole app 500s. RED-H1.2b and #130 each found fresh ways to
+reach that state from a PUBLIC url.
+
+═══ WHY THE HEALING LADDER IS GONE RATHER THAN IMPROVED ═══
+
+The response to that outage was a five-step recovery ladder: probe,
+rollback, re-probe, reconnect. It worked, and it made the underlying
+defect worse in one specific way — step 3 called `rollback()` on a
+connection OTHER REQUESTS WERE USING, as a repair, silently. Every heal
+was a data-loss event for whatever else was in flight.
+
+It is deleted, not extended. A pool of per-request connections has
+nothing to heal: a poisoned connection is discarded at the end of the one
+request that poisoned it, and no other request ever saw it.
+
+═══ HOW 103 CALL SITES DID NOT HAVE TO CHANGE ═══
+
+`db.conn` is now a PROXY. It looks and behaves exactly as before —
+`.cursor()`, `.commit()`, `.rollback()` — but it resolves, per request,
+to that request's own connection from the pool.
+
+That is deliberate. Rewriting 103 call sites by hand, in one diff, in the
+module that every endpoint depends on, is how you turn a correctness fix
+into an outage. The proxy makes the change one that can be REASONED about
+rather than reviewed line by line: if the proxy resolves correctly, every
+call site is correct, and the tests aim at the proxy.
+
+Scoping uses `contextvars`, not thread-locals, because both async and
+sync endpoints exist here. Starlette copies the context into the
+threadpool worker, so a sync endpoint sees the connection the middleware
+checked out for it; thread-locals would silently fail for the async ones.
+
+═══ OUTSIDE A REQUEST ═══
+
+Scripts, startup, migrations and the baseline harnesses have no request
+to scope to. They get a lazily-created dedicated connection — one, the
+old shape — because a CLI script is genuinely single-threaded and the
+concurrency argument above does not apply to it.
 """
+import contextlib
 import os
+import threading
+from contextvars import ContextVar
+from typing import Optional
 
 import psycopg2
 from dotenv import load_dotenv
 from fastapi import HTTPException
+from psycopg2 import pool as _pgpool
 
 from db_rows import ROW_FACTORY
 
 load_dotenv()
 
-# Database connection with auto-reconnect support
 DB_URL = os.getenv("DATABASE_URL") or os.getenv("DB_URL")
-if DB_URL:
-    conn = psycopg2.connect(DB_URL, cursor_factory=ROW_FACTORY, connect_timeout=10)
-else:
-    conn = None
-    print("Warning: No database connection URL found")
 
-# T2: make sure the stored-PDF table exists (idempotent; no Alembic in this repo)
-if conn:
+# Sized against Postgres's max_connections, not against traffic. The
+# threadpool is 40 workers, so 40 is the most that can be in flight — but
+# a managed Postgres commonly allows ~100 TOTAL across every client, and
+# this app is not the only connector (migrations, the psql a human has
+# open, the billing SQLAlchemy engine). Overshooting the server limit
+# turns a load spike into "FATAL: too many connections" for everyone,
+# which is the failure this ticket exists to prevent, wearing a new hat.
+POOL_MIN = int(os.getenv("DB_POOL_MIN", "1"))
+POOL_MAX = int(os.getenv("DB_POOL_MAX", "20"))
+
+_pool: Optional[_pgpool.ThreadedConnectionPool] = None
+_pool_lock = threading.Lock()
+
+# The connection belonging to the request currently being served.
+_current: ContextVar[Optional[object]] = ContextVar("db_current_conn", default=None)
+
+# The fallback for code that runs outside any request.
+_standalone = None
+_standalone_lock = threading.Lock()
+
+
+def _new_connection():
+    return psycopg2.connect(DB_URL, cursor_factory=ROW_FACTORY, connect_timeout=10)
+
+
+def get_pool() -> Optional[_pgpool.ThreadedConnectionPool]:
+    """The pool, created on first use."""
+    global _pool
+    if not DB_URL:
+        return None
+    if _pool is None:
+        with _pool_lock:
+            if _pool is None:
+                _pool = _pgpool.ThreadedConnectionPool(
+                    POOL_MIN, POOL_MAX, DB_URL,
+                    cursor_factory=ROW_FACTORY, connect_timeout=10,
+                )
+    return _pool
+
+
+def _standalone_connection():
+    """One dedicated connection for non-request code paths.
+
+    Recreated if it has been closed or poisoned, because a script that
+    hits an error and keeps going would otherwise fail every later
+    statement — the same aborted-transaction trap, in the one place where
+    a single connection is legitimate.
+    """
+    global _standalone
+    with _standalone_lock:
+        if _standalone is None or _standalone.closed:
+            _standalone = _new_connection()
+            return _standalone
+        try:
+            with _standalone.cursor() as cur:
+                cur.execute("SELECT 1")
+        except psycopg2.Error:
+            try:
+                _standalone.rollback()
+                with _standalone.cursor() as cur:
+                    cur.execute("SELECT 1")
+            except Exception:
+                with contextlib.suppress(Exception):
+                    _standalone.close()
+                _standalone = _new_connection()
+        return _standalone
+
+
+@contextlib.contextmanager
+def request_connection():
+    """Check a connection out for one request and put it back after.
+
+    Commits nothing on its own: call sites own their transactions and
+    always have. What this guarantees is that an UNFINISHED transaction
+    never outlives its request — the leak that let one request's failure
+    become the next request's error.
+    """
+    p = get_pool()
+    if p is None:
+        yield None
+        return
+
+    conn_obj = p.getconn()
+    token = _current.set(conn_obj)
     try:
-        from services.deed_pdf import ensure_deed_pdfs_table
-        ensure_deed_pdfs_table(conn)
-    except Exception as _pdf_table_error:
-        print(f"Warning: could not ensure deed_pdfs table: {_pdf_table_error}")
+        yield conn_obj
+    finally:
+        _current.reset(token)
+        # Whatever state the request left this connection in, it does not
+        # travel. rollback() on an already-committed connection is a
+        # no-op; on a poisoned one it is the cure; on an open transaction
+        # it is the correct default for a request that did not commit.
+        try:
+            conn_obj.rollback()
+        except Exception:
+            with contextlib.suppress(Exception):
+                conn_obj.close()
+        try:
+            p.putconn(conn_obj)
+        except Exception:
+            with contextlib.suppress(Exception):
+                conn_obj.close()
+
+
+def _active():
+    """The connection this caller should use."""
+    bound = _current.get()
+    if bound is not None:
+        return bound
+    if not DB_URL:
+        return None
+    return _standalone_connection()
+
+
+class _ConnectionProxy:
+    """`db.conn`, resolving per request.
+
+    Every attribute access forwards to the caller's own connection. The
+    proxy holds no connection of its own, which is the entire point: it
+    cannot be shared because it is not a connection.
+    """
+
+    def __bool__(self):
+        # Call sites do `if not db.conn: raise HTTPException(500)`. That
+        # question means "is the database usable", and it still does.
+        return _active() is not None
+
+    def __getattr__(self, name):
+        target = _active()
+        if target is None:
+            raise HTTPException(status_code=500,
+                                detail="Database connection not available")
+        if name == "close":
+            # Closing a POOLED connection out from under the pool is the
+            # exact hazard the ledger named when this work was parked.
+            # The request scope owns the lifecycle; a stray close() here
+            # would hand the pool a dead socket to give the next caller.
+            return lambda *a, **k: None
+        return getattr(target, name)
+
+    def __repr__(self):
+        target = _active()
+        return f"<db.conn -> {target!r}>"
+
+
+conn = _ConnectionProxy()
+
 
 def get_db_connection():
-    """Get database connection — healing a POISONED one, reconnecting a
-    dead one.
+    """Kept for callers that ask for a connection explicitly.
 
-    Production outage 2026-08-01: one failed query on this shared
-    connection, never rolled back, left the transaction aborted — and
-    Postgres then refuses EVERY later query on it ("current transaction
-    is aborted, commands ignored until end of transaction block"), which
-    surfaced as login 500s. The old liveness probe made it worse: it
-    caught only Operational/Interface errors, so the aborted-transaction
-    error (a different psycopg2 class) escaped to callers instead of
-    triggering recovery, and it never tried rollback() — the one call
-    that instantly cures that state.
+    THE HEALING LADDER IS GONE. It probed, rolled back, re-probed and
+    reconnected a SHARED connection — and its rollback step discarded
+    other in-flight requests' uncommitted work as a "repair".
 
-    Recovery ladder, in order:
-      1. closed/None      → reconnect
-      2. probe SELECT 1   → healthy, return
-      3. probe failed     → rollback() and re-probe (heals the poisoned
-                            case without dropping the connection)
-      4. still failing    → reconnect
-      5. reconnect failed → 500
+    There is nothing left to heal. A request's connection is its own; if
+    it is poisoned, it is poisoned for that request alone and is rolled
+    back and returned to the pool when the request ends.
     """
-    global conn
-    if not DB_URL:
-        raise HTTPException(status_code=500, detail="Database connection not available")
+    target = _active()
+    if target is None:
+        raise HTTPException(status_code=500,
+                            detail="Database connection not available")
+    return target
 
-    def _reconnect(reason):
-        global conn
-        print(f"⚠️ Database connection lost ({reason}), reconnecting...")
-        try:
-            conn = psycopg2.connect(DB_URL, cursor_factory=ROW_FACTORY, connect_timeout=10)
-            print("✅ Database reconnected successfully")
-        except Exception as reconnect_error:
-            print(f"❌ Failed to reconnect to database: {reconnect_error}")
-            raise HTTPException(status_code=500, detail="Database connection failed")
 
+def close_pool():
+    """Shutdown hook — closes every pooled connection."""
+    global _pool
+    with _pool_lock:
+        if _pool is not None:
+            with contextlib.suppress(Exception):
+                _pool.closeall()
+            _pool = None
+
+
+# T2: make sure the stored-PDF table exists (idempotent; no Alembic here).
+if DB_URL:
     try:
-        if conn is None or conn.closed:
-            print("⚠️ Database connection closed, reconnecting...")
-            conn = psycopg2.connect(DB_URL, cursor_factory=ROW_FACTORY, connect_timeout=10)
-            print("✅ Database reconnected successfully")
-        else:
-            # Liveness probe. ANY psycopg2 error here means the shared
-            # connection is unusable for callers — recover, never raise.
-            with conn.cursor() as cur:
-                cur.execute("SELECT 1")
-    except (psycopg2.Error, AttributeError) as e:
-        try:
-            conn.rollback()
-            with conn.cursor() as cur:
-                cur.execute("SELECT 1")
-            print(f"♻️ Healed poisoned connection via rollback ({e})")
-        except Exception:
-            _reconnect(e)
-
-    return conn
+        from services.deed_pdf import ensure_deed_pdfs_table
+        _boot = _standalone_connection()
+        ensure_deed_pdfs_table(_boot)
+    except Exception as _pdf_table_error:
+        print(f"Warning: could not ensure deed_pdfs table: {_pdf_table_error}")
+else:
+    print("Warning: No database connection URL found")

--- a/backend/main.py
+++ b/backend/main.py
@@ -54,6 +54,31 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+# RED-S1: one connection per request, checked out here and returned here.
+#
+# Registered AFTER the metrics middleware below, which means Starlette
+# runs it FIRST — the connection is bound before any handler touches
+# `db.conn` and returned after the response is produced.
+#
+# Before this, every request shared one connection and therefore one
+# TRANSACTION: request B's commit() could commit request A's uncommitted
+# write, and request C's rollback() could discard both. The 2026-08-01
+# outage was that defect reached from a failing query; #130 found it
+# reachable from a public URL with a single GET.
+#
+# The scope is a contextvar rather than a thread-local because this app
+# serves BOTH sync endpoints (which run in the threadpool, one thread per
+# request) and async ones (which share a thread). Starlette copies the
+# context into the threadpool worker, so both see their own connection; a
+# thread-local would silently hand every concurrent async request the
+# same one and reintroduce exactly the bug being removed.
+@app.middleware("http")
+async def db_connection_middleware(request: Request, call_next):
+    import db as _db
+    with _db.request_connection():
+        return await call_next(request)
+
+
 # Phase 6-2: Metrics tracking middleware
 @app.middleware("http")
 async def metrics_middleware(request: Request, call_next):

--- a/backend/scripts/s1_concurrency_proof.py
+++ b/backend/scripts/s1_concurrency_proof.py
@@ -1,0 +1,287 @@
+"""RED-S1 — the load proof, run against the real app.
+
+The acquirer's prescribed check, in two parts:
+
+  1. Two concurrent writes with an induced failure in one; the other's
+     row must survive. (Also pinned in tests/test_poisoned_connection.py,
+     which is where it belongs as a regression guard. Repeated here
+     because a proof nobody can RUN is a claim.)
+  2. A sustained ~20 RPS run against the real ASGI app with
+     pg_stat_activity sampled throughout, showing that connections stay
+     bounded by the pool and no request poisons another.
+
+Usage:
+  DATABASE_URL=postgresql://... JWT_SECRET_KEY=x python scripts/s1_concurrency_proof.py
+
+Exit code 1 on any failure, so it can gate rather than merely inform.
+
+WHAT THIS WOULD HAVE SHOWN BEFORE THE FIX: part 2's error column full of
+"current transaction is aborted", because a single failing request
+poisoned the one shared connection and every later request inherited it.
+"""
+import os
+import sys
+import threading
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import psycopg2  # noqa: E402
+
+DB_URL = os.getenv("DATABASE_URL")
+if not DB_URL:
+    print("DATABASE_URL is required")
+    sys.exit(1)
+
+TARGET_RPS = int(os.getenv("S1_RPS", "20"))
+DURATION_S = int(os.getenv("S1_DURATION", "10"))
+
+failures = []
+
+
+def check(label, ok, detail=""):
+    print(f"  {'PASS' if ok else 'FAIL'}  {label}{(' — ' + detail) if detail else ''}")
+    if not ok:
+        failures.append(label)
+
+
+def sample_connections():
+    c = psycopg2.connect(DB_URL, connect_timeout=10)
+    try:
+        with c.cursor() as cur:
+            cur.execute("""
+                SELECT count(*) FROM pg_stat_activity
+                WHERE datname = current_database() AND pid <> pg_backend_pid()
+            """)
+            return cur.fetchone()[0]
+    finally:
+        c.close()
+
+
+def part1_induced_failure():
+    print("\n[1] two concurrent writes, one induced failure")
+    import db
+
+    db.close_pool()
+    ok_tag = f"proof-ok-{uuid.uuid4().hex[:8]}@test.local"
+    bad_tag = f"proof-bad-{uuid.uuid4().hex[:8]}@test.local"
+    barrier = threading.Barrier(2, timeout=15)
+
+    def failing():
+        with db.request_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("INSERT INTO users (email, password_hash) VALUES (%s,%s)",
+                            (bad_tag, "x"))
+            barrier.wait()
+            try:
+                with conn.cursor() as cur:
+                    cur.execute("SELECT * FROM table_that_does_not_exist_xyz")
+            except psycopg2.Error:
+                pass
+            conn.rollback()
+            barrier.wait()
+
+    def succeeding():
+        with db.request_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("INSERT INTO users (email, password_hash) VALUES (%s,%s)",
+                            (ok_tag, "x"))
+            barrier.wait()
+            barrier.wait()
+            conn.commit()
+
+    ts = [threading.Thread(target=failing), threading.Thread(target=succeeding)]
+    for t in ts:
+        t.start()
+    for t in ts:
+        t.join(timeout=20)
+
+    c = psycopg2.connect(DB_URL, connect_timeout=10)
+    try:
+        with c.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM users WHERE email = %s", (ok_tag,))
+            survived = cur.fetchone()[0]
+            cur.execute("SELECT COUNT(*) FROM users WHERE email = %s", (bad_tag,))
+            gone = cur.fetchone()[0]
+            cur.execute("DELETE FROM users WHERE email IN (%s,%s)", (ok_tag, bad_tag))
+            c.commit()
+    finally:
+        c.close()
+
+    check("the succeeding writer's row survived", survived == 1)
+    check("the failing writer's row was rolled back", gone == 0)
+
+
+def part2_load():
+    print(f"\n[2] ~{TARGET_RPS} RPS for {DURATION_S}s against the real app")
+    from fastapi.testclient import TestClient
+    from main import app
+
+    client = TestClient(app)
+    samples = []
+    stop = threading.Event()
+    results = {"ok": 0, "err": 0}
+    errors = {}
+    lock = threading.Lock()
+
+    def sampler():
+        while not stop.is_set():
+            try:
+                samples.append(sample_connections())
+            except Exception:
+                pass
+            time.sleep(0.25)
+
+    def one_request(i):
+        # A mix: a read, a 404 lookup, and — every 5th — a request that
+        # FAILS inside the handler. Under the shared connection those
+        # failures were what poisoned everyone else.
+        try:
+            if i % 5 == 0:
+                r = client.get(f"/approve/{uuid.uuid4()}/pdf")
+            elif i % 3 == 0:
+                r = client.post("/users/login", json={
+                    "email": f"nobody-{i}@test.local", "password": "wrong"})
+            else:
+                r = client.get("/health")
+            with lock:
+                if r.status_code < 500:
+                    results["ok"] += 1
+                else:
+                    results["err"] += 1
+                    errors[r.status_code] = errors.get(r.status_code, 0) + 1
+        except Exception as e:
+            with lock:
+                results["err"] += 1
+                key = type(e).__name__
+                errors[key] = errors.get(key, 0) + 1
+
+    t = threading.Thread(target=sampler, daemon=True)
+    t.start()
+
+    total = TARGET_RPS * DURATION_S
+    started = time.monotonic()
+    with ThreadPoolExecutor(max_workers=TARGET_RPS) as pool:
+        for i in range(total):
+            pool.submit(one_request, i)
+            time.sleep(1.0 / TARGET_RPS)
+    elapsed = time.monotonic() - started
+    stop.set()
+    t.join(timeout=2)
+
+    peak = max(samples) if samples else -1
+    print(f"      requests: {total} in {elapsed:.1f}s "
+          f"({total / elapsed:.1f}/s effective)")
+    print(f"      ok: {results['ok']}   5xx/exceptions: {results['err']} {errors or ''}")
+    print(f"      pg_stat_activity peak: {peak} connections "
+          f"(samples: {len(samples)}, pool max {os.getenv('DB_POOL_MAX', '20')})")
+
+    check("no request returned 5xx or raised", results["err"] == 0, str(errors))
+    check("connections stayed bounded by the pool",
+          0 < peak <= int(os.getenv("DB_POOL_MAX", "20")) + 5,
+          f"peak {peak}")
+
+    # A paced 20 RPS of millisecond responses is only ever ~1-2 requests
+    # in flight, so the number above says little about the pool under
+    # pressure. Reported honestly rather than presented as a stress
+    # result — and followed by a burst that actually is one.
+    part3_burst(client)
+
+
+def part3_burst(client):
+    print("\n[3] burst — 40 simultaneous requests (the threadpool's width)")
+    import db
+
+    inflight = {"now": 0, "peak": 0}
+    lock = threading.Lock()
+    original = db.request_connection
+
+    import contextlib
+
+    @contextlib.contextmanager
+    def counting():
+        with lock:
+            inflight["now"] += 1
+            inflight["peak"] = max(inflight["peak"], inflight["now"])
+        try:
+            with original() as c:
+                yield c
+        finally:
+            with lock:
+                inflight["now"] -= 1
+
+    db.request_connection = counting
+    conn_samples = []
+    stop = threading.Event()
+
+    def sampler():
+        while not stop.is_set():
+            try:
+                conn_samples.append(sample_connections())
+            except Exception:
+                pass
+            time.sleep(0.02)
+
+    t = threading.Thread(target=sampler, daemon=True)
+    t.start()
+    try:
+        errs = []
+
+        def hit(i):
+            try:
+                # Every third request FAILS inside the handler, so the
+                # burst is not just parallel reads — it is parallel reads
+                # racing parallel failures, which is the shape that broke
+                # the shared connection.
+                if i % 3 == 0:
+                    client.get(f"/approve/{uuid.uuid4()}/pdf")
+                else:
+                    client.post("/users/login", json={
+                        "email": f"burst-{i}@test.local", "password": "wrong"})
+            except Exception as e:
+                errs.append(type(e).__name__)
+
+        threads = [threading.Thread(target=hit, args=(i,)) for i in range(40)]
+        for th in threads:
+            th.start()
+        for th in threads:
+            th.join(timeout=30)
+    finally:
+        stop.set()
+        t.join(timeout=2)
+        db.request_connection = original
+
+    peak_scopes = inflight["peak"]
+    peak_conns = max(conn_samples) if conn_samples else -1
+    pool_max = int(os.getenv("DB_POOL_MAX", "20"))
+    print(f"      peak concurrent request scopes: {peak_scopes}")
+    print(f"      peak pg_stat_activity: {peak_conns} (pool max {pool_max})")
+
+    check("the burst was genuinely concurrent", peak_scopes >= 5,
+          f"peak {peak_scopes} scopes")
+    check("no exception escaped under burst", errs == [], str(errs[:5]))
+    check("connections never exceeded the pool ceiling",
+          peak_conns <= pool_max + 5, f"peak {peak_conns}")
+
+    # The tell-tale of the old defect.
+    c = psycopg2.connect(DB_URL, connect_timeout=10)
+    try:
+        with c.cursor() as cur:
+            cur.execute("SELECT 1")
+            check("the database is still serving after the run", cur.fetchone()[0] == 1)
+    finally:
+        c.close()
+
+
+if __name__ == "__main__":
+    print("RED-S1 concurrency proof")
+    part1_induced_failure()
+    part2_load()
+    print()
+    if failures:
+        print(f"FAILED: {failures}")
+        sys.exit(1)
+    print("ALL CHECKS PASSED")

--- a/backend/tests/test_poisoned_connection.py
+++ b/backend/tests/test_poisoned_connection.py
@@ -1,139 +1,255 @@
-"""Production outage 2026-08-01 — the poisoned shared connection, pinned.
+"""The 2026-08-01 outage, and why it can no longer happen. RED-S1.
 
-One failed query on the module-level psycopg2 connection, never rolled
-back, aborted the transaction — and Postgres then refused EVERY later
-query on it, surfacing as login 500s ("current transaction is aborted,
-commands ignored until end of transaction block"). Three stacked defects
-let it stick: the liveness probe caught only Operational/Interface
-errors (the aborted-transaction class escaped to callers), it never
-tried rollback() (the instant cure), and the login handler's rollback
-fallback referenced an unbound local when get_db_connection raised.
+═══ WHAT THIS FILE USED TO PIN, AND WHY THAT IS GONE ═══
 
-Pins: get_db_connection HEALS a poisoned connection via rollback (fake
-connection, CI-safe), the recovery ladder falls through to reconnect,
-and — against the live test DB — a genuinely poisoned psycopg2
-connection comes back usable and the login route answers 401, not 500.
+It pinned the HEALING LADDER: that `get_db_connection()` would probe a
+poisoned shared connection, `rollback()` it, re-probe, and reconnect if
+that failed. Those tests were correct and they passed. They are deleted
+here, in the same diff that makes them false — the condition their own
+docstring named.
+
+The ladder treated the symptom. One failed query on the ONE shared
+connection aborted the transaction, and Postgres then refused every later
+query on it, which surfaced as login 500s for everybody. The ladder
+healed that after the fact — and its cure was `rollback()` on a
+connection OTHER REQUESTS WERE USING, which silently discarded whatever
+uncommitted work they had in flight. Every heal was a small data-loss
+event, performed as a repair.
+
+RED-S1 removed the thing being healed. Each request checks a connection
+out of a pool and returns it; a poisoned connection is poisoned for
+exactly one request, is rolled back on the way back to the pool, and no
+other request ever sees it.
+
+So the pins invert. They no longer assert that a shared connection
+RECOVERS. They assert that requests cannot reach each other at all —
+which is the property that made recovery necessary in the first place.
 """
 import os
+import threading
 
 import psycopg2
 import pytest
 
 import db
+from tests.source_text import code_only
 
-
-class FakePoisonedConn:
-    """Mimics psycopg2's aborted-transaction state: every query raises
-    until rollback() is called."""
-
-    closed = 0
-
-    def __init__(self):
-        self.poisoned = True
-        self.rollbacks = 0
-
-    def cursor(self):
-        conn = self
-
-        class _Cur:
-            def __enter__(self):
-                return self
-
-            def __exit__(self, *a):
-                return False
-
-            def execute(self, sql, params=None):
-                if conn.poisoned:
-                    raise psycopg2.errors.InFailedSqlTransaction(
-                        "current transaction is aborted, commands ignored "
-                        "until end of transaction block\n"
-                    )
-
-        return _Cur()
-
-    def rollback(self):
-        self.rollbacks += 1
-        self.poisoned = False
-
-
-class FakeDeadConn(FakePoisonedConn):
-    """Rollback does NOT help — forces the reconnect rung."""
-
-    def rollback(self):
-        self.rollbacks += 1  # still poisoned
-
-
-def test_poisoned_connection_heals_via_rollback(monkeypatch):
-    fake = FakePoisonedConn()
-    monkeypatch.setattr(db, "conn", fake)
-    monkeypatch.setattr(db, "DB_URL", "postgresql://unused/healed-before-reconnect")
-
-    healed = db.get_db_connection()
-
-    assert healed is fake            # same connection, not a reconnect
-    assert fake.rollbacks == 1       # the cure was rollback
-    assert not fake.poisoned
-
-
-def test_unhealable_connection_falls_through_to_reconnect(monkeypatch):
-    fake = FakeDeadConn()
-    fresh = FakePoisonedConn()
-    fresh.poisoned = False
-    monkeypatch.setattr(db, "conn", fake)
-    monkeypatch.setattr(db, "DB_URL", "postgresql://unused/reconnect-rung")
-    monkeypatch.setattr(db.psycopg2, "connect", lambda *a, **k: fresh)
-
-    healed = db.get_db_connection()
-
-    assert healed is fresh           # rollback failed → reconnected
-    assert fake.rollbacks == 1       # ... but rollback WAS attempted first
-
-
+BACKEND = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 LIVE_DB = os.getenv("DATABASE_URL")
 
+pytestmark = pytest.mark.skipif(not LIVE_DB, reason="live test DB required")
 
-@pytest.mark.skipif(not LIVE_DB, reason="live test DB required")
-def test_real_poisoned_connection_recovers_and_login_returns_401():
-    """The production failure, reproduced end to end: poison a REAL
-    psycopg2 connection with a failing statement, install it as the
-    shared conn, and prove (a) the helper heals it and (b) the login
-    route answers 401 for bad credentials — never the outage's 500."""
-    from fastapi.testclient import TestClient
-    from main import app
 
-    poisoned = psycopg2.connect(LIVE_DB, connect_timeout=10)
+@pytest.fixture(autouse=True)
+def _fresh_pool():
+    db.close_pool()
+    yield
+    db.close_pool()
+
+
+# ── The ladder is gone, and stays gone ────────────────────────────────
+
+
+def test_the_healing_ladder_is_deleted():
+    """Not weakened, not made conditional — removed.
+
+    A reconnect-and-rollback recovery path is meaningful ONLY for a
+    shared connection. If one reappears here, so has the shared
+    connection, and with it the outage.
+    """
+    src = code_only(os.path.join(BACKEND, "db.py"))
+    assert "Recovery ladder" not in src
+    assert "_reconnect" not in src
+    assert "Healed poisoned connection" not in src
+
+
+def test_the_module_exposes_no_shared_connection_object():
+    """`db.conn` is a PROXY now. The distinction is the whole ticket: a
+    proxy cannot be shared between requests because it holds nothing."""
+    assert type(db.conn).__name__ == "_ConnectionProxy"
+    assert not isinstance(db.conn, psycopg2.extensions.connection)
+
+
+# ── Requests cannot reach each other ──────────────────────────────────
+
+
+def test_two_requests_get_different_connections():
+    seen = []
+    for _ in range(2):
+        with db.request_connection() as c:
+            seen.append(id(c))
+            # Hold nothing; the pool may legitimately hand back the same
+            # object once it is returned. What matters is the next test.
+    assert len(seen) == 2
+
+
+def test_concurrent_requests_never_share_a_connection():
+    """THE property. Two requests in flight AT THE SAME TIME must hold
+    two different connections, or one's commit is the other's."""
+    ids = []
+    barrier = threading.Barrier(2, timeout=10)
+    lock = threading.Lock()
+
+    def worker():
+        with db.request_connection() as c:
+            barrier.wait()          # both inside their request together
+            with lock:
+                ids.append(id(c))
+            barrier.wait()          # neither returns before both recorded
+
+    threads = [threading.Thread(target=worker) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=15)
+
+    assert len(ids) == 2
+    assert ids[0] != ids[1], "two concurrent requests shared one connection"
+
+
+def test_a_poisoned_request_does_not_poison_a_concurrent_one():
+    """The outage, reproduced under the new model — and refused.
+
+    Request A runs a failing statement and aborts its transaction, which
+    is exactly what happened on 2026-08-01. Request B, in flight at the
+    same time, must be entirely unaffected. Under the shared connection
+    B's next query raised InFailedSqlTransaction; that is what "login
+    500s for everybody" was.
+    """
+    results = {}
+    barrier = threading.Barrier(2, timeout=10)
+
+    def poisoner():
+        with db.request_connection() as c:
+            with pytest.raises(psycopg2.Error):
+                with c.cursor() as cur:
+                    cur.execute("SELECT * FROM table_that_does_not_exist_xyz")
+            barrier.wait()          # A is poisoned; let B try
+            barrier.wait()
+
+    def victim():
+        with db.request_connection() as c:
+            barrier.wait()          # wait until A is poisoned
+            try:
+                with c.cursor() as cur:
+                    cur.execute("SELECT 1 AS ok")
+                    results["victim"] = cur.fetchone()["ok"]
+            except psycopg2.Error as e:
+                results["victim"] = f"POISONED: {type(e).__name__}"
+            barrier.wait()
+
+    threads = [threading.Thread(target=poisoner), threading.Thread(target=victim)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=15)
+
+    assert results.get("victim") == 1, (
+        f"a concurrent request was affected by another's failure: {results}")
+
+
+def test_an_induced_failure_does_not_roll_back_the_other_writer():
+    """The acquirer's prescribed proof: two concurrent WRITES, one fails,
+    the other's row must survive.
+
+    Under the shared connection this could not hold — A's rollback (or
+    the healing ladder's) discarded B's uncommitted INSERT along with
+    A's, because there was only ever one transaction.
+    """
+    import uuid
+    tag_ok = f"s1-ok-{uuid.uuid4().hex[:10]}"
+    tag_bad = f"s1-bad-{uuid.uuid4().hex[:10]}"
+    barrier = threading.Barrier(2, timeout=10)
+
+    def failing_writer():
+        with db.request_connection() as c:
+            with c.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO users (email, password_hash) VALUES (%s,%s)",
+                    (f"{tag_bad}@test.local", "x"))
+            barrier.wait()              # both have an open write
+            with pytest.raises(psycopg2.Error):
+                with c.cursor() as cur:
+                    cur.execute("SELECT * FROM table_that_does_not_exist_xyz")
+            c.rollback()                # A discards its own work
+            barrier.wait()
+
+    def good_writer():
+        with db.request_connection() as c:
+            with c.cursor() as cur:
+                cur.execute(
+                    "INSERT INTO users (email, password_hash) VALUES (%s,%s)",
+                    (f"{tag_ok}@test.local", "x"))
+            barrier.wait()
+            barrier.wait()              # A has now failed and rolled back
+            c.commit()                  # B commits AFTER A's rollback
+
+    threads = [threading.Thread(target=failing_writer),
+               threading.Thread(target=good_writer)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=15)
+
+    check = psycopg2.connect(LIVE_DB, connect_timeout=10)
     try:
-        with poisoned.cursor() as cur:
-            cur.execute("SELECT 1")   # open a transaction
-        try:
-            with poisoned.cursor() as cur:
-                cur.execute("SELECT * FROM table_that_does_not_exist_xyz")
-        except psycopg2.Error:
-            pass                      # transaction now aborted — poisoned
-
-        # Confirm the poisoned state is real before installing it:
-        with pytest.raises(psycopg2.Error):
-            with poisoned.cursor() as cur:
-                cur.execute("SELECT 1")
-
-        original = db.conn
-        db.conn = poisoned
-        try:
-            healed = db.get_db_connection()
-            with healed.cursor() as cur:
-                cur.execute("SELECT 1")   # usable again
-
-            db.conn = poisoned if healed is poisoned else healed
-            client = TestClient(app)
-            resp = client.post("/users/login", json={
-                "email": "poisoned-conn-probe@example.com",
-                "password": "wrong-password",
-            })
-            assert resp.status_code == 401, resp.text
-        finally:
-            db.conn = original
+        with check.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM users WHERE email = %s",
+                        (f"{tag_ok}@test.local",))
+            survived = cur.fetchone()[0]
+            cur.execute("SELECT COUNT(*) FROM users WHERE email = %s",
+                        (f"{tag_bad}@test.local",))
+            rolled_back = cur.fetchone()[0]
+            cur.execute("DELETE FROM users WHERE email IN (%s,%s)",
+                        (f"{tag_ok}@test.local", f"{tag_bad}@test.local"))
+            check.commit()
     finally:
-        try:
-            poisoned.close()
-        except Exception:
-            pass
+        check.close()
+
+    assert survived == 1, "the succeeding writer's row was destroyed by the other's failure"
+    assert rolled_back == 0, "the failing writer's row should not have survived"
+
+
+# ── The connection does not outlive its request ───────────────────────
+
+
+def test_an_uncommitted_transaction_never_escapes_its_request():
+    """A request that opens a write and never commits must not leave that
+    transaction open on a pooled connection for the next caller to
+    inherit — the leak that turns one request's mistake into another's."""
+    import uuid
+    tag = f"s1-leak-{uuid.uuid4().hex[:10]}@test.local"
+
+    with db.request_connection() as c:
+        with c.cursor() as cur:
+            cur.execute("INSERT INTO users (email, password_hash) VALUES (%s,%s)",
+                        (tag, "x"))
+        # deliberately no commit, no rollback
+
+    check = psycopg2.connect(LIVE_DB, connect_timeout=10)
+    try:
+        with check.cursor() as cur:
+            cur.execute("SELECT COUNT(*) FROM users WHERE email = %s", (tag,))
+            assert cur.fetchone()[0] == 0, "uncommitted work escaped its request"
+    finally:
+        check.close()
+
+
+def test_the_proxy_refuses_to_close_a_pooled_connection():
+    """Closing a pooled connection hands the pool a dead socket to give
+    the next caller — the hazard the ledger named when this work was
+    parked."""
+    with db.request_connection() as c:
+        db.conn.close()
+        assert not c.closed
+        with db.conn.cursor() as cur:
+            cur.execute("SELECT 1 AS ok")
+            assert cur.fetchone()["ok"] == 1
+
+
+def test_outside_a_request_there_is_still_a_usable_connection():
+    """Scripts, migrations and the baseline harnesses have no request to
+    scope to and must keep working."""
+    with db.conn.cursor() as cur:
+        cur.execute("SELECT 1 AS ok")
+        assert cur.fetchone()["ok"] == 1

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -15,8 +15,8 @@ authority and it is re-ruled, not re-derived.
 
 | # | ticket | state |
 |---|---|---|
-| 1 | **RED-S1** — per-request pool, per-request transactions, induced-failure concurrency test, 20 RPS run, healing ladder RETIRED by the fix | next |
-| 2 | **RED-S2** — object storage for `deed_pdfs`, `ON DELETE CASCADE` removed, backup runbook, EXECUTED restore drill with hash verification | queued |
+| 1 | ~~**RED-S1**~~ — per-request pool, per-request transactions, induced-failure concurrency test, 20 RPS + burst run, healing ladder RETIRED | **SHIPPED** |
+| 2 | **RED-S2** — object storage for `deed_pdfs`, `ON DELETE CASCADE` removed, backup runbook, EXECUTED restore drill with hash verification | **next** |
 | 3 | **RED-S3** — sessions: refresh + revocation (jti), login lockout, edge rate limiting, and frontend expiry as pause → preserve → re-auth → resume, never data loss | queued |
 | 4 | **RED-S4** — recording fields (`recorded_at`, `instrument_number`) as officer-recorded statements, + the rate-registry version stamped into deed metadata at generation | queued |
 | 5 | **Doctrine ticket A** — vested-owner extraction SPLIT: names flow as fact-candidates; the vesting characterisation routes to the vesting section as a violet proposal, never a carried fact | queued (ruled) |
@@ -295,17 +295,22 @@ we reach it.
   question — doctrine §3 removed QR codes from recorded pages on the
   reasoning that "verification survives as data."
 
-- **Connection-helper LIFECYCLE collapse** — **THIS IS NOW RED-S1** (queue
-  position 1 above); it stopped being a parked item on 2026-08-04 and is
-  recorded here so the two names are not tracked as two tickets. Its
-  risk note below is still the reason it needs its own verification, and
-  RED0 sharpened it: the shared connection is not merely a lifecycle
-  inconsistency but a correctness defect under concurrency (one
-  transaction, up to 40 threadpool workers), and the #100 healing ladder
-  calls `rollback()` on other in-flight requests as a repair. RED-H1.2
-  moved the fresh-connection callers onto a closing context manager,
-  which removes the "their close() kills the shared connection" hazard
-  named below — the remaining work is the pool itself.
+- ~~**Connection-helper LIFECYCLE collapse**~~ — **RESOLVED AS RED-S1,
+  shipped 2026-08-04.** `db.conn` is now a per-request proxy over a
+  pooled connection; the shared connection and its healing ladder are
+  both gone. The risk note below was the right one and it is preserved
+  as the record of why this needed its own ticket — the direction chosen
+  was "converge on per-request", and the `close()` hazard it warned about
+  is handled by the proxy refusing `close()` outright (pinned).
+  **One thing it named is NOT done and is deliberately out of S1's
+  ruled scope:** `database.get_db_connection()` still opens a FRESH
+  connection per call rather than drawing from the pool. That is correct
+  (RED-H1.2 made every one of those close on every exit) but it means an
+  endpoint using both helpers holds two connections for one request.
+  Converging it is an efficiency change, not a correctness fix — it is
+  flagged here rather than folded in, because folding unruled work into
+  the ticket that fixes the outage is how a safe diff becomes an unsafe
+  one.
   Parked 2026-08-03 by owner
   ruling; explicitly NOT to be absorbed into another ticket. PR #107
   unified the ROW CONTRACT (one cursor factory, rows readable both


### PR DESCRIPTION
The acquirer's demand #1, and the real fix for the 2026-08-01 outage.

## The defect

One module-level psycopg2 connection served **103 call sites**. Nearly every endpoint is a sync `def`, which FastAPI runs in a **40-worker threadpool**.

Forty threads. One connection. **One transaction.** psycopg2 makes cursors thread-safe but cannot make transactions per-thread — there is exactly one per connection. So request B's `commit()` could commit request A's uncommitted write, and request C's `rollback()` could discard both.

## The healing ladder is deleted, not extended

Its step 3 called `rollback()` on a connection **other requests were using**, as a repair — so every heal was a small data-loss event performed as maintenance.

A pool of per-request connections has nothing to heal: a poisoned connection is poisoned for one request, is rolled back on its way back to the pool, and no other request ever sees it.

## 103 call sites did not change

`db.conn` is now a **proxy** resolving, per request, to that request's own pooled connection.

That's deliberate. Rewriting 103 sites by hand, in one diff, in the module every endpoint depends on, is how a correctness fix becomes an outage. The proxy makes the change one that can be **reasoned about** rather than reviewed line by line: if the proxy resolves correctly, every call site is correct — so the tests aim at the proxy.

Scoping is **contextvars, not thread-locals**, because this app serves both sync endpoints (threadpool, one thread each) and async ones (shared thread). Starlette copies the context into the worker so both see their own connection; a thread-local would hand concurrent async requests the same one and rebuild the exact bug.

## The proof, as prescribed — `scripts/s1_concurrency_proof.py`

Runnable, exit-code-gating, not a claim:

```
[1] two concurrent writes, induced failure in one
      PASS  the succeeding writer's row survived
      PASS  the failing writer's row was rolled back

[2] ~20 RPS for 10s against the real app
      requests: 200 in 10.0s (19.9/s)   ok: 200   5xx/exceptions: 0
      pg_stat_activity peak: 2 connections

[3] burst — 40 simultaneous (a third failing inside the handler)
      peak concurrent request scopes: 25
      peak pg_stat_activity: 12 (pool max 20)
      PASS  no exception escaped under burst
      PASS  connections never exceeded the pool ceiling
```

**Part [2] alone is not a proof, and the script says so.** At 20 RPS with millisecond responses only ~1–2 requests are ever in flight — which is why the first run showed a peak of **2**. That number was honest and weak, so I checked whether the harness was serializing (it wasn't — 20 concurrent scopes) and added part [3], which actually stresses the pool. Reporting the weak number and the reason beats reporting a green tick.

## The pins invert rather than die

`test_poisoned_connection.py` no longer asserts that a shared connection **recovers**. It asserts that concurrent requests **cannot reach each other** — the property that made recovery necessary. Including the outage reproduced under the new model and refused, an uncommitted transaction proven not to escape its request, and the proxy refusing `close()` on a pooled connection (the hazard the ledger named).

The #130 poisoning pin retires in the same diff that makes it false.

## Ledger

S1 struck through, S2 marked next, and the parked *"connection-helper LIFECYCLE collapse"* closed as resolved — with the one piece **deliberately not folded in** flagged there: `database.get_db_connection()` still opens fresh per call. That's correct (H1.2 made them all close) but means an endpoint using both helpers holds two connections. Converging it is efficiency, not correctness — folding unruled work into the ticket that fixes the outage is how a safe diff becomes an unsafe one.

## Gates

| gate | result |
|---|---|
| backend pytest | **595 passed** |
| jest | 502, 35 suites |
| tsc | 94 — unchanged |
| six-flow | ✔ verify |
| API baseline | ✔ verify |
| banned-claims | ✔ clean |
| concurrency proof | ✔ all checks |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_