### PR TITLE
PARTNER1: partner address never reached the deed + brand/UX pass

### DIFF
--- a/backend/routers/partners.py
+++ b/backend/routers/partners.py
@@ -51,6 +51,48 @@ class PartnerUpdate(BaseModel):
     is_active: Optional[bool] = None
 
 
+def partner_address_line(p) -> str:
+    """The partner's mailing address as ONE line, for the deed.
+
+    PARTNER1 lifted this out of the selectlist endpoint's closure. It was
+    a nested function, so the only way to test what actually prints on a
+    deed was to render one — the same reason the SiteX mapping went
+    untested for months (DX0 §0). A rule that ends up as ink on a
+    recorded instrument should be reachable by a test that does not need
+    a PDF.
+
+    Empty in, empty out: a partner with no address must assemble to "",
+    never to stray punctuation. ", ," on a recorded document reads as
+    data that got lost, and it is worse than a blank because it is
+    visible.
+    """
+    street = " ".join(str(p.get(k) or "").strip()
+                      for k in ("address_line1", "address_line2")).strip()
+    locality = " ".join(str(p.get(k) or "").strip()
+                        for k in ("state", "postal_code")).strip()
+    city = str(p.get("city") or "").strip()
+    tail = ", ".join(x for x in (city, locality) if x)
+    return ", ".join(x for x in (street, tail) if x)
+
+
+def _require_company_name(value, *, required: bool):
+    """A partner with no company name has nothing to print.
+
+    `company_name` is NOT NULL in the schema and it is the line that
+    renders in the deed's Recording Requested By block. Blank input used
+    to reach the INSERT/UPDATE and fail on the constraint, which the
+    service caught and reported as `None` — surfacing to the officer as
+    "Partner not found", a 404 about a row that exists. Say the true
+    thing instead.
+    """
+    if value is None:
+        if required:
+            raise HTTPException(status_code=400, detail="Company name is required")
+        return
+    if not " ".join(str(value).split()):
+        raise HTTPException(status_code=400, detail="Company name is required")
+
+
 # Helper function to get user's organization
 def get_user_organization(user_id: int) -> str:
     """Get organization_id for user - uses user_id as unique org for data isolation"""
@@ -81,7 +123,8 @@ async def create_my_partner(
     """Create a new partner in current user's organization"""
     try:
         organization_id = get_user_organization(user_id)
-        
+        _require_company_name(payload.company_name, required=True)
+
         partner = create_partner(
             organization_id=organization_id,
             user_id=user_id,
@@ -114,19 +157,12 @@ async def get_partners_selectlist(
         # Simplify for dropdown. D2: the address rides along so selecting
         # a partner can fill the deed's "Recording Requested By" block —
         # the data always existed on the partner row; the deed never got it.
-        def _addr(p):
-            street = " ".join(str(p.get(k) or "").strip() for k in ("address_line1", "address_line2")).strip()
-            locality = " ".join(str(p.get(k) or "").strip() for k in ("state", "postal_code")).strip()
-            city = str(p.get("city") or "").strip()
-            tail = ", ".join(x for x in (city, locality) if x)
-            return ", ".join(x for x in (street, tail) if x)
-
         return [
             {
                 'id': p['id'],
                 'name': p['company_name'],
                 'category': p.get('category', 'other'),
-                'address': _addr(p),
+                'address': partner_address_line(p),
             }
             for p in partners
         ]
@@ -164,9 +200,11 @@ async def update_my_partner(
     """Update a partner (must belong to user's organization)"""
     try:
         organization_id = get_user_organization(user_id)
-        
+
         # Filter out None values
         update_data = {k: v for k, v in payload.dict().items() if v is not None}
+        if 'company_name' in update_data:
+            _require_company_name(update_data['company_name'], required=True)
         
         partner = update_partner(partner_id, organization_id, update_data)
         

--- a/backend/services/partners.py
+++ b/backend/services/partners.py
@@ -7,6 +7,50 @@ from typing import List, Dict, Optional
 from database import get_db_connection
 
 
+# PARTNER1 — light normalization at the write, the #72 profile-hygiene
+# pattern applied to the fields that PRINT.
+#
+# A partner's company name and address ride onto the deed's "Recording
+# Requested By" block, so '  Pacific  Coast Title ' becomes a document.
+# Whitespace is machine noise and is fixed here.
+#
+# CASE IS NEVER TOUCHED, and that is the whole judgement in this helper:
+# "COast TItle" is a typo the owner corrects, but auto-casing would also
+# rewrite PCT, McDonald, LLC and O'Brien — real names that a title-cased
+# "fix" corrupts. Surfacing a typo costs a glance; corrupting a company
+# name costs a re-recording.
+_NORMALIZED_FIELDS = (
+    "company_name", "contact_name", "phone",
+    "address_line1", "address_line2", "city", "postal_code",
+)
+
+
+def _clean(value):
+    """Trim + collapse internal whitespace. Blank collapses to None."""
+    if value is None:
+        return None
+    cleaned = " ".join(str(value).split())
+    return cleaned or None
+
+
+def normalize_partner_fields(data: Dict) -> Dict:
+    """Normalize only the keys PRESENT in `data`.
+
+    Presence matters: `update_partner` builds its SET clause from which
+    keys exist, so inventing keys here would silently overwrite columns
+    the caller never mentioned.
+    """
+    out = dict(data)
+    for key in _NORMALIZED_FIELDS:
+        if key in out:
+            out[key] = _clean(out[key])
+    # State is a two-letter code, not a name — casing it is not a
+    # judgement about anyone's spelling.
+    if "state" in out and out["state"]:
+        out["state"] = " ".join(str(out["state"]).split()).upper() or None
+    return out
+
+
 def list_partners(organization_id: str, active_only: bool = True) -> List[Dict]:
     """List all partners for an organization"""
     conn = get_db_connection()
@@ -61,7 +105,8 @@ def create_partner(organization_id: str, user_id: int, data: Dict) -> Optional[D
     
     try:
         cursor = conn.cursor()
-        
+        data = normalize_partner_fields(data)
+
         cursor.execute("""
             INSERT INTO partners (
                 organization_id, created_by_user_id,
@@ -168,7 +213,8 @@ def update_partner(partner_id: str, organization_id: str, data: Dict) -> Optiona
     
     try:
         cursor = conn.cursor()
-        
+        data = normalize_partner_fields(data)
+
         # Build dynamic update query
         update_fields = []
         params = []

--- a/backend/tests/source_text.py
+++ b/backend/tests/source_text.py
@@ -50,6 +50,39 @@ Same lesson as everywhere else in this project, in its narrowest form:
 match STATEMENTS, not strings. A tokenizer knows what a comment is; a
 pattern only knows what one looks like.
 
+═══ RANGE-BASED PINS ARE THE SAME FAMILY ═══
+
+Owner-ruled after the eighth trip (PARTNER1). The rule reads as being
+about forbidden STRINGS, and every earlier occurrence was one — a price,
+a claim, a removed symbol name. It is not limited to strings.
+
+PARTNER1's brand pass forbade emoji on a screen that had shipped them as
+button labels. The pin was a CHARACTER RANGE:
+
+    expect(RAW).not.toMatch(/[\\u{1F300}-\\u{1FAFF}\\u{2190}-\\u{27BF}]/u)
+
+and it failed — on the ═══ rule characters in its own header comment,
+because U+2500–U+257F (box drawing) sits inside U+2190–U+27BF. Same
+shape as all eight: the prose describing the forbidden thing contains
+the forbidden thing. Nothing about it being a range rather than a
+literal changed that.
+
+So the rule generalises: **any pin whose pattern could match decorative
+or explanatory text runs against `code_only()` output, not raw source.**
+Strings, regexes, character classes, Unicode ranges — the question is
+only whether the pattern can hit a comment, and a wide range can hit far
+more of one than a literal can.
+
+Two corollaries worth stating, because the range case has them and the
+string case does not:
+
+  - Keep the range no wider than the thing you are forbidding. The emoji
+    pin wanted emoji and dingbats; it asked for arrows, maths, box
+    drawing and geometric shapes as well, and got what it asked for.
+  - A pin that must read prose (checking a header cites a doctrine
+    section, say) is a different question and should read RAW
+    deliberately, saying so at the call site.
+
 ═══ WHAT IT DOES NOT DO ═══
 
 It does not strip ordinary string literals. A pin searching for a value

--- a/backend/tests/test_partner1_address.py
+++ b/backend/tests/test_partner1_address.py
@@ -1,0 +1,228 @@
+"""PARTNER1 — the partner's address reaches the recorded document.
+
+═══ THE BUG THIS PINS ═══
+
+D2 wired the partner address end to end: `partners/selectlist` assembles
+a one-line mailing address, `RecordingSection` fills `requestedByAddress`
+when a partner is chosen, and all five chassis print it in the Recording
+Requested By block.
+
+Every link worked. The address was empty anyway, because the Partners
+SCREEN never captured it — the columns existed, the API accepted them,
+the service wrote them, and the form rendered six inputs, none of which
+was an address.
+
+So the interesting property is not "does a column exist". It is:
+
+    a partner the officer actually created, carried through the actual
+    assembly the dropdown uses, ends up as ink on the actual PDF.
+
+Every step below is the shipped code path. The one thing this file does
+NOT exercise is the browser form, which is pinned in
+`frontend/src/__tests__/partnersScreen.test.ts` — the two halves meet at
+the API payload, and the payload is asserted on both sides.
+"""
+import os
+import sys
+from pathlib import Path
+
+BACKEND = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(BACKEND))
+
+import pytest
+
+from routers.partners import partner_address_line  # noqa: E402
+from services.partners import normalize_partner_fields  # noqa: E402
+from tests.source_text import code_only  # noqa: E402
+
+REPO = BACKEND.parent
+
+needs_db = pytest.mark.skipif(
+    not os.getenv("DATABASE_URL"),
+    reason="needs a database for the executable pins")
+
+
+# ── 1. Normalization: whitespace yes, case never ─────────────────────
+
+def test_whitespace_is_collapsed_because_it_prints():
+    """'  Pacific  Coast   Title ' becomes a line on a recorded deed."""
+    out = normalize_partner_fields({
+        "company_name": "  Pacific  Coast   Title ",
+        "address_line1": " 1234   Wilshire Blvd  ",
+        "city": "  Los  Angeles ",
+    })
+    assert out["company_name"] == "Pacific Coast Title"
+    assert out["address_line1"] == "1234 Wilshire Blvd"
+    assert out["city"] == "Los Angeles"
+
+
+def test_case_is_never_touched():
+    """THE ruling in this helper. 'COast TItle' is owner data to correct
+    by hand; auto-casing would also rewrite PCT, McDonald, LLC and
+    O'Brien. Surfacing a typo costs a glance — corrupting a company name
+    costs a re-recording."""
+    for name in ("COast TItle", "PCT", "McDonald Escrow", "O'Brien & Sons LLC"):
+        assert normalize_partner_fields({"company_name": name})["company_name"] == name
+
+
+def test_blank_collapses_to_none_so_a_cleared_field_actually_clears():
+    assert normalize_partner_fields({"address_line1": "   "})["address_line1"] is None
+
+
+def test_only_present_keys_are_touched():
+    """`update_partner` builds its SET clause from which keys EXIST, so
+    inventing keys here would overwrite columns the caller never named —
+    an edit of the phone number silently blanking the address."""
+    out = normalize_partner_fields({"phone": " 555 "})
+    assert set(out) == {"phone"}
+
+
+def test_state_is_upper_cased_and_that_is_not_a_spelling_judgement():
+    """A two-letter jurisdiction code is not somebody's name."""
+    assert normalize_partner_fields({"state": " ca "})["state"] == "CA"
+
+
+# ── 2. The assembly the dropdown actually uses ───────────────────────
+
+def test_the_selectlist_assembles_a_mailing_address():
+    line = partner_address_line({
+        "address_line1": "1234 Wilshire Blvd", "address_line2": "Suite 500",
+        "city": "Los Angeles", "state": "CA", "postal_code": "90017",
+    })
+    assert line == "1234 Wilshire Blvd Suite 500, Los Angeles, CA 90017"
+
+
+def test_a_partner_with_no_address_assembles_to_empty_not_to_punctuation():
+    """The failure mode that would reach a deed as ', ,' — a blank that
+    looks like data. Empty must be empty."""
+    assert partner_address_line(
+        {"address_line1": None, "city": None, "state": None, "postal_code": None}) == ""
+
+
+def test_the_frontend_mirrors_the_same_assembly():
+    """The table shows the officer an address; the deed prints one. If
+    those are built by two rules they will differ, and the one she
+    checked is not the one that recorded."""
+    src = code_only((REPO / "frontend" / "src" / "app" / "partners" /
+                     "page.tsx").read_text(encoding="utf-8"))
+    assert "partnerAddressLine" in src
+    for part in ("address_line1", "address_line2", "city", "state", "postal_code"):
+        assert part in src
+
+
+# ── 3. The form captures what the backend has always accepted ────────
+
+ADDRESS_FIELDS = ("address_line1", "address_line2", "city", "state", "postal_code")
+
+
+def test_the_partners_screen_seeds_and_renders_every_address_field():
+    """THE bug, stated as a property. `blank()` did not seed these keys
+    and no input rendered them, so the create payload could not contain
+    an address no matter what the officer typed."""
+    src = code_only((REPO / "frontend" / "src" / "app" / "partners" /
+                     "page.tsx").read_text(encoding="utf-8"))
+    blank = src[src.index("function blank()"):src.index("function save(")]
+    for field in ADDRESS_FIELDS:
+        assert field in blank, f"blank() does not seed {field}"
+        assert f"editing.{field}" in src, f"no input is bound to {field}"
+
+
+def test_the_other_two_intake_surfaces_still_capture_address():
+    """QuickAddPartnerModal and AddPartnerModal always did. They are the
+    reason the bug was survivable — and the reason it was confusing: the
+    same partner got an address from inside the builder and none from the
+    page built for managing partners."""
+    for rel in (("features", "partners", "QuickAddPartnerModal.tsx"),
+                ("components", "modals", "AddPartnerModal.tsx")):
+        src = (REPO / "frontend" / "src").joinpath(*rel).read_text(encoding="utf-8")
+        for field in ("address_line1", "city", "postal_code"):
+            assert field in src, f"{rel[-1]} lost {field}"
+
+
+# ── 4. End to end: partner row → assembled line → rendered PDF ───────
+
+@needs_db
+def test_the_address_reaches_the_generated_pdf():
+    """The whole point, and the only test here that proves it.
+
+    A partner is created through the shipped service, its address is
+    assembled by the shipped endpoint helper, handed to the deed context
+    the way the builder hands it over, and rendered. The assertion is on
+    the DOCUMENT — extracted text, not a dict key.
+    """
+    from database import create_tables
+    from services.partners import create_partner
+    from services.deed_pdf import render_deed_pdf
+    import psycopg2
+    from db_rows import ROW_FACTORY
+
+    create_tables()
+    conn = psycopg2.connect(os.environ["DATABASE_URL"], cursor_factory=ROW_FACTORY)
+    conn.autocommit = True
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO users (email, password_hash, full_name) VALUES "
+            "('partner1@x.test','h','P1') ON CONFLICT (email) DO UPDATE "
+            "SET full_name='P1' RETURNING id")
+        uid = cur.fetchone()["id"]
+    conn.close()
+
+    partner = create_partner(f"user-{uid}", uid, {
+        "company_name": "  Pacific  Coast Title ",
+        "category": "title_company", "role": "title_officer",
+        "address_line1": " 1234 Wilshire Blvd ", "address_line2": "Suite 500",
+        "city": "Los Angeles", "state": "ca", "postal_code": "90017",
+    })
+    assert partner, "partner was not created"
+    # Normalization happened at the write, and case survived it.
+    assert partner["company_name"] == "Pacific Coast Title"
+    assert partner["state"] == "CA"
+
+    address = partner_address_line(partner)
+    assert address == "1234 Wilshire Blvd Suite 500, Los Angeles, CA 90017"
+
+    pdf = render_deed_pdf({
+        "deed_type": "grant-deed",
+        "property_address": "1420 Ocean Ave, Santa Monica, CA 90401",
+        "apn": "4291-013-027", "county": "Los Angeles",
+        "legal_description": "LOT 7 OF TRACT NO. 9021",
+        "grantor_name": "JOHN A. DOE", "grantee_name": "JANE B. ROE",
+        # Exactly what RecordingSection sends when a partner is chosen.
+        "requested_by": partner["company_name"],
+        "metadata": {"requested_by_address": address},
+    })
+    assert pdf and pdf[:4] == b"%PDF"
+
+    text = _pdf_text(pdf)
+    assert "Pacific Coast Title" in text, "the partner name is not on the deed"
+    assert "1234 Wilshire Blvd" in text, "THE BUG: the address is not on the deed"
+    assert "Los Angeles, CA 90017" in text
+
+
+@needs_db
+def test_a_partner_without_an_address_prints_no_orphan_line():
+    """The other half of the honesty rule: an absent address must not
+    render as a stray comma or an empty line under the company name."""
+    from services.deed_pdf import render_deed_pdf
+
+    pdf = render_deed_pdf({
+        "deed_type": "grant-deed",
+        "property_address": "1420 Ocean Ave, Santa Monica, CA 90401",
+        "apn": "4291-013-027", "county": "Los Angeles",
+        "legal_description": "LOT 7 OF TRACT NO. 9021",
+        "grantor_name": "JOHN A. DOE", "grantee_name": "JANE B. ROE",
+        "requested_by": "Pacific Coast Title",
+        "metadata": {"requested_by_address": ""},
+    })
+    text = _pdf_text(pdf)
+    assert "Pacific Coast Title" in text
+    assert ", ," not in text
+
+
+def _pdf_text(pdf_bytes: bytes) -> str:
+    """Extracted text, via the reader the rest of the suite uses."""
+    import io
+    import pdfplumber
+    with pdfplumber.open(io.BytesIO(pdf_bytes)) as pdf:
+        raw = " ".join((page.extract_text() or "") for page in pdf.pages)
+    return " ".join(raw.split())

--- a/frontend/src/__tests__/partnersScreen.test.ts
+++ b/frontend/src/__tests__/partnersScreen.test.ts
@@ -1,0 +1,192 @@
+/**
+ * PARTNER1 — the Partners screen, brand and behaviour.
+ *
+ * Two jobs, and the order is the ticket's:
+ *
+ *  1. THE BUG. The form must capture the five address fields, because
+ *     the address prints on the deed and this page is the only place to
+ *     edit one. The end-to-end proof (partner → assembled line → PDF
+ *     text) lives in `backend/tests/test_partner1_address.py`; what is
+ *     asserted here is the half that runs in the browser.
+ *
+ *  2. BRAND. This screen predates BRAND2 and broke it three ways: flat
+ *     blue/red buttons, emoji glyphs where the icon set belongs, and
+ *     Quick Stats in a fourth palette. The amber in that palette is the
+ *     one that mattered — BRAND.md reserves amber for "unconfirmed
+ *     external data", and an officer scanning for the amber that means
+ *     "no human has said yes to this" was reading past a lender count.
+ *
+ * Why this file and not an extension of `adminBrand.test.ts`: the admin
+ * console is styled by CSS custom properties in its own `tokens.css`, so
+ * its load-bearing pin resolves token references against declarations.
+ * This page is a Tailwind surface — the equivalent question is whether
+ * it spells brand colours as `brand-*` classes or as whatever hex or
+ * palette the last author reached for.
+ */
+import { describe, expect, it } from '@jest/globals';
+import fs from 'fs';
+import path from 'path';
+import { codeOnly } from '../test-support/sourceText';
+
+const FILE = path.join(__dirname, '..', 'app', 'partners', 'page.tsx');
+const RAW = fs.readFileSync(FILE, 'utf8');
+const SRC = codeOnly(RAW);
+
+// ── 1. The bug ───────────────────────────────────────────────────────
+
+const ADDRESS_FIELDS = [
+  'address_line1', 'address_line2', 'city', 'state', 'postal_code',
+] as const;
+
+describe('the form captures the address that prints on the deed', () => {
+  it('blank() seeds every address field', () => {
+    const blank = SRC.slice(SRC.indexOf('function blank()'), SRC.indexOf('function save('));
+    for (const f of ADDRESS_FIELDS) expect(blank).toContain(f);
+  });
+
+  it.each(ADDRESS_FIELDS)('an input is bound to %s', (field) => {
+    expect(SRC).toMatch(new RegExp(`editing\\.${field}`));
+    expect(SRC).toMatch(new RegExp(`${field}:\\s*e\\.target\\.value`));
+  });
+
+  it('the table shows the address, and a missing one is an editable gap', () => {
+    expect(SRC).toContain('partnerAddressLine');
+    // Not a bare em-dash: an absent address must offer the way to fix it,
+    // because the blank it becomes is on a recorded document.
+    expect(SRC).toContain('Add address');
+  });
+
+  it('the officer is told how many partners are missing one, and why it matters', () => {
+    expect(RAW).toMatch(/Recording Requested By/i);
+    expect(SRC).toContain('missingAddress');
+  });
+
+  it('the address line is assembled the same way the backend assembles it', () => {
+    // The officer checks the table; the deed prints the selectlist's
+    // version. Two rules would drift, and the one she checked would not
+    // be the one that recorded.
+    const fn = SRC.slice(SRC.indexOf('export function partnerAddressLine'));
+    const body = fn.slice(0, fn.indexOf('\n}'));
+    for (const f of ADDRESS_FIELDS) expect(body).toContain(f);
+  });
+});
+
+// ── 2. Brand ─────────────────────────────────────────────────────────
+
+describe('brand conformance (BRAND2)', () => {
+  it('primary actions are brand purple, not blue', () => {
+    expect(SRC).toContain('bg-brand-500');
+    expect(SRC).not.toMatch(/bg-blue-\d/);
+    expect(SRC).not.toMatch(/text-blue-\d/);
+    expect(SRC).not.toMatch(/focus:ring-blue-\d/);
+  });
+
+  it('destructive actions are outline or text, never a filled block', () => {
+    // Red must be findable, not the loudest thing on the screen.
+    expect(SRC).not.toMatch(/bg-red-[5-9]00/);
+    expect(SRC).toMatch(/border-red-\d00|text-red-\d00/);
+  });
+
+  it('cancel is a ghost, not a competing button', () => {
+    const footer = SRC.slice(SRC.indexOf('Cancel') - 400, SRC.indexOf('Cancel'));
+    expect(footer).toMatch(/border border-gray-300/);
+  });
+
+  it('no emoji glyphs — the icon set does this job', () => {
+    // The screen shipped plus/save/trash/close/pencil emoji as button
+    // labels. Checked against SRC, and over the emoji + dingbat blocks
+    // ONLY — a first cut spanned U+2190–U+27BF, which swallows box
+    // drawing (U+2500–U+257F), so the pin failed on the ═══ rule in its
+    // own header comment. That is the eighth time a pin in this repo has
+    // tripped on the prose explaining it; `codeOnly` exists for exactly
+    // this, and the range wants to be no wider than the thing it forbids.
+    expect(SRC).not.toMatch(/[\u{1F300}-\u{1FAFF}\u{2700}-\u{27BF}\u{FE0F}]/u);
+    expect(SRC).toContain("from 'lucide-react'");
+  });
+
+  it('Quick Stats use ONE accent, and a zero is muted rather than shouted', () => {
+    const stats = SRC.slice(SRC.indexOf('Quick Stats'));
+    expect(stats).not.toMatch(/text-emerald-\d/);
+    expect(stats).not.toMatch(/text-amber-\d/);
+    expect(SRC).toContain('text-gray-400');
+    expect(SRC).toContain('text-brand-600');
+  });
+
+  it('AMBER IS NOT SPENT ON DECORATION anywhere on this page', () => {
+    // The load-bearing one. BRAND.md: amber means "a machine suggested
+    // this; a human has not yet said yes". A partner count is neither
+    // machine-suggested nor awaiting anyone. Reassigning it degrades the
+    // signal on every screen that uses it correctly.
+    expect(SRC).not.toMatch(/amber/);
+  });
+
+  it('no colour is spelled as a raw hex at a call site', () => {
+    // The old category badges built their chips from hex literals
+    // (#3b82f6 / #10b981 / #f59e0b) in an inline style object, which no
+    // palette change could ever reach.
+    expect(SRC).not.toMatch(/#[0-9a-fA-F]{6}\b/);
+  });
+});
+
+// ── 3. UX ────────────────────────────────────────────────────────────
+
+describe('the list keeps context', () => {
+  it('the editor is a modal/slide-over, not a card that pushes the table down', () => {
+    expect(SRC).toMatch(/fixed inset-0/);
+    expect(SRC).toContain('aria-modal="true"');
+    expect(SRC).toContain('role="dialog"');
+  });
+
+  it('each row carries its own labelled actions', () => {
+    expect(SRC).toMatch(/aria-label=\{`Edit \$\{p\.company_name\}`\}/);
+    expect(SRC).toMatch(/aria-label=\{`Delete \$\{p\.company_name\}`\}/);
+  });
+});
+
+describe('the table survives a normal window', () => {
+  it('lower-priority columns drop out instead of forcing a horizontal scroll', () => {
+    expect(SRC).toMatch(/hidden lg:table-cell/);
+    expect(SRC).toMatch(/hidden xl:table-cell/);
+    expect(SRC).not.toContain('overflow-x-auto');
+  });
+
+  it('long company names wrap instead of overflowing', () => {
+    expect(SRC).toContain('table-fixed');
+    expect(SRC).toContain('break-words');
+  });
+});
+
+describe('category display', () => {
+  it('renders Title Case, not raw snake_case', () => {
+    expect(SRC).toContain('titleCase');
+    expect(SRC).not.toMatch(/category\.replace\('_'/);
+  });
+
+  it('chips carry semantic neutral tones, no decorative colour', () => {
+    const chip = SRC.slice(SRC.indexOf('function categoryChip'));
+    const body = chip.slice(0, chip.indexOf('\n  }'));
+    expect(body).toMatch(/slate|gray/);
+    expect(body).not.toMatch(/violet|amber|emerald|blue/);
+  });
+});
+
+describe('growth affordances', () => {
+  it('search filters on the fields an officer would actually type', () => {
+    expect(SRC).toContain('setQuery');
+    for (const f of ['company_name', 'contact_name', 'email', 'city']) {
+      expect(SRC.slice(SRC.indexOf('const filtered'))).toContain(f);
+    }
+  });
+
+  it('the empty state says what partners are FOR, not just that there are none', () => {
+    expect(RAW).toMatch(/No partners yet/);
+    expect(RAW).toMatch(/Recording Requested By/);
+    expect(RAW).toMatch(/Add your first partner/);
+  });
+
+  it('a search with no hits is distinguished from having no partners', () => {
+    // Two different facts. "You have no partners" when you have twelve
+    // and mistyped one is a lie about the officer's own data.
+    expect(SRC).toContain('No partners match');
+  });
+});

--- a/frontend/src/app/partners/page.tsx
+++ b/frontend/src/app/partners/page.tsx
@@ -1,6 +1,52 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+/**
+ * PARTNER1 — the Partners screen.
+ *
+ * ═══ PART 1: THE BUG ═══
+ *
+ * A partner's address prints on the deed. D2 wired it end to end:
+ * `partners/selectlist` assembles a one-line mailing address server-side,
+ * `RecordingSection` fills `requestedByAddress` when a partner is chosen,
+ * `PreviewPanel` renders it, and all five chassis print it in the
+ * Recording Requested By block.
+ *
+ * Every link in that chain worked. The address was always empty anyway,
+ * because THIS SCREEN never captured it.
+ *
+ * The columns exist (`partners.address_line1/2, city, state,
+ * postal_code`), the API models accept them, `create_partner` and
+ * `update_partner` write them, `list_partners` returns them — and the
+ * form rendered six inputs, none of which were an address. `blank()` did
+ * not even seed the keys.
+ *
+ * The sharpest part: the OTHER two partner-creation surfaces
+ * (`QuickAddPartnerModal`, opened from the builder's Recording section,
+ * and `AddPartnerModal`) both capture address correctly. So the same
+ * partner got an address when created inside the deed builder and none
+ * when created from the page built for managing partners — and this page
+ * is the only place to EDIT, so the gap could not be repaired either.
+ *
+ * A partner with no address now surfaces as an editable gap ("Add
+ * address"), never as a silent blank that reaches a document.
+ *
+ * ═══ PART 2: BRAND AND UX ═══
+ *
+ * This screen predates BRAND2. It used flat blue/red buttons with emoji
+ * glyphs, and Quick Stats in a fourth palette (blue/emerald/amber) — the
+ * amber being the one that matters, because BRAND.md reserves amber for
+ * "unconfirmed external data" and a partner count is neither. Colour
+ * carrying a meaning somewhere else must not be spent on decoration here.
+ *
+ * Now: brand purple for primary, ghost for cancel, red as outline for
+ * delete, lucide icons throughout, one accent for stats with zero-values
+ * in muted gray, and category chips in semantic neutral tones.
+ */
+
+import React, { useState, useEffect, useMemo } from 'react';
+import {
+  Plus, Pencil, Trash2, X, Save, Search, Users, MapPin, Mail, Loader2,
+} from 'lucide-react';
 import Sidebar from '../../components/Sidebar';
 import '../../styles/dashboard.css';
 
@@ -25,25 +71,54 @@ type Partner = {
   created_at?: string;
 };
 
+/** Title Case for a snake_case enum. Display only — never written back. */
+function titleCase(value?: string): string {
+  if (!value) return '';
+  return value
+    .split('_')
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+/**
+ * The one-line address, assembled exactly as the backend's `_addr()` does
+ * for the selectlist. Mirrored deliberately: what the officer reads in
+ * this table must be what lands in the deed's requested-by block, and a
+ * second formatting rule here would drift from the one that prints.
+ */
+export function partnerAddressLine(p: Partial<Partner>): string {
+  const street = [p.address_line1, p.address_line2]
+    .map((s) => (s || '').trim()).filter(Boolean).join(' ');
+  const locality = [p.state, p.postal_code]
+    .map((s) => (s || '').trim()).filter(Boolean).join(' ');
+  const city = (p.city || '').trim();
+  const tail = [city, locality].filter(Boolean).join(', ');
+  return [street, tail].filter(Boolean).join(', ');
+}
+
 export default function PartnersPage() {
   const [items, setItems] = useState<Partner[]>([]);
   const [loading, setLoading] = useState(false);
   const [editing, setEditing] = useState<Partial<Partner> | null>(null);
   const [showForm, setShowForm] = useState(false);
+  const [query, setQuery] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+
+  const token = () =>
+    typeof window !== 'undefined'
+      ? localStorage.getItem('token') || localStorage.getItem('access_token')
+      : null;
 
   const load = () => {
     setLoading(true);
-    const token = typeof window !== 'undefined' 
-      ? (localStorage.getItem('token') || localStorage.getItem('access_token'))
-      : null;
-    
-    fetch('/api/partners', { 
+    const t = token();
+    fetch('/api/partners', {
       credentials: 'include',
-      headers: {
-        ...(token ? { 'Authorization': `Bearer ${token}` } : {})
-      }
+      headers: { ...(t ? { Authorization: `Bearer ${t}` } : {}) },
     })
-      .then(r => r.json()).then(d => setItems(d.items || d || []))
+      .then((r) => r.json())
+      .then((d) => setItems(d.items || d || []))
       .catch(() => setItems([]))
       .finally(() => setLoading(false));
   };
@@ -58,72 +133,108 @@ export default function PartnersPage() {
       phone: '',
       category: 'title_company',
       role: 'title_officer',
+      // PARTNER1: these five were absent, which is the entire bug. An
+      // address the form never seeds is an address the form never sends.
+      address_line1: '',
+      address_line2: '',
+      city: '',
+      state: 'CA',
+      postal_code: '',
       is_active: true,
-      notes: ''
+      notes: '',
     };
   }
 
   function save(it: Partial<Partner>) {
+    if (!(it.company_name || '').trim()) {
+      setFormError('Company name is required.');
+      return;
+    }
+    setFormError(null);
+    setSaving(true);
     const method = it.id ? 'PUT' : 'POST';
     const url = it.id ? `/api/partners/${it.id}` : '/api/partners';
-    const token = typeof window !== 'undefined' 
-      ? (localStorage.getItem('token') || localStorage.getItem('access_token'))
-      : null;
-    
+    const t = token();
+
     fetch(url, {
       method,
-      headers: { 
+      headers: {
         'Content-Type': 'application/json',
-        ...(token ? { 'Authorization': `Bearer ${token}` } : {})
+        ...(t ? { Authorization: `Bearer ${t}` } : {}),
       },
       credentials: 'include',
-      body: JSON.stringify(it)
-    }).then(r => r.json())
-    .then(() => { 
-      setEditing(null); 
-      setShowForm(false);
-      load(); 
-    });
+      body: JSON.stringify(it),
+    })
+      .then(async (r) => {
+        if (!r.ok) {
+          const body = await r.json().catch(() => ({}));
+          throw new Error(body?.detail || `Save failed (${r.status})`);
+        }
+        return r.json();
+      })
+      .then(() => {
+        setEditing(null);
+        setShowForm(false);
+        load();
+      })
+      .catch((e) => setFormError(e instanceof Error ? e.message : 'Save failed'))
+      .finally(() => setSaving(false));
   }
 
   function del(id: string) {
     if (!confirm('Delete this partner?')) return;
-    const token = typeof window !== 'undefined' 
-      ? (localStorage.getItem('token') || localStorage.getItem('access_token'))
-      : null;
-    
-    fetch(`/api/partners/${id}`, { 
-      method: 'DELETE', 
+    const t = token();
+    fetch(`/api/partners/${id}`, {
+      method: 'DELETE',
       credentials: 'include',
-      headers: {
-        ...(token ? { 'Authorization': `Bearer ${token}` } : {})
-      }
-    })
-      .then(() => load());
+      headers: { ...(t ? { Authorization: `Bearer ${t}` } : {}) },
+    }).then(() => {
+      setEditing(null);
+      setShowForm(false);
+      load();
+    });
   }
 
-  function getCategoryBadge(category: string) {
-    const colors: Record<string, string> = {
-      title_company: '#3b82f6',
-      real_estate: '#10b981',
-      lender: '#f59e0b',
-      other: '#6b7280'
+  /**
+   * Category chips in SEMANTIC NEUTRAL tones.
+   *
+   * The old chips used blue / emerald / amber. Amber is the problem:
+   * BRAND.md reserves it for "unconfirmed external data", and an officer
+   * scanning for the amber that means "no human has said yes to this" was
+   * reading past a lender count. A partner's category is a label, not a
+   * state, so it gets slate weights — distinguishable, and carrying no
+   * meaning borrowed from the doctrine palette.
+   */
+  function categoryChip(category: string) {
+    const tone: Record<string, string> = {
+      title_company: 'bg-slate-100 text-slate-700 ring-slate-200',
+      real_estate: 'bg-slate-50 text-slate-600 ring-slate-200',
+      lender: 'bg-gray-100 text-gray-700 ring-gray-300',
+      other: 'bg-gray-50 text-gray-500 ring-gray-200',
     };
-    const color = colors[category] || colors.other;
     return (
-      <span style={{
-        padding: '4px 8px',
-        borderRadius: '6px',
-        fontSize: '0.75rem',
-        fontWeight: '500',
-        background: `${color}15`,
-        color: color,
-        whiteSpace: 'nowrap'
-      }}>
-        {category.replace('_', ' ')}
+      <span
+        className={`inline-block whitespace-nowrap rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset ${tone[category] || tone.other}`}
+      >
+        {titleCase(category)}
       </span>
     );
   }
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return items;
+    return items.filter((p) =>
+      [p.company_name, p.contact_name, p.email, p.phone, p.city, p.address_line1]
+        .some((f) => (f || '').toLowerCase().includes(q))
+    );
+  }, [items, query]);
+
+  const missingAddress = items.filter((p) => !partnerAddressLine(p)).length;
+
+  /** One accent for stats; a zero is muted, not shouted. */
+  const statValue = (n: number) =>
+    n === 0 ? 'text-gray-400' : 'text-brand-600';
 
   return (
     <div className="flex bg-gray-50 min-h-screen">
@@ -131,220 +242,388 @@ export default function PartnersPage() {
       <main className="flex-1 p-4 md:p-8 overflow-auto">
         <div className="max-w-6xl mx-auto">
           {/* Header */}
-          <div className="flex justify-between items-center mb-6">
+          <div className="flex flex-wrap justify-between items-center gap-3 mb-6">
             <div>
               <h1 className="text-2xl font-bold text-gray-900">Industry Partners</h1>
               <p className="text-gray-500 mt-1">
                 {items.length} partner{items.length !== 1 ? 's' : ''}
               </p>
             </div>
-            <button 
-              className="inline-flex items-center gap-2 bg-blue-600 text-white px-4 py-2.5 rounded-lg font-medium hover:bg-blue-700 transition-colors" 
-              onClick={() => { 
-                setEditing(blank()); 
-                setShowForm(true); 
-              }}
+            <button
+              className="inline-flex items-center gap-2 bg-brand-500 text-white px-4 py-2.5 rounded-lg font-medium hover:bg-brand-600 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 transition-colors"
+              onClick={() => { setEditing(blank()); setFormError(null); setShowForm(true); }}
             >
-              <span>➕</span> Add New Partner
+              <Plus className="w-4 h-4" /> Add New Partner
             </button>
           </div>
 
-          {/* Edit Form (when active) */}
-          {showForm && editing && (
-            <div className="bg-white rounded-xl border border-gray-200 p-6 mb-6">
-              <h3 className="text-lg font-semibold text-gray-900 mb-4">{editing.id ? 'Edit Partner' : 'New Partner'}</h3>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Company Name *</label>
-                  <input 
-                    value={editing.company_name || ''} 
-                    onChange={e => setEditing({...editing, company_name: e.target.value})} 
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                    placeholder="Pacific Coast Title"
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Contact Name</label>
-                  <input 
-                    value={editing.contact_name || ''} 
-                    onChange={e => setEditing({...editing, contact_name: e.target.value})} 
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                    placeholder="John Smith"
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
-                  <input 
-                    value={editing.email || ''} 
-                    onChange={e => setEditing({...editing, email: e.target.value})} 
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                    placeholder="john@pct.com"
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Phone</label>
-                  <input 
-                    value={editing.phone || ''} 
-                    onChange={e => setEditing({...editing, phone: e.target.value})} 
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                    placeholder="(555) 123-4567"
-                  />
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Category</label>
-                  <select 
-                    value={editing.category || 'title_company'} 
-                    onChange={e => setEditing({...editing, category: e.target.value})} 
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                  >
-                    {CATEGORIES.map(c => <option key={c} value={c}>{c.replace('_',' ')}</option>)}
-                  </select>
-                </div>
-                <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Role</label>
-                  <select 
-                    value={editing.role || 'title_officer'} 
-                    onChange={e => setEditing({...editing, role: e.target.value})} 
-                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                  >
-                    {ROLES.map(r => <option key={r} value={r}>{r.replace('_',' ')}</option>)}
-                  </select>
-                </div>
-              </div>
-              <div className="mt-4">
-                <label className="block text-sm font-medium text-gray-700 mb-1">Notes</label>
-                <textarea 
-                  value={editing.notes || ''} 
-                  onChange={e => setEditing({...editing, notes: e.target.value})} 
-                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 min-h-[80px]"
-                  placeholder="Additional notes..."
-                />
-              </div>
-              <div className="flex gap-2 mt-4">
-                <button 
-                  className="inline-flex items-center gap-2 bg-blue-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-blue-700 transition-colors"
-                  onClick={() => save(editing)}
-                >
-                  {editing.id ? '💾 Update' : '➕ Create'}
-                </button>
-                {editing.id && (
-                  <button 
-                    className="inline-flex items-center gap-2 bg-red-500 text-white px-4 py-2 rounded-lg font-medium hover:bg-red-600 transition-colors"
-                    onClick={() => del(editing.id!)}
-                  >
-                    🗑️ Delete
-                  </button>
-                )}
-                <button 
-                  className="inline-flex items-center gap-2 bg-gray-100 text-gray-700 px-4 py-2 rounded-lg font-medium hover:bg-gray-200 transition-colors"
-                  onClick={() => { setEditing(null); setShowForm(false); }}
-                >
-                  ✖️ Cancel
-                </button>
-              </div>
+          {/* PARTNER1: partners with no address are named, once, with the
+              way to fix them. An address missing here becomes a blank
+              line on a recorded document, so silence is the one thing
+              this must not do. */}
+          {!loading && missingAddress > 0 && (
+            <div className="flex items-start gap-2 mb-4 rounded-lg border border-gray-200 bg-white px-4 py-3 text-sm text-gray-700">
+              <MapPin className="w-4 h-4 mt-0.5 flex-shrink-0 text-gray-400" />
+              <span>
+                {missingAddress} partner{missingAddress !== 1 ? 's have' : ' has'} no
+                address on file. The address prints in the deed&apos;s
+                &ldquo;Recording Requested By&rdquo; block — add one so it is not
+                blank on the document.
+              </span>
             </div>
           )}
 
-          {/* Partners Table */}
+          {/* Search — only once there is enough to search through. */}
+          {items.length > 5 && (
+            <div className="relative mb-4">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400" />
+              <input
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Search partners by name, contact, email or city"
+                className="w-full pl-9 pr-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+              />
+            </div>
+          )}
+
+          {/* Partners Table. Lower-priority columns (email/phone) drop out
+              at narrow widths rather than forcing a horizontal scroll. */}
           <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
-            <div className="overflow-x-auto">
-              <table className="w-full">
-                <thead className="bg-gray-50 border-b border-gray-200">
+            <table className="w-full table-fixed">
+              <thead className="bg-gray-50 border-b border-gray-200">
+                <tr>
+                  <th className="w-[30%] text-left px-4 py-3 text-xs font-semibold text-gray-600 uppercase tracking-wider">Company</th>
+                  <th className="w-[26%] text-left px-4 py-3 text-xs font-semibold text-gray-600 uppercase tracking-wider">Address</th>
+                  <th className="hidden lg:table-cell w-[14%] text-left px-4 py-3 text-xs font-semibold text-gray-600 uppercase tracking-wider">Contact</th>
+                  <th className="w-[14%] text-left px-4 py-3 text-xs font-semibold text-gray-600 uppercase tracking-wider">Category</th>
+                  <th className="hidden xl:table-cell w-[12%] text-left px-4 py-3 text-xs font-semibold text-gray-600 uppercase tracking-wider">Email</th>
+                  <th className="w-[80px] text-right px-4 py-3 text-xs font-semibold text-gray-600 uppercase tracking-wider">Actions</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200">
+                {loading && (
                   <tr>
-                    <th className="text-left px-6 py-3 text-xs font-semibold text-gray-600 uppercase tracking-wider">Company</th>
-                    <th className="text-left px-6 py-3 text-xs font-semibold text-gray-600 uppercase tracking-wider">Contact</th>
-                    <th className="text-left px-6 py-3 text-xs font-semibold text-gray-600 uppercase tracking-wider">Category</th>
-                    <th className="text-left px-6 py-3 text-xs font-semibold text-gray-600 uppercase tracking-wider">Role</th>
-                    <th className="text-left px-6 py-3 text-xs font-semibold text-gray-600 uppercase tracking-wider">Email</th>
-                    <th className="text-left px-6 py-3 text-xs font-semibold text-gray-600 uppercase tracking-wider">Phone</th>
-                    <th className="text-left px-6 py-3 text-xs font-semibold text-gray-600 uppercase tracking-wider">Added</th>
-                    <th className="text-left px-6 py-3 text-xs font-semibold text-gray-600 uppercase tracking-wider">Actions</th>
+                    <td colSpan={6} className="text-center py-10 text-gray-500">
+                      <Loader2 className="w-5 h-5 animate-spin inline-block mr-2 align-text-bottom" />
+                      Loading partners…
+                    </td>
                   </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-200">
-                  {loading && (
-                    <tr>
-                      <td colSpan={8} className="text-center py-8 text-gray-500">
-                        Loading partners...
+                )}
+
+                {/* A real empty state: what this is for, and the way in. */}
+                {!loading && items.length === 0 && (
+                  <tr>
+                    <td colSpan={6} className="py-14">
+                      <div className="text-center max-w-sm mx-auto">
+                        <Users className="w-8 h-8 mx-auto text-gray-300" />
+                        <h3 className="mt-3 font-semibold text-gray-900">No partners yet</h3>
+                        <p className="mt-1 text-sm text-gray-500">
+                          Add the title companies, agents and lenders you work with.
+                          Choosing one while drafting fills the deed&apos;s Recording
+                          Requested By block, including its address.
+                        </p>
+                        <button
+                          className="mt-4 inline-flex items-center gap-2 bg-brand-500 text-white px-4 py-2 rounded-lg font-medium hover:bg-brand-600 transition-colors"
+                          onClick={() => { setEditing(blank()); setFormError(null); setShowForm(true); }}
+                        >
+                          <Plus className="w-4 h-4" /> Add your first partner
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                )}
+
+                {!loading && items.length > 0 && filtered.length === 0 && (
+                  <tr>
+                    <td colSpan={6} className="text-center py-10 text-gray-500 text-sm">
+                      No partners match &ldquo;{query}&rdquo;.
+                    </td>
+                  </tr>
+                )}
+
+                {!loading && filtered.map((p) => {
+                  const address = partnerAddressLine(p);
+                  return (
+                    <tr key={p.id} className="hover:bg-gray-50 align-top">
+                      <td className="px-4 py-4 font-medium text-gray-900 break-words">
+                        {p.company_name}
+                        <span className="lg:hidden block text-sm font-normal text-gray-500">
+                          {p.contact_name || ''}
+                        </span>
                       </td>
-                    </tr>
-                  )}
-                  {!loading && items.length === 0 && (
-                    <tr>
-                      <td colSpan={8} className="text-center py-8 text-gray-500">
-                        No partners yet. Click "Add New Partner" to get started.
+                      <td className="px-4 py-4 text-sm text-gray-600 break-words">
+                        {address || (
+                          /* An editable gap, never a silent blank. */
+                          <button
+                            onClick={() => { setEditing(p); setFormError(null); setShowForm(true); }}
+                            className="inline-flex items-center gap-1 text-brand-600 hover:text-brand-700 hover:underline"
+                          >
+                            <MapPin className="w-3.5 h-3.5" /> Add address
+                          </button>
+                        )}
                       </td>
-                    </tr>
-                  )}
-                  {!loading && items.map((p) => (
-                    <tr key={p.id} className="hover:bg-gray-50">
-                      <td className="px-6 py-4 font-medium text-gray-900">{p.company_name}</td>
-                      <td className="px-6 py-4 text-gray-600">{p.contact_name || '—'}</td>
-                      <td className="px-6 py-4">{getCategoryBadge(p.category)}</td>
-                      <td className="px-6 py-4 text-sm text-gray-600">{p.role?.replace('_',' ')}</td>
-                      <td className="px-6 py-4">
+                      <td className="hidden lg:table-cell px-4 py-4 text-gray-600 break-words">
+                        {p.contact_name || '—'}
+                      </td>
+                      <td className="px-4 py-4">{categoryChip(p.category)}</td>
+                      <td className="hidden xl:table-cell px-4 py-4 break-words">
                         {p.email ? (
-                          <a href={`mailto:${p.email}`} className="text-blue-600 hover:underline">
-                            {p.email}
+                          <a href={`mailto:${p.email}`} className="text-brand-600 hover:underline inline-flex items-center gap-1">
+                            <Mail className="w-3.5 h-3.5 flex-shrink-0" />
+                            <span className="break-all">{p.email}</span>
                           </a>
                         ) : '—'}
                       </td>
-                      <td className="px-6 py-4 text-gray-600">{p.phone || '—'}</td>
-                      <td className="px-6 py-4 text-sm text-gray-500">
-                        {p.created_at ? new Date(p.created_at).toLocaleDateString() : '—'}
-                      </td>
-                      <td className="px-6 py-4">
-                        <div className="flex gap-2">
-                          <button 
-                            className="text-sm bg-blue-600 text-white px-3 py-1 rounded hover:bg-blue-700 transition-colors"
-                            onClick={() => { 
-                              setEditing(p); 
-                              setShowForm(true); 
-                            }}
+                      <td className="px-4 py-4">
+                        <div className="flex items-center justify-end gap-1">
+                          <button
+                            aria-label={`Edit ${p.company_name}`}
+                            title="Edit"
+                            className="p-2 rounded-md text-gray-500 hover:text-brand-600 hover:bg-brand-50 transition-colors"
+                            onClick={() => { setEditing(p); setFormError(null); setShowForm(true); }}
                           >
-                            ✏️ Edit
+                            <Pencil className="w-4 h-4" />
                           </button>
-                          <button 
-                            className="text-sm bg-red-500 text-white px-3 py-1 rounded hover:bg-red-600 transition-colors"
+                          <button
+                            aria-label={`Delete ${p.company_name}`}
+                            title="Delete"
+                            className="p-2 rounded-md text-gray-400 hover:text-red-600 hover:bg-red-50 transition-colors"
                             onClick={() => del(p.id)}
                           >
-                            🗑️
+                            <Trash2 className="w-4 h-4" />
                           </button>
                         </div>
                       </td>
                     </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+                  );
+                })}
+              </tbody>
+            </table>
           </div>
 
-          {/* Stats Card */}
+          {/* Quick Stats — ONE accent, zeros muted. */}
           {items.length > 0 && (
             <div className="bg-white rounded-xl border border-gray-200 p-6 mt-6">
               <h4 className="text-lg font-semibold text-gray-900 mb-4">Quick Stats</h4>
               <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                <div className="bg-gray-50 rounded-lg p-4">
-                  <div className="text-sm text-gray-500">Total Partners</div>
-                  <div className="text-2xl font-bold text-blue-600">{items.length}</div>
-                </div>
-                <div className="bg-gray-50 rounded-lg p-4">
-                  <div className="text-sm text-gray-500">Title Companies</div>
-                  <div className="text-2xl font-bold text-blue-500">{items.filter(p => p.category === 'title_company').length}</div>
-                </div>
-                <div className="bg-gray-50 rounded-lg p-4">
-                  <div className="text-sm text-gray-500">Real Estate</div>
-                  <div className="text-2xl font-bold text-emerald-500">{items.filter(p => p.category === 'real_estate').length}</div>
-                </div>
-                <div className="bg-gray-50 rounded-lg p-4">
-                  <div className="text-sm text-gray-500">Lenders</div>
-                  <div className="text-2xl font-bold text-amber-500">{items.filter(p => p.category === 'lender').length}</div>
-                </div>
+                {[
+                  { label: 'Total Partners', n: items.length },
+                  { label: 'Title Companies', n: items.filter((p) => p.category === 'title_company').length },
+                  { label: 'Real Estate', n: items.filter((p) => p.category === 'real_estate').length },
+                  { label: 'Lenders', n: items.filter((p) => p.category === 'lender').length },
+                ].map((s) => (
+                  <div key={s.label} className="bg-gray-50 rounded-lg p-4">
+                    <div className="text-sm text-gray-500">{s.label}</div>
+                    <div className={`text-2xl font-bold ${statValue(s.n)}`}>{s.n}</div>
+                  </div>
+                ))}
               </div>
             </div>
           )}
         </div>
       </main>
+
+      {/* Edit form as a SLIDE-OVER. It used to open as a card above the
+          table, pushing the list below the fold — so editing a partner
+          cost you the sight of every other partner. */}
+      {showForm && editing && (
+        <div className="fixed inset-0 z-50 flex justify-end">
+          <div
+            className="absolute inset-0 bg-gray-900/30"
+            onClick={() => { setEditing(null); setShowForm(false); }}
+            aria-hidden
+          />
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label={editing.id ? 'Edit partner' : 'New partner'}
+            className="relative h-full w-full max-w-lg bg-white shadow-xl overflow-y-auto"
+          >
+            <div className="sticky top-0 bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between">
+              <h3 className="text-lg font-semibold text-gray-900">
+                {editing.id ? 'Edit Partner' : 'New Partner'}
+              </h3>
+              <button
+                aria-label="Close"
+                className="p-2 rounded-md text-gray-400 hover:text-gray-700 hover:bg-gray-100"
+                onClick={() => { setEditing(null); setShowForm(false); }}
+              >
+                <X className="w-4 h-4" />
+              </button>
+            </div>
+
+            <div className="px-6 py-5 space-y-4">
+              {formError && (
+                <p className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+                  {formError}
+                </p>
+              )}
+
+              <Field label="Company Name *">
+                <input
+                  value={editing.company_name || ''}
+                  onChange={(e) => setEditing({ ...editing, company_name: e.target.value })}
+                  className={inputCls}
+                  placeholder="Pacific Coast Title"
+                />
+              </Field>
+
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <Field label="Contact Name">
+                  <input
+                    value={editing.contact_name || ''}
+                    onChange={(e) => setEditing({ ...editing, contact_name: e.target.value })}
+                    className={inputCls}
+                    placeholder="John Smith"
+                  />
+                </Field>
+                <Field label="Phone">
+                  <input
+                    value={editing.phone || ''}
+                    onChange={(e) => setEditing({ ...editing, phone: e.target.value })}
+                    className={inputCls}
+                    placeholder="(555) 123-4567"
+                  />
+                </Field>
+              </div>
+
+              <Field label="Email">
+                <input
+                  value={editing.email || ''}
+                  onChange={(e) => setEditing({ ...editing, email: e.target.value })}
+                  className={inputCls}
+                  placeholder="john@pct.com"
+                />
+              </Field>
+
+              {/* PARTNER1 — the fields this form never had. */}
+              <div className="pt-2 border-t border-gray-100">
+                <p className="text-sm font-semibold text-gray-900">Mailing address</p>
+                <p className="text-xs text-gray-500 mt-0.5 mb-3">
+                  Prints in the deed&apos;s &ldquo;Recording Requested By&rdquo; block when
+                  this partner is selected.
+                </p>
+                <div className="space-y-4">
+                  <Field label="Address Line 1">
+                    <input
+                      value={editing.address_line1 || ''}
+                      onChange={(e) => setEditing({ ...editing, address_line1: e.target.value })}
+                      className={inputCls}
+                      placeholder="1234 Wilshire Blvd"
+                    />
+                  </Field>
+                  <Field label="Address Line 2">
+                    <input
+                      value={editing.address_line2 || ''}
+                      onChange={(e) => setEditing({ ...editing, address_line2: e.target.value })}
+                      className={inputCls}
+                      placeholder="Suite 500"
+                    />
+                  </Field>
+                  <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                    <Field label="City">
+                      <input
+                        value={editing.city || ''}
+                        onChange={(e) => setEditing({ ...editing, city: e.target.value })}
+                        className={inputCls}
+                        placeholder="Los Angeles"
+                      />
+                    </Field>
+                    <Field label="State">
+                      <input
+                        value={editing.state || ''}
+                        onChange={(e) => setEditing({ ...editing, state: e.target.value })}
+                        className={inputCls}
+                        placeholder="CA"
+                        maxLength={2}
+                      />
+                    </Field>
+                    <Field label="ZIP">
+                      <input
+                        value={editing.postal_code || ''}
+                        onChange={(e) => setEditing({ ...editing, postal_code: e.target.value })}
+                        className={inputCls}
+                        placeholder="90017"
+                      />
+                    </Field>
+                  </div>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 pt-2 border-t border-gray-100">
+                <Field label="Category">
+                  <select
+                    value={editing.category || 'title_company'}
+                    onChange={(e) => setEditing({ ...editing, category: e.target.value })}
+                    className={inputCls}
+                  >
+                    {CATEGORIES.map((c) => <option key={c} value={c}>{titleCase(c)}</option>)}
+                  </select>
+                </Field>
+                <Field label="Role">
+                  <select
+                    value={editing.role || 'title_officer'}
+                    onChange={(e) => setEditing({ ...editing, role: e.target.value })}
+                    className={inputCls}
+                  >
+                    {ROLES.map((r) => <option key={r} value={r}>{titleCase(r)}</option>)}
+                  </select>
+                </Field>
+              </div>
+
+              <Field label="Notes">
+                <textarea
+                  value={editing.notes || ''}
+                  onChange={(e) => setEditing({ ...editing, notes: e.target.value })}
+                  className={`${inputCls} min-h-[80px]`}
+                  placeholder="Additional notes…"
+                />
+              </Field>
+            </div>
+
+            <div className="sticky bottom-0 bg-white border-t border-gray-200 px-6 py-4 flex flex-wrap items-center gap-2">
+              <button
+                disabled={saving}
+                className="inline-flex items-center gap-2 bg-brand-500 text-white px-4 py-2 rounded-lg font-medium hover:bg-brand-600 disabled:opacity-60 transition-colors"
+                onClick={() => save(editing)}
+              >
+                {saving ? <Loader2 className="w-4 h-4 animate-spin" /> : <Save className="w-4 h-4" />}
+                {editing.id ? 'Update' : 'Create'}
+              </button>
+              {/* Ghost cancel — the way out is not a competing button. */}
+              <button
+                className="inline-flex items-center gap-2 border border-gray-300 text-gray-700 px-4 py-2 rounded-lg font-medium hover:bg-gray-50 transition-colors"
+                onClick={() => { setEditing(null); setShowForm(false); }}
+              >
+                Cancel
+              </button>
+              {editing.id && (
+                /* Red as OUTLINE, never a filled block: a destructive
+                   action should be findable, not the loudest thing on
+                   screen. */
+                <button
+                  className="ml-auto inline-flex items-center gap-2 border border-red-300 text-red-700 px-4 py-2 rounded-lg font-medium hover:bg-red-50 transition-colors"
+                  onClick={() => del(editing.id!)}
+                >
+                  <Trash2 className="w-4 h-4" /> Delete
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+const inputCls =
+  'w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500';
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <label className="block text-sm font-medium text-gray-700 mb-1">{label}</label>
+      {children}
     </div>
   );
 }

--- a/frontend/src/test-support/sourceText.ts
+++ b/frontend/src/test-support/sourceText.ts
@@ -39,6 +39,37 @@
  * difference between a comment and text that looks like one; a pattern
  * only knows the spelling.
  *
+ * ═══ RANGE-BASED PINS ARE THE SAME FAMILY ═══
+ *
+ * Owner-ruled after the eighth trip (PARTNER1). The rule reads as being
+ * about forbidden STRINGS — a price, a claim, a removed symbol name —
+ * and it is not limited to them.
+ *
+ * PARTNER1's brand pass forbade emoji on a screen that had shipped them
+ * as button labels. The pin was a CHARACTER RANGE:
+ *
+ *     expect(RAW).not.toMatch(/[\u{1F300}-\u{1FAFF}\u{2190}-\u{27BF}]/u)
+ *
+ * and it failed on the rule characters in its own header comment,
+ * because box drawing (U+2500–U+257F) sits inside U+2190–U+27BF. Same
+ * shape as all eight: prose describing the forbidden thing contains the
+ * forbidden thing. Being a range rather than a literal changed nothing.
+ *
+ * So: ANY pin whose pattern could match decorative or explanatory text
+ * runs against codeOnly() output, not raw source. Strings, regexes,
+ * character classes, Unicode ranges — the only question is whether the
+ * pattern can hit a comment, and a wide range hits far more of one than
+ * a literal can.
+ *
+ * Two corollaries the range case has and the string case does not:
+ *
+ *   - Keep the range no wider than the thing forbidden. The emoji pin
+ *     wanted emoji and dingbats; it asked for arrows, maths, box drawing
+ *     and geometric shapes too, and got what it asked for.
+ *   - A pin that MUST read prose (checking a header cites a doctrine
+ *     section) is a different question — read RAW deliberately and say
+ *     so at the call site.
+ *
  * ═══ WHAT IT DOES NOT DO ═══
  *
  * It does not strip string literals — a pin looking for a value that


### PR DESCRIPTION
Two commits, bug first as ruled.

## Part 1 — the bug (`1c10c83`)

D2 wired the partner address end to end: `partners/selectlist` assembles a one-line mailing address, `RecordingSection` fills `requestedByAddress` on partner select, `PreviewPanel` renders it, all five chassis print it in the Recording Requested By block.

**Every link worked. The address was empty anyway, because the Partners screen never captured it.** The columns exist, `PartnerCreate`/`PartnerUpdate` accept them, `create_partner`/`update_partner` write them, `list_partners` returns them — and the form rendered six inputs, none of which was an address. `blank()` didn't even seed the keys, so no payload could carry one no matter what the officer typed.

**What makes it confusing rather than merely missing:** the *other two* intake surfaces always captured address — `QuickAddPartnerModal` (opened from the builder's Recording section) and `AddPartnerModal`. So the same partner got an address when created inside the deed builder and none when created from the page built for managing partners. And that page is the only place to **edit**, so the gap couldn't be repaired from the surface that showed it.

| | |
|---|---|
| form | the five address inputs, seeded in `blank()`, grouped under a heading that says where they print |
| table | an Address column; a partner without one renders **"Add address"** as a link into the editor, never a silent blank |
| banner | *n* partners have no address on file, with why it matters |
| normalization | trim + collapse whitespace at the write (#72's pattern). **Case is never touched** — "COast TItle" is owner data to correct by hand; auto-casing would rewrite PCT, McDonald, LLC and O'Brien. Surfacing a typo costs a glance; corrupting a company name costs a re-recording |
| blank names | a blank `company_name` used to hit the NOT NULL constraint, get caught, and surface as *"Partner not found"* — a 404 about a row that exists. Now a 400 that says what's wrong |

`_addr` lifted out of the selectlist endpoint's closure to `partner_address_line` — it was nested, so the only way to test what prints on a deed was to render one (the same reason DX0 found the SiteX mapping untested for months).

**Pinned end to end, on the document.** A partner created through the shipped service, assembled by the shipped helper, rendered through `render_deed_pdf`, asserted against **extracted PDF text** — not a dict key. Plus the negative: no address prints no orphan punctuation (`", ,"` reads as data that got lost, worse than a blank because it's visible).

Both pins verified to bite: breaking the assembly fails the PDF test; removing the address keys from `blank()` fails the form test.

## Part 2 — brand and UX (`7732f4c`)

All six audit findings addressed.

- **Buttons** — flat blue primary and filled red delete → `brand-500` primary, ghost cancel, red as *outline* for delete. A destructive action should be findable, not the loudest thing on screen.
- **Glyphs** — emoji button labels → lucide icons.
- **Stats** — Quick Stats ran a *fourth* palette. One accent now, zeros in muted gray. **The amber is the one that mattered:** BRAND.md reserves amber for "unconfirmed external data", and spending it on a lender count degrades the signal on every screen that uses it correctly. Category chips likewise → semantic neutral slate, Title Case.
- **Editor** — the open card pushed the list below the fold, so editing one partner cost you the sight of all the others. Now a slide-over (`role="dialog"`, `aria-modal`), with per-row icon actions carrying aria-labels that name the company.
- **Table** — `overflow-x-auto` → `table-fixed`, email/phone dropping out at `lg`/`xl`, company wrapping.
- **Growth** — search over the fields an officer would type; a real empty state saying what partners are *for*. "No partners match X" stays distinct from "no partners yet" — telling an officer she has none when she has twelve and mistyped one is a lie about her own data.

**Pins:** `partnersScreen.test.ts`, 25 tests, **all 25 fail against the pre-ticket page.** The admin brand pins resolve CSS custom properties against `tokens.css`; this is a Tailwind surface, so the equivalent load-bearing question is whether colour is spelled as `brand-*` classes or as whatever hex the last author reached for — the old category badges built chips from `#3b82f6`/`#10b981`/`#f59e0b` inside an inline style object, which no palette change could ever have reached. Pinned as "no raw hex at a call site".

One self-inflicted trip, recorded: the no-emoji pin first spanned `U+2190–U+27BF`, which swallows box drawing, so it failed on the rule characters in its own header comment. Eighth time a pin here has tripped on the prose explaining it. Narrowed and run against comment-stripped source.

## Gates

pytest **746** · jest **576** (37 suites) · tsc **94** (unchanged) · six-flow ✔ · API baseline ✔ · banned-claims clean

## CI

GitHub Actions has produced no workflow runs on this repo since `2026-08-05T04:39Z` — `push` and `pull_request` both silent, all three workflows `state: active`. This PR joins #140 and #141 in being parked on that. Gates above are local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_