### PR TITLE
RED-S2: a second copy, no cascade, and a restore drill that was actually run

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -185,12 +185,48 @@ def create_tables():
             "ALTER TABLE deeds ADD COLUMN IF NOT EXISTS superseded_by INTEGER REFERENCES deeds(id)",
             "ALTER TABLE deeds ADD COLUMN IF NOT EXISTS superseded_at TIMESTAMPTZ",
             "CREATE INDEX IF NOT EXISTS idx_deeds_superseded_by ON deeds(superseded_by)",
+            # RED-S2: RESTRICT, not CASCADE.
+            #
+            # §9 refuses to OVERWRITE a stored instrument, and the
+            # application enforces that carefully. The schema meanwhile
+            # handed DELETE a cascade: remove a deed row and its PDF and
+            # sha256 went with it, silently, in the same statement.
+            #
+            # The doctrine guarded one verb. A cleanup script — `DELETE
+            # FROM deeds WHERE created_at < ...`, the kind somebody
+            # writes on a Friday — would have taken every notarised
+            # instrument with it and left nothing to prove what had been
+            # there.
+            #
+            # RESTRICT makes that impossible: the delete fails while an
+            # artifact exists, and removing the artifact becomes a
+            # deliberate act rather than a side effect. Deletion is
+            # already SOFT everywhere in this product (status='deleted'),
+            # so nothing legitimate is blocked by this.
             """CREATE TABLE IF NOT EXISTS deed_pdfs (
-                deed_id INTEGER PRIMARY KEY REFERENCES deeds(id) ON DELETE CASCADE,
+                deed_id INTEGER PRIMARY KEY REFERENCES deeds(id) ON DELETE RESTRICT,
                 pdf_data BYTEA NOT NULL,
                 sha256 VARCHAR(64) NOT NULL,
                 generated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )""",
+            # Existing databases were created with CASCADE, and a
+            # CREATE TABLE IF NOT EXISTS does not alter them. Rebuild the
+            # constraint by name, idempotently.
+            """DO $$
+            BEGIN
+                IF EXISTS (
+                    SELECT 1 FROM pg_constraint c
+                    JOIN pg_class t ON t.oid = c.conrelid
+                    WHERE t.relname = 'deed_pdfs'
+                      AND c.contype = 'f'
+                      AND c.confdeltype = 'c'
+                ) THEN
+                    ALTER TABLE deed_pdfs DROP CONSTRAINT deed_pdfs_deed_id_fkey;
+                    ALTER TABLE deed_pdfs
+                        ADD CONSTRAINT deed_pdfs_deed_id_fkey
+                        FOREIGN KEY (deed_id) REFERENCES deeds(id) ON DELETE RESTRICT;
+                END IF;
+            END $$;""",
             """CREATE TABLE IF NOT EXISTS deed_shares (
                 id SERIAL PRIMARY KEY,
                 deed_id INT NOT NULL,

--- a/backend/db.py
+++ b/backend/db.py
@@ -64,6 +64,7 @@ concurrency argument above does not apply to it.
 import contextlib
 import os
 import threading
+import time
 from contextvars import ContextVar
 from typing import Optional
 
@@ -86,7 +87,10 @@ DB_URL = os.getenv("DATABASE_URL") or os.getenv("DB_URL")
 # turns a load spike into "FATAL: too many connections" for everyone,
 # which is the failure this ticket exists to prevent, wearing a new hat.
 POOL_MIN = int(os.getenv("DB_POOL_MIN", "1"))
-POOL_MAX = int(os.getenv("DB_POOL_MAX", "20"))
+# Default raised to the threadpool width: 40 sync endpoints can be in
+# flight at once, so a smaller ceiling guarantees contention the app
+# creates for itself.
+POOL_MAX = int(os.getenv("DB_POOL_MAX", "40"))
 
 _pool: Optional[_pgpool.ThreadedConnectionPool] = None
 _pool_lock = threading.Lock()
@@ -146,6 +150,43 @@ def _standalone_connection():
         return _standalone
 
 
+# How long a request waits for a free connection before giving up.
+CHECKOUT_TIMEOUT_S = float(os.getenv("DB_POOL_TIMEOUT", "10"))
+
+
+def _checkout(p):
+    """Wait for a connection; 503 only if the wait genuinely expires.
+
+    FOUND BY THE S1 PROOF ITSELF, on a wider burst than the run that
+    shipped it (35 concurrent scopes against a pool of 20 rather than
+    25). psycopg2's ThreadedConnectionPool.getconn() does NOT block when
+    the pool is exhausted — it raises PoolError immediately. So a burst
+    wider than DB_POOL_MAX turned into hard 500s.
+
+    That was a failure mode S1 INTRODUCED. The shared connection could
+    not exhaust a pool because there was no pool; trading one defect for
+    a smaller one is still trading.
+
+    A short spike should WAIT — connections free in milliseconds — and
+    only a genuine, sustained overload should be refused, with a 503 that
+    says "try again" rather than a 500 that says "something broke".
+    """
+    deadline = time.monotonic() + CHECKOUT_TIMEOUT_S
+    delay = 0.005
+    while True:
+        try:
+            return p.getconn()
+        except _pgpool.PoolError:
+            if time.monotonic() >= deadline:
+                raise HTTPException(
+                    status_code=503,
+                    detail="The service is busy. Please try again in a moment.",
+                    headers={"Retry-After": "1"},
+                )
+            time.sleep(delay)
+            delay = min(delay * 2, 0.1)
+
+
 @contextlib.contextmanager
 def request_connection():
     """Check a connection out for one request and put it back after.
@@ -160,7 +201,7 @@ def request_connection():
         yield None
         return
 
-    conn_obj = p.getconn()
+    conn_obj = _checkout(p)
     token = _current.set(conn_obj)
     try:
         yield conn_obj

--- a/backend/scripts/s1_concurrency_proof.py
+++ b/backend/scripts/s1_concurrency_proof.py
@@ -176,13 +176,14 @@ def part2_load():
     print(f"      requests: {total} in {elapsed:.1f}s "
           f"({total / elapsed:.1f}/s effective)")
     print(f"      ok: {results['ok']}   5xx/exceptions: {results['err']} {errors or ''}")
+    import db as _dbm
     print(f"      pg_stat_activity peak: {peak} connections "
-          f"(samples: {len(samples)}, pool max {os.getenv('DB_POOL_MAX', '20')})")
+          f"(samples: {len(samples)}, pool max {_dbm.POOL_MAX})")
 
     check("no request returned 5xx or raised", results["err"] == 0, str(errors))
+    import db as _db
     check("connections stayed bounded by the pool",
-          0 < peak <= int(os.getenv("DB_POOL_MAX", "20")) + 5,
-          f"peak {peak}")
+          0 < peak <= _db.POOL_MAX + 5, f"peak {peak}, ceiling {_db.POOL_MAX}")
 
     # A paced 20 RPS of millisecond responses is only ever ~1-2 requests
     # in flight, so the number above says little about the pool under
@@ -256,7 +257,13 @@ def part3_burst(client):
 
     peak_scopes = inflight["peak"]
     peak_conns = max(conn_samples) if conn_samples else -1
-    pool_max = int(os.getenv("DB_POOL_MAX", "20"))
+    # Read the REAL ceiling rather than re-deriving it from an env
+    # default. A gate that hardcodes its own copy of a constant measures
+    # against the wrong number the moment the constant moves — which is
+    # exactly what happened here: db.py's default became 40 and this
+    # still compared against 20, failing a run that was behaving
+    # correctly. A gate that misfires is as useless as one that flatters.
+    pool_max = db.POOL_MAX
     print(f"      peak concurrent request scopes: {peak_scopes}")
     print(f"      peak pg_stat_activity: {peak_conns} (pool max {pool_max})")
 

--- a/backend/scripts/s2_restore_drill.py
+++ b/backend/scripts/s2_restore_drill.py
@@ -1,0 +1,244 @@
+"""RED-S2 — the restore drill. Executed, not documented.
+
+═══ WHY A DRILL AND NOT A RUNBOOK ═══
+
+"We have backups" is a belief until someone restores one. The finding
+this answers was not "there is no backup procedure" — it was that no
+restore had ever been performed, so nobody could say whether the stored
+instruments would come back or whether they would come back INTACT.
+
+This script proves both, end to end, against real Postgres and a real
+second copy:
+
+  A. GENERATE   a deed with a real stored PDF, and record its sha256.
+  B. BACK UP    with pg_dump — the actual tool, not a SELECT loop.
+  C. DESTROY    restore into a SEPARATE database and confirm the
+                artifact is present there.
+  D. VERIFY     hash the recovered bytes against the sha256 recorded at
+                generation. Bytes that do not hash are not a recovery.
+  E. SECOND COPY  delete the row from the restored database entirely and
+                recover the instrument from the object store alone,
+                hash-verifying again. This is the scenario the ticket
+                exists for: the database is gone.
+  F. CASCADE    prove a deed row can no longer be deleted out from under
+                its artifact.
+
+Exit code 1 on any failure, so it can gate rather than inform.
+
+Usage:
+  DATABASE_URL=postgresql://... \
+  ARTIFACT_STORE=filesystem ARTIFACT_FS_ROOT=/tmp/artifacts \
+  python scripts/s2_restore_drill.py
+
+═══ ON WHAT THIS DRILL CANNOT PROVE ═══
+
+It runs against the configured backend. With ARTIFACT_STORE=filesystem it
+proves the mechanism and the recovery completely. It does NOT prove that
+a particular S3 bucket is reachable, because bucket credentials are
+owner-supplied by standing rule and never live here.
+
+That limit is stated rather than glossed: what is verified is that the
+second copy is written, is found, and hash-matches. Pointing the same
+code at S3 is a configuration change, and the first production run of
+this drill against the real bucket is an owner-side step.
+"""
+import hashlib
+import os
+import subprocess
+import sys
+import tempfile
+import uuid
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import psycopg2  # noqa: E402
+from psycopg2.extras import RealDictCursor  # noqa: E402
+
+DB_URL = os.getenv("DATABASE_URL")
+if not DB_URL:
+    print("DATABASE_URL is required")
+    sys.exit(1)
+
+RESTORE_DB = os.getenv("S2_RESTORE_DB", "deedpro_restore_drill")
+failures = []
+
+
+def check(label, ok, detail=""):
+    print(f"  {'PASS' if ok else 'FAIL'}  {label}{(' — ' + detail) if detail else ''}")
+    if not ok:
+        failures.append(label)
+
+
+def admin_conn():
+    import re
+    root = re.sub(r"/[^/?]+(\?|$)", r"/postgres\1", DB_URL)
+    c = psycopg2.connect(root, connect_timeout=10)
+    c.autocommit = True
+    return c
+
+
+def restore_url():
+    import re
+    return re.sub(r"/[^/?]+(\?|$)", f"/{RESTORE_DB}\\1", DB_URL)
+
+
+def main():
+    print("RED-S2 restore drill\n")
+
+    from services.artifact_store import artifact_key, get_store, reset_store
+    reset_store()
+    store = get_store()
+    print(f"  artifact store: {store.describe()}\n")
+    if store.name == "none":
+        print("  REFUSING TO RUN: ARTIFACT_STORE=none means there is no second")
+        print("  copy to restore from. A drill against nothing proves nothing.")
+        sys.exit(1)
+
+    # ── A. generate ───────────────────────────────────────────────────
+    print("[A] generate a deed with a stored PDF")
+    tag = uuid.uuid4().hex[:10]
+    email = f"drill-{tag}@test.local"
+    pdf_bytes = b"%PDF-1.4\n% restore drill artifact " + tag.encode() + b"\n%%EOF\n"
+    digest = hashlib.sha256(pdf_bytes).hexdigest()
+
+    src = psycopg2.connect(DB_URL, cursor_factory=RealDictCursor, connect_timeout=10)
+    try:
+        with src.cursor() as cur:
+            cur.execute("INSERT INTO users (email, password_hash) VALUES (%s,%s) RETURNING id",
+                        (email, "x"))
+            uid = cur.fetchone()["id"]
+            cur.execute("""INSERT INTO deeds (user_id, deed_type, status, property_address)
+                           VALUES (%s,'grant-deed','completed',%s) RETURNING id""",
+                        (uid, f"{tag} Drill St"))
+            deed_id = cur.fetchone()["id"]
+            cur.execute("""INSERT INTO deed_pdfs (deed_id, pdf_data, sha256)
+                           VALUES (%s,%s,%s)""",
+                        (deed_id, psycopg2.Binary(pdf_bytes), digest))
+            src.commit()
+        store.put(artifact_key(deed_id, digest), pdf_bytes)
+        print(f"      deed {deed_id}, sha256 {digest[:16]}…")
+        check("the second copy exists in the object store",
+              store.exists(artifact_key(deed_id, digest)))
+
+        # ── B. back up ────────────────────────────────────────────────
+        print("\n[B] pg_dump")
+        dump_path = Path(tempfile.gettempdir()) / f"s2_drill_{tag}.dump"
+        r = subprocess.run(["pg_dump", "--format=custom", "--file", str(dump_path), DB_URL],
+                           capture_output=True, text=True)
+        check("pg_dump succeeded", r.returncode == 0, r.stderr.strip()[:200])
+        size = dump_path.stat().st_size if dump_path.exists() else 0
+        check("the dump is non-empty", size > 0, f"{size} bytes")
+        if r.returncode != 0:
+            return
+
+        # ── C. restore into a separate database ───────────────────────
+        print("\n[C] restore into a SEPARATE database")
+        a = admin_conn()
+        try:
+            with a.cursor() as cur:
+                cur.execute(f'DROP DATABASE IF EXISTS "{RESTORE_DB}"')
+                cur.execute(f'CREATE DATABASE "{RESTORE_DB}"')
+        finally:
+            a.close()
+        r = subprocess.run(["pg_restore", "--no-owner", "--dbname", restore_url(),
+                            str(dump_path)], capture_output=True, text=True)
+        # pg_restore warns about roles/extensions on a clean target; the
+        # verification below is what decides, not its exit code.
+        print(f"      pg_restore exit {r.returncode}")
+
+        rest = psycopg2.connect(restore_url(), cursor_factory=RealDictCursor,
+                                connect_timeout=10)
+        try:
+            with rest.cursor() as cur:
+                cur.execute("SELECT pdf_data, sha256 FROM deed_pdfs WHERE deed_id = %s",
+                            (deed_id,))
+                row = cur.fetchone()
+            check("the artifact is present in the restored database", row is not None)
+            if not row:
+                return
+
+            # ── D. verify ─────────────────────────────────────────────
+            print("\n[D] hash-verify the recovered bytes")
+            recovered = bytes(row["pdf_data"])
+            actual = hashlib.sha256(recovered).hexdigest()
+            check("recovered bytes hash to the sha256 recorded at generation",
+                  actual == digest, f"{actual[:16]}… vs {digest[:16]}…")
+            check("recovered bytes are byte-identical to the original",
+                  recovered == pdf_bytes)
+            check("the recorded sha256 itself survived the restore",
+                  row["sha256"] == digest)
+
+            # ── E. the database is gone ───────────────────────────────
+            print("\n[E] recover from the SECOND COPY alone (database row destroyed)")
+            with rest.cursor() as cur:
+                cur.execute("DELETE FROM deed_pdfs WHERE deed_id = %s", (deed_id,))
+                rest.commit()
+                cur.execute("SELECT 1 FROM deed_pdfs WHERE deed_id = %s", (deed_id,))
+                check("the artifact row is really gone from the database",
+                      cur.fetchone() is None)
+
+            from_store = store.get(artifact_key(deed_id, digest))
+            check("the instrument is recoverable from the object store",
+                  from_store is not None)
+            if from_store is not None:
+                check("object-store bytes hash to the recorded sha256",
+                      hashlib.sha256(from_store).hexdigest() == digest)
+                check("object-store bytes are byte-identical to the original",
+                      from_store == pdf_bytes)
+
+            # ── F. the cascade is gone ────────────────────────────────
+            print("\n[F] a deed row can no longer be deleted out from under its artifact")
+            with rest.cursor() as cur:
+                cur.execute("""INSERT INTO deeds (user_id, deed_type, status)
+                               VALUES ((SELECT id FROM users WHERE email=%s),
+                                       'grant-deed','completed') RETURNING id""",
+                            (email,))
+                keep_id = cur.fetchone()["id"]
+                cur.execute("""INSERT INTO deed_pdfs (deed_id, pdf_data, sha256)
+                               VALUES (%s,%s,%s)""",
+                            (keep_id, psycopg2.Binary(b"x"), "0" * 64))
+                rest.commit()
+            refused = False
+            try:
+                with rest.cursor() as cur:
+                    cur.execute("DELETE FROM deeds WHERE id = %s", (keep_id,))
+                    rest.commit()
+            except psycopg2.errors.ForeignKeyViolation:
+                rest.rollback()
+                refused = True
+            check("deleting a deed with a stored artifact is REFUSED", refused)
+        finally:
+            rest.close()
+    finally:
+        # cleanup: source rows, dump, restore database
+        try:
+            with src.cursor() as cur:
+                cur.execute("DELETE FROM deed_pdfs WHERE deed_id IN "
+                            "(SELECT id FROM deeds WHERE user_id = "
+                            "(SELECT id FROM users WHERE email=%s))", (email,))
+                cur.execute("DELETE FROM deeds WHERE user_id = "
+                            "(SELECT id FROM users WHERE email=%s)", (email,))
+                cur.execute("DELETE FROM users WHERE email = %s", (email,))
+                src.commit()
+        except Exception as e:
+            print(f"      (cleanup note: {e})")
+        src.close()
+        a = admin_conn()
+        try:
+            with a.cursor() as cur:
+                cur.execute(f'DROP DATABASE IF EXISTS "{RESTORE_DB}"')
+        except Exception:
+            pass
+        finally:
+            a.close()
+
+
+if __name__ == "__main__":
+    main()
+    print()
+    if failures:
+        print(f"DRILL FAILED: {failures}")
+        sys.exit(1)
+    print("DRILL PASSED — a generated instrument survived backup, restore and "
+          "database loss, hash-verified at every step.")

--- a/backend/services/artifact_store.py
+++ b/backend/services/artifact_store.py
@@ -1,0 +1,253 @@
+"""A second copy of every stored instrument. RED-S2.
+
+═══ THE FINDING THIS ANSWERS ═══
+
+Every generated deed existed in exactly ONE place: `deed_pdfs.pdf_data`,
+a BYTEA column in a single Postgres. No object store, no replica, no
+export. The only S3 code in the repository stored INVOICES.
+
+So the company replicated its billing PDFs and kept its customers' legal
+instruments in one database column — and the sha256 that makes those
+instruments verifiable lived in the same row, so losing the database lost
+the documents AND the ability to prove what they had been.
+
+═══ WHY A SECOND COPY IS NOT THE SAME AS A BACKUP ═══
+
+A backup answers "can we get yesterday's data back". A second copy
+answers "does this document exist anywhere else RIGHT NOW". They fail
+differently and both are required: a backup taken before a deed was
+generated does not contain it, and an object store does not protect
+against a bad write it faithfully replicates.
+
+RED-S2 does both. This module is the second copy; `scripts/
+s2_restore_drill.py` is the backup, and — the part that matters — it is
+EXECUTED rather than documented.
+
+═══ ON NOT HAVING CREDENTIALS ═══
+
+Production object storage needs credentials, and credentials are
+owner-only by standing rule (Tier 3: env vars on Render, never committed
+or pasted). So this module ships THREE backends:
+
+  filesystem — a real second copy on a real volume. Works with no
+               credentials, which is what makes the drill runnable here
+               and in CI rather than aspirational.
+  s3         — the production shape. Reads its configuration from the
+               environment; the owner supplies it.
+  none       — explicitly no second copy.
+
+`none` is a legitimate choice for local development and an indefensible
+one for production, so it is LOUD: it logs what it is not doing every
+time it is asked to store something. A silent no-op backend would
+recreate the exact defect this ticket exists to remove, while reporting
+success — which is invariant #4's disease with a storage adapter on.
+
+There is deliberately no automatic fallback from `s3` to `none`. If the
+production backend is configured and broken, the honest outcome is a
+recorded failure, not a quiet downgrade to storing nothing.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import shutil
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+
+class ArtifactStoreError(Exception):
+    """A second copy could not be written or read. Never swallowed."""
+
+
+def artifact_key(deed_id: int, sha256: str) -> str:
+    """Content-addressed within a deed's folder.
+
+    The sha256 is IN the key on purpose. It means a re-render that
+    produces different bytes cannot overwrite the stored artifact — it
+    lands beside it — so §9's insert-or-refuse holds in the object store
+    as well as the database, rather than only where it is enforced by
+    application code.
+    """
+    return f"deeds/{deed_id}/{sha256}.pdf"
+
+
+class BaseStore:
+    name = "base"
+
+    def put(self, key: str, data: bytes) -> None:
+        raise NotImplementedError
+
+    def get(self, key: str) -> Optional[bytes]:
+        raise NotImplementedError
+
+    def exists(self, key: str) -> bool:
+        raise NotImplementedError
+
+    def describe(self) -> str:
+        return self.name
+
+
+class FilesystemStore(BaseStore):
+    """A real second copy, on a real path.
+
+    Not a stub for S3 — a working backend. On a host with a mounted
+    volume this is a legitimate production choice, and it is what makes
+    the restore drill executable without credentials.
+    """
+
+    name = "filesystem"
+
+    def __init__(self, root: str):
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def _path(self, key: str) -> Path:
+        p = (self.root / key).resolve()
+        root = self.root.resolve()
+        # A key is built from a deed id and a hex digest, so traversal is
+        # not reachable today. Checked anyway: the cost is one comparison
+        # and the failure mode is writing outside the store.
+        if not str(p).startswith(str(root)):
+            raise ArtifactStoreError(f"key escapes the store root: {key!r}")
+        return p
+
+    def put(self, key: str, data: bytes) -> None:
+        p = self._path(key)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        # Write-then-rename: a reader never sees a half-written artifact,
+        # and a crash mid-write leaves a temp file rather than a
+        # truncated "instrument".
+        tmp = p.with_suffix(p.suffix + ".partial")
+        tmp.write_bytes(data)
+        os.replace(tmp, p)
+
+    def get(self, key: str) -> Optional[bytes]:
+        p = self._path(key)
+        return p.read_bytes() if p.exists() else None
+
+    def exists(self, key: str) -> bool:
+        return self._path(key).exists()
+
+    def describe(self) -> str:
+        return f"filesystem:{self.root}"
+
+
+class S3Store(BaseStore):
+    """The production shape. Configuration is owner-supplied.
+
+    No credentials are read, defaulted or logged here — the boto3 client
+    resolves them from the environment/instance role in the usual way, so
+    nothing secret passes through this file.
+    """
+
+    name = "s3"
+
+    def __init__(self, bucket: str, prefix: str = ""):
+        try:
+            import boto3
+        except ImportError as e:
+            raise ArtifactStoreError(
+                "ARTIFACT_STORE=s3 but boto3 is not installed") from e
+        self.bucket = bucket
+        self.prefix = prefix.strip("/")
+        self._client = boto3.client("s3")
+
+    def _key(self, key: str) -> str:
+        return f"{self.prefix}/{key}" if self.prefix else key
+
+    def put(self, key: str, data: bytes) -> None:
+        self._client.put_object(Bucket=self.bucket, Key=self._key(key), Body=data)
+
+    def get(self, key: str) -> Optional[bytes]:
+        try:
+            resp = self._client.get_object(Bucket=self.bucket, Key=self._key(key))
+            return resp["Body"].read()
+        except Exception as e:
+            if "NoSuchKey" in str(e) or "404" in str(e):
+                return None
+            raise ArtifactStoreError(f"s3 get failed for {key}: {e}") from e
+
+    def exists(self, key: str) -> bool:
+        try:
+            self._client.head_object(Bucket=self.bucket, Key=self._key(key))
+            return True
+        except Exception:
+            return False
+
+    def describe(self) -> str:
+        return f"s3:{self.bucket}/{self.prefix}"
+
+
+class NullStore(BaseStore):
+    """No second copy — and it says so, every time.
+
+    This is the pre-RED-S2 state, made explicit and noisy instead of
+    being the unexamined default. If these lines appear in a production
+    log, the finding this ticket closed is open again.
+    """
+
+    name = "none"
+
+    def put(self, key: str, data: bytes) -> None:
+        logger.warning(
+            "[artifact-store] NO SECOND COPY: %s (%d bytes) exists only in "
+            "Postgres. Set ARTIFACT_STORE to enable durable storage.",
+            key, len(data))
+
+    def get(self, key: str) -> Optional[bytes]:
+        return None
+
+    def exists(self, key: str) -> bool:
+        return False
+
+
+_store: Optional[BaseStore] = None
+
+
+def get_store() -> BaseStore:
+    """The configured backend, built once."""
+    global _store
+    if _store is not None:
+        return _store
+
+    kind = (os.getenv("ARTIFACT_STORE") or "none").strip().lower()
+    if kind == "s3":
+        bucket = os.getenv("ARTIFACT_S3_BUCKET")
+        if not bucket:
+            raise ArtifactStoreError(
+                "ARTIFACT_STORE=s3 requires ARTIFACT_S3_BUCKET")
+        _store = S3Store(bucket, os.getenv("ARTIFACT_S3_PREFIX", ""))
+    elif kind == "filesystem":
+        root = os.getenv("ARTIFACT_FS_ROOT")
+        if not root:
+            raise ArtifactStoreError(
+                "ARTIFACT_STORE=filesystem requires ARTIFACT_FS_ROOT")
+        _store = FilesystemStore(root)
+    elif kind == "none":
+        _store = NullStore()
+    else:
+        raise ArtifactStoreError(
+            f"unknown ARTIFACT_STORE={kind!r} (filesystem | s3 | none)")
+
+    logger.info("[artifact-store] using %s", _store.describe())
+    return _store
+
+
+def reset_store() -> None:
+    """Test hook."""
+    global _store
+    _store = None
+
+
+def verify(data: bytes, expected_sha256: str) -> bool:
+    return hashlib.sha256(data).hexdigest() == expected_sha256
+
+
+def copy_tree(src: Path, dst: Path) -> None:
+    """Used by the restore drill to snapshot a filesystem store."""
+    if dst.exists():
+        shutil.rmtree(dst)
+    shutil.copytree(src, dst)

--- a/backend/services/deed_pdf.py
+++ b/backend/services/deed_pdf.py
@@ -10,6 +10,7 @@ import hashlib
 import json
 import os
 from datetime import datetime, timezone
+from typing import Optional
 
 import psycopg2
 from jinja2 import Environment, FileSystemLoader, select_autoescape
@@ -143,10 +144,18 @@ def render_deed_pdf(row) -> bytes:
 
 
 def ensure_deed_pdfs_table(conn):
+    """RED-S2: RESTRICT, not CASCADE — and see database.py for the why.
+
+    This CREATE is a second copy of a statement that also lives in
+    `database.create_tables()`, which is the one schema authority (H1).
+    It exists because db.py calls it at import to guarantee the table
+    before anything reads it. Both copies now say RESTRICT; if they ever
+    disagree again, a pinned test fails.
+    """
     with conn.cursor() as cur:
         cur.execute("""
             CREATE TABLE IF NOT EXISTS deed_pdfs (
-                deed_id INTEGER PRIMARY KEY REFERENCES deeds(id) ON DELETE CASCADE,
+                deed_id INTEGER PRIMARY KEY REFERENCES deeds(id) ON DELETE RESTRICT,
                 pdf_data BYTEA NOT NULL,
                 sha256 VARCHAR(64) NOT NULL,
                 generated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
@@ -234,7 +243,103 @@ def store_deed_pdf(conn, deed_id: int, pdf_bytes: bytes) -> str:
             WHERE id = %s
         """, (f"/deeds/{deed_id}/download", stamp, deed_id))
         conn.commit()
+
+    # RED-S2: the second copy.
+    #
+    # Until this ticket, the line above was the ONLY place a generated
+    # instrument existed. Losing the database lost every deed and the
+    # sha256 that made each one verifiable, in one event.
+    #
+    # Written AFTER the commit, deliberately. The database row is the
+    # system of record; a store that is slow or down must not hold up an
+    # officer's deed, and a rolled-back transaction must not leave an
+    # orphan artifact claiming to be an instrument that was never stored.
+    #
+    # The failure is RECORDED, not swallowed (invariant #4). The
+    # precedent is the email path: a failed send does not lose the lead,
+    # it writes `notify_error` on the row so the queue shows it flagged.
+    # Same shape here — `artifact_error` on the deed's metadata, and a
+    # loud log. An officer is never blocked by it; an operator can always
+    # find it.
+    _mirror_to_artifact_store(conn, deed_id, pdf_bytes, digest)
     return digest
+
+
+def _mirror_to_artifact_store(conn, deed_id: int, pdf_bytes: bytes, digest: str):
+    from services.artifact_store import artifact_key, get_store
+
+    key = artifact_key(deed_id, digest)
+    try:
+        store = get_store()
+        store.put(key, pdf_bytes)
+        note = json.dumps({"artifact_key": key, "artifact_store": store.name,
+                           "artifact_error": None})
+    except Exception as e:
+        # Loud, recorded, and non-blocking — in that order.
+        print(f"[artifact-store] ❌ SECOND COPY FAILED for deed {deed_id} "
+              f"({key}): {type(e).__name__}: {e}")
+        note = json.dumps({"artifact_key": key, "artifact_store": None,
+                           "artifact_error": f"{type(e).__name__}: {str(e)[:300]}"})
+
+    try:
+        with conn.cursor() as cur:
+            cur.execute("""
+                UPDATE deeds
+                SET metadata = COALESCE(metadata, '{}'::jsonb) || %s::jsonb
+                WHERE id = %s
+            """, (note, deed_id))
+            conn.commit()
+    except Exception as e:
+        try:
+            conn.rollback()
+        except Exception:
+            pass
+        print(f"[artifact-store] could not record mirror state for deed "
+              f"{deed_id}: {e}")
+
+
+def read_stored_pdf(conn, deed_id: int) -> Optional[bytes]:
+    """The stored instrument, from the database or the second copy.
+
+    Order matters and is the opposite of what you might expect: the
+    DATABASE is tried first, because it is the system of record and its
+    bytes are the ones the sha256 was computed over at generation. The
+    object store is the fallback for exactly the case this ticket exists
+    for — the row is gone or unreadable.
+
+    Both paths hash-verify before returning. A second copy that returns
+    the wrong bytes is worse than one that returns nothing, because the
+    caller would have no way to tell.
+    """
+    from services.artifact_store import artifact_key, get_store, verify
+
+    stored_sha = None
+    with conn.cursor() as cur:
+        cur.execute("SELECT pdf_data, sha256 FROM deed_pdfs WHERE deed_id = %s",
+                    (deed_id,))
+        row = cur.fetchone()
+        if row:
+            data = bytes(row["pdf_data"] if isinstance(row, dict) else row[0])
+            stored_sha = row["sha256"] if isinstance(row, dict) else row[1]
+            if verify(data, stored_sha):
+                return data
+            print(f"[artifact-store] ⚠️ deed {deed_id}: stored bytes do NOT "
+                  f"match their recorded sha256 — falling back to the "
+                  f"second copy")
+
+    if not stored_sha:
+        with conn.cursor() as cur:
+            cur.execute("SELECT metadata->>'pdf_sha256' AS s FROM deeds WHERE id = %s",
+                        (deed_id,))
+            r = cur.fetchone()
+            stored_sha = (r["s"] if isinstance(r, dict) else r[0]) if r else None
+    if not stored_sha:
+        return None
+
+    data = get_store().get(artifact_key(deed_id, stored_sha))
+    if data is not None and verify(data, stored_sha):
+        return data
+    return None
 
 
 def generate_and_store(conn, row) -> str:

--- a/backend/tests/test_red_s2_artifact_durability.py
+++ b/backend/tests/test_red_s2_artifact_durability.py
@@ -1,0 +1,236 @@
+"""RED-S2 — the stored instrument exists in more than one place.
+
+Before this, every generated deed lived in exactly one column of one
+Postgres, and the sha256 that made it verifiable lived in the same row.
+One lost database lost the documents AND the ability to prove what they
+had been.
+
+These pins guard the three parts of the answer, and the direction each
+would fail in:
+
+  1. There is a SECOND COPY, it is written on generation, and a failure
+     to write it is recorded rather than swallowed. The dangerous
+     direction here is silence: a store that no-ops and reports success
+     rebuilds the finding while the tests stay green.
+  2. The schema no longer CASCADEs a deed delete into its artifact. §9
+     guarded overwrite; the schema handed DELETE a cascade, so the
+     doctrine covered one verb.
+  3. A recovery hash-verifies. Bytes that do not hash are not a recovery,
+     and returning them would be worse than returning nothing because
+     the caller could not tell.
+"""
+import hashlib
+import os
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+BACKEND = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(BACKEND))
+
+from services import artifact_store as store_mod  # noqa: E402
+from tests.source_text import code_only  # noqa: E402
+
+LIVE_DB = os.getenv("DATABASE_URL")
+
+
+@pytest.fixture(autouse=True)
+def _clean_store(monkeypatch, tmp_path):
+    store_mod.reset_store()
+    monkeypatch.setenv("ARTIFACT_STORE", "filesystem")
+    monkeypatch.setenv("ARTIFACT_FS_ROOT", str(tmp_path / "artifacts"))
+    yield
+    store_mod.reset_store()
+
+
+# ── 1. The second copy ────────────────────────────────────────────────
+
+
+def test_round_trip_through_the_filesystem_store():
+    s = store_mod.get_store()
+    key = store_mod.artifact_key(42, "a" * 64)
+    s.put(key, b"%PDF-1.4 bytes")
+    assert s.exists(key)
+    assert s.get(key) == b"%PDF-1.4 bytes"
+
+
+def test_a_missing_artifact_reads_as_none_not_an_error():
+    assert store_mod.get_store().get("deeds/1/nope.pdf") is None
+
+
+def test_the_key_is_content_addressed_so_a_rerender_cannot_overwrite():
+    """§9 in the object store: different bytes land BESIDE the original,
+    never on top of it. Enforced by the key, not by a check somebody has
+    to remember to write."""
+    a = store_mod.artifact_key(7, "a" * 64)
+    b = store_mod.artifact_key(7, "b" * 64)
+    assert a != b
+    s = store_mod.get_store()
+    s.put(a, b"first")
+    s.put(b, b"second")
+    assert s.get(a) == b"first"
+
+
+def test_a_partial_write_is_never_visible():
+    """Write-then-rename: a reader sees the whole artifact or nothing.
+    A truncated file that still parses as a PDF is the worst outcome."""
+    src = code_only(BACKEND / "services" / "artifact_store.py")
+    assert "os.replace" in src
+    assert ".partial" in src
+
+
+def test_the_null_store_is_loud_about_storing_nothing():
+    """`none` is legitimate locally and indefensible in production, so it
+    must never be quiet. A silent no-op backend is invariant #4's disease
+    wearing a storage adapter."""
+    src = code_only(BACKEND / "services" / "artifact_store.py")
+    null = src[src.index("class NullStore"):src.index("_store: Optional")]
+    assert "logger.warning" in null
+    assert "NO SECOND COPY" in null
+
+
+def test_there_is_no_silent_fallback_from_s3_to_none():
+    """If the production backend is configured and broken, the honest
+    outcome is a recorded failure — not a quiet downgrade to storing
+    nothing, which would look identical to success."""
+    src = code_only(BACKEND / "services" / "artifact_store.py")
+    s3_block = src[src.index("if kind == \"s3\""):src.index("elif kind == \"filesystem\"")]
+    assert "NullStore" not in s3_block
+
+
+def test_an_unknown_backend_name_is_refused():
+    store_mod.reset_store()
+    os.environ["ARTIFACT_STORE"] = "dropbox"
+    try:
+        with pytest.raises(store_mod.ArtifactStoreError):
+            store_mod.get_store()
+    finally:
+        os.environ["ARTIFACT_STORE"] = "filesystem"
+        store_mod.reset_store()
+
+
+def test_generation_mirrors_to_the_store_and_records_failures():
+    src = code_only(BACKEND / "services" / "deed_pdf.py")
+    assert "_mirror_to_artifact_store" in src
+    # The failure is recorded on the row, not swallowed — the email
+    # path's precedent.
+    assert "artifact_error" in src
+    # ...and it never blocks the officer: the mirror runs after commit.
+    body = src[src.index("def _mirror_to_artifact_store"):src.index("def read_stored_pdf")]
+    assert "except Exception" in body
+
+
+# ── 2. The cascade is gone ────────────────────────────────────────────
+
+
+def test_neither_schema_authority_still_says_cascade_for_deed_pdfs():
+    """Two files create this table. Both must agree, or a fresh database
+    and an existing one diverge — which is the H1 incident's shape."""
+    for rel in [("database.py",), ("services", "deed_pdf.py")]:
+        src = code_only(BACKEND.joinpath(*rel))
+        block_start = src.find("CREATE TABLE IF NOT EXISTS deed_pdfs")
+        assert block_start != -1, rel
+        block = src[block_start:block_start + 400]
+        assert "ON DELETE RESTRICT" in block, rel
+        assert "ON DELETE CASCADE" not in block, rel
+
+
+def test_the_migration_converges_an_existing_cascade():
+    """CREATE TABLE IF NOT EXISTS does not alter an existing table, so a
+    production database created with CASCADE would have kept it."""
+    src = code_only(BACKEND / "database.py")
+    assert "confdeltype = 'c'" in src
+    assert "deed_pdfs_deed_id_fkey" in src
+
+
+@pytest.mark.skipif(not LIVE_DB, reason="live test DB required")
+def test_the_live_constraint_is_restrict():
+    """The executable version: what the database actually says, not what
+    the source says it should."""
+    import psycopg2
+    from database import create_tables
+    create_tables()
+    c = psycopg2.connect(LIVE_DB, connect_timeout=10)
+    try:
+        with c.cursor() as cur:
+            cur.execute("""
+                SELECT c.confdeltype FROM pg_constraint c
+                JOIN pg_class t ON t.oid = c.conrelid
+                WHERE t.relname = 'deed_pdfs' AND c.contype = 'f'
+            """)
+            rows = cur.fetchall()
+        assert rows, "no foreign key found on deed_pdfs"
+        for (deltype,) in rows:
+            assert deltype == "r", f"expected RESTRICT, got confdeltype={deltype!r}"
+    finally:
+        c.close()
+
+
+@pytest.mark.skipif(not LIVE_DB, reason="live test DB required")
+def test_deleting_a_deed_with_an_artifact_is_refused():
+    import psycopg2
+    from database import create_tables
+    create_tables()
+    tag = uuid.uuid4().hex[:10]
+    c = psycopg2.connect(LIVE_DB, connect_timeout=10)
+    try:
+        with c.cursor() as cur:
+            cur.execute("INSERT INTO users (email, password_hash) VALUES (%s,%s) RETURNING id",
+                        (f"s2-{tag}@test.local", "x"))
+            uid = cur.fetchone()[0]
+            cur.execute("""INSERT INTO deeds (user_id, deed_type, status)
+                           VALUES (%s,'grant-deed','completed') RETURNING id""", (uid,))
+            did = cur.fetchone()[0]
+            cur.execute("INSERT INTO deed_pdfs (deed_id, pdf_data, sha256) VALUES (%s,%s,%s)",
+                        (did, psycopg2.Binary(b"%PDF"), "0" * 64))
+            c.commit()
+
+        with pytest.raises(psycopg2.errors.ForeignKeyViolation):
+            with c.cursor() as cur:
+                cur.execute("DELETE FROM deeds WHERE id = %s", (did,))
+        c.rollback()
+
+        with c.cursor() as cur:
+            cur.execute("DELETE FROM deed_pdfs WHERE deed_id = %s", (did,))
+            cur.execute("DELETE FROM deeds WHERE id = %s", (did,))
+            cur.execute("DELETE FROM users WHERE id = %s", (uid,))
+            c.commit()
+    finally:
+        c.close()
+
+
+# ── 3. Recovery hash-verifies ─────────────────────────────────────────
+
+
+def test_verify_rejects_altered_bytes():
+    data = b"%PDF-1.4 real"
+    digest = hashlib.sha256(data).hexdigest()
+    assert store_mod.verify(data, digest)
+    assert not store_mod.verify(data + b" tampered", digest)
+
+
+def test_the_reader_hash_checks_both_paths():
+    """A second copy that returns the WRONG bytes is worse than one that
+    returns nothing, because the caller cannot tell."""
+    src = code_only(BACKEND / "services" / "deed_pdf.py")
+    fn = src[src.index("def read_stored_pdf"):]
+    assert fn.count("verify(") >= 2
+
+
+def test_the_drill_refuses_to_run_against_no_store():
+    """A drill that passes against ARTIFACT_STORE=none proves nothing and
+    would be the most dangerous green tick in the repository."""
+    src = code_only(BACKEND / "scripts" / "s2_restore_drill.py")
+    assert "REFUSING TO RUN" in src or 'name == "none"' in src
+    assert "sys.exit(1)" in src
+
+
+def test_the_drill_checks_the_whole_chain():
+    """Each stage named, so a future edit that quietly drops one is
+    visible in the diff."""
+    src = code_only(BACKEND / "scripts" / "s2_restore_drill.py")
+    for stage in ["pg_dump", "pg_restore", "hash", "DELETE FROM deed_pdfs",
+                  "ForeignKeyViolation"]:
+        assert stage in src, stage

--- a/docs/BACKUP_AND_RESTORE.md
+++ b/docs/BACKUP_AND_RESTORE.md
@@ -1,0 +1,176 @@
+# Backup and restore — the runbook, and the drill that proves it
+
+**Status: the drill has been EXECUTED and passes.** Not "documented as a
+procedure" — run, against real Postgres, with hash verification at every
+step. See "Running the drill" below; the output is the evidence.
+
+---
+
+## What is being protected, and why it is unusual
+
+Every deed this product generates is an **instrument**. It was rendered,
+hashed with sha256, stored, and may have been printed, signed, notarised
+and recorded. The hash is not a checksum for our convenience — doctrine
+§3 removed QR codes from recorded pages on the reasoning that
+*"verification survives as data"*, and this is that data.
+
+So losing the database would not merely lose files. It would lose the
+documents **and** the ability to prove what they had been, in one event.
+
+Before RED-S2 there was exactly one copy: `deed_pdfs.pdf_data`, a BYTEA
+column, in one Postgres, with the sha256 in the same row. The only
+object-storage code in the repository stored **invoices**.
+
+---
+
+## The two things that are not the same
+
+| | answers | fails when |
+|---|---|---|
+| **Backup** | "can we get yesterday's data back?" | the deed was generated after the backup |
+| **Second copy** | "does this document exist anywhere else *right now*?" | a bad write is faithfully replicated |
+
+Both are required. RED-S2 ships both.
+
+---
+
+## The second copy — configuration
+
+`services/artifact_store.py`, selected by `ARTIFACT_STORE`:
+
+| value | what it does | use |
+|---|---|---|
+| `filesystem` | real second copy on a mounted volume; needs `ARTIFACT_FS_ROOT` | local, CI, and a legitimate production choice on a host with a volume |
+| `s3` | needs `ARTIFACT_S3_BUCKET`, optional `ARTIFACT_S3_PREFIX` | production |
+| `none` | **no second copy** — logs a warning every time it is asked to store | local development only |
+
+`none` is the pre-RED-S2 state made explicit and noisy. **If those
+warnings appear in a production log, the finding is open again.**
+
+There is deliberately **no automatic fallback from `s3` to `none`**. A
+configured-and-broken production backend produces a recorded failure, not
+a quiet downgrade to storing nothing — which would look identical to
+success.
+
+### Owner-side (Tier 3 — credentials never appear in this repo)
+
+Set on Render, never committed, never pasted into chat:
+
+- `ARTIFACT_STORE=s3`
+- `ARTIFACT_S3_BUCKET=<bucket>`
+- `ARTIFACT_S3_PREFIX=<optional prefix>`
+- AWS credentials by the standard chain (instance role preferred over
+  keys; no credential is read or logged by our code)
+
+**The first production run of the drill against the real bucket is an
+owner-side step**, for the same reason: this repository cannot hold the
+credentials that would let CI do it.
+
+---
+
+## Writing: how the second copy is kept
+
+`store_deed_pdf()` writes the database row, commits, **then** mirrors to
+the object store.
+
+That order is deliberate:
+
+- The database row is the system of record. A slow or down object store
+  must never hold up an officer's deed.
+- Mirroring after the commit means a rolled-back transaction cannot leave
+  an orphan artifact claiming to be an instrument that was never stored.
+- A mirror failure is **recorded, not swallowed** — `artifact_error` on
+  the deed's metadata plus a loud log. Same shape as the email path,
+  where a failed send flags the row instead of losing the lead.
+
+The object key is **content-addressed**: `deeds/{deed_id}/{sha256}.pdf`.
+A re-render producing different bytes lands *beside* the original rather
+than on top of it, so §9's insert-or-refuse holds in the object store
+too — enforced by the key, not by a check someone has to remember.
+
+---
+
+## Deletion: the cascade is gone
+
+`deed_pdfs.deed_id` was `REFERENCES deeds(id) ON DELETE CASCADE`.
+
+§9 refuses to **overwrite** a stored instrument and the application
+enforces that carefully — but the schema handed **DELETE** a cascade. The
+doctrine guarded one verb. A cleanup script (`DELETE FROM deeds WHERE
+created_at < ...` — the kind somebody writes on a Friday) would have
+taken every notarised instrument with it, silently, and left nothing to
+prove what had been there.
+
+It is now `ON DELETE RESTRICT`, with an idempotent migration that
+converges existing databases. Deletion is already **soft** everywhere in
+this product (`status='deleted'`), so nothing legitimate is blocked.
+
+---
+
+## Running the drill
+
+```bash
+cd backend
+DATABASE_URL=postgresql://...              \
+ARTIFACT_STORE=filesystem                  \
+ARTIFACT_FS_ROOT=/var/artifacts            \
+python scripts/s2_restore_drill.py
+```
+
+Exit code 1 on any failure, so it can gate rather than inform. It
+**refuses to run** against `ARTIFACT_STORE=none` — a drill that passes
+against nothing would be the most dangerous green tick in the repository.
+
+### What it proves, in order
+
+| stage | proves |
+|---|---|
+| **A** generate | a deed with a real stored PDF and a recorded sha256; the second copy exists |
+| **B** `pg_dump` | the actual tool produces a non-empty dump |
+| **C** restore | `pg_restore` into a **separate** database; the artifact is present there |
+| **D** verify | recovered bytes hash to the sha256 recorded at generation, and are byte-identical |
+| **E** database loss | the row is **deleted** from the restored database and the instrument is recovered from the object store alone — hash-verified again |
+| **F** cascade | deleting a deed that has a stored artifact is **refused** |
+
+Stage E is the scenario the ticket exists for: the database is gone.
+
+### Last executed
+
+`2026-08-04` — all stages passed. Dump 2,339,103 bytes; recovered bytes
+byte-identical and hash-matching at both D and E; the delete at F was
+refused with `ForeignKeyViolation`.
+
+---
+
+## What this does not prove
+
+The drill runs against the **configured** backend. With
+`ARTIFACT_STORE=filesystem` it proves the mechanism and the recovery
+completely.
+
+It does **not** prove that a particular S3 bucket is reachable, because
+bucket credentials are owner-supplied by standing rule and never live
+here. Pointing the same code at S3 is a configuration change; the first
+production run is an owner-side step.
+
+Stated rather than glossed, because "we ran the drill" and "we ran the
+drill against production storage" are different claims and only one of
+them is true today.
+
+---
+
+## Restoring for real
+
+1. **Stop writes** if the situation allows it — a restore that races
+   live traffic produces a database nobody can reason about.
+2. `pg_restore --no-owner --dbname <target> <dump>`.
+3. **Verify before trusting**: for a sample of deeds, hash
+   `deed_pdfs.pdf_data` and compare to `deed_pdfs.sha256`. Bytes that do
+   not hash are not a recovery.
+4. For any deed whose row is missing or fails its hash, recover from the
+   object store at `deeds/{deed_id}/{sha256}.pdf`. The sha256 also lives
+   on `deeds.metadata->>'pdf_sha256'`, so it survives the loss of the
+   `deed_pdfs` row itself.
+5. `read_stored_pdf()` already implements exactly this order —
+   database first (it is the system of record), object store as the
+   fallback, hash-verified on both paths.


### PR DESCRIPTION
Acquirer's demand #2. **The drill was executed, not documented** — output below.

## The finding

Every generated deed lived in exactly one place: `deed_pdfs.pdf_data`, a BYTEA column in one Postgres, with the sha256 that makes it verifiable **in the same row**. Losing the database would have lost the documents *and* the ability to prove what they had been, in one event.

The only object-storage code in the repository stored **invoices**.

## The second copy

`services/artifact_store.py` — `filesystem` | `s3` | `none`.

**Content-addressed keys** (`deeds/{id}/{sha256}.pdf`): a re-render producing different bytes lands *beside* the original, never on top — §9's insert-or-refuse enforced by the key rather than by a check someone has to remember. Write-then-rename, so a reader never sees a half-written instrument.

**`none` is loud.** It's the pre-S2 state made explicit, and it logs what it is *not* doing every time. A silent no-op backend would rebuild the finding while reporting success. There is **no automatic `s3` → `none` fallback**: a configured-and-broken production store must produce a recorded failure, not a quiet downgrade that looks identical to working.

The mirror runs **after** commit — the database is the system of record, a slow store must not hold up an officer's deed, and a rolled-back transaction must not leave an orphan artifact. Failures are recorded on the row (`artifact_error`) and logged, never swallowed — the email path's precedent.

## The cascade

`deed_pdfs.deed_id` was `REFERENCES deeds(id) ON DELETE CASCADE`.

§9 refuses to **overwrite** an instrument and the app enforces that carefully. The schema handed **DELETE** a cascade — so the doctrine guarded one verb. A Friday-afternoon `DELETE FROM deeds WHERE created_at < ...` would have taken every notarised instrument with it and left nothing to prove what had been there.

Now `RESTRICT`, in **both** schema authorities — `database.py` and `deed_pdf.ensure_deed_pdfs_table()` had diverging copies — with an idempotent migration. **Verified by querying `confdeltype` on a live database, not by reading the source.**

## The drill

```
[A] generate      PASS  the second copy exists in the object store
[B] pg_dump       PASS  succeeded, 2,339,103 bytes
[C] restore       PASS  artifact present in a SEPARATE database
[D] verify        PASS  hashes to the sha256 recorded at generation
                  PASS  byte-identical to the original
[E] db destroyed  PASS  row really gone
                  PASS  recoverable from the object store alone
                  PASS  object-store bytes hash-match, byte-identical
[F] cascade       PASS  deleting a deed with an artifact is REFUSED

DRILL PASSED — a generated instrument survived backup, restore and
database loss, hash-verified at every step.
```

It **refuses to run** against `ARTIFACT_STORE=none` — a drill that passes against nothing would be the most dangerous green tick in the repository.

## Two defects the S1 proof caught on itself

**1. A real bug I shipped in S1.** `ThreadedConnectionPool.getconn()` does **not** block when exhausted — it raises `PoolError`. A burst wider than `DB_POOL_MAX` became hard 500s. That's a failure mode **S1 introduced**: a shared connection cannot exhaust a pool that doesn't exist, so trading one defect for a smaller one is still trading.

Found because the burst was wider this run (35 scopes vs 25) — timing variance, not a new test. Fixed with a bounded wait + backoff, pool default raised to the threadpool width (40), and an honest **503 with `Retry-After`** only if the wait genuinely expires. Four consecutive proof runs clean at 31–38 concurrent scopes.

**2. The gate measured against the wrong ceiling.** The proof script hardcoded its own `DB_POOL_MAX` default of 20 while `db.py`'s moved to 40 — so it failed a run that was behaving correctly. It now reads `db.POOL_MAX`. A gate that misfires is as useless as one that flatters.

## Runbook

`docs/BACKUP_AND_RESTORE.md`, including **what the drill does not prove**: a specific S3 bucket, because credentials are owner-only. Stated rather than glossed — *"we ran the drill"* and *"we ran the drill against production storage"* are different claims and only one is true today. The first production run against the real bucket is an owner-side step.

## Gates

| gate | result |
|---|---|
| backend pytest | **611 passed** |
| jest | 502, 35 suites |
| tsc | 94 — unchanged |
| six-flow | ✔ | 
| API baseline | ✔ |
| banned-claims | ✔ |
| S1 concurrency proof | ✔ ×4 consecutive |
| S2 restore drill | ✔ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_