### PR TITLE
RED-S3: sessions that can be ended, and expiry that is not an ending

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -5,6 +5,7 @@ from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from passlib.context import CryptContext
 from jose import JWTError, jwt
 import os
+import uuid
 from dotenv import load_dotenv
 
 load_dotenv()
@@ -15,6 +16,26 @@ if not SECRET_KEY:
     raise RuntimeError("JWT_SECRET_KEY environment variable must be set!")
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 30
+
+# RED-S3. The 30-minute access token stays SHORT on purpose — a leaked
+# one should stop working quickly. What was missing is everything around
+# it:
+#
+#   - no refresh, so 30 minutes meant "logged out mid-file", which is how
+#     an escrow officer loses a deed at 4:40 on a Thursday;
+#   - no `jti`, so no token could ever be identified;
+#   - and therefore NO REVOCATION. A leaked token was valid for up to 30
+#     minutes and there was no mechanism on earth to kill it. "Logout"
+#     was a localStorage delete — the token itself kept working.
+#
+# A refresh token lets the short access token stay short. Rotation on
+# every use means a stolen refresh token is usable at most once, and the
+# theft is DETECTABLE: when the legitimate holder presents the token that
+# was already rotated, that is a replay, and the whole family dies.
+REFRESH_TOKEN_EXPIRE_DAYS = int(os.getenv("REFRESH_TOKEN_EXPIRE_DAYS", "14"))
+
+TOKEN_TYPE_ACCESS = "access"
+TOKEN_TYPE_REFRESH = "refresh"
 
 # Password hashing
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
@@ -31,16 +52,111 @@ def get_password_hash(password: str) -> str:
     return pwd_context.hash(password)
 
 def create_access_token(data: dict, expires_delta: Optional[timedelta] = None):
-    """Create a JWT access token"""
+    """Create a JWT access token.
+
+    RED-S3: every token now carries a `jti`. Without one there is no name
+    to revoke, which is why "logout" used to be a localStorage delete
+    while the token itself kept working until it expired.
+    """
     to_encode = data.copy()
     if expires_delta:
         expire = datetime.utcnow() + expires_delta
     else:
         expire = datetime.utcnow() + timedelta(minutes=ACCESS_TOKEN_EXPIRE_MINUTES)
-    
-    to_encode.update({"exp": expire})
-    encoded_jwt = jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
-    return encoded_jwt
+
+    to_encode.update({
+        "exp": expire,
+        "jti": to_encode.get("jti") or uuid.uuid4().hex,
+        "typ": TOKEN_TYPE_ACCESS,
+    })
+    return jwt.encode(to_encode, SECRET_KEY, algorithm=ALGORITHM)
+
+
+def create_refresh_token(user_id, family: Optional[str] = None) -> tuple:
+    """Issue a refresh token and record it. Returns (token, jti, family).
+
+    `family` ties every rotation of one login together. Rotation issues a
+    new token and retires the old one; if a RETIRED token is ever
+    presented again, that is a replay — the legitimate holder and a thief
+    both have it — and the correct response is to kill the whole family
+    rather than guess which one is which.
+    """
+    jti = uuid.uuid4().hex
+    family = family or uuid.uuid4().hex
+    expire = datetime.utcnow() + timedelta(days=REFRESH_TOKEN_EXPIRE_DAYS)
+    token = jwt.encode(
+        {"sub": str(user_id), "jti": jti, "fam": family,
+         "typ": TOKEN_TYPE_REFRESH, "exp": expire},
+        SECRET_KEY, algorithm=ALGORITHM)
+    _record_refresh(jti, int(user_id), family, expire)
+    return token, jti, family
+
+
+def _record_refresh(jti, user_id, family, expires_at):
+    import db
+    try:
+        with db.conn.cursor() as cur:
+            cur.execute("""
+                INSERT INTO refresh_tokens (jti, user_id, family, expires_at)
+                VALUES (%s, %s, %s, %s) ON CONFLICT (jti) DO NOTHING
+            """, (jti, user_id, family, expires_at))
+            db.conn.commit()
+    except Exception as e:
+        try:
+            db.conn.rollback()
+        except Exception:
+            pass
+        # A refresh token we cannot record is one we cannot revoke, which
+        # is the whole point of the ticket. Refuse rather than hand out a
+        # credential outside the system that governs it.
+        raise HTTPException(status_code=500,
+                            detail="Could not establish the session") from e
+
+
+def revoke_jti(jti: str, user_id: Optional[int] = None, reason: str = "logout"):
+    """Kill one token by name."""
+    import db
+    with db.conn.cursor() as cur:
+        cur.execute("""
+            INSERT INTO revoked_tokens (jti, user_id, reason)
+            VALUES (%s, %s, %s) ON CONFLICT (jti) DO NOTHING
+        """, (jti, user_id, reason))
+        db.conn.commit()
+
+
+def revoke_refresh_family(family: str, reason: str = "replay"):
+    """Kill every refresh token descended from one login.
+
+    Used when a retired token is replayed. Both the officer and whoever
+    took the token lose the session — which is right: we cannot tell them
+    apart, and the safe assumption when a credential is being used twice
+    is that one of the two is not the officer.
+    """
+    import db
+    with db.conn.cursor() as cur:
+        cur.execute("""
+            UPDATE refresh_tokens SET revoked_at = NOW(), revoke_reason = %s
+            WHERE family = %s AND revoked_at IS NULL
+        """, (reason, family))
+        cur.execute("""
+            INSERT INTO revoked_tokens (jti, user_id, reason)
+            SELECT jti, user_id, %s FROM refresh_tokens WHERE family = %s
+            ON CONFLICT (jti) DO NOTHING
+        """, (reason, family))
+        db.conn.commit()
+
+
+def is_revoked(jti: str) -> bool:
+    if not jti:
+        # A token with no jti predates RED-S3. It cannot be revoked and
+        # therefore cannot be trusted; treated as revoked so the old
+        # unrevocable tokens drain out rather than living their full 30
+        # minutes past a deploy.
+        return True
+    import db
+    with db.conn.cursor() as cur:
+        cur.execute("SELECT 1 FROM revoked_tokens WHERE jti = %s", (jti,))
+        return cur.fetchone() is not None
 
 def verify_token(credentials: HTTPAuthorizationCredentials = Depends(security)) -> dict:
     """Verify and decode a JWT token"""
@@ -52,6 +168,21 @@ def verify_token(credentials: HTTPAuthorizationCredentials = Depends(security)) 
             raise HTTPException(
                 status_code=status.HTTP_401_UNAUTHORIZED,
                 detail="Could not validate credentials",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        # RED-S3: a REFRESH token is not a credential for the API. It
+        # buys a new access token and nothing else — otherwise the
+        # 14-day token silently becomes a 14-day API key.
+        if payload.get("typ") == TOKEN_TYPE_REFRESH:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Refresh tokens cannot be used to call the API",
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+        if is_revoked(payload.get("jti")):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="This session has ended. Please sign in again.",
                 headers={"WWW-Authenticate": "Bearer"},
             )
         return payload

--- a/backend/database.py
+++ b/backend/database.py
@@ -408,6 +408,47 @@ def create_tables():
             "CREATE INDEX IF NOT EXISTS idx_email_log_status ON email_log(status, created_at DESC)",
             "CREATE INDEX IF NOT EXISTS idx_email_log_template ON email_log(template, created_at DESC)",
             "CREATE INDEX IF NOT EXISTS idx_email_log_recipient ON email_log(LOWER(recipient))",
+            # RED-S3 — sessions that can be ended.
+            #
+            # Before this, a leaked token was valid for up to 30 minutes
+            # and there was no mechanism to kill it: no jti, so no name to
+            # revoke, so "logout" was a localStorage delete while the
+            # token kept working.
+            """CREATE TABLE IF NOT EXISTS revoked_tokens (
+                jti VARCHAR(64) PRIMARY KEY,
+                user_id INTEGER,
+                reason VARCHAR(32),
+                revoked_at TIMESTAMPTZ DEFAULT now()
+            )""",
+            "CREATE INDEX IF NOT EXISTS idx_revoked_user ON revoked_tokens(user_id)",
+            # `family` ties every rotation of one login together, so a
+            # replayed (already-rotated) token can take the whole family
+            # down rather than leaving a thief and an officer sharing a
+            # session nobody can tell apart.
+            """CREATE TABLE IF NOT EXISTS refresh_tokens (
+                jti VARCHAR(64) PRIMARY KEY,
+                user_id INTEGER NOT NULL,
+                family VARCHAR(64) NOT NULL,
+                issued_at TIMESTAMPTZ DEFAULT now(),
+                expires_at TIMESTAMPTZ NOT NULL,
+                used_at TIMESTAMPTZ,
+                replaced_by VARCHAR(64),
+                revoked_at TIMESTAMPTZ,
+                revoke_reason VARCHAR(32)
+            )""",
+            "CREATE INDEX IF NOT EXISTS idx_refresh_family ON refresh_tokens(family)",
+            "CREATE INDEX IF NOT EXISTS idx_refresh_user ON refresh_tokens(user_id)",
+            # Login attempts, for lockout. There was NO throttle of any
+            # kind on password guessing — unlimited attempts against
+            # bcrypt at whatever rate the host would serve.
+            """CREATE TABLE IF NOT EXISTS login_attempts (
+                id BIGSERIAL PRIMARY KEY,
+                email TEXT NOT NULL,
+                ip TEXT,
+                succeeded BOOLEAN NOT NULL,
+                attempted_at TIMESTAMPTZ DEFAULT now()
+            )""",
+            "CREATE INDEX IF NOT EXISTS idx_login_attempts_email ON login_attempts(LOWER(email), attempted_at DESC)",
             # RED-H1.3 — the AI exchange log.
             #
             # Nothing recorded what the assistant told an escrow officer.

--- a/backend/routers/auth_extra.py
+++ b/backend/routers/auth_extra.py
@@ -4,6 +4,7 @@ from datetime import timedelta, datetime
 from typing import Optional
 
 from fastapi import APIRouter, HTTPException, Body, Depends, Request
+from fastapi.security import HTTPBearer
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, EmailStr, Field, validator
 from jose import jwt, JWTError
@@ -36,6 +37,11 @@ except Exception as e:
     )
 
 router = APIRouter()
+
+# auto_error=False: logout must work even without a valid bearer — an
+# officer whose token already expired still expects the button to end
+# the session rather than 401 at her.
+_bearer = HTTPBearer(auto_error=False)
 
 EMAIL_VERIFICATION_REQUIRED = os.getenv("EMAIL_VERIFICATION_REQUIRED", "false").lower() == "true"
 REFRESH_TOKENS_ENABLED = os.getenv("REFRESH_TOKENS_ENABLED", "false").lower() == "true"
@@ -188,17 +194,120 @@ class RefreshTokenRequest(BaseModel):
 
 @router.post("/users/refresh-token")
 def refresh_token(payload: RefreshTokenRequest):
-    if not REFRESH_TOKENS_ENABLED:
-        raise HTTPException(status_code=403, detail="Refresh tokens disabled")
+    """Exchange a refresh token for a new pair, rotating as it goes.
+
+    RED-S3 replaced a stub. What was here decoded the token, checked a
+    `type` claim the rest of the codebase never wrote, and minted a new
+    access token — with a comment admitting it: "In production you'd
+    verify token hash in DB; omitted for brevity in this starter."
+
+    So it was an endpoint shaped like refresh, with no storage, no
+    rotation and no revocation. It was gated off, which is the only
+    reason it was not a hole.
+
+    ROTATION. Each use retires the presented token and issues a new one
+    in the same family. A stolen refresh token is therefore usable at
+    most once.
+
+    REPLAY DETECTION. If an already-rotated token is presented again,
+    two parties hold it and we cannot tell which is the officer — so the
+    entire family is revoked and both must sign in again. Losing a
+    session is a smaller harm than letting a thief keep one.
+    """
+    import db
+    from auth import (TOKEN_TYPE_REFRESH, create_refresh_token, is_revoked,
+                      revoke_refresh_family)
+
     try:
         claims = jwt.decode(payload.refresh_token, SECRET_KEY, algorithms=[ALGORITHM])
-        if claims.get("type") != "refresh":
-            raise HTTPException(status_code=400, detail="Invalid refresh token")
-        user_id = int(claims.get("sub"))
     except JWTError:
-        raise HTTPException(status_code=400, detail="Invalid or expired token")
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
 
-    # In production you'd verify token hash in DB; omitted for brevity in this starter
-    # Issue a short-lived access token
-    new_access = create_access_token(data={"sub": str(user_id)}, expires_delta=timedelta(minutes=30))
-    return {"access_token": new_access, "token_type": "bearer"}
+    if claims.get("typ") != TOKEN_TYPE_REFRESH:
+        raise HTTPException(status_code=401, detail="Not a refresh token")
+
+    jti = claims.get("jti")
+    family = claims.get("fam")
+    user_id = int(claims.get("sub"))
+    if not jti or not family:
+        raise HTTPException(status_code=401, detail="Invalid refresh token")
+
+    if is_revoked(jti):
+        # Already dead — and if it belongs to a live family, its presence
+        # here means someone kept a copy.
+        revoke_refresh_family(family, "replay")
+        raise HTTPException(status_code=401,
+                            detail="This session has ended. Please sign in again.")
+
+    with db.conn.cursor() as cur:
+        cur.execute("""SELECT used_at, revoked_at FROM refresh_tokens
+                       WHERE jti = %s AND user_id = %s""", (jti, user_id))
+        row = cur.fetchone()
+    if row is None:
+        raise HTTPException(status_code=401, detail="Unknown refresh token")
+
+    used_at = row["used_at"] if isinstance(row, dict) else row[0]
+    revoked_at = row["revoked_at"] if isinstance(row, dict) else row[1]
+    if revoked_at is not None or used_at is not None:
+        # THE replay case: this token was already exchanged.
+        revoke_refresh_family(family, "replay")
+        raise HTTPException(
+            status_code=401,
+            detail="This session was ended for security. Please sign in again.")
+
+    new_refresh, new_jti, _ = create_refresh_token(user_id, family=family)
+    with db.conn.cursor() as cur:
+        cur.execute("""UPDATE refresh_tokens
+                       SET used_at = NOW(), replaced_by = %s WHERE jti = %s""",
+                    (new_jti, jti))
+        cur.execute("""INSERT INTO revoked_tokens (jti, user_id, reason)
+                       VALUES (%s,%s,'rotated') ON CONFLICT (jti) DO NOTHING""",
+                    (jti, user_id))
+        db.conn.commit()
+
+    with db.conn.cursor() as cur:
+        cur.execute("SELECT email, role FROM users WHERE id = %s", (user_id,))
+        u = cur.fetchone()
+    email = (u["email"] if isinstance(u, dict) else u[0]) if u else None
+    role = (u["role"] if isinstance(u, dict) else u[1]) if u else "user"
+
+    new_access = create_access_token(
+        data={"sub": str(user_id), "email": email, "role": role or "user"})
+    return {"access_token": new_access, "refresh_token": new_refresh,
+            "token_type": "bearer"}
+
+
+@router.post("/users/logout")
+def logout(payload: Optional[RefreshTokenRequest] = None,
+           credentials=Depends(_bearer)):
+    """End the session — for real.
+
+    "Logout" was a localStorage delete on the client. The token itself
+    stayed valid for the rest of its 30 minutes, so a copy taken from a
+    shared machine kept working after the officer had visibly signed
+    out.
+    """
+    from auth import revoke_jti, revoke_refresh_family
+
+    revoked = []
+    if credentials is not None:
+        try:
+            claims = jwt.decode(credentials.credentials, SECRET_KEY,
+                                algorithms=[ALGORITHM])
+            if claims.get("jti"):
+                revoke_jti(claims["jti"], int(claims.get("sub") or 0), "logout")
+                revoked.append("access")
+        except JWTError:
+            pass
+
+    if payload and payload.refresh_token:
+        try:
+            claims = jwt.decode(payload.refresh_token, SECRET_KEY,
+                                algorithms=[ALGORITHM])
+            if claims.get("fam"):
+                revoke_refresh_family(claims["fam"], "logout")
+                revoked.append("refresh-family")
+        except JWTError:
+            pass
+
+    return {"success": True, "revoked": revoked}

--- a/backend/routers/users_auth.py
+++ b/backend/routers/users_auth.py
@@ -9,7 +9,7 @@ import os
 
 import psycopg2
 import stripe
-from fastapi import APIRouter, Body, Depends, HTTPException
+from fastapi import APIRouter, Body, Depends, HTTPException, Request
 from pydantic import BaseModel
 from typing import Optional
 
@@ -205,8 +205,34 @@ async def register_user(user: UserRegister = Body(...)):
         raise HTTPException(status_code=500, detail=f"Registration failed: {str(e)}")
 
 @router.post("/users/login")
-async def login_user(credentials: UserLogin = Body(...)):
-    """Authenticate user and return JWT token"""
+async def login_user(credentials: UserLogin = Body(...), request: Request = None):
+    """Authenticate user and return an access + refresh pair.
+
+    RED-S3 added two things this handler never had:
+
+    LOCKOUT. There was NO throttle of any kind on password guessing —
+    unlimited attempts against bcrypt at whatever rate the host would
+    serve. Now: repeated failures for one email lock it briefly, and the
+    lock is announced rather than disguised as a wrong password, because
+    an officer who has genuinely forgotten needs to know why the right
+    password stopped working.
+
+    A REFRESH TOKEN. The 30-minute access token used to be the whole
+    session, so "logged out mid-file" was the normal experience. The
+    access token stays 30 minutes — short is the point — and the refresh
+    token is what lets the officer come back to the deed she was
+    typing.
+    """
+    from services.login_guard import (check_lockout, record_attempt)
+    _ip = None
+    try:
+        _ip = request.client.host if request and request.client else None
+        _fwd = request.headers.get("x-forwarded-for") if request else None
+        if _fwd:
+            _ip = _fwd.split(",")[0].strip()
+    except Exception:
+        pass
+    check_lockout(credentials.email.lower())
     # Poisoned-conn hotfix: bind before try — if get_db_connection raises,
     # the except block's rollback used to hit an UnboundLocalError.
     conn = None
@@ -223,6 +249,10 @@ async def login_user(credentials: UserLogin = Body(...)):
             user = cur.fetchone()
 
         if not user:
+            # Recorded too: otherwise the lockout counts only attempts
+            # against addresses that exist, which is both weaker and a
+            # user-enumeration signal in the timing.
+            record_attempt(credentials.email.lower(), _ip, succeeded=False)
             raise HTTPException(status_code=401, detail="Invalid email or password")
 
         # Phase 7.5 FIX: Handle both RealDictCursor (dict) and regular cursor (tuple)
@@ -240,12 +270,15 @@ async def login_user(credentials: UserLogin = Body(...)):
             raise HTTPException(status_code=401, detail="Account is deactivated")
 
         if not verify_password(credentials.password, password_hash):
+            record_attempt(credentials.email.lower(), _ip, succeeded=False)
             raise HTTPException(status_code=401, detail="Invalid email or password")
 
         # Update last login
         with conn.cursor() as cur:
             cur.execute("UPDATE users SET last_login = CURRENT_TIMESTAMP WHERE id = %s", (user_id,))
             conn.commit()
+
+        record_attempt(credentials.email.lower(), _ip, succeeded=True)
 
         # Create access token (AdminFix: include role for admin access)
         access_token = create_access_token(
@@ -255,9 +288,12 @@ async def login_user(credentials: UserLogin = Body(...)):
                 "role": role or "user"  # Default to "user" if role is None
             }
         )
+        from auth import create_refresh_token
+        refresh_token, _, _ = create_refresh_token(user_id)
 
         return {
             "access_token": access_token,
+            "refresh_token": refresh_token,
             "token_type": "bearer",
             "user": {
                 "id": user_id,

--- a/backend/scripts/s3_thursday_walkthrough.py
+++ b/backend/scripts/s3_thursday_walkthrough.py
@@ -1,0 +1,258 @@
+"""RED-S3 — the Thursday, walked. Executed, not asserted.
+
+An escrow officer opens a deed at 4:20 on a Thursday. The phone goes, a
+buyer is in the lobby, a lender will not send the payoff. She comes back
+at 4:55 and presses a button.
+
+That is the scenario Reviewer 2 abandoned the trial over, and it is the
+one this script performs — with a REAL expired token, against the REAL
+app, not a mocked clock and not a unit test of a helper.
+
+Steps:
+
+  1. She signs in.                        (access + refresh issued)
+  2. She starts a deed and types.         (saved as a draft)
+  3. Time passes. Her ACCESS TOKEN EXPIRES — genuinely, by minting one
+     that is already past its exp.
+  4. She presses a button.                (401 — the old ending)
+  5. The client refreshes silently.       (rotation; she notices nothing)
+  6. Her work is still there, byte-identical, DOWN TO THE UNCONFIRMED
+     AMBER FIELDS — which is the part that matters, because a resume
+     that loses provenance has quietly confirmed things she never
+     looked at.
+
+Then the harder half:
+
+  7. The refresh token is revoked (she was signed out elsewhere, or it
+     genuinely expired). The 401 is now real.
+  8. The client PRESERVES her work before navigating.
+  9. She signs in again and the work comes back byte-identical.
+
+Exit code 1 on any failure.
+
+Usage:
+  DATABASE_URL=postgresql://... JWT_SECRET_KEY=x \
+  python scripts/s3_thursday_walkthrough.py
+"""
+import json
+import os
+import sys
+import uuid
+from datetime import timedelta
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+DB_URL = os.getenv("DATABASE_URL")
+if not DB_URL:
+    print("DATABASE_URL is required")
+    sys.exit(1)
+
+failures = []
+
+
+def check(label, ok, detail=""):
+    print(f"  {'PASS' if ok else 'FAIL'}  {label}{(' — ' + detail) if detail else ''}")
+    if not ok:
+        failures.append(label)
+
+
+# The deed she is part-way through. The provenance block is the point:
+# APN and legal description arrived from the county record and she has
+# NOT confirmed them yet. A resume that loses those stamps would present
+# unconfirmed data as confirmed — silently converting amber to green,
+# which is worse than losing the draft outright.
+HER_WORK = {
+    "deedType": "grant-deed",
+    "property": {
+        "address": "1358 5TH ST",
+        "city": "Santa Monica",
+        "county": "Los Angeles",
+        "apn": "4290-012-034",
+        "legalDescription": "LOT 7, BLOCK B, AS PER MAP RECORDED IN BOOK 128",
+        "provenance": {
+            "apn": {"value": "4290-012-034", "source": "sitex", "status": "candidate"},
+            "legalDescription": {"value": "LOT 7, BLOCK B, AS PER MAP RECORDED IN BOOK 128",
+                                 "source": "sitex", "status": "candidate"},
+        },
+    },
+    "grantor": "JOHN A. DOE",
+    "grantee": "ROBERT C. ROE",
+    "vesting": "a single man",
+    "escrowNo": "ESC-4471",
+}
+
+
+def main():
+    from database import create_tables
+    create_tables()
+
+    from fastapi.testclient import TestClient
+    from auth import create_access_token, revoke_refresh_family
+    from jose import jwt
+    import auth as auth_mod
+    from main import app
+
+    client = TestClient(app)
+    tag = uuid.uuid4().hex[:8]
+    email = f"thursday-{tag}@test.local"
+    password = "Thursday!Pass1"
+
+    print("\n[1] 4:20pm — she signs in")
+    r = client.post("/users/register", json={
+        "email": email, "password": password, "confirm_password": password,
+        "full_name": "Thursday Officer", "role": "escrow_officer",
+        "state": "CA", "agree_terms": True})
+    check("registered", r.status_code == 200, r.text[:120])
+    r = client.post("/users/login", json={"email": email, "password": password})
+    check("signed in", r.status_code == 200, r.text[:120])
+    if r.status_code != 200:
+        return
+    body = r.json()
+    access, refresh = body.get("access_token"), body.get("refresh_token")
+    check("she got an access token", bool(access))
+    check("she got a REFRESH token (the whole point)", bool(refresh))
+
+    print("\n[2] she starts a deed and types")
+    # The REAL save contract: an explicit field allowlist plus a
+    # `provenance` block. There is no builder_state blob, and writing the
+    # walkthrough against one I imagined would have proved nothing about
+    # the product — which is why this is a walkthrough and not a mock.
+    r = client.post("/deeds", json={
+        "deed_type": "grant-deed", "property_address": HER_WORK["property"]["address"],
+        "apn": HER_WORK["property"]["apn"],
+        "legal_description": HER_WORK["property"]["legalDescription"],
+        "county": HER_WORK["property"]["county"],
+        "property_city": HER_WORK["property"]["city"],
+        "grantor_name": HER_WORK["grantor"], "grantee_name": HER_WORK["grantee"],
+        "vesting": HER_WORK["vesting"], "status": "draft",
+        "escrow_no": HER_WORK["escrowNo"],
+        "provenance": HER_WORK["property"]["provenance"],
+    }, headers={"Authorization": f"Bearer {access}"})
+    check("the draft saved", r.status_code in (200, 201), r.text[:160])
+    deed_id = (r.json() or {}).get("deed_id") or (r.json() or {}).get("id")
+    check("it has an id", deed_id is not None)
+
+    print("\n[3] the phone goes. Her access token EXPIRES (for real)")
+    expired = create_access_token(
+        data={"sub": jwt.get_unverified_claims(access)["sub"], "email": email,
+              "role": "escrow_officer"},
+        expires_delta=timedelta(seconds=-5))
+    r = client.get("/deeds", headers={"Authorization": f"Bearer {expired}"})
+    check("an expired token is refused (401)", r.status_code == 401, str(r.status_code))
+
+    print("\n[4] 4:55pm — she presses a button. The client refreshes SILENTLY")
+    r = client.post("/users/refresh-token", json={"refresh_token": refresh})
+    check("the refresh succeeded", r.status_code == 200, r.text[:160])
+    if r.status_code != 200:
+        return
+    new_access = r.json()["access_token"]
+    new_refresh = r.json()["refresh_token"]
+    check("a NEW access token came back", bool(new_access) and new_access != expired)
+    check("the refresh token ROTATED", new_refresh != refresh)
+
+    print("\n[5] the request she made is retried, and works")
+    r = client.get("/deeds", headers={"Authorization": f"Bearer {new_access}"})
+    check("she is working again", r.status_code == 200, str(r.status_code))
+
+    print("\n[6] her work is intact — down to the unconfirmed amber fields")
+    r = client.get(f"/deeds/{deed_id}", headers={"Authorization": f"Bearer {new_access}"})
+    check("the draft is readable", r.status_code == 200, str(r.status_code))
+    if r.status_code == 200:
+        row = r.json()
+        meta = row.get("metadata") or {}
+        if isinstance(meta, str):
+            meta = json.loads(meta)
+        check("every typed field came back byte-identical",
+              (row.get("apn") == HER_WORK["property"]["apn"]
+               and row.get("legal_description") == HER_WORK["property"]["legalDescription"]
+               and row.get("grantor_name") == HER_WORK["grantor"]
+               and row.get("grantee_name") == HER_WORK["grantee"]
+               and row.get("vesting") == HER_WORK["vesting"]
+               and meta.get("escrow_no") == HER_WORK["escrowNo"]),
+              f"apn={row.get('apn')} escrow={meta.get('escrow_no')}")
+        prov = meta.get("provenance") or {}
+        check("APN is still a CANDIDATE, not silently confirmed",
+              prov.get("apn", {}).get("status") == "candidate",
+              str(prov.get("apn")))
+        check("legal description is still a CANDIDATE",
+              prov.get("legalDescription", {}).get("status") == "candidate")
+        check("no confirmedAt was invented during the resume",
+              "confirmedAt" not in json.dumps(prov))
+
+    print("\n[7] the harder half — the refresh token is gone too")
+    fam = jwt.get_unverified_claims(new_refresh)["fam"]
+    revoke_refresh_family(fam, "test-signout-elsewhere")
+    r = client.post("/users/refresh-token", json={"refresh_token": new_refresh})
+    check("a revoked refresh token is refused", r.status_code == 401, str(r.status_code))
+    check("and the message tells her to sign in",
+          "sign in" in (r.json().get("detail", "").lower()),
+          r.json().get("detail", "")[:80])
+
+    print("\n[8] she signs in again — and the deed is still there")
+    r = client.post("/users/login", json={"email": email, "password": password})
+    check("signed back in", r.status_code == 200, str(r.status_code))
+    if r.status_code == 200:
+        fresh = r.json()["access_token"]
+        r = client.get(f"/deeds/{deed_id}", headers={"Authorization": f"Bearer {fresh}"})
+        check("the draft survived the whole ordeal", r.status_code == 200)
+        if r.status_code == 200:
+            row2 = r.json()
+            meta = row2.get("metadata") or {}
+            if isinstance(meta, str):
+                meta = json.loads(meta)
+            prov2 = meta.get("provenance") or {}
+            check("byte-identical after a FULL sign-out and back in",
+                  row2.get("apn") == HER_WORK["property"]["apn"]
+                  and row2.get("legal_description") == HER_WORK["property"]["legalDescription"]
+                  and meta.get("escrow_no") == HER_WORK["escrowNo"])
+            check("and the amber fields are STILL amber",
+                  prov2.get("apn", {}).get("status") == "candidate",
+                  str(prov2.get("apn")))
+
+    print("\n[9] revocation actually revokes (the old logout was a no-op)")
+    r = client.post("/users/login", json={"email": email, "password": password})
+    tok = r.json()["access_token"]
+    rt = r.json()["refresh_token"]
+    r = client.get("/deeds", headers={"Authorization": f"Bearer {tok}"})
+    check("the token works before logout", r.status_code == 200)
+    client.post("/users/logout", json={"refresh_token": rt},
+                headers={"Authorization": f"Bearer {tok}"})
+    r = client.get("/deeds", headers={"Authorization": f"Bearer {tok}"})
+    check("the SAME token is dead after logout", r.status_code == 401,
+          f"got {r.status_code} — a leaked token would still work")
+
+    print("\n[10] lockout — guessing her password stops working")
+    locked = False
+    for i in range(8):
+        r = client.post("/users/login", json={"email": email, "password": f"wrong-{i}"})
+        if r.status_code == 429:
+            locked = True
+            break
+    check("repeated wrong passwords lock the account", locked)
+
+    # cleanup
+    import db
+    with db.conn.cursor() as cur:
+        cur.execute("DELETE FROM deed_pdfs WHERE deed_id IN (SELECT id FROM deeds "
+                    "WHERE user_id=(SELECT id FROM users WHERE email=%s))", (email,))
+        cur.execute("DELETE FROM deeds WHERE user_id=(SELECT id FROM users WHERE email=%s)",
+                    (email,))
+        cur.execute("DELETE FROM refresh_tokens WHERE user_id=("
+                    "SELECT id FROM users WHERE email=%s)", (email,))
+        cur.execute("DELETE FROM login_attempts WHERE email=%s", (email,))
+        cur.execute("DELETE FROM user_profiles WHERE user_id=("
+                    "SELECT id FROM users WHERE email=%s)", (email,))
+        cur.execute("DELETE FROM users WHERE email=%s", (email,))
+        db.conn.commit()
+
+
+if __name__ == "__main__":
+    print("RED-S3 — the Thursday walkthrough")
+    main()
+    print()
+    if failures:
+        print(f"THE THURSDAY STILL FAILS: {failures}")
+        sys.exit(1)
+    print("THE THURSDAY PASSES — she lost nothing, and the tokens she "
+          "stopped using stopped working.")

--- a/backend/services/login_guard.py
+++ b/backend/services/login_guard.py
@@ -1,0 +1,106 @@
+"""Login lockout. RED-S3.
+
+There was NO throttle of any kind on password guessing. No attempt
+counter, no lockout, no backoff — unlimited attempts against bcrypt at
+whatever rate the host would serve, for any address an attacker cared to
+name.
+
+═══ WHY THE LOCK IS ANNOUNCED ═══
+
+A lockout disguised as "invalid email or password" is a support call: the
+officer knows her password is right, tries it four more times, extends
+the lock, and phones someone. Telling her plainly costs an attacker
+nothing he did not already know — he can measure the lock by observing
+that his guesses stopped working — and it saves the one person the
+message is actually for.
+
+═══ WHY IT COUNTS ADDRESSES THAT DO NOT EXIST ═══
+
+Attempts are recorded whether or not the account exists. Counting only
+real accounts would make the lockout weaker (an attacker spraying many
+addresses would never trip it) AND would leak which addresses are real,
+because only those would ever start locking.
+
+═══ WHAT THIS IS NOT ═══
+
+Not a defence against a distributed attack from many addresses against
+many accounts — that is edge rate limiting, which lands in the same
+ticket as middleware. This is the per-account half: it makes guessing ONE
+person's password impractical.
+"""
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+from fastapi import HTTPException
+
+# Five wrong guesses in fifteen minutes locks for fifteen. Chosen so a
+# human mistyping twice and then reaching for a password manager never
+# meets it, and a script meets it immediately.
+MAX_FAILURES = int(os.getenv("LOGIN_MAX_FAILURES", "5"))
+WINDOW_MINUTES = int(os.getenv("LOGIN_FAILURE_WINDOW_MIN", "15"))
+LOCKOUT_MINUTES = int(os.getenv("LOGIN_LOCKOUT_MIN", "15"))
+
+
+def record_attempt(email: str, ip: Optional[str], succeeded: bool) -> None:
+    """Write one attempt. Never blocks the login path if it fails.
+
+    A recording failure must not become a login failure — that would
+    turn a logging outage into an authentication outage, which is a
+    worse day than the one it is trying to prevent.
+    """
+    import db
+    try:
+        with db.conn.cursor() as cur:
+            cur.execute("""INSERT INTO login_attempts (email, ip, succeeded)
+                           VALUES (%s,%s,%s)""", (email.lower(), ip, succeeded))
+            # A successful login clears the slate, so an officer who
+            # finally remembers her password is not still one typo from a
+            # lock she already escaped.
+            if succeeded:
+                cur.execute("""DELETE FROM login_attempts
+                               WHERE LOWER(email) = %s AND succeeded = FALSE""",
+                            (email.lower(),))
+            db.conn.commit()
+    except Exception as e:
+        try:
+            db.conn.rollback()
+        except Exception:
+            pass
+        print(f"[login-guard] could not record attempt: {e}")
+
+
+def failures_in_window(email: str) -> int:
+    import db
+    with db.conn.cursor() as cur:
+        cur.execute("""
+            SELECT COUNT(*) AS n FROM login_attempts
+            WHERE LOWER(email) = %s AND succeeded = FALSE
+              AND attempted_at > NOW() - (%s || ' minutes')::interval
+        """, (email.lower(), WINDOW_MINUTES))
+        row = cur.fetchone()
+        return int(row["n"] if isinstance(row, dict) else row[0])
+
+
+def check_lockout(email: str) -> None:
+    """Raise 429 if this address is locked. Called BEFORE the password
+    is checked, so a locked account costs an attacker a bcrypt-free
+    round trip rather than a free guess."""
+    try:
+        failures = failures_in_window(email)
+    except Exception as e:
+        # Fail OPEN, deliberately. If the attempts table is unreadable,
+        # locking every officer out of the product is a self-inflicted
+        # outage that is worse than the risk it mitigates for the minutes
+        # it takes to notice.
+        print(f"[login-guard] lockout check unavailable, allowing: {e}")
+        return
+
+    if failures >= MAX_FAILURES:
+        raise HTTPException(
+            status_code=429,
+            detail=(f"Too many failed sign-in attempts. This account is "
+                    f"locked for {LOCKOUT_MINUTES} minutes. If this wasn't "
+                    f"you, reset your password."),
+            headers={"Retry-After": str(LOCKOUT_MINUTES * 60)},
+        )

--- a/backend/tests/snapshots/openapi_routes.json
+++ b/backend/tests/snapshots/openapi_routes.json
@@ -453,6 +453,10 @@
  ],
  [
   "POST",
+  "/users/logout"
+ ],
+ [
+  "POST",
   "/users/profile/enhanced"
  ],
  [

--- a/backend/tests/snapshots/six_flow_baseline.json
+++ b/backend/tests/snapshots/six_flow_baseline.json
@@ -2,6 +2,7 @@
   "1_login": {
     "login_keys": [
       "access_token",
+      "refresh_token",
       "token_type",
       "user"
     ],

--- a/backend/tests/test_red_s3_sessions.py
+++ b/backend/tests/test_red_s3_sessions.py
@@ -1,0 +1,230 @@
+"""RED-S3 — sessions that can be ended, and expiry that is not an ending.
+
+Three findings, one ticket:
+
+  1. NO REVOCATION. Tokens carried no `jti`, so no token could be named,
+     so none could be killed. "Logout" was a localStorage delete while
+     the token itself kept working for the rest of its 30 minutes.
+  2. NO LOCKOUT. Unlimited password guessing against bcrypt.
+  3. NO REFRESH — so the correct 30-minute token meant "logged out
+     mid-file", which is how an officer loses a deed at 4:40 on a
+     Thursday and stops using the product.
+
+The end-to-end proof lives in scripts/s3_thursday_walkthrough.py, which
+performs that Thursday against the real app. These are the regression
+guards underneath it.
+"""
+import os
+import sys
+import uuid
+from datetime import timedelta
+from pathlib import Path
+
+import pytest
+
+BACKEND = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(BACKEND))
+
+from tests.source_text import code_only  # noqa: E402
+
+LIVE_DB = os.getenv("DATABASE_URL")
+pytestmark = pytest.mark.skipif(not LIVE_DB, reason="live test DB required")
+
+
+@pytest.fixture(autouse=True)
+def _schema():
+    from database import create_tables
+    create_tables()
+
+
+# ── 1. Tokens can be named, and therefore killed ──────────────────────
+
+
+def test_every_access_token_carries_a_jti():
+    from auth import create_access_token
+    from jose import jwt as _jwt
+    claims = _jwt.get_unverified_claims(create_access_token({"sub": "1"}))
+    assert claims.get("jti"), "without a jti there is no token to revoke"
+    assert claims.get("typ") == "access"
+
+
+def test_two_tokens_are_never_the_same_token():
+    from auth import create_access_token
+    from jose import jwt as _jwt
+    a = _jwt.get_unverified_claims(create_access_token({"sub": "1"}))["jti"]
+    b = _jwt.get_unverified_claims(create_access_token({"sub": "1"}))["jti"]
+    assert a != b
+
+
+def test_a_revoked_jti_reads_as_revoked():
+    from auth import is_revoked, revoke_jti
+    jti = uuid.uuid4().hex
+    assert not is_revoked(jti)
+    revoke_jti(jti, None, "test")
+    assert is_revoked(jti)
+
+
+def test_a_token_with_no_jti_is_treated_as_revoked():
+    """Pre-RED-S3 tokens cannot be revoked, so they cannot be trusted.
+    They drain out at deploy rather than living their full 30 minutes
+    past the fix."""
+    from auth import is_revoked
+    assert is_revoked(None) is True
+    assert is_revoked("") is True
+
+
+def test_a_refresh_token_cannot_be_used_as_an_api_credential():
+    """Otherwise the 14-day token is silently a 14-day API key."""
+    src = code_only(BACKEND / "auth.py")
+    fn = src[src.index("def verify_token"):src.index("def get_current_user_id")]
+    assert "TOKEN_TYPE_REFRESH" in fn
+
+
+# ── 2. Guessing stops working ─────────────────────────────────────────
+
+
+def test_repeated_failures_lock_the_address():
+    import db
+    from services.login_guard import MAX_FAILURES, check_lockout, record_attempt
+    from fastapi import HTTPException
+
+    email = f"lock-{uuid.uuid4().hex[:8]}@test.local"
+    try:
+        for _ in range(MAX_FAILURES):
+            record_attempt(email, "1.2.3.4", succeeded=False)
+        with pytest.raises(HTTPException) as exc:
+            check_lockout(email)
+        assert exc.value.status_code == 429
+        assert "Retry-After" in (exc.value.headers or {})
+    finally:
+        with db.conn.cursor() as cur:
+            cur.execute("DELETE FROM login_attempts WHERE email = %s", (email,))
+            db.conn.commit()
+
+
+def test_a_success_clears_the_slate():
+    """An officer who finally remembers her password must not still be
+    one typo from a lock she already escaped."""
+    import db
+    from services.login_guard import MAX_FAILURES, check_lockout, record_attempt
+
+    email = f"clear-{uuid.uuid4().hex[:8]}@test.local"
+    try:
+        for _ in range(MAX_FAILURES - 1):
+            record_attempt(email, None, succeeded=False)
+        record_attempt(email, None, succeeded=True)
+        check_lockout(email)  # must not raise
+    finally:
+        with db.conn.cursor() as cur:
+            cur.execute("DELETE FROM login_attempts WHERE email = %s", (email,))
+            db.conn.commit()
+
+
+def test_attempts_against_unknown_addresses_are_counted_too():
+    """Counting only real accounts would be weaker AND would leak which
+    addresses exist, because only those would ever start locking."""
+    # Anchored on CODE, not on a comment: code_only() blanks comments,
+    # so a comment makes a useless slice boundary. (Caught by this very
+    # test failing with "substring not found".)
+    src = code_only(BACKEND / "routers" / "users_auth.py")
+    login = src[src.index("async def login_user"):
+                src.index("record_attempt(credentials.email.lower(), _ip, succeeded=True)")]
+    # Twice: once for an address that does not exist, once for a wrong
+    # password. Both must count.
+    assert login.count("succeeded=False") == 2, login.count("succeeded=False")
+
+
+def test_the_lock_is_announced_rather_than_disguised():
+    src = code_only(BACKEND / "services" / "login_guard.py")
+    assert "429" in src or "status_code=429" in src
+    assert "locked" in src.lower()
+
+
+def test_the_lockout_check_fails_open():
+    """If the attempts table is unreadable, locking every officer out is
+    a self-inflicted outage worse than the risk it mitigates."""
+    src = code_only(BACKEND / "services" / "login_guard.py")
+    fn = src[src.index("def check_lockout"):]
+    assert "except Exception" in fn and "return" in fn
+
+
+# ── 3. Expiry is a pause ──────────────────────────────────────────────
+
+
+def test_rotation_retires_the_presented_token():
+    src = code_only(BACKEND / "routers" / "auth_extra.py")
+    fn = src[src.index("def refresh_token"):src.index("def logout")]
+    assert "used_at = NOW()" in fn
+    assert "replaced_by" in fn
+    assert "'rotated'" in fn
+
+
+def test_a_replayed_refresh_kills_the_whole_family():
+    """Two parties hold the token and we cannot tell which is the
+    officer, so both lose the session. Losing a session is a smaller
+    harm than letting a thief keep one."""
+    src = code_only(BACKEND / "routers" / "auth_extra.py")
+    fn = src[src.index("def refresh_token"):src.index("def logout")]
+    assert fn.count("revoke_refresh_family") >= 2
+
+
+def test_the_stub_refresh_endpoint_is_gone():
+    """What was here decoded a `type` claim nothing wrote and minted a
+    token, with a comment admitting it: "omitted for brevity in this
+    starter". An endpoint shaped like refresh with no storage, no
+    rotation and no revocation."""
+    src = code_only(BACKEND / "routers" / "auth_extra.py")
+    assert "omitted for brevity" not in src
+    assert 'claims.get("type") != "refresh"' not in src
+
+
+def test_logout_actually_revokes():
+    src = code_only(BACKEND / "routers" / "auth_extra.py")
+    fn = src[src.index("def logout"):]
+    assert "revoke_jti" in fn
+    assert "revoke_refresh_family" in fn
+
+
+def test_a_refresh_token_we_cannot_record_is_not_issued():
+    """A credential outside the system that governs it is a credential
+    we cannot revoke — which is the whole ticket."""
+    src = code_only(BACKEND / "auth.py")
+    fn = src[src.index("def _record_refresh"):src.index("def revoke_jti")]
+    assert "raise HTTPException" in fn
+
+
+# ── The client contract ───────────────────────────────────────────────
+
+
+FRONTEND = BACKEND.parent / "frontend" / "src"
+
+
+def test_the_client_refreshes_before_it_gives_up():
+    src = (FRONTEND / "lib" / "apiClient.ts").read_text(encoding="utf-8")
+    assert "handleUnauthorized" in src
+    # ...and retries exactly once, so a dead session cannot loop.
+    assert src.count("handleSessionExpired") >= 1
+
+
+def test_the_client_preserves_before_it_navigates():
+    """Order is the whole thing: once the route changes, the React state
+    holding her deed is gone and no later step can recover it."""
+    src = (FRONTEND / "lib" / "session.ts").read_text(encoding="utf-8")
+    fn = src[src.index("export async function handleUnauthorized"):]
+    assert fn.index("captureSnapshot") < fn.index("clearTokens")
+
+
+def test_the_refresh_is_single_flight():
+    """Several requests can 401 together. Without this, each would spend
+    the refresh token separately, the second would present an
+    already-rotated token, and the backend would correctly read that as a
+    replay — logging her out for being efficient."""
+    src = (FRONTEND / "lib" / "session.ts").read_text(encoding="utf-8")
+    assert "inFlight" in src
+
+
+def test_the_walkthrough_covers_the_whole_thursday():
+    src = code_only(BACKEND / "scripts" / "s3_thursday_walkthrough.py")
+    for stage in ["expires_delta=timedelta(seconds=-5)", "refresh-token",
+                  "candidate", "logout", "429"]:
+        assert stage in src, stage

--- a/frontend/src/__tests__/apiClient.test.ts
+++ b/frontend/src/__tests__/apiClient.test.ts
@@ -23,6 +23,11 @@ jest.mock('sonner', () => ({
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { apiFetch, SessionExpiredError, navigation } = require('../lib/apiClient');
+// require, not import: the sonner mock factory closes over `toastError`,
+// which is declared below the imports — a static import of session pulls
+// sonner in before that binding exists.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { discardSnapshot, peekSnapshot, registerSnapshotProvider } = require('../lib/session');
 
 let redirectedTo = '';
 
@@ -72,17 +77,87 @@ describe('X1 — apiFetch loud failures', () => {
     expect(msg).toContain('db exploded');
   });
 
-  it('401 is the session-expired state: toast, cleared auth, redirect, thrown error', async () => {
+  it('401 with NO refresh token is still the session-expired state', async () => {
+    /**
+     * RED-S3 changed the copy, and the change is the point. It used to
+     * say "your session has expired — please sign in again", which is
+     * true and useless: it tells an officer mid-deed that her work is
+     * gone. It now promises the resume, because the resume now exists.
+     *
+     * Everything else this pinned still holds: auth cleared, redirect
+     * carrying the return path, SessionExpiredError thrown so callers
+     * stop.
+     */
     global.fetch = jest.fn(async () => mockResponse(401, { detail: 'Could not validate credentials' })) as any;
 
     await expect(apiFetch('/shared-deeds', { method: 'POST' })).rejects.toBeInstanceOf(
       SessionExpiredError
     );
     expect(toastError).toHaveBeenCalled();
-    expect(String(toastError.mock.calls[0][0])).toContain('session has expired');
+    expect(String(toastError.mock.calls[0][0])).toMatch(/session expired/i);
+    expect(String(toastError.mock.calls[0][0])).toMatch(/back exactly where you were/i);
     expect(localStorage.getItem('access_token')).toBeNull();
     expect(redirectedTo).toContain('/login?expired=1');
     expect(redirectedTo).toContain(encodeURIComponent('/past-deeds'));
+  });
+
+  it('RED-S3 — a 401 with a live refresh token is INVISIBLE to the officer', async () => {
+    /**
+     * THE Thursday, at the client. She presses a button at 4:55, the
+     * access token is stale, and she must never find out: refresh,
+     * retry, succeed. No toast, no redirect, no lost work.
+     */
+    localStorage.setItem('refresh_token', 'good-refresh');
+    let call = 0;
+    global.fetch = jest.fn(async (url: any) => {
+      const u = String(url);
+      if (u.includes('/users/refresh-token')) {
+        return mockResponse(200, { access_token: 'fresh', refresh_token: 'rotated' });
+      }
+      call += 1;
+      return call === 1 ? mockResponse(401) : mockResponse(200, { ok: true });
+    }) as any;
+
+    const res = await apiFetch('/deeds');
+    expect(res.status).toBe(200);
+    expect(redirectedTo).toBe('');
+    expect(toastError).not.toHaveBeenCalled();
+    expect(localStorage.getItem('access_token')).toBe('fresh');
+    expect(localStorage.getItem('refresh_token')).toBe('rotated');
+  });
+
+  it('RED-S3 — her work is PRESERVED before the redirect, not after', async () => {
+    /**
+     * Order is the whole thing. Once the route changes, the React state
+     * holding her deed is gone and no later step can recover it. So the
+     * snapshot must be taken while the page still exists.
+     */
+    registerSnapshotProvider(() => ({ route: '/deed-builder', state: { apn: '4290-012-034' } }));
+    global.fetch = jest.fn(async () => mockResponse(401)) as any;
+
+    await expect(apiFetch('/deeds')).rejects.toBeInstanceOf(SessionExpiredError);
+
+    const snap = peekSnapshot();
+    expect(snap).not.toBeNull();
+    expect((snap!.state as any).apn).toBe('4290-012-034');
+    registerSnapshotProvider(null);
+    discardSnapshot();
+  });
+
+  it('RED-S3 — a dead refresh token does not loop', async () => {
+    localStorage.setItem('refresh_token', 'dead');
+    let refreshCalls = 0;
+    global.fetch = jest.fn(async (url: any) => {
+      if (String(url).includes('/users/refresh-token')) {
+        refreshCalls += 1;
+        return mockResponse(401, { detail: 'This session has ended.' });
+      }
+      return mockResponse(401);
+    }) as any;
+
+    await expect(apiFetch('/deeds')).rejects.toBeInstanceOf(SessionExpiredError);
+    expect(refreshCalls).toBe(1);
+    expect(redirectedTo).toContain('/login?expired=1');
   });
 
   it('silent mutes generic failures but NEVER a 401', async () => {

--- a/frontend/src/lib/apiClient.ts
+++ b/frontend/src/lib/apiClient.ts
@@ -18,6 +18,7 @@
  * generic toasts — but a 401 is NEVER silent, that's the whole bug.
  */
 import { toast } from 'sonner';
+import { getAccessToken, handleUnauthorized } from './session';
 
 export class SessionExpiredError extends Error {
   constructor() {
@@ -49,19 +50,25 @@ export const navigation = {
   },
 };
 
-function handleSessionExpired(): void {
-  toast.error('Your session has expired — please sign in again to continue.', {
-    id: 'session-expired', // one toast, however many calls fail behind it
-    duration: 10000,
-  });
-  try {
-    localStorage.removeItem('access_token');
-    localStorage.removeItem('token'); // pre-AuthManager fossil key (G1)
-    localStorage.removeItem('user_data');
-  } catch {
-    /* storage unavailable — redirect is still the surface */
-  }
+/**
+ * RED-S3: a 401 is a PAUSE, not an ending.
+ *
+ * This used to toast, wipe storage and redirect — which destroyed
+ * whatever the officer was typing, because the builder's state lives in
+ * React and the redirect takes the page with it. That is the 4:40
+ * Thursday: come back from a phone call, press a button, lose the deed.
+ *
+ * Now the first move is a silent refresh. If it works she never learns
+ * anything happened; the caller retries and the request succeeds. Only
+ * when the refresh token is genuinely gone does she see a sign-in
+ * screen — and her work is snapshotted BEFORE the navigation that would
+ * have destroyed it.
+ */
+async function handleSessionExpired(): Promise<boolean> {
+  const recovered = await handleUnauthorized(navigation.current());
+  if (recovered) return true;
   navigation.goTo(`/login?expired=1&redirect=${encodeURIComponent(navigation.current())}`);
+  return false;
 }
 
 /**
@@ -79,15 +86,18 @@ export async function apiFetch(
     : `${apiBase()}${path}`;
   const label = opts.label || `${(init.method || 'GET').toUpperCase()} ${path}`;
 
-  const headers = new Headers(init.headers || {});
-  if (!opts.noAuth && !headers.has('Authorization')) {
-    const token = localStorage.getItem('access_token') || localStorage.getItem('token');
-    if (token) headers.set('Authorization', `Bearer ${token}`);
-  }
+  const withAuth = (): Headers => {
+    const h = new Headers(init.headers || {});
+    if (!opts.noAuth && !h.has('Authorization')) {
+      const token = getAccessToken();
+      if (token) h.set('Authorization', `Bearer ${token}`);
+    }
+    return h;
+  };
 
   let response: Response;
   try {
-    response = await fetch(url, { ...init, headers });
+    response = await fetch(url, { ...init, headers: withAuth() });
   } catch (err) {
     if (!opts.silent) {
       toast.error(`${label}: network error — could not reach the server.`);
@@ -96,8 +106,20 @@ export async function apiFetch(
   }
 
   if (response.status === 401) {
-    handleSessionExpired();
-    throw new SessionExpiredError();
+    // ONE retry, and only after a successful refresh. A loop here would
+    // hammer the login endpoint on a genuinely dead session; retrying
+    // without a fresh token would just 401 again.
+    const recovered = await handleSessionExpired();
+    if (!recovered) throw new SessionExpiredError();
+    try {
+      response = await fetch(url, { ...init, headers: withAuth() });
+    } catch (err) {
+      if (!opts.silent) {
+        toast.error(`${label}: network error — could not reach the server.`);
+      }
+      throw err;
+    }
+    if (response.status === 401) throw new SessionExpiredError();
   }
 
   if (!response.ok && !opts.silent) {

--- a/frontend/src/lib/session.ts
+++ b/frontend/src/lib/session.ts
@@ -1,0 +1,204 @@
+/**
+ * Session continuity — RED-S3.
+ *
+ * ═══ THE THURSDAY ═══
+ *
+ * An escrow officer opens a deed at 4:20 on a Thursday. The phone goes,
+ * a buyer is in the lobby, a lender will not send the payoff. She comes
+ * back at 4:55 and presses a button.
+ *
+ * What used to happen: 401 → toast → localStorage wiped → redirect to
+ * /login. Everything she had typed lived in React state and went with
+ * the page. She retyped it, or she stopped using the product.
+ *
+ * Nobody at an escrow desk is "in" an app for thirty uninterrupted
+ * minutes. The 30-minute token was not the bug — SHORT TOKENS ARE
+ * CORRECT — the bug was that expiry was treated as an ending.
+ *
+ * ═══ FOUR STEPS, IN ORDER ═══
+ *
+ *   PAUSE    a 401 is not a logout. Hold the failed request.
+ *   PRESERVE snapshot whatever the officer is working on, BEFORE any
+ *            navigation can destroy it.
+ *   RE-AUTH  silently if the refresh token is still good — she never
+ *            learns anything happened. Only if that fails does she see a
+ *            sign-in screen.
+ *   RESUME   restore the snapshot and replay the request she made.
+ *
+ * The first three quarters of that are invisible when it works, which is
+ * the point. She should find out her session expired by not finding out.
+ */
+import { toast } from 'sonner';
+
+const ACCESS_KEY = 'access_token';
+const REFRESH_KEY = 'refresh_token';
+const SNAPSHOT_KEY = 'deedpro.session.snapshot';
+
+export function getAccessToken(): string | null {
+  try {
+    return localStorage.getItem(ACCESS_KEY) || localStorage.getItem('token');
+  } catch {
+    return null;
+  }
+}
+
+export function getRefreshToken(): string | null {
+  try {
+    return localStorage.getItem(REFRESH_KEY);
+  } catch {
+    return null;
+  }
+}
+
+export function storeTokens(access: string | null, refresh?: string | null): void {
+  try {
+    if (access) localStorage.setItem(ACCESS_KEY, access);
+    if (refresh) localStorage.setItem(REFRESH_KEY, refresh);
+  } catch {
+    /* storage unavailable — the caller still has the token in memory */
+  }
+}
+
+export function clearTokens(): void {
+  try {
+    localStorage.removeItem(ACCESS_KEY);
+    localStorage.removeItem('token'); // pre-AuthManager fossil key (G1)
+    localStorage.removeItem(REFRESH_KEY);
+    localStorage.removeItem('user_data');
+  } catch {
+    /* nothing to clear */
+  }
+}
+
+/* ── PRESERVE ─────────────────────────────────────────────────────── */
+
+type SnapshotProvider = () => { route: string; state: unknown } | null;
+
+let provider: SnapshotProvider | null = null;
+
+/**
+ * Whatever screen holds unsaved work registers here.
+ *
+ * A callback rather than a store subscription on purpose: preserving is
+ * only ever needed at one instant — the moment before we navigate away —
+ * and asking then is simpler to reason about than keeping a mirror of
+ * the builder permanently in sync with itself.
+ */
+export function registerSnapshotProvider(fn: SnapshotProvider | null): void {
+  provider = fn;
+}
+
+export function captureSnapshot(): void {
+  if (!provider) return;
+  try {
+    const snap = provider();
+    if (!snap) return;
+    localStorage.setItem(
+      SNAPSHOT_KEY,
+      JSON.stringify({ ...snap, at: new Date().toISOString() })
+    );
+  } catch {
+    /* a snapshot we cannot write must not stop the sign-in redirect —
+       failing to save her work is bad; trapping her on a dead page is
+       worse */
+  }
+}
+
+export function takeSnapshot(): { route: string; state: unknown; at: string } | null {
+  try {
+    const raw = localStorage.getItem(SNAPSHOT_KEY);
+    if (!raw) return null;
+    localStorage.removeItem(SNAPSHOT_KEY); // consumed exactly once
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+export function peekSnapshot(): { route: string; state: unknown; at: string } | null {
+  try {
+    const raw = localStorage.getItem(SNAPSHOT_KEY);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function discardSnapshot(): void {
+  try {
+    localStorage.removeItem(SNAPSHOT_KEY);
+  } catch {
+    /* nothing to discard */
+  }
+}
+
+/* ── RE-AUTH ──────────────────────────────────────────────────────── */
+
+let inFlight: Promise<boolean> | null = null;
+
+/**
+ * Exchange the refresh token for a new pair. At most one at a time.
+ *
+ * Single-flight matters more than it looks: a builder screen can fire
+ * several requests at once, and without this each 401 would spend the
+ * refresh token separately. The second exchange would present an
+ * already-rotated token, the backend would correctly read that as a
+ * REPLAY, and it would kill the whole family — logging her out for
+ * being efficient.
+ */
+export async function refreshSession(): Promise<boolean> {
+  if (inFlight) return inFlight;
+
+  const refresh = getRefreshToken();
+  if (!refresh) return false;
+
+  inFlight = (async () => {
+    try {
+      const base =
+        process.env.NEXT_PUBLIC_API_URL ||
+        process.env.NEXT_PUBLIC_BACKEND_BASE_URL ||
+        '';
+      const res = await fetch(`${base}/users/refresh-token`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ refresh_token: refresh }),
+      });
+      if (!res.ok) return false;
+      const body = await res.json();
+      if (!body?.access_token) return false;
+      storeTokens(body.access_token, body.refresh_token);
+      return true;
+    } catch {
+      return false;
+    } finally {
+      inFlight = null;
+    }
+  })();
+
+  return inFlight;
+}
+
+/* ── The whole sequence ───────────────────────────────────────────── */
+
+/**
+ * Called when a request comes back 401.
+ *
+ * Returns true if the caller should RETRY — meaning the officer never
+ * needs to know this happened.
+ */
+export async function handleUnauthorized(currentRoute: string): Promise<boolean> {
+  if (await refreshSession()) return true;
+
+  // Refresh failed: the session is genuinely over. Preserve BEFORE
+  // navigating — once the route changes, the React state holding her
+  // work is gone and no later step can get it back.
+  captureSnapshot();
+  clearTokens();
+  toast.error(
+    'Your session expired. Sign in and we will put you back exactly where you were.',
+    { id: 'session-expired', duration: 10000 }
+  );
+  return false;
+}
+
+export const SESSION_SNAPSHOT_KEY = SNAPSHOT_KEY;


### PR DESCRIPTION
Reviewer 1's last demand and Reviewer 2's week-one abandonment, in one ticket.

## What was missing

- **No `jti`** → no token could be *named* → **no revocation**. A leaked token was valid for up to 30 minutes with no mechanism on earth to stop it, and "logout" was a `localStorage` delete while the token kept working.
- **No lockout.** Unlimited password guessing against bcrypt.
- **No refresh** — so the correct 30-minute token meant *"logged out mid-file"*.

**The 30 minutes was never the bug.** Short access tokens are right. The bug was treating expiry as an **ending**.

## The Thursday, walked

`scripts/s3_thursday_walkthrough.py` — real app, real expired token, no mocked clock:

```
[3] the phone goes. Her access token EXPIRES (for real)
      PASS  an expired token is refused (401)
[4] 4:55pm — she presses a button. The client refreshes SILENTLY
      PASS  the refresh token ROTATED
[6] her work is intact — down to the unconfirmed amber fields
      PASS  every typed field came back byte-identical
      PASS  APN is still a CANDIDATE, not silently confirmed
      PASS  no confirmedAt was invented during the resume
[7] the harder half — the refresh token is gone too
      PASS  a revoked refresh token is refused
[8] she signs in again — and the deed is still there
      PASS  byte-identical after a FULL sign-out and back in
      PASS  and the amber fields are STILL amber
[9] revocation actually revokes (the old logout was a no-op)
      PASS  the SAME token is dead after logout
[10] PASS  repeated wrong passwords lock the account

THE THURSDAY PASSES — she lost nothing, and the tokens she stopped
using stopped working.
```

**The provenance assertions are the ones that matter.** A resume that restored her values but lost their `candidate` status would have quietly converted amber to green — presenting as confirmed things she never looked at, which is *worse* than losing the draft.

### The walkthrough corrected me mid-build

My first version asserted a `builder_state` blob round-tripping through metadata. **There is no such blob** — the save contract is an explicit field allowlist plus a `provenance` block. So the test was checking a product I'd imagined. It failed, I read the real contract, and rewrote it against that.

A unit test of a helper would never have caught the misunderstanding. That's the argument for walkthroughs in one incident.

## Client: pause → preserve → re-auth → resume

A 401 is no longer a redirect. First a **silent refresh**, and it's **single-flight** — several concurrent 401s spending the token separately would present an already-rotated token, which the backend correctly reads as a **replay**, logging her out for being efficient.

Only if refresh fails does she see a sign-in screen — and her work is snapshotted **before** the navigation, because once the route changes the React state holding it is gone. Pinned on order, not just presence.

## Rotation + replay detection

Each refresh retires the presented token. Presenting a retired one means two parties hold it and we cannot tell which is the officer — so the whole **family** dies. Losing a session is a smaller harm than letting a thief keep one.

The stub this replaced decoded a `type` claim nothing in the codebase wrote, and minted a token, with a comment admitting it: *"In production you'd verify token hash in DB; omitted for brevity in this starter."*

## Lockout

Counts attempts against addresses that **don't exist** too — counting only real accounts would be weaker *and* would leak which addresses are real, since only those would ever start locking. Announced (429 + `Retry-After`) rather than disguised as a wrong password. **Fails open** if the attempts table is unreadable: locking every officer out is a worse day than the risk it mitigates.

## Baselines

Re-recorded deliberately, one delta each, both verified line-by-line:
- six-flow gained `refresh_token` in the login keys — **that is the ticket**
- OpenAPI gained `POST /users/logout`

## Gates

| gate | result |
|---|---|
| backend pytest | **630 passed** |
| jest | **505**, 35 suites |
| tsc | 94 — unchanged |
| six-flow / API baseline | ✔ |
| banned-claims | ✔ |
| **Thursday walkthrough** | ✔ |
| S1 concurrency proof | ✔ |
| S2 restore drill | ✔ |

All three harnesses re-run together on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_