### PR TITLE
docs: PRELIM_FIELD_MAP — DeedPro's extraction slots, as H1 open item #1's input

### DIFF
--- a/backend/tests/test_prelim_field_map.py
+++ b/backend/tests/test_prelim_field_map.py
@@ -1,0 +1,127 @@
+"""docs/PRELIM_FIELD_MAP.md describes the code, and keeps describing it.
+
+The map is the named input to open item #1 of the H1 contract (§6.1,
+§10.1): structured `prelim_data` from TitleSense must land in the same
+slots DeedPro's own parser fills.
+
+A field map that drifts from the parser is worse than none, because the
+contract on the other side of the wire is mapped against it. Someone
+adding an extraction key without adding it here would leave TitleSense
+mapping to a product that no longer exists — and nothing would say so.
+
+So the document's central table is checked against the code it claims to
+describe, in both directions.
+"""
+import sys
+from pathlib import Path
+
+BACKEND = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(BACKEND))
+
+REPO = BACKEND.parent
+MAP = REPO / "docs" / "PRELIM_FIELD_MAP.md"
+CONTRACT = REPO / "docs" / "integrations" / "H1_CONTRACT.md"
+
+
+def test_the_map_exists_where_the_contract_names_it():
+    """§10.1 names the path explicitly. A contract that points at a file
+    that is not there is an open item nobody can close."""
+    assert MAP.exists(), "docs/PRELIM_FIELD_MAP.md is the named input to H1 open item #1"
+
+
+def test_the_contract_is_committed_and_reachable():
+    assert CONTRACT.exists()
+    assert "PRELIM_FIELD_MAP.md" in CONTRACT.read_text(encoding="utf-8")
+
+
+def test_every_extraction_key_appears_in_the_map():
+    """The direction that catches an ADDED field: a new extraction slot
+    that TitleSense would never learn about."""
+    from services.prelim_import import FIELD_LABELS
+    text = MAP.read_text(encoding="utf-8")
+    missing = [k for k in FIELD_LABELS if f"`{k}`" not in text]
+    assert missing == [], f"extraction keys absent from the field map: {missing}"
+
+
+def test_the_map_invents_no_slots_the_parser_does_not_fill():
+    """The direction that catches a REMOVED field: the contract would go
+    on mapping into a slot nothing fills."""
+    from services.prelim_import import FIELD_LABELS
+    text = MAP.read_text(encoding="utf-8")
+    table = text[text.index("## 1. The slots"):text.index("## 2. Amber semantics")]
+
+    # Column 2 specifically — the EXTRACTION KEY. A naive "any backticked
+    # snake_case cell" match also scoops column 5 (the save-contract
+    # field, e.g. `current_owner`) and reports a correct document as
+    # wrong. Row-wise parsing, not a pattern over the whole table.
+    claimed = set()
+    for line in table.splitlines():
+        if not line.startswith("| ") or line.startswith("|---"):
+            continue
+        cells = [c.strip() for c in line.strip("|").split("|")]
+        if len(cells) < 2 or not cells[0].isdigit():
+            continue
+        key = cells[1].strip("`")
+        claimed.add(key)
+
+    assert claimed, "no rows parsed out of the slots table"
+    unknown = claimed - set(FIELD_LABELS)
+    assert unknown == set(), f"the map claims slots the parser does not fill: {unknown}"
+    assert claimed == set(FIELD_LABELS), (
+        f"map rows and parser keys disagree: "
+        f"map-only={claimed - set(FIELD_LABELS)} parser-only={set(FIELD_LABELS) - claimed}")
+
+
+def test_the_labels_match():
+    from services.prelim_import import FIELD_LABELS
+    text = MAP.read_text(encoding="utf-8")
+    for key, label in FIELD_LABELS.items():
+        assert label in text, f"label for {key} ({label!r}) not in the map"
+
+
+def test_the_mixed_content_slot_is_flagged_and_cited():
+    """Row 3 is the one that does not map, and the map must say so
+    against the section that legislates it — not in its own words."""
+    text = MAP.read_text(encoding="utf-8")
+    assert "vested_owner" in text
+    assert "mixed_content" in text
+    assert "2.2" in text, "the mixed-content rule must cite H1 §2.2"
+    # And it must be honest that the product currently violates it.
+    assert "forbids" in text or "does the thing the contract" in text
+
+
+def test_the_map_names_what_is_NOT_extracted():
+    """§6.1 lists prelim_data facts DeedPro has no slot for. Silence
+    there would let the mapping assume slots that do not exist."""
+    text = MAP.read_text(encoding="utf-8")
+    section = text[text.index("## 4. What T-6 does NOT extract"):]
+    for absent in ["exception", "recording reference", "effective date", "order number"]:
+        assert absent.lower() in section.lower(), absent
+
+
+def test_the_map_records_the_templates_as_unverified():
+    """Bears on §6.1's 'demoted to fallback': the fallback is weaker than
+    its structure suggests."""
+    from services.prelim_import import TEMPLATES
+    text = MAP.read_text(encoding="utf-8")
+    assert "UNVERIFIED" in text
+    for t in TEMPLATES:
+        assert t.underwriter.split()[0] in text, t.underwriter
+
+
+def test_the_refusal_semantics_are_recorded():
+    """A structured finding must not be able to produce a state the
+    parser refuses to produce."""
+    from services.prelim_import import MIN_TEXT_CHARS
+    text = MAP.read_text(encoding="utf-8")
+    assert str(MIN_TEXT_CHARS) in text
+    assert "PrelimUnreadable" in text
+
+
+def test_the_source_label_matches_the_enum():
+    """`prelim`, not `ai_suggested` — mislabelling would smuggle in an
+    LLM ruling nobody has made."""
+    text = MAP.read_text(encoding="utf-8")
+    assert "'prelim'" in text
+    builder = (REPO / "frontend" / "src" / "types" / "builder.ts").read_text(encoding="utf-8")
+    assert "'prelim'" in builder

--- a/docs/PRELIM_FIELD_MAP.md
+++ b/docs/PRELIM_FIELD_MAP.md
@@ -1,0 +1,189 @@
+# PRELIM_FIELD_MAP — DeedPro's extraction slots
+
+**Purpose.** This is the named input to open item #1 of
+[`docs/integrations/H1_CONTRACT.md`](integrations/H1_CONTRACT.md) (§6.1,
+§10.1): the inventory of every slot DeedPro's T-6 prelim PDF import
+fills, so structured `prelim_data` from TitleSense and DeedPro's own
+extraction land in **the same slots** — with the PDF parser demoted to
+third-party-paper fallback rather than kept as a parallel truth.
+
+**Status.** Descriptive of what ships today, not aspirational. Every row
+below was read out of the code named in it. Where the contract and the
+product disagree, the disagreement is stated rather than smoothed —
+§6.1's whole point is that structured findings must land where the
+parser already lands, and that is only checkable if this document is
+honest about where that is.
+
+---
+
+## 1. The slots
+
+T-6 (`backend/services/prelim_import.py`, `FIELD_LABELS`) extracts
+**five** fields. That number is a ruling, not a limit reached by
+accident: it is the set an officer retypes from a prelim every time.
+
+| # | extraction key | label shown | builder field | save-contract field | type | arrives |
+|---|---|---|---|---|---|---|
+| 1 | `apn` | APN | `property.apn` | `apn` | string | **amber** — candidate |
+| 2 | `legal_description` | Legal description | `property.legalDescription` | `legal_description` | string (long) | **amber** — candidate |
+| 3 | `vested_owner` | Vested owner | `property.owner` | `current_owner` | string | **amber** — candidate ⚠️ **see §3** |
+| 4 | `county` | County | `property.county` | `county` | string | **amber** — candidate |
+| 5 | `property_address` | Property address | `property.address` | `property_address` | string | **amber** — candidate |
+
+Sources of truth for that table:
+
+- extraction keys and labels — `backend/services/prelim_import.py`
+- builder fields — `PropertyData` in `frontend/src/types/builder.ts`
+- save-contract fields — `DeedCreate` in `backend/routers/deeds_crud.py`
+
+---
+
+## 2. Amber semantics
+
+Every extracted value is a **candidate**, never a confirmed value. The
+carrier is `PropertyProvenance` (`frontend/src/types/builder.ts`):
+
+```ts
+{ value: string; source: FieldSource; status: FieldStatus; confirmedAt?: string }
+
+FieldSource = 'sitex' | 'google' | 'user' | 'titlepoint' | 'prelim' | 'ai_suggested'
+FieldStatus = 'candidate' | 'confirmed'
+```
+
+Rules that hold for every row above:
+
+- **`source: 'prelim'`** on import. Deliberately **not** `ai_suggested`:
+  a labelled pattern match is not a suggestion, and mislabelling it
+  would smuggle in an LLM ruling nobody has made.
+- **`status: 'candidate'`** on arrival. `confirmedAt` is absent until the
+  officer acts; a resume that invented one would forge a review that
+  never happened (pinned in `scripts/s3_thursday_walkthrough.py`).
+- **An empty field has nothing to confirm** and never blocks generation
+  (U0). Absence is not a candidate.
+- **A field with no provenance stamp is treated as a candidate** — legacy
+  data fails toward re-asking, never toward assumed-confirmed.
+
+### For the wire (§2.1)
+
+Rows 1, 2, 4, 5 are **facts** and map cleanly onto contract candidate
+facts. They arrive amber in both worlds and the mapping is one-to-one.
+
+Row 3 does not. See below.
+
+---
+
+## 3. ⚠️ Row 3 is mixed content — the one slot that does not map
+
+`vested_owner` is extracted by this pattern
+(`prelim_import.py`, `_VESTED`):
+
+> `Title to said estate or interest at the date hereof is vested in:`
+
+What follows that phrase on a real preliminary report is typically:
+
+```
+JOHN A. DOE AND JANE B. DOE, HUSBAND AND WIFE AS JOINT TENANTS
+```
+
+That is **a name plus a legal characterization of how title is held** —
+precisely the case H1 §2.2 legislates:
+
+> **2.2 — Mixed content is emitted split, never whole.** […] TitleSense
+> emits the parties as facts and the vesting characterization as a
+> separate interpreted field. TitleSense never emits the composite string
+> as a single value in a fact position. The composite may be carried in
+> `verbatim` for audit, flagged `mixed_content: true`.
+
+**Today DeedPro does the thing the contract forbids**: the composite
+lands whole in `property.owner`, a fact position, as a single candidate.
+RED0 found the same defect from the inside (R3-2) — the taxonomy is
+drawn by field *name* rather than by *content*, and the one field whose
+content is mixed slipped through on its label.
+
+So this row is the mapping's open edge, and it is open on **both** sides
+of the wire for the same reason.
+
+**Resolved by Doctrine A** (queued, ruled): extraction emits names as
+fact-candidates and the vesting characterization as a separate violet
+proposal; the composite is carried verbatim for audit, flagged
+`mixed_content`; no code path may write a characterization into a
+confirmed field without an acceptance record. When that ships, row 3
+becomes:
+
+| extraction key | lands as | position | arrives |
+|---|---|---|---|
+| `vested_owner.parties` | `property.owner` | fact | amber — candidate |
+| `vested_owner.vesting_characterization` | vesting section | **interpretation** | **violet — proposal**, acceptance recorded |
+| `vested_owner.verbatim` | audit only | neither | `mixed_content: true` |
+
+**This table is the acceptance criterion for Doctrine A**, and it is
+also what §10.1's mapping work should be written against — not against
+today's single slot, which is the defect.
+
+---
+
+## 4. What T-6 does NOT extract
+
+Named so §6.1's mapping does not assume a slot that does not exist.
+`prelim_data` facts outside this list have **no landing slot today**;
+adding one is a product decision, not a mapping detail.
+
+- exception / requirement items (numbered) — **not extracted**
+- recording references as cited — **not extracted**
+- effective date of the report — **not extracted**
+- order number — **not extracted** (the builder has `title_order_no`,
+  but the officer types it; the parser does not read it)
+- vesting *document* references — **not extracted**
+
+§6.1 lists several of these as `prelim_data` facts. That is a real gap
+between what the contract can send and what DeedPro can currently
+receive, and it is the substance of open item #1 rather than an
+oversight to be papered over.
+
+---
+
+## 5. Refusal semantics — what "no data" means
+
+Relevant to the mapping because a structured `prelim_data` finding must
+not be able to produce a state the parser refuses to produce.
+
+- **No text layer** (a scanned prelim) → `PrelimUnreadable`, raised
+  loudly. Never an empty-but-successful result. `MIN_TEXT_CHARS = 200`,
+  because scanned PDFs commonly yield a handful of stray characters from
+  a fax banner and `== 0` would let exactly those through.
+- **Readable but unparseable** → also a refusal. An empty candidate list
+  rendered as a result would tell the officer her prelim was empty,
+  which is a different and untrue statement.
+- **Per-field absence** → the field is simply not in `candidates`, and
+  appears in `not_found`. The officer types it.
+
+The mapping consequence: a `prelim_data` finding carrying *no* facts is
+a refusal, not an empty success, and must surface as one.
+
+---
+
+## 6. Underwriter templates — UNVERIFIED
+
+`prelim_import.TEMPLATES` names five underwriters (First American,
+Fidelity National, Chicago Title, Old Republic, Stewart). **All five
+currently use the generic patterns**, and all are marked `UNVERIFIED` in
+source: they are hypotheses about label conventions, not observations of
+real reports.
+
+Recorded here because it bears directly on §6.1's "demoted to
+third-party-paper fallback": the fallback is weaker than its structure
+suggests, which strengthens rather than weakens the case for structured
+`prelim_data`.
+
+Verification needs real prelims from each underwriter — an owner-side
+input, already ledgered.
+
+---
+
+## 7. Change discipline
+
+This document is an **input to a contract**. If the slots change, this
+file changes in the same PR, and §10.1's mapping is re-checked.
+
+Adding an extraction key without adding it here means the contract is
+mapping against a product that no longer exists.


### PR DESCRIPTION
The named input to open item #1 of `docs/integrations/H1_CONTRACT.md` (§6.1, §10.1).

**Path note:** the contract landed at `docs/integrations/H1_CONTRACT.md` — plural `integrations`, not `integration`. Treated as authoritative, cited by that path.

## What it is

The inventory of every slot T-6's prelim import fills, so structured `prelim_data` and DeedPro's own extraction land in the **same** slots rather than becoming two truths. Five slots, their builder fields, their save-contract fields, their amber semantics — **every row read out of the code it cites** (`prelim_import.FIELD_LABELS`, `PropertyData`, `DeedCreate`), not written from memory.

## The honest part is row 3

`vested_owner` extracts:

```
JOHN A. DOE AND JANE B. DOE, HUSBAND AND WIFE AS JOINT TENANTS
```

A name **plus** a legal characterization — exactly what **H1 §2.2** forbids emitting whole: *"Mixed content is emitted split, never whole."*

**DeedPro currently lands that composite in `property.owner` — a fact position — as a single candidate.** So the product violates the contract rule today. RED0 found the identical defect from the inside (R3-2): the taxonomy is drawn by field *name* rather than by *content*, and the one field whose content is mixed slipped through on its label.

The map says so plainly rather than describing the slot as if it mapped, and specifies the post-Doctrine-A shape as that ticket's **acceptance criterion**:

| extraction key | lands as | position | arrives |
|---|---|---|---|
| `vested_owner.parties` | `property.owner` | fact | amber — candidate |
| `vested_owner.vesting_characterization` | vesting section | **interpretation** | **violet — proposal** |
| `vested_owner.verbatim` | audit only | neither | `mixed_content: true` |

§10.1's mapping should be written against *that* table, not against today's single slot — which is the defect.

## Also recorded, because silence would let the mapping assume slots that don't exist

- **What T-6 does NOT extract**: exceptions/requirements, recording references, effective date, order number. §6.1 lists several as `prelim_data` facts — a real gap between what the contract can send and what DeedPro can receive.
- **Refusal semantics** a structured finding must not be able to bypass (no text layer → loud refusal; readable-but-unparseable → also a refusal).
- **All five underwriter templates remain UNVERIFIED** — which bears directly on §6.1's *"demoted to third-party-paper fallback"*: the fallback is weaker than its structure suggests, which strengthens the case for structured `prelim_data`.

## Pinned in both directions

An added extraction key that never reaches this document **fails**; a slot claimed here that the parser doesn't fill **fails**. A field map that drifts is worse than none, because the contract on the other side of the wire is mapped against it.

One test bug caught while writing it: the second pin's regex scooped the save-contract column as well as the extraction-key column and reported a correct document as wrong. Row-wise parsing now.

## Gates

| gate | result |
|---|---|
| backend pytest | **657 passed** |
| banned-claims | ✔ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_