### PR TITLE
Doctrine A: a vested-owner string is a name PLUS a characterization

### DIFF
--- a/backend/services/prelim_import.py
+++ b/backend/services/prelim_import.py
@@ -201,7 +201,36 @@ def import_prelim(pdf_bytes: bytes) -> Dict[str, Any]:
 
     Raises PrelimUnreadable when there is no text layer — the caller
     surfaces that verbatim rather than rendering an empty result.
+
+    ═══ DOCTRINE A — FOUR OF THE FIVE FIELDS ARE FACTS ═══
+
+    `vested_owner` is not. What follows "vested in:" on a real report is a
+    NAME PLUS A LEGAL CHARACTERIZATION — "JOHN A. DOE AND JANE B. DOE,
+    HUSBAND AND WIFE AS JOINT TENANTS" — and this function used to put the
+    whole string in `candidates`, which is a fact position, as a single
+    amber value. H1 §2.2 forbids exactly that on the wire; RED0 found the
+    same defect from the inside (R3-2). The taxonomy was drawn by field
+    NAME rather than by CONTENT, and the one field whose content is mixed
+    slipped through on its label.
+
+    So the composite is split by `services.vesting_split`, the same module
+    the SiteX path uses, and lands in three different places:
+
+      candidates  the PARTIES, as a fact — amber, confirmable, unchanged
+                  in every other respect
+      proposals   the CHARACTERIZATION — violet, NOT confirmable by the
+                  field gate, reaching the deed only through an explicit
+                  acceptance that is recorded as a legal choice
+      verbatim    the composite as printed, for audit. A bare string, so
+                  nothing that walks `candidates` can pick it up.
+
+    A composite we cannot split confidently offers NEITHER half and lands
+    in `needs_review` instead: an honest "we could not separate this"
+    beats a confident wrong answer, and it is the same refusal posture as
+    the scanned-prelim path above.
     """
+    from services.vesting_split import as_candidates as split_owner
+
     text = read_text_or_refuse(pdf_bytes)
     template = pick_template(text)
     fields = extract_fields(text, template)
@@ -216,16 +245,49 @@ def import_prelim(pdf_bytes: bytes) -> Dict[str, Any]:
             "layout is one we have not seen. Nothing was extracted."
         )
 
+    candidates: List[Dict[str, Any]] = []
+    proposals: List[Dict[str, Any]] = []
+    verbatim: Dict[str, Any] = {}
+    needs_review: List[Dict[str, Any]] = []
+
+    for f in fields:
+        if f.key != "vested_owner":
+            candidates.append({"key": f.key, "label": f.label, "value": f.value,
+                               "source": "prelim", "status": "candidate"})
+            continue
+
+        split = split_owner(f.value, "prelim")
+        verbatim["vested_owner"] = {
+            "text": split["verbatim"],
+            "mixed_content": split["mixed_content"],
+        }
+        owner = split.get("owner")
+        if owner:
+            candidates.append({"key": "vested_owner", "label": f.label,
+                               **owner})
+        proposal = split.get("vesting_proposal")
+        if proposal:
+            proposals.append({"key": "vesting", "label": "Vesting",
+                              **proposal})
+        if split.get("needs_review"):
+            needs_review.append({"key": "vested_owner", "label": f.label,
+                                 "message": split["needs_review"],
+                                 "verbatim": split["verbatim"]})
+
     return {
         "underwriter": template.underwriter,
-        # Every value is a CANDIDATE. The gate is untouched: these arrive
-        # amber and the officer confirms them exactly as she confirms
-        # county-record data.
-        "candidates": [
-            {"key": f.key, "label": f.label, "value": f.value,
-             "source": "prelim", "status": "candidate"}
-            for f in fields
-        ],
+        # Every value here is a FACT and a CANDIDATE. The gate is
+        # untouched: these arrive amber and the officer confirms them
+        # exactly as she confirms county-record data.
+        "candidates": candidates,
+        # And every value here is an INTERPRETATION. 'proposed', not
+        # 'candidate' — a legal choice is never auto-applied and never
+        # sits in candidate state inside the deed.
+        "proposals": proposals,
+        # Audit only. Never rendered as a value, never confirmable.
+        "verbatim": verbatim,
+        # Read, but not separable. Not the same statement as "absent".
+        "needs_review": needs_review,
         "not_found": [
             FIELD_LABELS[k] for k in template.patterns
             if k not in {f.key for f in fields}

--- a/backend/services/vesting_cases.json
+++ b/backend/services/vesting_cases.json
@@ -1,0 +1,169 @@
+{
+  "_readme": [
+    "Doctrine A — the shared corpus. THE SPLIT IS ONE RULE IN TWO LANGUAGES.",
+    "",
+    "backend/services/vesting_split.py and frontend/src/lib/vestingSplit.ts are",
+    "the same law written twice, because one runs on the prelim path (Python)",
+    "and one runs on the SiteX path (TypeScript). Two implementations of a rule",
+    "drift; that is not a risk, it is a schedule.",
+    "",
+    "So neither implementation is the authority — THIS FILE is. Both test",
+    "suites read it and assert the same split on every case. A change to one",
+    "side that the other does not make fails in the language that did not",
+    "change, which is the only failure mode that catches a one-sided edit.",
+    "",
+    "A marker-list mirror test also pins the patterns character-for-character.",
+    "That guards the spelling. This corpus guards the property. Both are here",
+    "because a pin that guards a spelling does not guard a property.",
+    "",
+    "`parties: null` means: nothing may be offered as a fact from this string.",
+    "`absent: true` means the splitter returns nothing at all (U0)."
+  ],
+  "cases": [
+    {
+      "input": "JOHN A. DOE AND JANE B. DOE, HUSBAND AND WIFE AS JOINT TENANTS",
+      "verbatim": "JOHN A. DOE AND JANE B. DOE, HUSBAND AND WIFE AS JOINT TENANTS",
+      "parties": "JOHN A. DOE AND JANE B. DOE",
+      "characterization": "HUSBAND AND WIFE AS JOINT TENANTS",
+      "mixed_content": true,
+      "needs_review": false,
+      "why": "H1 §2.2's own example. Two names, one characterization, one split."
+    },
+    {
+      "input": "JOHN A. DOE",
+      "verbatim": "JOHN A. DOE",
+      "parties": "JOHN A. DOE",
+      "characterization": null,
+      "mixed_content": false,
+      "needs_review": false,
+      "why": "A bare name is a fact, whole. The common case, and it must not be disturbed."
+    },
+    {
+      "input": "MARIA GONZALEZ, A SINGLE WOMAN",
+      "verbatim": "MARIA GONZALEZ, A SINGLE WOMAN",
+      "parties": "MARIA GONZALEZ",
+      "characterization": "A SINGLE WOMAN",
+      "mixed_content": true,
+      "needs_review": false,
+      "why": "Marital status is a characterization even when it names no tenancy."
+    },
+    {
+      "input": "JOHN DOE AND JANE DOE, HUSBAND AND WIFE, AS COMMUNITY PROPERTY WITH RIGHT OF SURVIVORSHIP",
+      "verbatim": "JOHN DOE AND JANE DOE, HUSBAND AND WIFE, AS COMMUNITY PROPERTY WITH RIGHT OF SURVIVORSHIP",
+      "parties": "JOHN DOE AND JANE DOE",
+      "characterization": "HUSBAND AND WIFE, AS COMMUNITY PROPERTY WITH RIGHT OF SURVIVORSHIP",
+      "mixed_content": true,
+      "needs_review": false,
+      "why": "Two adjacent markers separated by nothing but punctuation are ONE characterization, not an ambiguity."
+    },
+    {
+      "input": "ROBERT SMITH AND LINDA SMITH, TRUSTEES OF THE SMITH FAMILY TRUST DATED JANUARY 5, 2011",
+      "verbatim": "ROBERT SMITH AND LINDA SMITH, TRUSTEES OF THE SMITH FAMILY TRUST DATED JANUARY 5, 2011",
+      "parties": "ROBERT SMITH AND LINDA SMITH",
+      "characterization": "TRUSTEES OF THE SMITH FAMILY TRUST DATED JANUARY 5, 2011",
+      "mixed_content": true,
+      "needs_review": false,
+      "why": "The trust's name is a fact, but it arrives welded to a CAPACITY. The whole tail is proposed rather than half of it silently promoted."
+    },
+    {
+      "input": "PATRICIA WONG, A WIDOW",
+      "verbatim": "PATRICIA WONG, A WIDOW",
+      "parties": "PATRICIA WONG",
+      "characterization": "A WIDOW",
+      "mixed_content": true,
+      "needs_review": false,
+      "why": "Short characterizations are still characterizations."
+    },
+    {
+      "input": "ACME HOLDINGS, LLC",
+      "verbatim": "ACME HOLDINGS, LLC",
+      "parties": "ACME HOLDINGS, LLC",
+      "characterization": null,
+      "mixed_content": false,
+      "needs_review": false,
+      "why": "An entity's NAME includes its suffix. Stripping 'LLC' would corrupt the fact — the marker requires the article ('a California limited liability company'), which is the recital, not the name."
+    },
+    {
+      "input": "ACME HOLDINGS, LLC, A CALIFORNIA LIMITED LIABILITY COMPANY",
+      "verbatim": "ACME HOLDINGS, LLC, A CALIFORNIA LIMITED LIABILITY COMPANY",
+      "parties": "ACME HOLDINGS, LLC",
+      "characterization": "A CALIFORNIA LIMITED LIABILITY COMPANY",
+      "mixed_content": true,
+      "needs_review": false,
+      "why": "The entity recital is the characterization; the name keeps its suffix."
+    },
+    {
+      "input": "DOE JOHN A & DOE JANE B",
+      "verbatim": "DOE JOHN A & DOE JANE B",
+      "parties": "DOE JOHN A & DOE JANE B",
+      "characterization": null,
+      "mixed_content": false,
+      "needs_review": false,
+      "why": "County-record surname-first format. Ugly, but entirely fact — and it must not be mistaken for mixed content."
+    },
+    {
+      "input": "HUSBAND AND WIFE AS JOINT TENANTS",
+      "verbatim": "HUSBAND AND WIFE AS JOINT TENANTS",
+      "parties": null,
+      "characterization": "HUSBAND AND WIFE AS JOINT TENANTS",
+      "mixed_content": true,
+      "needs_review": true,
+      "why": "A characterization with no name in front of it. There is no fact to offer, and inventing one from the characterization would be exactly backwards."
+    },
+    {
+      "input": "JOHN DOE, AN UNMARRIED MAN AND MARY ROE, A SINGLE WOMAN, AS TENANTS IN COMMON",
+      "verbatim": "JOHN DOE, AN UNMARRIED MAN AND MARY ROE, A SINGLE WOMAN, AS TENANTS IN COMMON",
+      "parties": null,
+      "characterization": null,
+      "mixed_content": true,
+      "needs_review": true,
+      "why": "THE CASE THAT MATTERS. Splitting at the first marker would put MARY ROE inside the characterization and drop a real owner out of the fact position — a missing grantor is worse than an unsplit string. A name between two markers means we cannot split confidently, so we do not."
+    },
+    {
+      "input": "JOHN DOE, A MARRIED MAN, AS HIS SOLE AND SEPARATE PROPERTY",
+      "verbatim": "JOHN DOE, A MARRIED MAN, AS HIS SOLE AND SEPARATE PROPERTY",
+      "parties": "JOHN DOE",
+      "characterization": "A MARRIED MAN, AS HIS SOLE AND SEPARATE PROPERTY",
+      "mixed_content": true,
+      "needs_review": false,
+      "why": "Two markers, no name between them — one characterization."
+    },
+    {
+      "input": "John Doe and Jane Doe, husband and wife as joint tenants",
+      "verbatim": "John Doe and Jane Doe, husband and wife as joint tenants",
+      "parties": "John Doe and Jane Doe",
+      "characterization": "husband and wife as joint tenants",
+      "mixed_content": true,
+      "needs_review": false,
+      "why": "Not every source shouts. The split is case-insensitive; the OUTPUT keeps the source's casing, because a verbatim that has been re-cased is not a verbatim."
+    },
+    {
+      "input": "JOHN DOE,\nA SINGLE MAN",
+      "verbatim": "JOHN DOE, A SINGLE MAN",
+      "parties": "JOHN DOE",
+      "characterization": "A SINGLE MAN",
+      "mixed_content": true,
+      "needs_review": false,
+      "why": "A PDF text layer wraps mid-line. The wrap is layout, not content, so runs of whitespace normalise to one space before anything is matched — otherwise the marker straddles a newline and is never found."
+    },
+    {
+      "input": "  JOHN A. DOE,  ",
+      "verbatim": "JOHN A. DOE",
+      "parties": "JOHN A. DOE",
+      "characterization": null,
+      "mixed_content": false,
+      "needs_review": false,
+      "why": "Edge whitespace and a dangling separator are trimmed. A trailing comma is punctuation left over from the line above it, not part of anyone's name."
+    },
+    {
+      "input": "",
+      "absent": true,
+      "why": "U0 — absence is not a candidate. An empty string produces NOTHING, not an empty candidate for the officer to confirm."
+    },
+    {
+      "input": "   ",
+      "absent": true,
+      "why": "Whitespace is absence."
+    }
+  ]
+}

--- a/backend/services/vesting_split.py
+++ b/backend/services/vesting_split.py
@@ -1,0 +1,269 @@
+"""Doctrine A — a vested-owner string is a name PLUS a characterization.
+
+═══ THE RULE, AND WHERE IT IS WRITTEN ═══
+
+`docs/integrations/H1_CONTRACT.md` §2.2, verbatim:
+
+    2.2 — Mixed content is emitted split, never whole.
+    A vested-owner string such as `JOHN DOE AND JANE DOE, HUSBAND AND
+    WIFE AS JOINT TENANTS` is a name PLUS a legal characterization.
+    TitleSense emits the parties as facts and the vesting
+    characterization as a separate interpreted field. TitleSense never
+    emits the composite string as a single value in a fact position. The
+    composite may be carried in `verbatim` for audit, flagged
+    `mixed_content: true`.
+
+That is the WIRE law. This module is the same law INSIDE the product, so
+the two cannot drift: a rule enforced only at the boundary is a rule the
+product breaks internally and exports correctly.
+
+RED0 found the identical defect from the inside (R3-2): DeedPro's
+taxonomy is drawn by field NAME rather than by CONTENT, and the one field
+whose content is mixed — `vested_owner` — slipped through on its label.
+Both the prelim parser and the SiteX prefill were landing the composite
+in a FACT position as a single candidate.
+
+═══ WHY THE HALVES ARE DIFFERENT KINDS OF THING ═══
+
+  "JOHN A. DOE AND JANE B. DOE"        → a FACT. Who is named on the
+                                          instrument. Transcription.
+  "HUSBAND AND WIFE AS JOINT TENANTS"  → an INTERPRETATION. How title is
+                                          held: a legal characterization
+                                          with consequences for
+                                          survivorship, severability and
+                                          the form of the next deed.
+
+Landing the second in a fact position asks the officer to CONFIRM a legal
+conclusion using the same amber affordance she uses to confirm an APN.
+The confirmation record then shows her accepting a transcription when
+what she accepted was a characterization — which is doctrine §1's exact
+prohibition, wearing a data label.
+
+═══ THE CHARACTERIZATION WE READ IS THE OLD ONE ═══
+
+Worth saying once, loudly, because the mistake is easy and expensive:
+this string describes how the CURRENT owner holds title. It is not how
+the grantees will hold title under the deed being drafted. It informs
+that decision — who must sign, whether a survivorship recital is needed —
+and it never makes it. Everything downstream carries a basis line saying
+so, and nothing is ever pre-selected from it.
+
+═══ WHEN WE CANNOT TELL ═══
+
+A string we cannot confidently split is NOT guessed apart and NOT passed
+through whole into a fact position. It is carried verbatim, flagged, and
+the officer is asked. That is the same posture as T-6's refusal on a
+scanned prelim: an honest "we could not read this" beats a confident
+wrong answer, and the failure mode we are protecting against is
+specifically a SILENT one.
+
+The case that forced the rule:
+
+    JOHN DOE, AN UNMARRIED MAN AND MARY ROE, A SINGLE WOMAN,
+    AS TENANTS IN COMMON
+
+Splitting at the first marker puts MARY ROE inside the characterization
+and drops a real owner out of the fact position. A missing grantor is
+worse than an unsplit string, so a name appearing BETWEEN two markers
+means we do not split at all.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+from typing import Dict, List, NamedTuple, Optional
+
+# Characterization markers, most specific phrase first inside each
+# family so the longer form wins.
+#
+# NOT an attempt to enumerate every possible vesting. It does not need to
+# be: an unrecognised string falls through as a plain name, and a
+# half-recognised one falls to the flagged path — both safe directions. A
+# list that tried to be exhaustive would fail CONFIDENTLY on the one it
+# got wrong.
+#
+# MIRRORED, character for character, in frontend/src/lib/vestingSplit.ts.
+# `backend/services/vesting_cases.json` is what actually holds the two
+# implementations together; this list is pinned as well because a
+# divergence caught at the pattern is cheaper to read than one caught at
+# a behaviour.
+MARKERS: List[str] = [
+    r"AS COMMUNITY PROPERTY WITH RIGHT[S]? OF SURVIVORSHIP",
+    r"AS COMMUNITY PROPERTY",
+    r"AS JOINT TENANTS WITH RIGHT[S]? OF SURVIVORSHIP",
+    r"AS JOINT TENANTS",
+    r"AS TENANTS IN COMMON",
+    r"AS TENANTS BY THE ENTIRETY",
+    r"AS (?:HIS|HER|THEIR) SOLE AND SEPARATE PROPERTY",
+    r"AN UNMARRIED (?:MAN|WOMAN|PERSON)",
+    r"A MARRIED (?:MAN|WOMAN|PERSON)",
+    r"A SINGLE (?:MAN|WOMAN|PERSON)",
+    r"A WIDOW(?:ER)?",
+    r"HUSBAND AND WIFE",
+    r"WIFE AND HUSBAND",
+    r"REGISTERED DOMESTIC PARTNERS",
+    r"TRUSTEE[S]? (?:OF|UNDER)",
+    r"(?:A|AN) (?:CALIFORNIA |DELAWARE )?(?:LIMITED LIABILITY COMPANY|LIMITED PARTNERSHIP|GENERAL PARTNERSHIP|CORPORATION|PARTNERSHIP|LLC)",
+]
+
+# \b at both ends so a marker cannot match inside a longer word — the
+# reason "A MARRIED MAN" must not fire on "A MARRIED MANAGER".
+_MARKER_RX = re.compile(
+    r"\b(?:" + "|".join(f"(?:{m})" for m in MARKERS) + r")\b", re.IGNORECASE
+)
+
+# What may legitimately sit BETWEEN two characterization markers: joining
+# words and punctuation, nothing else. Anything else is a name, and a
+# name there means the string is not ours to split.
+#
+# MIRRORED in vestingSplit.ts.
+_SEPARATOR_ONLY = re.compile(
+    r"^[\s,;&/()\.-]*(?:\b(?:AND|OR)\b[\s,;&/()\.-]*)*$", re.IGNORECASE
+)
+
+_EDGE = " ,;"
+
+CASES_PATH = os.path.join(os.path.dirname(__file__), "vesting_cases.json")
+
+
+class VestedOwner(NamedTuple):
+    """The split. `parties` is a fact; `characterization` is not."""
+
+    verbatim: str
+    parties: Optional[str]
+    characterization: Optional[str]
+    mixed_content: bool
+    # True when we could not split confidently. The composite is then
+    # carried for audit and NOTHING is offered as a fact.
+    needs_review: bool
+
+
+def split_vested_owner(raw: Optional[str]) -> Optional[VestedOwner]:
+    """Split a vested-owner string into its fact and its interpretation.
+
+    Returns None for an empty input — absence is not a candidate (U0).
+    """
+    if raw is None:
+        return None
+    # Runs of whitespace collapse BEFORE matching. A PDF text layer wraps
+    # mid-phrase, and a marker that straddles a newline is a marker we
+    # never find — which would silently promote a composite to a fact.
+    text = " ".join(raw.split()).strip(_EDGE)
+    if not text:
+        return None
+
+    matches = list(_MARKER_RX.finditer(text))
+    if not matches:
+        # A bare name is a fact, whole. The common and safe case:
+        # "JOHN A. DOE" carries no characterization to strip.
+        return VestedOwner(verbatim=text, parties=text, characterization=None,
+                           mixed_content=False, needs_review=False)
+
+    # A name sitting between two markers means there are parties on BOTH
+    # sides of the first one. Cutting there loses an owner.
+    for earlier, later in zip(matches, matches[1:]):
+        if not _SEPARATOR_ONLY.match(text[earlier.end():later.start()]):
+            return VestedOwner(verbatim=text, parties=None,
+                               characterization=None,
+                               mixed_content=True, needs_review=True)
+
+    first = matches[0]
+    parties = text[:first.start()].strip(_EDGE)
+    characterization = text[first.start():].strip(_EDGE)
+
+    if not parties:
+        # The whole string is a characterization with no name in front of
+        # it. We have no fact to offer, and inventing one from the
+        # characterization would be exactly backwards.
+        return VestedOwner(verbatim=text, parties=None,
+                           characterization=characterization,
+                           mixed_content=True, needs_review=True)
+
+    return VestedOwner(verbatim=text, parties=parties,
+                       characterization=characterization,
+                       mixed_content=True, needs_review=False)
+
+
+def as_candidates(raw: Optional[str], source: str) -> Dict[str, object]:
+    """The split, in the shape both import paths hand to the builder.
+
+    THE CONTRACT OF THIS FUNCTION, and the reason it exists rather than
+    each caller doing its own thing:
+
+      - `owner`            a FACT candidate — parties only, never the
+                           composite. Absent when we could not split.
+      - `vesting_proposal` an INTERPRETATION — violet, unconfirmed, and
+                           it does NOT occupy a fact position. It carries
+                           its own basis so the officer accepting it
+                           knows whose reading it is (§2.3's principle,
+                           applied internally).
+      - `verbatim`         audit only. Never rendered as a value, never
+                           confirmable, flagged `mixed_content`.
+
+    A caller that wants "the owner string" gets the parties. There is no
+    accessor that returns the composite as a value, because the composite
+    is not a value — it is two things that were printed together.
+    """
+    split = split_vested_owner(raw)
+    if split is None:
+        return {}
+
+    out: Dict[str, object] = {
+        "verbatim": split.verbatim,
+        "mixed_content": split.mixed_content,
+    }
+
+    if split.parties and not split.needs_review:
+        out["owner"] = {
+            "value": split.parties,
+            "source": source,
+            "status": "candidate",
+        }
+
+    if split.characterization:
+        out["vesting_proposal"] = {
+            "value": split.characterization,
+            "source": source,
+            # NOT 'candidate'. A legal choice is never auto-applied and
+            # never sits in candidate state inside the deed — it is
+            # proposed, and the officer's acceptance is what writes it.
+            "status": "proposed",
+            "basis": basis_for(source, split.characterization),
+        }
+
+    if split.needs_review:
+        out["needs_review"] = (
+            "This vesting line could not be separated into a name and a "
+            "vesting characterization. Enter the parties and the vesting "
+            "yourself, using the original as printed."
+        )
+
+    return out
+
+
+def basis_for(source: str, characterization: str) -> str:
+    """Whose reading this is, in words the officer sees at decision time.
+
+    §2.3 makes `basis.claimant` mandatory on the wire because two
+    proposals of equal confidence can carry unequal warrant. The same is
+    true inside: "the preliminary report states this" and "the county
+    record shows this" are different claims, and the officer accepting
+    one deserves to know which.
+
+    The second sentence is not decoration. It is the only thing standing
+    between "how the seller holds title" and "how the buyers will hold
+    title" — two different questions that happen to be answered in the
+    same words.
+    """
+    whose = {
+        "prelim": "The preliminary title report states",
+        "titlesense.prelim_extraction": "The preliminary title report states",
+        "sitex": "The county record shows",
+        "titlepoint": "The title plant shows",
+    }.get(source, "The source document states")
+    return (
+        f'{whose} the CURRENT owner holds title "{characterization}". '
+        f"That is how title is held today; how the grantees will hold it "
+        f"under this deed is your decision."
+    )

--- a/backend/tests/test_prelim_field_map.py
+++ b/backend/tests/test_prelim_field_map.py
@@ -80,14 +80,55 @@ def test_the_labels_match():
 
 
 def test_the_mixed_content_slot_is_flagged_and_cited():
-    """Row 3 is the one that does not map, and the map must say so
+    """Row 3 is the one whose content is mixed, and the map must say so
     against the section that legislates it — not in its own words."""
     text = MAP.read_text(encoding="utf-8")
     assert "vested_owner" in text
     assert "mixed_content" in text
     assert "2.2" in text, "the mixed-content rule must cite H1 §2.2"
-    # And it must be honest that the product currently violates it.
-    assert "forbids" in text or "does the thing the contract" in text
+
+
+def test_the_map_records_row_3_as_split_and_names_the_code_that_splits_it():
+    """Doctrine A resolved row 3. The map's job is now to describe the
+    resolution accurately enough that §10.1's mapping can be written
+    against it — three slots, not one, and a named module per side."""
+    text = MAP.read_text(encoding="utf-8")
+    section = text[text.index("## 3."):text.index("## 4.")]
+
+    for slot in ("vested_owner.parties",
+                 "vested_owner.vesting_characterization",
+                 "vested_owner.verbatim"):
+        assert slot in section, slot
+
+    # The modules, by path, on both sides of the language boundary.
+    assert "backend/services/vesting_split.py" in section
+    assert "frontend/src/lib/vestingSplit.ts" in section
+    assert "vesting_cases.json" in section, \
+        "the shared corpus is what stops the two from drifting"
+
+    # And the two statements that are easy to lose and expensive to lose:
+    # the refusal, and which question the characterization answers.
+    assert "needs_review" in section
+    assert "MARY ROE" in section, "the unsplittable case is named, not implied"
+    assert "TODAY" in section
+
+
+def test_the_split_slots_are_what_the_code_actually_produces():
+    """The map is checked against the parser in §1; row 3's three slots
+    must be checked too, or the one row that changed is the one row
+    nobody is verifying."""
+    from services.vesting_split import as_candidates
+
+    payload = as_candidates(
+        "JOHN A. DOE AND JANE B. DOE, HUSBAND AND WIFE AS JOINT TENANTS",
+        "prelim")
+    assert payload["owner"]["status"] == "candidate"
+    assert payload["vesting_proposal"]["status"] == "proposed"
+    assert payload["mixed_content"] is True
+    assert payload["verbatim"]
+
+    text = MAP.read_text(encoding="utf-8")
+    assert "'proposed'" in text or "`proposed`" in text or "proposed" in text
 
 
 def test_the_map_names_what_is_NOT_extracted():

--- a/backend/tests/test_prelim_import.py
+++ b/backend/tests/test_prelim_import.py
@@ -128,7 +128,10 @@ def test_the_five_fields_come_out_of_a_real_shaped_prelim():
     result = import_prelim(_text_pdf(PRELIM_TEXT))
     by_key = {c["key"]: c["value"] for c in result["candidates"]}
     assert by_key["apn"] == "4291-013-027"
-    assert "MARIA L. TORRES" in by_key["vested_owner"]
+    # DOCTRINE A: the NAME, and only the name. `in` was the assertion this
+    # test shipped with, and it passed just as happily on the composite —
+    # which is how the defect survived a green suite.
+    assert by_key["vested_owner"] == "MARIA L. TORRES"
     assert "LOT 7 OF TRACT NO. 9021" in by_key["legal_description"]
     assert by_key["county"] == "Los Angeles"
     assert "1420 OCEAN AVE" in by_key["property_address"]
@@ -154,6 +157,125 @@ def test_fields_we_could_not_find_are_named():
     result = import_prelim(_text_pdf(text))
     assert "APN" in result["not_found"]
     assert not any(c["key"] == "apn" for c in result["candidates"])
+
+
+# ── Doctrine A: the one field whose content is mixed ─────────────────
+
+def test_the_characterization_does_not_ride_in_on_the_owner_name():
+    """H1 §2.2, from the inside. The prelim says
+
+        MARIA L. TORRES, a married woman as her sole and separate property
+
+    which is a fact welded to a legal conclusion. The conclusion must not
+    be sitting in `candidates` wearing the amber affordance built for
+    transcriptions."""
+    from services.vesting_split import MARKERS
+    import re
+
+    marker_rx = re.compile(
+        r"\b(?:" + "|".join(f"(?:{m})" for m in MARKERS) + r")\b", re.I)
+
+    result = import_prelim(_text_pdf(PRELIM_TEXT))
+    for c in result["candidates"]:
+        assert not marker_rx.search(c["value"]), (
+            f"{c['key']} carries a vesting characterization into a fact "
+            f"position: {c['value']!r}")
+
+
+def test_the_characterization_is_offered_as_a_proposal_instead():
+    result = import_prelim(_text_pdf(PRELIM_TEXT))
+    vesting = [p for p in result["proposals"] if p["key"] == "vesting"]
+    assert len(vesting) == 1
+    p = vesting[0]
+    assert p["value"] == "a married woman as her sole and separate property"
+    # 'proposed', NOT 'candidate' — the field gate must not be able to
+    # sweep a legal choice up with the APNs.
+    assert p["status"] == "proposed"
+    assert p["source"] == "prelim"
+    assert "preliminary title report" in p["basis"]
+    assert "CURRENT owner" in p["basis"], (
+        "the officer must be told this is how title is held TODAY, not how "
+        "the grantees will hold it")
+
+
+def test_the_composite_survives_verbatim_but_not_as_a_value():
+    result = import_prelim(_text_pdf(PRELIM_TEXT))
+    v = result["verbatim"]["vested_owner"]
+    assert v["text"] == (
+        "MARIA L. TORRES, a married woman as her sole and separate property")
+    assert v["mixed_content"] is True
+    # It is not in candidates, and it is not shaped like one.
+    assert v["text"] not in [c["value"] for c in result["candidates"]]
+    assert "status" not in v
+
+
+def test_a_bare_owner_name_is_left_alone():
+    """The common case must not be disturbed by the split: a name with no
+    characterization attached is a fact, whole, exactly as before."""
+    text = PRELIM_TEXT.replace(
+        "MARIA L. TORRES, a married woman as her sole and separate property",
+        "MARIA L. TORRES")
+    result = import_prelim(_text_pdf(text))
+    by_key = {c["key"]: c["value"] for c in result["candidates"]}
+    assert by_key["vested_owner"] == "MARIA L. TORRES"
+    assert result["proposals"] == []
+    assert result["verbatim"]["vested_owner"]["mixed_content"] is False
+    assert result["needs_review"] == []
+
+
+def test_an_unsplittable_vesting_line_offers_neither_half():
+    """Two owners with their own characterizations. Cutting at the first
+    marker would put the second owner inside the characterization and drop
+    a real party out of the fact position, so we do not cut at all."""
+    text = PRELIM_TEXT.replace(
+        "MARIA L. TORRES, a married woman as her sole and separate property",
+        "JOHN DOE, an unmarried man and MARY ROE, a single woman, "
+        "as tenants in common")
+    result = import_prelim(_text_pdf(text))
+
+    assert not any(c["key"] == "vested_owner" for c in result["candidates"]), \
+        "a name we could not isolate is not a fact"
+    assert result["proposals"] == [], \
+        "and a characterization we could not isolate is not a proposal"
+
+    review = result["needs_review"]
+    assert len(review) == 1
+    assert review[0]["key"] == "vested_owner"
+    assert "MARY ROE" in review[0]["verbatim"], "the original survives whole"
+    assert "yourself" in review[0]["message"]
+
+    # And this is NOT the same statement as "the field was absent".
+    assert "Vested owner" not in result["not_found"]
+
+
+def test_both_import_paths_use_the_same_split():
+    """T-6's parser and the SiteX path converge on ONE module. Two
+    implementations of this rule would drift, and the half that drifted
+    would go on landing composites in fact positions while the other
+    reported clean."""
+    from pathlib import Path
+    from tests.source_text import code_only
+
+    py = code_only(Path(__file__).resolve().parents[1] / "services/prelim_import.py")
+    assert "vesting_split" in py
+
+    ts = code_only((Path(__file__).resolve().parents[2] / "frontend" / "src" /
+                    "lib" / "sitexProperty.ts").read_text(encoding="utf-8"))
+    assert "ownerCandidates" in ts, \
+        "the SiteX path must go through the shared split, not its own"
+
+    # And the mapping is not ALSO done inline in the component — a second
+    # copy in the UI would be a second rule, and the one in the UI is the
+    # one nobody tests.
+    section = code_only((Path(__file__).resolve().parents[2] / "frontend" /
+                         "src" / "components" / "builder" / "sections" /
+                         "PropertySection.tsx").read_text(encoding="utf-8"))
+    assert "sitexProperty" in section
+    assert "mapSiteXResponse = " not in section, (
+        "the component defines its own county-record mapping again — that "
+        "mapping lives in lib/sitexProperty.ts precisely so the 'can a "
+        "characterization reach a fact position' question can be asked "
+        "without rendering a component, which is why nobody asked it")
 
 
 # ── Everything arrives amber, through the untouched gate ─────────────

--- a/backend/tests/test_source_text_helper.py
+++ b/backend/tests/test_source_text_helper.py
@@ -132,6 +132,12 @@ RAW_TEXT_ALLOWED = {
     "test_red_h1_requirements.py": "requirements.txt is not Python; the encoding IS the subject",
     "test_source_text_helper.py": "this file tests the helper itself",
     "test_share_pdf_source.py": "reads SQL/schema from the database, not source text",
+    "test_prelim_field_map.py": (
+        "reads Markdown, not Python. It trips this pin because the "
+        "Markdown it checks NAMES a .py file — the field map has to cite "
+        "the module that performs the split, so the string '.py' appears "
+        "in an assertion about documentation. Stripping comments from a "
+        "doc would defeat the point of checking the doc."),
 }
 
 

--- a/backend/tests/test_vesting_split.py
+++ b/backend/tests/test_vesting_split.py
@@ -1,0 +1,188 @@
+"""Doctrine A — the split, pinned on the property rather than the spelling.
+
+Three kinds of test live here, and the order is the argument:
+
+  1. THE CORPUS. `services/vesting_cases.json` is the authority for what
+     the split does. The TypeScript twin reads the same file and asserts
+     the same answers, so a change made in one language and not the other
+     fails in the language that did not change.
+
+  2. THE POSITION. Not "does the function return the right tuple" but
+     "can a characterization reach a fact position by ANY path we ship".
+     That question is asked of the actual import outputs, because the
+     defect RED0 found was never in a function — it was in where a value
+     landed.
+
+  3. THE MIRROR. The two marker lists are compared character for
+     character. This one guards a spelling, which is why it is third and
+     not first.
+"""
+import json
+import re
+import sys
+from pathlib import Path
+
+BACKEND = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(BACKEND))
+
+import pytest
+
+from services.vesting_split import (  # noqa: E402
+    CASES_PATH, MARKERS, as_candidates, split_vested_owner,
+)
+from tests.source_text import code_only  # noqa: E402
+
+CASES = json.loads(Path(CASES_PATH).read_text(encoding="utf-8"))["cases"]
+REPO = BACKEND.parent
+
+
+def _ids():
+    return [c["input"][:48] or "<empty>" for c in CASES]
+
+
+# ── 1. The corpus ──────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("case", CASES, ids=_ids())
+def test_the_corpus(case):
+    """Every case, exactly as written. `why` is on each row so a failure
+    reads as a broken rule rather than a broken assertion."""
+    got = split_vested_owner(case["input"])
+
+    if case.get("absent"):
+        assert got is None, case["why"]
+        assert as_candidates(case["input"], "prelim") == {}, case["why"]
+        return
+
+    assert got is not None, case["why"]
+    assert got.verbatim == case["verbatim"], case["why"]
+    assert got.parties == case["parties"], case["why"]
+    assert got.characterization == case["characterization"], case["why"]
+    assert got.mixed_content == case["mixed_content"], case["why"]
+    assert got.needs_review == case["needs_review"], case["why"]
+
+
+def test_the_corpus_is_not_empty_and_covers_both_outcomes():
+    """A corpus that quietly lost its hard cases would pass everything.
+
+    The two that matter are the ones where NOTHING becomes a fact: a
+    characterization with no name, and a name buried between markers.
+    """
+    assert len(CASES) >= 12
+    assert any(c.get("needs_review") for c in CASES)
+    assert any(c.get("needs_review") and c.get("characterization") is None
+               for c in CASES), "the buried-name case must stay in the corpus"
+    assert any(c.get("absent") for c in CASES)
+    assert any(not c.get("absent") and not c["mixed_content"] for c in CASES), \
+        "a bare name must stay in the corpus — the split must not disturb it"
+
+
+# ── 2. The position ────────────────────────────────────────────────────
+
+MARKER_RX = re.compile(
+    r"\b(?:" + "|".join(f"(?:{m})" for m in MARKERS) + r")\b", re.IGNORECASE)
+
+
+def _fact_values(payload):
+    """Every string in `payload` that occupies a FACT position."""
+    values = []
+    owner = payload.get("owner")
+    if isinstance(owner, dict):
+        values.append(owner["value"])
+    for c in payload.get("candidates", []) or []:
+        values.append(c["value"])
+    return values
+
+
+@pytest.mark.parametrize("case", [c for c in CASES if not c.get("absent")],
+                         ids=[c["input"][:48] for c in CASES if not c.get("absent")])
+@pytest.mark.parametrize("source", ["prelim", "sitex"])
+def test_no_characterization_ever_reaches_a_fact_position(case, source):
+    """THE property. Not "the splitter splits" — "nothing we emit as a
+    fact contains a legal characterization", asked of every case and both
+    sources."""
+    payload = as_candidates(case["input"], source)
+    for value in _fact_values(payload):
+        assert not MARKER_RX.search(value), (
+            f"{value!r} occupies a fact position and contains a "
+            f"characterization — {case['why']}")
+
+
+@pytest.mark.parametrize("case", [c for c in CASES if not c.get("absent")],
+                         ids=[c["input"][:48] for c in CASES if not c.get("absent")])
+def test_a_proposal_is_never_a_candidate(case):
+    """A legal choice is never auto-applied and never sits in candidate
+    state inside the deed (doctrine §1). 'proposed' is a different word
+    on purpose: code that treats candidates as confirmable-by-the-gate
+    must not sweep this up."""
+    proposal = as_candidates(case["input"], "prelim").get("vesting_proposal")
+    if proposal:
+        assert proposal["status"] == "proposed"
+        assert proposal["status"] != "candidate"
+        assert proposal.get("basis"), "§2.3 — a proposal names whose reading it is"
+
+
+def test_the_basis_says_whose_reading_it_is_and_which_question_it_answers():
+    """Two things the officer cannot see from the value alone: where it
+    came from, and that it describes TODAY's title rather than the deed
+    she is drafting."""
+    prelim = as_candidates(
+        "JOHN DOE, A SINGLE MAN", "prelim")["vesting_proposal"]["basis"]
+    sitex = as_candidates(
+        "JOHN DOE, A SINGLE MAN", "sitex")["vesting_proposal"]["basis"]
+    assert "preliminary title report" in prelim
+    assert "county record" in sitex
+    assert prelim != sitex, "the claimant is part of the claim"
+    for basis in (prelim, sitex):
+        assert "CURRENT owner" in basis
+        assert "your decision" in basis
+
+
+def test_an_unsplittable_string_offers_nothing_and_says_so():
+    payload = as_candidates(
+        "JOHN DOE, AN UNMARRIED MAN AND MARY ROE, A SINGLE WOMAN, "
+        "AS TENANTS IN COMMON", "prelim")
+    assert "owner" not in payload, "a name we could not extract is not a fact"
+    assert "vesting_proposal" not in payload, \
+        "and a characterization we could not isolate is not a proposal"
+    assert payload["mixed_content"] is True
+    assert payload["verbatim"], "the original survives for audit"
+    assert "yourself" in payload["needs_review"]
+
+
+def test_the_verbatim_is_carried_but_is_not_offered_as_a_value():
+    payload = as_candidates(
+        "JOHN A. DOE AND JANE B. DOE, HUSBAND AND WIFE AS JOINT TENANTS",
+        "prelim")
+    assert payload["verbatim"] == (
+        "JOHN A. DOE AND JANE B. DOE, HUSBAND AND WIFE AS JOINT TENANTS")
+    # It is a bare string, not a Sourced/candidate shape. Nothing in the
+    # confirmation model can pick it up and offer it for confirmation,
+    # because it does not have the shape of something confirmable.
+    assert isinstance(payload["verbatim"], str)
+    assert payload["owner"]["value"] == "JOHN A. DOE AND JANE B. DOE"
+
+
+# ── 3. The mirror ──────────────────────────────────────────────────────
+
+TWIN = REPO / "frontend" / "src" / "lib" / "vestingSplit.ts"
+
+
+def test_the_typescript_twin_carries_the_same_markers():
+    """Character for character. The corpus is what actually holds the two
+    implementations together — this is the cheaper failure to read."""
+    src = code_only(TWIN.read_text(encoding="utf-8"))
+    block = src[src.index("MARKERS"):src.index("];", src.index("MARKERS"))]
+    ts_markers = re.findall(r"'([^']*)'", block)
+    assert ts_markers == MARKERS, (
+        "the marker lists have diverged — backend-only="
+        f"{[m for m in MARKERS if m not in ts_markers]} frontend-only="
+        f"{[m for m in ts_markers if m not in MARKERS]}")
+
+
+def test_the_twin_reads_the_same_corpus():
+    """A twin with its own private fixture list would pass on cases the
+    Python side never sees, which is the drift the corpus exists to stop."""
+    spec = (REPO / "frontend" / "src" / "__tests__" / "vestingSplit.test.ts")
+    src = spec.read_text(encoding="utf-8")
+    assert "vesting_cases.json" in src
+    assert "'backend'" in src or '"backend"' in src

--- a/docs/DOCTRINE_CONFORMANCE.md
+++ b/docs/DOCTRINE_CONFORMANCE.md
@@ -394,10 +394,110 @@ proposal and the officer's acceptance is what writes it. (T-3/T-3b:
 
 ---
 
+## §11 — A field's kind is decided by its content, not its name
+
+**Ruled Doctrine A, 2026-08-05.** The internal statement of
+`docs/integrations/H1_CONTRACT.md` §2.2.
+
+**Statement.** §1 says a legal choice is never auto-applied. §11 is what
+§1 needs in order to mean anything: the system must be able to *tell*
+which values are legal choices. It had been telling by **field name** —
+`vesting` is a legal choice, `owner` is a fact — and that works right up
+until a single field carries both.
+
+One does. A preliminary report says
+
+> Title to said estate or interest at the date hereof is vested in:
+> **JOHN A. DOE AND JANE B. DOE, HUSBAND AND WIFE AS JOINT TENANTS**
+
+and a county record returns the same composite as `OwnerName`. The left
+half is a transcription. The right half is a legal characterization with
+consequences for survivorship, severability, who must sign, and the form
+of the next instrument. Both arrived in `property.owner` — a fact
+position — as one amber candidate.
+
+**Why that is worse than a plain auto-apply.** The officer was asked to
+confirm a legal conclusion using the affordance built for confirming an
+APN, and her confirmation was then recorded as if she had checked a
+transcription. §1 was not bypassed; it was satisfied on paper by a record
+that described the wrong act. RED0 found it from the inside (R3-2); H1
+§2.2 legislates it on the wire. Same defect, two vantage points.
+
+**The rule.** Mixed content is emitted **split, never whole**.
+
+| half | position | arrives as |
+|---|---|---|
+| the parties | fact | amber candidate — confirmable, unchanged |
+| the characterization | interpretation | **violet proposal** — `status: 'proposed'`, never `'candidate'`, carrying a basis that names its claimant |
+| the composite | neither | `verbatim`, audit only, `mixed_content: true` — a bare string, so nothing that walks the candidate list can offer it |
+
+`'proposed'` is deliberately not a member of `FieldStatus`. That is the
+enforcement, not the labelling: the generation gate
+(`collectCandidateFields`, `propertyCandidatesRemaining`) is
+type-incapable of picking a proposal up and offering it beside an APN.
+
+**And when we cannot tell, we say so.** A composite with a name on both
+sides of a characterization —
+`JOHN DOE, AN UNMARRIED MAN AND MARY ROE, A SINGLE WOMAN, AS TENANTS IN
+COMMON` — is not split at all. Cutting at the first marker files MARY ROE
+inside the characterization and drops a real owner out of the fact
+position; a missing grantor is worse than an unsplit string. Both halves
+are withheld, the original is shown as printed, and the officer types
+them. Same posture as T-6's refusal on a scanned prelim.
+
+**Corollary — the characterization we read is the OLD one.** It says how
+the *current* owner holds title, not how the grantees will hold it. The
+two questions are answered in the same words, which is exactly why the
+proposal is labelled "How title is held TODAY", why its basis says so in
+a sentence, and why nothing is pre-selected from it. Related to §10's
+corollary: being derivably right is what makes something a conclusion.
+
+**Corollary — a dormant code path is still a code path.** Doctrine A
+deleted `suggestVesting`/`detectMarriedCouple` from
+`services/propertyPrefill.ts`, which inferred *community property with
+right of survivorship* from two owners sharing a last word, and wrote it
+into `state.vesting` with no acceptance record. Nothing imported it —
+which is the only reason no deed carries a vesting DeedPro invented from
+a surname match. It was deleted rather than deprecated because "no code
+path may write a characterization into a confirmed field without an
+acceptance record" includes the paths not currently called.
+
+**Habitats checked.**
+- T-6 prelim import (`services/prelim_import.import_prelim`)
+- County-record prefill (`lib/sitexProperty.mapSiteXResponse`)
+- The dormant enrichment prefill (`services/propertyPrefill.ts`)
+- The generation gate (`lib/provenance.collectCandidateFields`)
+
+**Enforced by.** One rule in two languages —
+`backend/services/vesting_split.py` and
+`frontend/src/lib/vestingSplit.ts` — held together by a shared corpus,
+`backend/services/vesting_cases.json`, that **both** test suites read. A
+change made in one language and not the other fails in the language that
+did not change, which is the only failure mode that catches a one-sided
+edit.
+
+- `backend/tests/test_vesting_split.py` (corpus; position; marker mirror)
+- `frontend/src/__tests__/vestingSplit.test.ts` (same corpus; position
+  asked of the real county-record mapping; gate cannot offer a proposal)
+- `backend/tests/test_prelim_import.py` (no marker in any candidate;
+  proposal is `'proposed'`; unsplittable offers neither half)
+- `backend/tests/test_prelim_field_map.py` (the map describes the split
+  the code performs)
+
+**A note on the pin that would have caught it earlier.** The test that
+shipped with T-6 asserted `"MARIA L. TORRES" in by_key["vested_owner"]`.
+That passes just as happily on the composite. The assertion is now
+equality, and the property pin does not ask about the splitter at all —
+it asks whether anything in a fact position matches a characterization
+marker, of every corpus case, on both import paths.
+
+---
+
 ## Change log
 
 | Date | Change |
 |---|---|
+| 2026-08-05 | §11 added (Doctrine A) — a field's kind is decided by its content, not its name. `vested_owner` carried a name PLUS a legal characterization into a fact position on both import paths, so the officer confirmed a legal conclusion with the affordance built for an APN and the record described the wrong act. Split into fact / violet proposal / audit `verbatim`; `'proposed'` deliberately outside `FieldStatus` so the generation gate is type-incapable of offering it. Unsplittable composites offer NEITHER half. `suggestVesting` (community property inferred from a shared surname) deleted from the dormant prefill — a dormant code path is still a code path. One rule in two languages, pinned by a corpus both suites read. |
 | 2026-08-04 | §9's parked supersession model BUILT (T-5). `deeds.superseded_by` + `superseded_at` mirror `document_authenticity`'s shape; lineage state is derived rather than folded into `deeds.status`, because a superseded deed is still a completed deed. Supersession is a pointer written once (SQL-guarded), never a mutation — pinned. The T-0 copy removal reversed in the same diff that made the promise true. |
 | 2026-08-04 | §10 added — facts carry between documents with their ORIGINAL provenance (never re-stamped, always marked `carriedFrom`); legal choices never carry. T-4's matter grouping made the question live: an accepted DTT exemption travelling to the next instrument would be an auto-applied legal choice wearing the officer's own signature. Corollary recorded from T-3b: derivability is a reason for restraint, not licence — being derivably right is what makes something a legal conclusion. |
 | 2026-08-03 | §9 added — stored instruments are never overwritten. ADMIN0 found `deed_pdfs` stored via `ON CONFLICT DO UPDATE SET pdf_data`, replacing prior bytes AND their sha256 in place; the draft-resume 409 guard sits a layer above it, making this latent rather than live. Ruled in two parts: insert-or-refuse in ADMIN1 (differing hash = loud refusal, identical = no-op), full supersession as its own designed ticket. No admin deed-edit until supersession exists. |

--- a/docs/PRELIM_FIELD_MAP.md
+++ b/docs/PRELIM_FIELD_MAP.md
@@ -26,7 +26,7 @@ accident: it is the set an officer retypes from a prelim every time.
 |---|---|---|---|---|---|---|
 | 1 | `apn` | APN | `property.apn` | `apn` | string | **amber** — candidate |
 | 2 | `legal_description` | Legal description | `property.legalDescription` | `legal_description` | string (long) | **amber** — candidate |
-| 3 | `vested_owner` | Vested owner | `property.owner` | `current_owner` | string | **amber** — candidate ⚠️ **see §3** |
+| 3 | `vested_owner` | Vested owner | `property.owner` (**parties only**) | `current_owner` | string | **amber** — candidate ⚠️ **see §3** |
 | 4 | `county` | County | `property.county` | `county` | string | **amber** — candidate |
 | 5 | `property_address` | Property address | `property.address` | `property_address` | string | **amber** — candidate |
 
@@ -72,7 +72,7 @@ Row 3 does not. See below.
 
 ---
 
-## 3. ⚠️ Row 3 is mixed content — the one slot that does not map
+## 3. Row 3 is mixed content — split, as of Doctrine A
 
 `vested_owner` is extracted by this pattern
 (`prelim_import.py`, `_VESTED`):
@@ -94,21 +94,13 @@ precisely the case H1 §2.2 legislates:
 > as a single value in a fact position. The composite may be carried in
 > `verbatim` for audit, flagged `mixed_content: true`.
 
-**Today DeedPro does the thing the contract forbids**: the composite
-lands whole in `property.owner`, a fact position, as a single candidate.
-RED0 found the same defect from the inside (R3-2) — the taxonomy is
-drawn by field *name* rather than by *content*, and the one field whose
-content is mixed slipped through on its label.
+**Until Doctrine A, DeedPro did the thing the contract forbids**: the
+composite landed whole in `property.owner`, a fact position, as a single
+candidate. RED0 found the same defect from the inside (R3-2) — the
+taxonomy is drawn by field *name* rather than by *content*, and the one
+field whose content is mixed slipped through on its label.
 
-So this row is the mapping's open edge, and it is open on **both** sides
-of the wire for the same reason.
-
-**Resolved by Doctrine A** (queued, ruled): extraction emits names as
-fact-candidates and the vesting characterization as a separate violet
-proposal; the composite is carried verbatim for audit, flagged
-`mixed_content`; no code path may write a characterization into a
-confirmed field without an acceptance record. When that ships, row 3
-becomes:
+**Doctrine A shipped the split.** Row 3 now lands in three places:
 
 | extraction key | lands as | position | arrives |
 |---|---|---|---|
@@ -116,9 +108,55 @@ becomes:
 | `vested_owner.vesting_characterization` | vesting section | **interpretation** | **violet — proposal**, acceptance recorded |
 | `vested_owner.verbatim` | audit only | neither | `mixed_content: true` |
 
-**This table is the acceptance criterion for Doctrine A**, and it is
-also what §10.1's mapping work should be written against — not against
-today's single slot, which is the defect.
+That table was written as Doctrine A's acceptance criterion before the
+work started, and it is what §10.1's mapping should be written against.
+
+**In the code:** `backend/services/vesting_split.py` and
+`frontend/src/lib/vestingSplit.ts` — one rule in two languages, held
+together by the shared corpus at `backend/services/vesting_cases.json`
+which both test suites read. The prelim parser and the county-record
+(SiteX) mapping both go through it; neither has its own.
+
+**On the wire**, `import_prelim` now returns:
+
+```
+candidates    facts only — the PARTIES, amber, confirmable
+proposals     the CHARACTERIZATION — status 'proposed', never
+              'candidate', carrying a basis naming its claimant
+verbatim      {vested_owner: {text, mixed_content}} — audit only, a bare
+              string so nothing that walks `candidates` can offer it
+needs_review  read but not separable. NOT the same as `not_found`.
+```
+
+### The one thing this split refuses to do
+
+A composite with a name on **both** sides of a characterization —
+
+```
+JOHN DOE, AN UNMARRIED MAN AND MARY ROE, A SINGLE WOMAN,
+AS TENANTS IN COMMON
+```
+
+— is not split at all. Cutting at the first marker would file MARY ROE
+inside the characterization and drop a real owner out of the fact
+position; a missing grantor is worse than an unsplit string. Both halves
+are withheld, the original is shown as printed, and the officer types
+them. Same posture as §5's refusals: an honest "we could not separate
+this" beats a confident wrong answer.
+
+### And the characterization is the OLD one
+
+`vested_owner` says how the **current** owner holds title. It is not how
+the grantees will hold title under the deed being drafted. The proposal
+is labelled "How title is held TODAY", its basis says so in words, and
+nothing is pre-selected from it — the officer's acceptance is what writes
+a vesting, recorded as a legal choice with the basis she read.
+
+A mapping note for §10.1: structured `prelim_data` arriving already split
+(H1 §2.2 requires TitleSense to emit it split) maps straight onto these
+three slots. Structured data arriving UNSPLIT is a contract violation on
+the sender's side, and DeedPro will split it again rather than trust it —
+the internal rule does not defer to the wire on this.
 
 ---
 

--- a/frontend/src/__tests__/vestingSplit.test.ts
+++ b/frontend/src/__tests__/vestingSplit.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Doctrine A — the TypeScript half of the split, held to the same corpus.
+ *
+ * `backend/services/vesting_cases.json` is the authority. This suite reads
+ * the very same file the Python suite reads, so a rule changed in one
+ * language and not the other fails in the language that did not change.
+ * That is the only failure mode that catches a one-sided edit, and a
+ * one-sided edit is what "two implementations of one rule" always becomes.
+ *
+ * Three kinds of test, and the order is the argument:
+ *
+ *   1. THE CORPUS — what the split does, case by case.
+ *   2. THE POSITION — whether a characterization can reach a fact position
+ *      through the county-record mapping we actually ship. This is the
+ *      question RED0 answered "yes" to; it is asked here of the real
+ *      mapping function, not of a stand-in.
+ *   3. THE MIRROR — the marker lists, character for character. Third,
+ *      because it guards a spelling and the corpus guards the property.
+ */
+import { describe, expect, it } from '@jest/globals';
+import fs from 'fs';
+import path from 'path';
+import {
+  MARKERS,
+  basisFor,
+  ownerCandidates,
+  splitVestedOwner,
+} from '@/lib/vestingSplit';
+import { mapSiteXResponse } from '@/lib/sitexProperty';
+import { collectCandidateFields, propertyCandidatesRemaining } from '@/lib/provenance';
+import { codeOnly } from '../test-support/sourceText';
+import type { DeedBuilderState } from '@/types/builder';
+
+interface Case {
+  input: string;
+  verbatim?: string;
+  parties?: string | null;
+  characterization?: string | null;
+  mixed_content?: boolean;
+  needs_review?: boolean;
+  absent?: boolean;
+  why: string;
+}
+
+const CORPUS_PATH = path.join(
+  __dirname, '..', '..', '..', 'backend', 'services', 'vesting_cases.json');
+
+const CASES: Case[] = JSON.parse(fs.readFileSync(CORPUS_PATH, 'utf8')).cases;
+
+const MARKER_RX = new RegExp(`\\b(?:${MARKERS.map((m) => `(?:${m})`).join('|')})\\b`, 'i');
+
+// ── 1. The corpus ──────────────────────────────────────────────────────
+
+describe('the shared corpus, in TypeScript', () => {
+  it('is the same file the Python suite reads, and it is not empty', () => {
+    expect(fs.existsSync(CORPUS_PATH)).toBe(true);
+    expect(CASES.length).toBeGreaterThanOrEqual(12);
+  });
+
+  CASES.forEach((c) => {
+    it(`${c.input.slice(0, 56) || '<empty>'} — ${c.why.slice(0, 60)}`, () => {
+      const got = splitVestedOwner(c.input);
+
+      if (c.absent) {
+        expect(got).toBeNull();
+        expect(ownerCandidates(c.input, 'prelim')).toBeNull();
+        return;
+      }
+
+      expect(got).not.toBeNull();
+      expect(got!.verbatim).toBe(c.verbatim);
+      expect(got!.parties).toBe(c.parties);
+      expect(got!.characterization).toBe(c.characterization);
+      expect(got!.mixedContent).toBe(c.mixed_content);
+      expect(got!.needsReview).toBe(c.needs_review);
+    });
+  });
+});
+
+// ── 2. The position ────────────────────────────────────────────────────
+
+describe('no characterization ever reaches a fact position', () => {
+  CASES.filter((c) => !c.absent).forEach((c) => {
+    it(`county-record mapping — ${c.input.slice(0, 56)}`, () => {
+      const property = mapSiteXResponse(
+        { address: '1420 OCEAN AVE', apn: '4291-013-027', owner_name: c.input },
+        '1420 OCEAN AVE',
+      );
+
+      // THE property. Not "the splitter split" — "nothing this mapping
+      // puts in a fact position carries a legal characterization".
+      expect(property.owner ?? '').not.toMatch(MARKER_RX);
+      expect(property.provenance?.owner?.value ?? '').not.toMatch(MARKER_RX);
+
+      // And the composite survived for audit, unchanged.
+      expect(property.ownerSplit?.verbatim).toBe(c.verbatim);
+    });
+  });
+
+  it('the parties, and only the parties, become the owner fact', () => {
+    const property = mapSiteXResponse(
+      { owner_name: 'JOHN A. DOE AND JANE B. DOE, HUSBAND AND WIFE AS JOINT TENANTS' },
+      '',
+    );
+    expect(property.owner).toBe('JOHN A. DOE AND JANE B. DOE');
+    expect(property.provenance?.owner).toEqual({
+      value: 'JOHN A. DOE AND JANE B. DOE',
+      source: 'sitex',
+      status: 'candidate',
+    });
+    expect(property.ownerSplit?.mixedContent).toBe(true);
+  });
+
+  it('a bare name is left exactly alone — the common case is not disturbed', () => {
+    const property = mapSiteXResponse({ owner_name: 'DOE JOHN A & DOE JANE B' }, '');
+    expect(property.owner).toBe('DOE JOHN A & DOE JANE B');
+    expect(property.ownerSplit?.mixedContent).toBe(false);
+    expect(property.ownerSplit?.vestingProposal).toBeUndefined();
+    expect(property.ownerSplit?.needsReview).toBeUndefined();
+  });
+
+  it('separate owner fields are joined without a relationship being inferred', () => {
+    const property = mapSiteXResponse(
+      { primary_owner: { full_name: 'John Doe' }, secondary_owner: { full_name: 'Jane Doe' } },
+      '',
+    );
+    // Two people with the same surname. The old propertyPrefill read that
+    // as a marriage and proposed community property with right of
+    // survivorship — a legal conclusion drawn from a string comparison.
+    expect(property.owner).toBe('JOHN DOE AND JANE DOE');
+    expect(property.ownerSplit?.vestingProposal).toBeUndefined();
+  });
+
+  it('an unsplittable string offers NEITHER half and says so', () => {
+    const property = mapSiteXResponse(
+      {
+        owner_name:
+          'JOHN DOE, AN UNMARRIED MAN AND MARY ROE, A SINGLE WOMAN, AS TENANTS IN COMMON',
+      },
+      '',
+    );
+    expect(property.owner).toBe('');
+    expect(property.ownerSplit?.vestingProposal).toBeUndefined();
+    expect(property.ownerSplit?.needsReview).toContain('yourself');
+    expect(property.ownerSplit?.verbatim).toContain('MARY ROE');
+  });
+});
+
+describe('the proposal is not, and cannot become, a confirmable field', () => {
+  const withOwner = (ownerName: string): DeedBuilderState => ({
+    deedType: 'grant-deed',
+    property: mapSiteXResponse({ address: '1420 OCEAN AVE', owner_name: ownerName }, ''),
+    grantor: '',
+    grantee: '',
+    vesting: '',
+    dtt: null,
+    requestedBy: '',
+    returnTo: '',
+  });
+
+  it('status is "proposed", never "candidate"', () => {
+    const p = ownerCandidates('MARIA GONZALEZ, A SINGLE WOMAN', 'sitex')!;
+    expect(p.vestingProposal?.status).toBe('proposed');
+    expect(p.vestingProposal?.status).not.toBe('candidate');
+    expect(p.owner?.status).toBe('candidate');
+  });
+
+  it('the generation gate never asks the officer to confirm it', () => {
+    // THE reason 'proposed' is a different word. collectCandidateFields
+    // walks the material fields and offers each candidate for
+    // confirmation; a legal characterization must never appear in that
+    // list, because confirming it there would record her accepting a
+    // transcription when what she accepted was a conclusion.
+    const state = withOwner('JOHN DOE AND JANE DOE, HUSBAND AND WIFE AS JOINT TENANTS');
+    for (const field of collectCandidateFields(state)) {
+      expect(field.field.value).not.toMatch(MARKER_RX);
+    }
+    for (const key of propertyCandidatesRemaining(state.property)) {
+      expect(String(state.property![key] ?? '')).not.toMatch(MARKER_RX);
+    }
+  });
+
+  it('the characterization cannot reach the GRANTOR either', () => {
+    // The grantor is the fact position that literally prints on the face
+    // of the deed. It is prefilled from `property.owner` (InputPanel's
+    // `suggestedName`), so the split protects it for free — but "for
+    // free" is how a protection gets removed by someone who did not know
+    // it was load-bearing.
+    const property = mapSiteXResponse(
+      { owner_name: 'JOHN A. DOE AND JANE B. DOE, HUSBAND AND WIFE AS JOINT TENANTS' },
+      '',
+    );
+    const suggestedName = property.owner; // exactly what InputPanel passes
+    expect(suggestedName).not.toMatch(MARKER_RX);
+
+    const state: DeedBuilderState = {
+      deedType: 'grant-deed', property, grantor: suggestedName!, grantee: '',
+      vesting: '', dtt: null, requestedBy: '', returnTo: '',
+    };
+    for (const field of collectCandidateFields(state)) {
+      expect(field.field.value).not.toMatch(MARKER_RX);
+    }
+  });
+
+  it('an unsplittable owner blocks nothing — there is no empty field to confirm', () => {
+    // U0: absence is not a candidate. We read something and could not
+    // separate it, so we offer nothing; offering an EMPTY owner for
+    // confirmation would be a gate on a value that does not exist.
+    const state = withOwner(
+      'JOHN DOE, AN UNMARRIED MAN AND MARY ROE, A SINGLE WOMAN, AS TENANTS IN COMMON');
+    expect(propertyCandidatesRemaining(state.property)).not.toContain('owner');
+  });
+});
+
+describe('the basis names its claimant and its question', () => {
+  it('who is claiming this differs by source', () => {
+    expect(basisFor('sitex', 'A SINGLE MAN')).toContain('county record');
+    expect(basisFor('prelim', 'A SINGLE MAN')).toContain('preliminary title report');
+    expect(basisFor('sitex', 'X')).not.toBe(basisFor('prelim', 'X'));
+  });
+
+  it('and it says plainly that this is TODAY\'s vesting, not the deed\'s', () => {
+    // The expensive mistake this sentence exists to prevent: carrying the
+    // seller's vesting into the buyers' deed because both are called
+    // "vesting" and both are spelled the same way.
+    const basis = basisFor('sitex', 'HUSBAND AND WIFE AS JOINT TENANTS');
+    expect(basis).toContain('CURRENT owner');
+    expect(basis).toContain('your decision');
+  });
+});
+
+// ── 3. The mirror ──────────────────────────────────────────────────────
+
+describe('the two implementations are one rule', () => {
+  const py = fs.readFileSync(
+    path.join(__dirname, '..', '..', '..', 'backend', 'services', 'vesting_split.py'),
+    'utf8',
+  );
+
+  it('the marker lists match character for character', () => {
+    const block = py.slice(py.indexOf('MARKERS: List[str] = ['), py.indexOf(']\n\n#'));
+    const pyMarkers = [...block.matchAll(/r"([^"]*)"/g)].map((m) => m[1]);
+    expect(pyMarkers).toEqual(MARKERS);
+  });
+
+  it('neither side keeps a private fixture list', () => {
+    // A twin with its own cases would pass on strings the other never
+    // sees, which is exactly the drift the corpus exists to stop.
+    const src = codeOnly(fs.readFileSync(
+      path.join(__dirname, '..', 'lib', 'vestingSplit.ts'), 'utf8'));
+    expect(src).not.toMatch(/HUSBAND AND WIFE AS JOINT TENANTS/);
+    expect(py).toContain('vesting_cases.json');
+  });
+
+  it('the county-record path and the prelim path call the same module', () => {
+    const sitex = codeOnly(fs.readFileSync(
+      path.join(__dirname, '..', 'lib', 'sitexProperty.ts'), 'utf8'));
+    expect(sitex).toContain('ownerCandidates');
+    const prelim = fs.readFileSync(
+      path.join(__dirname, '..', '..', '..', 'backend', 'services', 'prelim_import.py'),
+      'utf8');
+    expect(prelim).toContain('vesting_split');
+  });
+});

--- a/frontend/src/components/builder/InputPanel.tsx
+++ b/frontend/src/components/builder/InputPanel.tsx
@@ -218,6 +218,10 @@ export function InputPanel({
               onChange(vestingDecision ? { vesting, vestingDecision } : { vesting })
             }
             decision={state.vestingDecision}
+            /* Doctrine A: the characterization the county record / prelim
+               shipped welded to the owner's name arrives here as a proposal,
+               never as a value. */
+            recordProposal={state.property?.ownerSplit?.vestingProposal}
             granteeCount={countGrantees(state.grantee)}
             deedType={state.deedType}
             grantee={state.grantee}

--- a/frontend/src/components/builder/sections/PropertySection.tsx
+++ b/frontend/src/components/builder/sections/PropertySection.tsx
@@ -7,6 +7,7 @@ import { useAIAssist } from "@/contexts/AIAssistContext"
 import { AISuggestion } from "../AISuggestion"
 import { ConfirmableField } from "../ConfirmableField"
 import { propertyCandidatesRemaining } from "@/lib/provenance"
+import { mapSiteXResponse } from "@/lib/sitexProperty"
 import { formatSuggestionSecondary } from "@/lib/addressLabels"
 
 interface PropertySectionProps {
@@ -475,49 +476,6 @@ export function PropertySection({ value, onChange, onComplete }: PropertySection
     }
   }
 
-  // Map SiteX response to PropertyData
-  const mapSiteXResponse = (data: {
-    address?: string;
-    city?: string;
-    county?: string;
-    state?: string;
-    zip_code?: string;
-    zip?: string;
-    apn?: string;
-    legal_description?: string;
-    primary_owner?: { full_name?: string };
-    secondary_owner?: { full_name?: string };
-    owner_name?: string;
-  }, fallbackAddress: string): PropertyData => {
-    const apn = data.apn || ''
-    const legalDescription = data.legal_description || ''
-    const owner = data.owner_name || formatOwnerName(data.primary_owner, data.secondary_owner)
-
-    // SiteX-sourced legal values arrive as unverified candidates. The officer
-    // must confirm (or edit) each one before it counts as authorized.
-    const candidate = (value: string): Sourced<string> => ({
-      value,
-      source: 'sitex',
-      status: 'candidate',
-    })
-
-    return {
-      address: data.address || fallbackAddress,
-      city: data.city || '',
-      county: data.county || '',
-      state: data.state || 'California',
-      zip: data.zip_code || data.zip || '',
-      apn,
-      legalDescription,
-      owner,
-      provenance: {
-        apn: candidate(apn),
-        legalDescription: candidate(legalDescription),
-        owner: candidate(owner),
-      },
-    }
-  }
-
   // Reset to search
   const handleReset = () => {
     setSearchQuery("")
@@ -637,10 +595,33 @@ export function PropertySection({ value, onChange, onComplete }: PropertySection
               onConfirm={() => confirmField('owner')}
               onEdit={(v) => editField('owner', v)}
             />
+          ) : value.ownerSplit?.needsReview ? (
+            /* DOCTRINE A — we read something and could not split it. That is
+               not "no owner returned", and saying so would be untrue. The
+               original is shown as printed, nothing is offered for
+               confirmation, and the officer types both halves. */
+            <div className="p-3 border border-amber-200 bg-amber-50 rounded-lg space-y-2">
+              <p className="text-sm text-amber-800">{value.ownerSplit.needsReview}</p>
+              <p className="text-xs text-gray-500 uppercase tracking-wide">As printed</p>
+              <p className="text-sm font-mono text-gray-700 break-words">
+                {value.ownerSplit.verbatim}
+              </p>
+            </div>
           ) : (
             <p className="text-sm text-gray-500 p-3 border border-gray-200 rounded-lg">
               Current owner: not returned by county records. The grantor you
               enter is what prints on the deed.
+            </p>
+          )}
+          {/* DOCTRINE A / H1 §2.2 — the composite the record actually
+              returned, for audit. Shown, never offered: there is no confirm
+              affordance here because this is not a value, it is two things
+              that were printed together. */}
+          {value.ownerSplit?.mixedContent && !value.ownerSplit.needsReview && (
+            <p className="text-xs text-gray-500 px-3">
+              County record as printed:{' '}
+              <span className="font-mono text-gray-600">{value.ownerSplit.verbatim}</span>
+              {' — '}the vesting words are handled in the Vesting section, not here.
             </p>
           )}
           {hasValue('legalDescription') && (
@@ -795,16 +776,4 @@ export function PropertySection({ value, onChange, onComplete }: PropertySection
   )
 }
 
-// Helper to format owner names
-function formatOwnerName(primary?: { full_name?: string }, secondary?: { full_name?: string }): string {
-  const names: string[] = []
-  
-  if (primary?.full_name) {
-    names.push(primary.full_name.toUpperCase())
-  }
-  if (secondary?.full_name) {
-    names.push(secondary.full_name.toUpperCase())
-  }
-  
-  return names.join(' AND ') || ''
-}
+

--- a/frontend/src/components/builder/sections/VestingSection.tsx
+++ b/frontend/src/components/builder/sections/VestingSection.tsx
@@ -6,7 +6,7 @@ import { useAIAssist } from "@/contexts/AIAssistContext"
 import { AISuggestion, AIHint } from "../AISuggestion"
 import { getVestingSuggestion, type VestingSuggestion } from "@/lib/ai-helpers"
 import { Scale, ShieldCheck, X } from "lucide-react"
-import type { LegalChoiceRecord } from "@/types/builder"
+import type { LegalChoiceRecord, VestingProposal } from "@/types/builder"
 
 interface VestingSectionProps {
   value: string
@@ -18,6 +18,14 @@ interface VestingSectionProps {
   deedType: string
   grantee: string
   decision?: LegalChoiceRecord
+  /**
+   * DOCTRINE A / H1 §2.2 — the vesting characterization that arrived welded
+   * to the county record's or the prelim's owner string. It is HOW THE
+   * CURRENT OWNER HOLDS TITLE, not how the grantees will hold it; it is
+   * offered here because that is the question it bears on, and it is offered
+   * as a proposal because answering that question is the officer's job.
+   */
+  recordProposal?: VestingProposal
 }
 
 export const VESTING_OPTIONS = [
@@ -51,11 +59,12 @@ const VESTING_EXPLANATIONS: Record<string, string> = {
   "trustee": "Property held by trustee for trust beneficiaries",
 }
 
-export function VestingSection({ value, onChange, granteeCount, deedType, grantee, decision }: VestingSectionProps) {
+export function VestingSection({ value, onChange, granteeCount, deedType, grantee, decision, recordProposal }: VestingSectionProps) {
   const { enabled: aiEnabled } = useAIAssist()
   const [showCustom, setShowCustom] = useState(false)
   const [customValue, setCustomValue] = useState("")
   const [suggestionApplied, setSuggestionApplied] = useState(false)
+  const [recordProposalDismissed, setRecordProposalDismissed] = useState(false)
 
   // Get AI suggestion
   const suggestion = useMemo(() => {
@@ -88,6 +97,22 @@ export function VestingSection({ value, onChange, granteeCount, deedType, grante
       status: "confirmed",
       confirmedAt: new Date().toISOString(),
     })
+  }
+
+  // DOCTRINE A — accepting the RECORD's characterization. Same rule as every
+  // other legal choice: the acceptance is the instruction, recorded with the
+  // source that claimed it and the basis line the officer actually read.
+  // Nothing here pre-selects, pre-fills or defaults; a proposal the officer
+  // never touches leaves the vesting unset.
+  const handleAcceptRecordProposal = () => {
+    if (!recordProposal) return
+    onChange(recordProposal.value, {
+      source: recordProposal.source,
+      status: "confirmed",
+      confirmedAt: new Date().toISOString(),
+      basis: recordProposal.basis,
+    })
+    setRecordProposalDismissed(true)
   }
 
   // Accepting the proposal records it as the authorized instruction, with
@@ -127,6 +152,43 @@ export function VestingSection({ value, onChange, granteeCount, deedType, grante
 
   return (
     <div className="space-y-4">
+      {/* DOCTRINE A / H1 §2.2 — the characterization that arrived attached to
+          the owner's name. Violet, dashed, unapplied: the same treatment the
+          AI proposal gets, because it is the same kind of thing — somebody
+          else's reading of a legal question that is the officer's to answer.
+          The heading says CURRENT because the commonest way to get this wrong
+          is to carry yesterday's vesting into tomorrow's deed. */}
+      {recordProposal && !value && !recordProposalDismissed && (
+        <div className="p-4 rounded-lg border-2 border-dashed border-violet-300 bg-violet-50">
+          <div className="flex items-center justify-between mb-1">
+            <span className="inline-flex items-center gap-1.5 text-xs font-semibold text-violet-700 uppercase tracking-wide">
+              <Scale className="w-3.5 h-3.5" />
+              How title is held TODAY — proposed, not applied
+            </span>
+          </div>
+          <p className="text-sm font-semibold text-gray-900">&quot;{recordProposal.value}&quot;</p>
+          <p className="text-sm text-gray-700 mt-1">{recordProposal.basis}</p>
+          <div className="flex items-center gap-2 mt-3">
+            <button
+              type="button"
+              onClick={handleAcceptRecordProposal}
+              className="inline-flex items-center gap-1 bg-violet-600 text-white px-3 py-1.5 rounded-md text-sm font-medium hover:bg-violet-700"
+            >
+              <ShieldCheck className="w-4 h-4" />
+              Use this vesting
+            </button>
+            <button
+              type="button"
+              onClick={() => setRecordProposalDismissed(true)}
+              className="inline-flex items-center gap-1 text-sm text-gray-600 hover:text-gray-900 px-2 py-1.5"
+            >
+              <X className="w-3.5 h-3.5" />
+              Dismiss — I&apos;ll choose manually
+            </button>
+          </div>
+        </div>
+      )}
+
       {/* PROPOSED vesting — visually distinct from an applied value.
           Nothing is written to the deed until the officer accepts. */}
       {suggestion && !value && !suggestionApplied && (
@@ -160,8 +222,11 @@ export function VestingSection({ value, onChange, granteeCount, deedType, grante
         </div>
       )}
 
-      {/* Recorded instruction indicator */}
-      {decision?.source === "ai_suggested" && value && (
+      {/* Recorded instruction indicator. Any accepted PROPOSAL shows it —
+          not just the AI's. A vesting taken from the county record or the
+          prelim is equally somebody else's reading that the officer adopted,
+          and the record must say she adopted it. */}
+      {decision && decision.source !== "user" && value && (
         <div className="flex items-center gap-2 text-sm text-violet-700 bg-violet-50 border border-violet-200 px-3 py-2 rounded-lg">
           <ShieldCheck className="w-4 h-4" />
           Vesting accepted by you

--- a/frontend/src/lib/ai-helpers.ts
+++ b/frontend/src/lib/ai-helpers.ts
@@ -1,64 +1,32 @@
-import type { DeedBuilderState, PropertyData, DTTData } from "@/types/builder"
 
-// ─────────────────────────────────────────────────────────────────
-// CONTEXT DETECTION
-// ─────────────────────────────────────────────────────────────────
-
-export interface AIContext {
-  ownershipType: "single" | "married" | "trust" | "entity" | "multiple" | "unknown"
-  flags: string[]
-}
-
-export function analyzePropertyContext(property: PropertyData | null): AIContext {
-  const context: AIContext = { ownershipType: "unknown", flags: [] }
-  
-  if (!property?.owner) return context
-  
-  const owner = property.owner.toUpperCase()
-
-  // Detect trust ownership
-  if (owner.includes("TRUST") || owner.includes("TRUSTEE") || owner.includes("TR ")) {
-    context.ownershipType = "trust"
-    context.flags.push("Property is currently held in a trust")
-    return context
-  }
-
-  // Detect entity ownership
-  if (
-    owner.includes(" LLC") ||
-    owner.includes(" INC") ||
-    owner.includes(" CORP") ||
-    owner.includes(" LP") ||
-    owner.includes(" LLP") ||
-    owner.includes("COMPANY")
-  ) {
-    context.ownershipType = "entity"
-    context.flags.push("Property owned by business entity")
-    return context
-  }
-
-  // Detect married couple patterns
-  if (
-    owner.includes("HUSBAND AND WIFE") ||
-    owner.includes("WIFE AND HUSBAND") ||
-    owner.includes("MARRIED") ||
-    owner.includes("H/W") ||
-    owner.includes("H&W")
-  ) {
-    context.ownershipType = "married"
-    return context
-  }
-
-  // Detect multiple owners (has "AND" but not obviously married)
-  if (owner.includes(" AND ") || owner.includes(" & ")) {
-    context.ownershipType = "multiple"
-    return context
-  }
-
-  // Single owner
-  context.ownershipType = "single"
-  return context
-}
+/**
+ * DOCTRINE A — `AIContext` and `analyzePropertyContext` were DELETED here.
+ *
+ * What it did: read `property.owner`, matched "HUSBAND AND WIFE" /
+ * "MARRIED" / "TRUSTEE" / " LLC" against it, and returned an
+ * `ownershipType` of "married" | "trust" | "entity" | "multiple" |
+ * "single" — a legal characterization of how title is held, derived by
+ * substring search over a name field.
+ *
+ * That is the same defect as `suggestVesting` in services/propertyPrefill,
+ * and the same defect RED0 named as R3-2: a taxonomy drawn by field NAME,
+ * reaching conclusions about CONTENT. Nothing imported it, which is the
+ * only reason no deed carries a conclusion it reached. A dormant code path
+ * is still a code path.
+ *
+ * It was also, as of the split, about to become quietly wrong: the vesting
+ * words it searched for no longer live in `property.owner` — they live in
+ * `property.ownerSplit.vestingProposal`, unaccepted. Every ownership it
+ * classified as "married" would have started coming back "multiple", and
+ * nothing would have said so. Deleting it beats fixing it: the honest
+ * source for how title is held is the record's own characterization,
+ * carried as a proposal the officer accepts, not an inference from
+ * somebody's surname.
+ *
+ * `getVestingSuggestion` below is a different thing and stays: it reads
+ * the GRANTEE the officer typed, proposes in violet, and is applied only
+ * by acceptance (§1, pinned in vestingDecision.test.ts).
+ */
 
 // ─────────────────────────────────────────────────────────────────
 // VESTING SUGGESTIONS

--- a/frontend/src/lib/sitexProperty.ts
+++ b/frontend/src/lib/sitexProperty.ts
@@ -1,0 +1,101 @@
+/**
+ * The SiteX response → PropertyData mapping.
+ *
+ * IT LIVES HERE SO IT CAN BE PINNED. It used to be a closure inside
+ * PropertySection, which meant the only way to ask "can a vesting
+ * characterization reach a fact position on the county-record path" was to
+ * render a component with a Google-autocomplete dependency and an AI
+ * context — so nobody asked, and the answer was yes for months.
+ *
+ * A rule you can only test through a UI is a rule you do not test.
+ */
+import type { PropertyData, Sourced } from '@/types/builder';
+import { ownerCandidates } from './vestingSplit';
+
+export interface SiteXProperty {
+  address?: string;
+  city?: string;
+  county?: string;
+  state?: string;
+  zip_code?: string;
+  zip?: string;
+  apn?: string;
+  legal_description?: string;
+  primary_owner?: { full_name?: string };
+  secondary_owner?: { full_name?: string };
+  owner_name?: string;
+}
+
+/**
+ * Join the owner names the county record returns as separate fields.
+ *
+ * Note what this does NOT do: it does not infer a relationship from them.
+ * Two people with the same surname are not evidence of a marriage, and a
+ * marriage is not evidence of community property. Those are legal
+ * conclusions and this function transcribes.
+ */
+export function formatOwnerName(
+  primary?: { full_name?: string },
+  secondary?: { full_name?: string },
+): string {
+  const names: string[] = [];
+  if (primary?.full_name) names.push(primary.full_name.toUpperCase());
+  if (secondary?.full_name) names.push(secondary.full_name.toUpperCase());
+  return names.join(' AND ') || '';
+}
+
+export function mapSiteXResponse(data: SiteXProperty, fallbackAddress: string): PropertyData {
+  const apn = data.apn || '';
+  const legalDescription = data.legal_description || '';
+  const ownerRaw = data.owner_name || formatOwnerName(data.primary_owner, data.secondary_owner);
+
+  // DOCTRINE A / H1 §2.2 — the county record hands us the parties and the
+  // vesting characterization welded into one `OwnerName` string, and this
+  // mapping used to land the whole thing in `provenance.owner`, a FACT
+  // position. The officer was then asked to confirm "HUSBAND AND WIFE AS
+  // JOINT TENANTS" with the same amber button she uses for an APN, and the
+  // confirmation record showed her accepting a transcription when what she
+  // accepted was a legal conclusion.
+  //
+  // Now the split runs first, through the same module the prelim parser
+  // uses. Only the PARTIES become the owner fact; the characterization
+  // becomes a proposal that reaches the deed through the officer's
+  // acceptance or not at all; the composite survives verbatim for audit. A
+  // string we cannot split confidently offers NEITHER half.
+  const split = ownerCandidates(ownerRaw, 'sitex');
+  const owner = split?.owner?.value ?? '';
+
+  // SiteX-sourced legal values arrive as unverified candidates. The officer
+  // must confirm (or edit) each one before it counts as authorized.
+  const candidate = (value: string): Sourced<string> => ({
+    value,
+    source: 'sitex',
+    status: 'candidate',
+  });
+
+  return {
+    address: data.address || fallbackAddress,
+    city: data.city || '',
+    county: data.county || '',
+    state: data.state || 'California',
+    zip: data.zip_code || data.zip || '',
+    apn,
+    legalDescription,
+    owner,
+    provenance: {
+      apn: candidate(apn),
+      legalDescription: candidate(legalDescription),
+      owner: candidate(owner),
+    },
+    ...(split
+      ? {
+          ownerSplit: {
+            verbatim: split.verbatim,
+            mixedContent: split.mixedContent,
+            ...(split.vestingProposal ? { vestingProposal: split.vestingProposal } : {}),
+            ...(split.needsReview ? { needsReview: split.needsReview } : {}),
+          },
+        }
+      : {}),
+  };
+}

--- a/frontend/src/lib/vestingSplit.ts
+++ b/frontend/src/lib/vestingSplit.ts
@@ -1,0 +1,262 @@
+/**
+ * Doctrine A — a vested-owner string is a name PLUS a characterization.
+ *
+ * THE TYPESCRIPT HALF. `backend/services/vesting_split.py` is the other
+ * half, and neither is the authority: `backend/services/vesting_cases.json`
+ * is, and both test suites read it. Two implementations of one rule drift;
+ * that is not a risk, it is a schedule, and the corpus is the schedule's
+ * only known cure.
+ *
+ * ═══ THE RULE, AND WHERE IT IS WRITTEN ═══
+ *
+ * `docs/integrations/H1_CONTRACT.md` §2.2, verbatim:
+ *
+ *     2.2 — Mixed content is emitted split, never whole.
+ *     A vested-owner string such as `JOHN DOE AND JANE DOE, HUSBAND AND
+ *     WIFE AS JOINT TENANTS` is a name PLUS a legal characterization.
+ *     TitleSense emits the parties as facts and the vesting
+ *     characterization as a separate interpreted field. TitleSense never
+ *     emits the composite string as a single value in a fact position.
+ *     The composite may be carried in `verbatim` for audit, flagged
+ *     `mixed_content: true`.
+ *
+ * That is the WIRE law. This module is the same law inside the product on
+ * the SiteX path, so the two cannot drift: a rule enforced only at the
+ * boundary is a rule the product breaks internally and exports correctly.
+ *
+ * ═══ WHY THE HALVES ARE DIFFERENT KINDS OF THING ═══
+ *
+ *   "JOHN A. DOE AND JANE B. DOE"       → a FACT. Who is named on the
+ *                                          instrument. Transcription.
+ *   "HUSBAND AND WIFE AS JOINT TENANTS" → an INTERPRETATION. How title is
+ *                                          held: a legal characterization
+ *                                          with consequences for
+ *                                          survivorship, severability and
+ *                                          the form of the next deed.
+ *
+ * The county record hands us both welded together and calls the result
+ * `OwnerName`. Landing that in `provenance.owner` asks the officer to
+ * CONFIRM a legal conclusion using the same amber affordance she uses to
+ * confirm an APN — and the confirmation record then shows her accepting a
+ * transcription when what she accepted was a characterization.
+ *
+ * ═══ THE CHARACTERIZATION WE READ IS THE OLD ONE ═══
+ *
+ * This string describes how the CURRENT owner holds title. It is not how
+ * the grantees will hold title under the deed being drafted. It informs
+ * that decision and never makes it, which is why the proposal carries a
+ * basis line saying so and why nothing is ever pre-selected from it.
+ *
+ * ═══ WHEN WE CANNOT TELL ═══
+ *
+ * A string we cannot confidently split is NOT guessed apart and NOT passed
+ * through whole into a fact position. The case that forced the rule:
+ *
+ *     JOHN DOE, AN UNMARRIED MAN AND MARY ROE, A SINGLE WOMAN,
+ *     AS TENANTS IN COMMON
+ *
+ * Splitting at the first marker puts MARY ROE inside the characterization
+ * and drops a real owner out of the fact position. A missing grantor is
+ * worse than an unsplit string, so a name appearing BETWEEN two markers
+ * means we do not split at all — we carry the original, flag it, and ask.
+ */
+import type { FieldSource, Sourced, VestingProposal } from '@/types/builder';
+
+/**
+ * Characterization markers, most specific phrase first inside each family
+ * so the longer form wins.
+ *
+ * MIRRORED, character for character, in backend/services/vesting_split.py
+ * (pinned by backend/tests/test_vesting_split.py). Not an attempt to
+ * enumerate every possible vesting: an unrecognised string falls through
+ * as a plain name and a half-recognised one falls to the flagged path —
+ * both safe directions. A list that tried to be exhaustive would fail
+ * CONFIDENTLY on the one it got wrong.
+ */
+export const MARKERS: string[] = [
+  'AS COMMUNITY PROPERTY WITH RIGHT[S]? OF SURVIVORSHIP',
+  'AS COMMUNITY PROPERTY',
+  'AS JOINT TENANTS WITH RIGHT[S]? OF SURVIVORSHIP',
+  'AS JOINT TENANTS',
+  'AS TENANTS IN COMMON',
+  'AS TENANTS BY THE ENTIRETY',
+  'AS (?:HIS|HER|THEIR) SOLE AND SEPARATE PROPERTY',
+  'AN UNMARRIED (?:MAN|WOMAN|PERSON)',
+  'A MARRIED (?:MAN|WOMAN|PERSON)',
+  'A SINGLE (?:MAN|WOMAN|PERSON)',
+  'A WIDOW(?:ER)?',
+  'HUSBAND AND WIFE',
+  'WIFE AND HUSBAND',
+  'REGISTERED DOMESTIC PARTNERS',
+  'TRUSTEE[S]? (?:OF|UNDER)',
+  '(?:A|AN) (?:CALIFORNIA |DELAWARE )?(?:LIMITED LIABILITY COMPANY|LIMITED PARTNERSHIP|GENERAL PARTNERSHIP|CORPORATION|PARTNERSHIP|LLC)',
+];
+
+// \b at both ends so a marker cannot match inside a longer word — the
+// reason 'A MARRIED MAN' must not fire on 'A MARRIED MANAGER'.
+const markerSource = `\\b(?:${MARKERS.map((m) => `(?:${m})`).join('|')})\\b`;
+
+/**
+ * What may legitimately sit BETWEEN two characterization markers: joining
+ * words and punctuation, nothing else. Anything else is a name, and a name
+ * there means the string is not ours to split. Mirrored in the Python.
+ */
+const SEPARATOR_ONLY = /^[\s,;&/()\.-]*(?:\b(?:AND|OR)\b[\s,;&/()\.-]*)*$/i;
+
+const trimEdges = (s: string): string => s.replace(/^[ ,;]+/, '').replace(/[ ,;]+$/, '');
+
+export interface VestedOwnerSplit {
+  /** The composite as extracted. Audit only — never a value, never confirmable. */
+  verbatim: string;
+  /** The FACT half. null when we could not isolate it. */
+  parties: string | null;
+  /** The INTERPRETATION half. null when we could not isolate it. */
+  characterization: string | null;
+  mixedContent: boolean;
+  /** True when we could not split confidently: nothing is offered as a fact. */
+  needsReview: boolean;
+}
+
+/**
+ * Split a vested-owner string into its fact and its interpretation.
+ * Returns null for an empty input — absence is not a candidate (U0).
+ */
+export function splitVestedOwner(raw: string | null | undefined): VestedOwnerSplit | null {
+  if (raw === null || raw === undefined) return null;
+  // Runs of whitespace collapse BEFORE matching. A PDF text layer wraps
+  // mid-phrase, and a marker that straddles a newline is a marker we never
+  // find — which would silently promote a composite to a fact.
+  const text = trimEdges(raw.trim().split(/\s+/).join(' '));
+  if (!text) return null;
+
+  const matches = [...text.matchAll(new RegExp(markerSource, 'gi'))];
+  if (matches.length === 0) {
+    // A bare name is a fact, whole. The common and safe case.
+    return {
+      verbatim: text,
+      parties: text,
+      characterization: null,
+      mixedContent: false,
+      needsReview: false,
+    };
+  }
+
+  // A name sitting between two markers means there are parties on BOTH
+  // sides of the first one. Cutting there loses an owner.
+  for (let i = 0; i + 1 < matches.length; i += 1) {
+    const end = (matches[i].index ?? 0) + matches[i][0].length;
+    const start = matches[i + 1].index ?? 0;
+    if (!SEPARATOR_ONLY.test(text.slice(end, start))) {
+      return {
+        verbatim: text,
+        parties: null,
+        characterization: null,
+        mixedContent: true,
+        needsReview: true,
+      };
+    }
+  }
+
+  const cut = matches[0].index ?? 0;
+  const parties = trimEdges(text.slice(0, cut));
+  const characterization = trimEdges(text.slice(cut));
+
+  if (!parties) {
+    // The whole string is a characterization with no name in front of it.
+    // We have no fact to offer, and inventing one from the characterization
+    // would be exactly backwards.
+    return {
+      verbatim: text,
+      parties: null,
+      characterization,
+      mixedContent: true,
+      needsReview: true,
+    };
+  }
+
+  return { verbatim: text, parties, characterization, mixedContent: true, needsReview: false };
+}
+
+/**
+ * Whose reading this is, in words the officer sees at decision time.
+ *
+ * §2.3 makes `basis.claimant` mandatory on the wire because two proposals
+ * of equal confidence can carry unequal warrant. The second sentence is
+ * not decoration — it is the only thing standing between "how the seller
+ * holds title" and "how the buyers will hold title", two different
+ * questions answered in the same words.
+ *
+ * Mirrored in vesting_split.py::basis_for.
+ */
+export function basisFor(source: FieldSource | string, characterization: string): string {
+  const whose: Record<string, string> = {
+    prelim: 'The preliminary title report states',
+    'titlesense.prelim_extraction': 'The preliminary title report states',
+    sitex: 'The county record shows',
+    titlepoint: 'The title plant shows',
+  };
+  const claimant = whose[source] || 'The source document states';
+  return (
+    `${claimant} the CURRENT owner holds title "${characterization}". ` +
+    'That is how title is held today; how the grantees will hold it ' +
+    'under this deed is your decision.'
+  );
+}
+
+/** What the split hands the builder. Mirrors vesting_split.as_candidates. */
+export interface OwnerSplitResult {
+  /** The composite as extracted. Audit only. */
+  verbatim: string;
+  mixedContent: boolean;
+  /** The FACT candidate — parties only, never the composite. */
+  owner?: Sourced<string>;
+  /** The INTERPRETATION — violet, unconfirmed, NOT in a fact position. */
+  vestingProposal?: VestingProposal;
+  /** Set when the string could not be split: nothing above is offered. */
+  needsReview?: string;
+}
+
+export const UNSPLITTABLE_MESSAGE =
+  'This vesting line could not be separated into a name and a vesting ' +
+  'characterization. Enter the parties and the vesting yourself, using ' +
+  'the original as printed.';
+
+/**
+ * The split in candidate shape.
+ *
+ * A caller that wants "the owner string" gets the parties. There is no
+ * accessor that returns the composite as a value, because the composite is
+ * not a value — it is two things that were printed together.
+ */
+export function ownerCandidates(
+  raw: string | null | undefined,
+  source: FieldSource,
+): OwnerSplitResult | null {
+  const split = splitVestedOwner(raw);
+  if (!split) return null;
+
+  const out: OwnerSplitResult = {
+    verbatim: split.verbatim,
+    mixedContent: split.mixedContent,
+  };
+
+  if (split.parties && !split.needsReview) {
+    out.owner = { value: split.parties, source, status: 'candidate' };
+  }
+
+  if (split.characterization) {
+    out.vestingProposal = {
+      value: split.characterization,
+      source,
+      // NOT 'candidate'. A legal choice is never auto-applied and never
+      // sits in candidate state inside the deed — it is proposed, and the
+      // officer's acceptance is what writes it.
+      status: 'proposed',
+      basis: basisFor(source, split.characterization),
+    };
+  }
+
+  if (split.needsReview) out.needsReview = UNSPLITTABLE_MESSAGE;
+
+  return out;
+}

--- a/frontend/src/services/propertyPrefill.ts
+++ b/frontend/src/services/propertyPrefill.ts
@@ -9,6 +9,7 @@
 
 import { addRecentProperty } from "./recentProperties"
 import { cityDttRate, isIncorporated } from "@/lib/jurisdictions"
+import { splitVestedOwner } from "@/lib/vestingSplit"
 
 /**
  * Property data from SiteX enrichment
@@ -121,40 +122,40 @@ export function formatGrantorName(primaryOwner?: string, secondaryOwner?: string
 }
 
 /**
- * Detect if names suggest a married couple
+ * DOCTRINE A — `suggestVesting` and `detectMarriedCouple` were DELETED here.
+ *
+ * What they did:
+ *
+ *     one owner                      → "Sole and Separate Property"
+ *     two owners, same last name     → "Community Property with Right of
+ *                                       Survivorship"
+ *     two owners, different surnames → "Tenants in Common"
+ *
+ * and `prefillFromEnrichment` wrote the result straight into
+ * `state.vesting` with no acceptance record, no basis, and no violet.
+ *
+ * Every line of that is a legal conclusion reached by comparing the last
+ * word of two strings. A shared surname is not a marriage — it is siblings,
+ * a parent and child, a coincidence. Different surnames are not tenancy in
+ * common — married couples routinely keep their own names. And "sole and
+ * separate" is a statement about a spouse's interest, asserted here about
+ * people whose marital status we never learned.
+ *
+ * Nothing imported these, which is the only reason no deed carries a
+ * vesting DeedPro invented from a surname match. But a dormant path is
+ * still a path, sitting in `services/` under an inviting name, and the next
+ * person wiring county-record prefill would have found it and used it. So
+ * it is deleted rather than deprecated: Doctrine A's pin is that no code
+ * path may write a characterization into a confirmed field without an
+ * acceptance record, and "no code path" includes the ones not currently
+ * called.
+ *
+ * The vesting a county record ACTUALLY reports is different in kind — it is
+ * an observation, not an inference — and it now travels the supported
+ * route: `lib/vestingSplit.ts` separates it from the owner's name, and it
+ * reaches the deed only through the officer's explicit acceptance in the
+ * Vesting section, recorded as a legal choice with its basis.
  */
-export function detectMarriedCouple(name1: string, name2: string): boolean {
-  if (!name1 || !name2) return false
-
-  // Check if they share a last name
-  const lastName1 = name1.split(" ").pop()?.toLowerCase()
-  const lastName2 = name2.split(" ").pop()?.toLowerCase()
-
-  return lastName1 === lastName2 && lastName1 !== undefined
-}
-
-/**
- * Suggest vesting based on property data
- */
-export function suggestVesting(
-  primaryOwner?: string,
-  secondaryOwner?: string
-): string | null {
-  if (!primaryOwner) return null
-
-  // Single owner
-  if (!secondaryOwner) {
-    return "Sole and Separate Property"
-  }
-
-  // Two owners with same last name - likely married
-  if (detectMarriedCouple(primaryOwner, secondaryOwner)) {
-    return "Community Property with Right of Survivorship"
-  }
-
-  // Two owners with different last names
-  return "Tenants in Common"
-}
 
 /**
  * Main prefill function - populates wizard state from SiteX data
@@ -165,7 +166,11 @@ export function prefillFromEnrichment(
 ): WizardState {
   const primaryOwnerName = propertyData.primary_owner?.full_name || ""
   const secondaryOwnerName = propertyData.secondary_owner?.full_name || ""
-  const grantorName = formatGrantorName(primaryOwnerName, secondaryOwnerName)
+  // DOCTRINE A: the joined owner string may be a name PLUS a vesting
+  // characterization. Only the parties may become the grantor.
+  const grantorSplit = splitVestedOwner(
+    formatGrantorName(primaryOwnerName, secondaryOwnerName))
+  const grantorName = grantorSplit?.parties ?? ""
   const dttAreaType = inferDTTAreaType(propertyData.city)
   const legalDesc = propertyData.legal_description || propertyData.legalDescription || ""
 
@@ -181,11 +186,6 @@ export function prefillFromEnrichment(
       legalDescription: legalDesc,
     })
   }
-
-  // Suggest vesting if not already set
-  const suggestedVesting = currentState.vesting
-    ? currentState.vesting
-    : suggestVesting(primaryOwnerName, secondaryOwnerName) || ""
 
   return {
     ...currentState,
@@ -218,8 +218,13 @@ export function prefillFromEnrichment(
     areaType: dttAreaType,
     cityName: dttAreaType === "city" ? propertyData.city : "",
 
-    // Vesting hint
-    vesting: propertyData.vesting_type || suggestedVesting,
+    // DOCTRINE A: vesting is NOT prefilled. `vesting_type` is the county
+    // record's reading of how the CURRENT owner holds title, and writing it
+    // here would answer a different question (how the grantees will hold it)
+    // with no acceptance record and no basis shown. It travels as a proposal
+    // on `property.ownerSplit.vestingProposal` instead, and the officer's
+    // acceptance in the Vesting section is what writes it.
+    vesting: currentState.vesting,
 
     // Metadata for AI assistance
     _enriched: true,

--- a/frontend/src/types/builder.ts
+++ b/frontend/src/types/builder.ts
@@ -38,6 +38,42 @@ export interface Sourced<T> {
 }
 
 /**
+ * Doctrine A — an INTERPRETATION offered for acceptance.
+ *
+ * Deliberately not a Sourced<string>: 'proposed' is not a FieldStatus, so
+ * nothing in the confirmation model (collectCandidateFields, the gate
+ * modal, propertyCandidatesRemaining) can pick this up and offer it beside
+ * an APN. A characterization must never be confirmable by the affordance
+ * built for transcriptions — that is the whole defect H1 §2.2 legislates
+ * and RED0 found from the inside.
+ *
+ * Acceptance produces a LegalChoiceRecord, exactly as the AI vesting
+ * proposal does. Until then the value is displayed and applied nowhere.
+ */
+export interface VestingProposal {
+  value: string;
+  source: FieldSource;
+  status: 'proposed';
+  /** Whose reading it is, and which question it answers (H1 §2.3). */
+  basis: string;
+}
+
+/**
+ * Doctrine A — what a mixed-content owner string decomposed into.
+ *
+ * `verbatim` is audit-only: a bare string, not a Sourced<>, because
+ * nothing that lacks the shape of a confirmable field can be confirmed by
+ * accident. `needsReview` set means we could not split the string and
+ * NEITHER half is offered — the officer types both.
+ */
+export interface OwnerSplit {
+  verbatim: string;
+  mixedContent: boolean;
+  vestingProposal?: VestingProposal;
+  needsReview?: string;
+}
+
+/**
  * Provenance for the SiteX-sourced PropertyData fields covered by Ticket #1.
  * Kept alongside the bare values so the deed PDF/generation path (which reads
  * property.apn etc.) is unchanged by this ticket.
@@ -62,6 +98,13 @@ export interface PropertyData {
    * and the generation payload continue to work against the bare value fields.
    */
   provenance?: PropertyProvenance;
+  /**
+   * Doctrine A: what the county record's owner string decomposed into.
+   * `owner` above carries the PARTIES only; the vesting characterization
+   * that arrived welded to them lives here as a proposal and reaches the
+   * deed only through the officer's acceptance.
+   */
+  ownerSplit?: OwnerSplit;
 }
 
 export interface DTTData {


### PR DESCRIPTION
Implements the ruled Doctrine A. Cites `docs/integrations/H1_CONTRACT.md` §2.2 in both implementations. Acceptance criterion is `docs/PRELIM_FIELD_MAP.md` §3's target table — row 3 maps.

## The defect

H1 §2.2 forbids emitting mixed content whole. DeedPro did it internally, on **both** import paths:

```
JOHN A. DOE AND JANE B. DOE, HUSBAND AND WIFE AS JOINT TENANTS
```

landed in `property.owner` — a **fact position** — as one amber candidate. The officer was asked to confirm a legal conclusion using the affordance built for confirming an APN, and her confirmation record then showed her accepting a transcription when what she accepted was a characterization. §1 was not bypassed; it was satisfied on paper by a record that described the wrong act.

RED0 found the same defect from the inside (R3-2): the taxonomy is drawn by field *name* rather than by *content*, and the one field whose content is mixed slipped through on its label.

## One rule in two languages

| | |
|---|---|
| `backend/services/vesting_split.py` | the prelim path (T-6) |
| `frontend/src/lib/vestingSplit.ts` | the county-record path (SiteX) |
| `backend/services/vesting_cases.json` | **the corpus both suites read** |

Neither implementation is the authority — the corpus is. A change made in one language and not the other fails in the language that did not change, which is the only failure mode that catches a one-sided edit. A marker mirror pins the patterns character-for-character as well, because a pin that guards a spelling does not guard a property, and vice versa. Both were negative-tested: breaking one marker in the TS fails the Python mirror and the jest mirror; landing the composite whole fails 11 of 15 corpus cases on the position pin.

## Where the halves go

| half | position | arrives as |
|---|---|---|
| the parties | fact | amber candidate — confirmable, unchanged |
| the characterization | interpretation | **violet proposal** — `status: 'proposed'`, never `'candidate'`, carrying a basis naming its claimant |
| the composite | neither | `verbatim`, audit only, `mixed_content: true` — a bare string, so nothing that walks the candidate list can offer it |

`'proposed'` is deliberately **not** a member of `FieldStatus`. That is the enforcement, not the labelling: `collectCandidateFields` and `propertyCandidatesRemaining` are type-incapable of picking a proposal up and offering it beside an APN. Pinned both ways.

## The refusal

```
JOHN DOE, AN UNMARRIED MAN AND MARY ROE, A SINGLE WOMAN, AS TENANTS IN COMMON
```

is **not split at all**. Cutting at the first marker files MARY ROE inside the characterization and drops a real owner out of the fact position — a missing grantor is worse than an unsplit string. Both halves withheld, original shown as printed, officer types them. Same posture as T-6's refusal on a scanned prelim, and it is surfaced as `needs_review`, which is not the same statement as `not_found`.

## The characterization is the OLD one

It says how the **current** owner holds title, not how the grantees will hold it under the deed being drafted. Two different questions answered in the same words. The proposal is labelled "How title is held TODAY", its basis says so in a sentence, and nothing is pre-selected from it — the officer's acceptance is what writes a vesting, recorded as a `LegalChoiceRecord` with the basis she read.

## Same-class findings, rolled

Two **dormant** paths of the same class, deleted rather than deprecated — "no code path may write a characterization into a confirmed field without an acceptance record" includes the paths not currently called:

- **`services/propertyPrefill.suggestVesting`** — inferred *community property with right of survivorship* from two owners sharing a last word, and `prefillFromEnrichment` wrote it into `state.vesting` with no acceptance record, no basis, no violet. A shared surname is siblings, a parent and child, a coincidence.
- **`lib/ai-helpers.analyzePropertyContext`** — classified `ownershipType` as `"married" | "trust" | "entity"` by substring search over the owner name. It was also about to become quietly wrong: the words it searches for no longer live in `property.owner`.

Neither was imported, which is the only reason no deed carries a conclusion either of them reached.

## Also

- The SiteX mapping moved out of `PropertySection` into `lib/sitexProperty.ts` so "can a characterization reach a fact position" can be asked of the **real** mapping without rendering a component. It could not be, which is why nobody asked.
- T-6's own pin asserted `"MARIA L. TORRES" in by_key["vested_owner"]` — which passes just as happily on the composite. Now equality, plus a property pin that asks the position rather than the function.
- The grantor is protected for free (prefilled from `property.owner`), and pinned explicitly, because "for free" is how a protection gets removed by someone who did not know it was load-bearing.
- `docs/DOCTRINE_CONFORMANCE.md` §11 added; `docs/PRELIM_FIELD_MAP.md` row 3 records the split it predicted, checked against the code that performs it.

## Gates

pytest **734** · jest **551** (36 suites) · tsc **94** (unchanged) · six-flow ✔ · API baseline ✔ · OpenAPI ✔ · banned-claims clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_