### PR TITLE
TRIAL1: a user can actually pay us (+ the row-contract class sweep)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -351,7 +351,7 @@ def check_plan_limits(user_id: int, action: str = "deed_creation") -> dict:
             if not result:
                 return {"allowed": False, "message": "User not found"}
 
-            plan = result[0]
+            plan = result['plan']
 
             # Get plan limits
             cur.execute("""
@@ -363,7 +363,13 @@ def check_plan_limits(user_id: int, action: str = "deed_creation") -> dict:
             if not limits:
                 return {"allowed": True, "message": "No limits configured"}
 
-            max_deeds, max_api_calls = limits
+            # Uncalled today (TRIAL1's audit found zero call sites), and
+            # fixed anyway: wiring it up as it stood would have compared
+            # the string 'max_deeds_per_month' against 0, raised
+            # TypeError, been swallowed by the except, and returned
+            # "allowing action" — a limit check that always says yes.
+            max_deeds = limits['max_deeds_per_month']
+            max_api_calls = limits['api_calls_per_month']
 
             if action == "deed_creation" and max_deeds > 0:
                 # Check monthly deed count
@@ -371,7 +377,7 @@ def check_plan_limits(user_id: int, action: str = "deed_creation") -> dict:
                     SELECT COUNT(*) FROM deeds
                     WHERE user_id = %s AND created_at >= DATE_TRUNC('month', CURRENT_DATE)
                 """, (user_id,))
-                deed_count = cur.fetchone()[0]
+                deed_count = cur.fetchone()['count']
 
                 if deed_count >= max_deeds:
                     return {

--- a/backend/migrations/fix_user5_password.py
+++ b/backend/migrations/fix_user5_password.py
@@ -7,6 +7,7 @@ Password: Test123!
 import os
 import sys
 import psycopg2
+from db_rows import ROW_FACTORY
 from passlib.hash import bcrypt
 
 # Add parent directory to path
@@ -30,7 +31,7 @@ def set_user5_password():
     try:
         # Connect
         print("📡 Connecting to database...")
-        conn = psycopg2.connect(database_url)
+        conn = psycopg2.connect(database_url, cursor_factory=ROW_FACTORY)
         cursor = conn.cursor()
         print("✅ Connected")
         print()
@@ -48,7 +49,7 @@ def set_user5_password():
                 print(f"  - User #{row[0]}: {row[1]}")
             return False
         
-        user_id, email, name = user
+        user_id, email, name = user['id'], user['email'], user['full_name']
         print(f"✅ Found: User #{user_id} - {name} ({email})")
         print()
         

--- a/backend/phase23_billing/router_webhook.py
+++ b/backend/phase23_billing/router_webhook.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import Session
 from datetime import datetime
 from sqlalchemy import text
 import json
+import os
 
 from .deps import get_db, get_settings, get_logger
 from .services.stripe_helpers import init_stripe, calc_stripe_fee
@@ -301,6 +302,68 @@ async def stripe_webhook(request: Request, db: Session = Depends(get_db)):
             "net": amount - fee
         })
         db.commit()
+        return {"ok": True}
+
+    # ── Renewal failure — the event dunning actually runs on ──────────
+    #
+    # TRIAL1. `payment_intent.payment_failed` was handled below, and it is
+    # the WRONG event for a subscription: it fires for one-off payment
+    # intents and wrote a payment_history row with user_id NULL, so a
+    # failed RENEWAL produced an unattributable row and no notification.
+    # A customer whose card expired kept full access, silently, forever.
+    #
+    # This is invoice.payment_failed: it carries the subscription and the
+    # customer, so the user can actually be resolved and told.
+    if etype == "invoice.payment_failed":
+        inv = obj
+        customer_id = inv.get("customer")
+        user_id = _resolve_user_id(db, customer_id)
+        amount = int(inv.get("amount_due") or 0)
+        currency = (inv.get("currency") or "usd").upper()
+
+        db.execute(text("""
+            INSERT INTO payment_history (invoice_id, user_id, stripe_payment_intent_id,
+                                         amount_cents, currency, status, payment_method,
+                                         failure_code, failure_message)
+            VALUES (NULL, :uid, :pi, :amt, :cur, 'failed', 'card', :code, :msg)
+        """), {
+            "uid": user_id,
+            "pi": inv.get("payment_intent"),
+            "amt": amount,
+            "cur": currency,
+            "code": "invoice_payment_failed",
+            "msg": (inv.get("last_finalization_error") or {}).get("message")
+                   or "Subscription renewal payment failed",
+        })
+        db.commit()
+
+        # Tell them. Through the E1 transport, so the attempt is on the
+        # record even when the send fails — a dunning email we cannot
+        # prove we sent is ADMIN3's problem all over again.
+        #
+        # Wrapped because notifying is strictly less important than
+        # returning 2xx to Stripe: an exception here would make Stripe
+        # retry an event we already recorded.
+        if user_id:
+            try:
+                row = db.execute(text(
+                    "SELECT email, full_name FROM users WHERE id = :uid"
+                ), {"uid": user_id}).mappings().first()
+                if row and row.get("email"):
+                    from utils.notifications import send_payment_failed_with_reason
+                    amount_text = f" of ${amount / 100:,.2f}" if amount else ""
+                    base = os.getenv("FRONTEND_URL", "http://localhost:3000")
+                    ok, reason = send_payment_failed_with_reason(
+                        row["email"], row.get("full_name") or "",
+                        amount_text, f"{base}/account-settings",
+                        user_id=user_id)
+                    if not ok:
+                        print(f"[billing] payment-failed email not sent "
+                              f"(user={user_id}): {reason}")
+            except Exception as e:
+                print(f"[billing] payment-failed notification error "
+                      f"(user={user_id}): {e}")
+
         return {"ok": True}
 
     if etype == "payment_intent.payment_failed":

--- a/backend/routers/auth_extra.py
+++ b/backend/routers/auth_extra.py
@@ -155,7 +155,12 @@ def request_verify_email(payload: VerifyEmailRequest):
             row = cur.fetchone()
         if not row:
             return {"message": "If the email exists, we sent a verification link."}
-        user_id, full_name, verified = row
+        # `verified` destructured to the STRING 'verified' — always
+        # truthy — so an unverified user asking for a verification link
+        # was told "Email already verified" and never got one.
+        user_id = row['id']
+        full_name = row['full_name']
+        verified = row['verified']
         if verified:
             return {"message": "Email already verified"}
         token = create_access_token(

--- a/backend/routers/pricing.py
+++ b/backend/routers/pricing.py
@@ -168,7 +168,10 @@ async def update_price(update: PriceUpdate, admin: str = Depends(get_current_adm
             if not result:
                 raise HTTPException(status_code=404, detail="Plan not found")
 
-            old_price_id, product_id = result
+            # Destructured to the column names, so Stripe was asked to
+            # create a price on product 'stripe_product_id'.
+            old_price_id = result['stripe_price_id']
+            product_id = result['stripe_product_id']
 
         # Create new price in Stripe (prices are immutable)
         new_price = stripe.Price.create(

--- a/backend/routers/sharing.py
+++ b/backend/routers/sharing.py
@@ -430,7 +430,13 @@ def get_shared_deed_feedback(shared_deed_id: int, user_id: int = Depends(get_cur
             row = cur.fetchone()
         if not row:
             raise HTTPException(status_code=404, detail="Shared deed not found")
-        feedback, feedback_at, feedback_by, owner_user_id = row
+        # `owner_user_id` destructured to the string 'owner_user_id', so
+        # `owner_user_id != user_id` was ALWAYS true: the deed's own owner
+        # got a permanent 403 reading feedback on her own shared deed.
+        feedback = row['feedback']
+        feedback_at = row['feedback_at']
+        feedback_by = row['feedback_by']
+        owner_user_id = row['owner_user_id']
         if owner_user_id != user_id:
             raise HTTPException(status_code=403, detail="You don't have permission to view this feedback")
         return {

--- a/backend/routers/users_auth.py
+++ b/backend/routers/users_auth.py
@@ -255,16 +255,18 @@ async def login_user(credentials: UserLogin = Body(...), request: Request = None
             record_attempt(credentials.email.lower(), _ip, succeeded=False)
             raise HTTPException(status_code=401, detail="Invalid email or password")
 
-        # Phase 7.5 FIX: Handle both RealDictCursor (dict) and regular cursor (tuple)
-        if isinstance(user, dict):
-            user_id = user.get('id')
-            password_hash = user.get('password_hash')
-            full_name = user.get('full_name')
-            plan = user.get('plan')
-            is_active = user.get('is_active')
-            role = user.get('role')
-        else:
-            user_id, password_hash, full_name, plan, is_active, role = user
+        # This branched on isinstance(user, dict) because the codebase
+        # once had two cursor factories. It has one (db_rows.ROW_FACTORY,
+        # pinned), so the tuple branch was unreachable — and unreachable
+        # is the worst place for this pattern to live, because it reads
+        # as proof that destructuring is a supported way to read a row.
+        # It is not. Read by key, always.
+        user_id = user['id']
+        password_hash = user['password_hash']
+        full_name = user['full_name']
+        plan = user['plan']
+        is_active = user['is_active']
+        role = user['role']
 
         if not is_active:
             raise HTTPException(status_code=401, detail="Account is deactivated")
@@ -446,7 +448,15 @@ async def upgrade_plan(req: UpgradeRequest, user_id: int = Depends(get_current_u
         if not user:
             raise HTTPException(status_code=404, detail="User not found")
 
-        customer_id, email, full_name = user
+        # ROW CONTRACT (db_rows.py): a HybridRow is a DICT subclass with
+        # integer indexing bolted on. It overrides __getitem__, NOT
+        # __iter__ — so destructuring it yields COLUMN NAMES, silently.
+        # `customer_id` became the string 'stripe_customer_id', which is
+        # truthy, so the Stripe customer was never created and Checkout
+        # was called with customer='stripe_customer_id'. Nobody could pay.
+        customer_id = user['stripe_customer_id']
+        email = user['email']
+        full_name = user['full_name']
 
         # Create Stripe customer if not exists
         if not customer_id:

--- a/backend/routers/users_auth.py
+++ b/backend/routers/users_auth.py
@@ -433,6 +433,21 @@ async def patch_user_profile(
             print(f"[PROFILE PATCH ROLLBACK ERROR] {rollback_error}")
         raise HTTPException(status_code=500, detail=f"Profile update failed: {str(e)}")
 
+# TRIAL1 — the canonical trial length, and the ONE place it is written
+# on the server. The marketing page states the same number and a test
+# compares them, because a trial whose advertised length and actual
+# length differ is discovered by the customer, on the day it ends.
+TRIAL_PERIOD_DAYS = 14
+
+# The canonical plan vocabulary. `users.plan` DEFAULT is 'free',
+# registration writes 'free', and the webhook downgrades to 'free' on
+# cancellation — so 'free' is what the database means by the free tier.
+# A fourth key ('starter') lived only in the billing UI and matched
+# nothing, which is why every free user saw a blank plan card.
+FREE_PLAN = 'free'
+PAID_PLANS = ('professional', 'enterprise')
+
+
 @router.post("/users/upgrade")
 async def upgrade_plan(req: UpgradeRequest, user_id: int = Depends(get_current_user_id)):
     """Initiate plan upgrade via Stripe Checkout"""
@@ -472,6 +487,19 @@ async def upgrade_plan(req: UpgradeRequest, user_id: int = Depends(get_current_u
                 cur.execute("UPDATE users SET stripe_customer_id = %s WHERE id = %s", (customer_id, user_id))
                 db.conn.commit()
 
+        # TRIAL1 — the free trial the marketing page has been promising.
+        #
+        # Card up front, N days free, auto-converts. Stripe runs the whole
+        # thing; nothing here tracks trial state, which is the point — a
+        # trial clock we kept ourselves would be a second source of truth
+        # about whether somebody has paid.
+        #
+        # 0 disables it, which is how you turn the trial off without a
+        # deploy. The value is MIRRORED on the marketing page and pinned
+        # (test_trial1_paid_path.py): a "14-day trial" in the copy and a
+        # 7-day trial on the session is a promise broken on day 8.
+        trial_days = int(os.getenv('STRIPE_TRIAL_PERIOD_DAYS', str(TRIAL_PERIOD_DAYS)))
+
         # Map plans to Stripe price IDs (create these in your Stripe dashboard)
         price_map = {
             'professional': os.getenv('STRIPE_PROFESSIONAL_PRICE_ID', 'price_professional_default'),
@@ -495,6 +523,8 @@ async def upgrade_plan(req: UpgradeRequest, user_id: int = Depends(get_current_u
             success_url=f"{os.getenv('FRONTEND_URL', 'http://localhost:3000')}/account-settings?success=true",
             cancel_url=f"{os.getenv('FRONTEND_URL', 'http://localhost:3000')}/account-settings?canceled=true",
             allow_promotion_codes=True,
+            **({'subscription_data': {'trial_period_days': trial_days}}
+               if trial_days > 0 else {}),
         )
 
         return {"session_url": session.url, "session_id": session.id}

--- a/backend/scripts/backfill_plan_sync.py
+++ b/backend/scripts/backfill_plan_sync.py
@@ -29,6 +29,7 @@ import sys
 from datetime import datetime, timezone
 
 import psycopg2
+from db_rows import ROW_FACTORY
 import stripe
 
 
@@ -106,7 +107,7 @@ def main():
             if customer not in expected or created > expected[customer][1]:
                 expected[customer] = (plan, created)
 
-    conn = psycopg2.connect(db_url)
+    conn = psycopg2.connect(db_url, cursor_factory=ROW_FACTORY)
     missed_upgrades = []   # (user_id, email, current_plan, expected_plan, sub_created)
     downgrade_candidates = []  # (user_id, email, current_plan)
     with conn.cursor() as cur:
@@ -118,7 +119,9 @@ def main():
 
     unmapped_customers = {cust for _, cust in unmapped.values() if cust}
     matched_customers = set()
-    for user_id, email, current_plan, customer_id in rows:
+    for _r in rows:
+        user_id, email, current_plan, customer_id = (
+            _r['id'], _r['email'], _r['plan'], _r['stripe_customer_id'])
         if customer_id in expected:
             matched_customers.add(customer_id)
             expected_plan, sub_created = expected[customer_id]

--- a/backend/scripts/init_db.py
+++ b/backend/scripts/init_db.py
@@ -1,4 +1,5 @@
 import psycopg2
+from db_rows import ROW_FACTORY
 from dotenv import load_dotenv
 import os
 from passlib.context import CryptContext
@@ -18,7 +19,7 @@ def init_database():
             print("❌ Error: DATABASE_URL or DB_URL not found in environment variables")
             return False
             
-        conn = psycopg2.connect(db_url)
+        conn = psycopg2.connect(db_url, cursor_factory=ROW_FACTORY)
         print("✅ Connected to database successfully")
         
         with conn.cursor() as cur:
@@ -272,7 +273,8 @@ def init_database():
             print(f"   👥 Total Users: {user_count}")
             print(f"   📄 Total Deeds: {deed_count}")
             print("   💼 Plan Distribution:")
-            for plan, count in plan_stats:
+            for _r in plan_stats:
+                plan, count = _r['plan'], _r['count']
                 print(f"      {plan.capitalize()}: {count} users")
             
             print("\n🔑 Test Accounts Created:")

--- a/backend/tests/test_admin3_email_outcomes.py
+++ b/backend/tests/test_admin3_email_outcomes.py
@@ -63,9 +63,14 @@ def test_no_module_outside_notifications_sends_mail():
 
 
 def test_every_template_routes_through_send():
-    """All eleven, named. A template that renders and sends without a
+    """All twelve, named. A template that renders and sends without a
     `_send` name is a template whose rows land under the wrong label —
-    which is worse than no label, because the log then lies quietly."""
+    which is worse than no label, because the log then lies quietly.
+
+    The count is asserted as well as the set, and it is a TRIP-WIRE
+    rather than a fact worth knowing: a new template must be a deliberate
+    edit here, not something that arrives with a diff nobody read. It
+    fired as designed when TRIAL1 added `payment_failed` (11 -> 12)."""
     import sys
     sys.path.insert(0, str(BACKEND))
     from utils.notifications import TEMPLATES
@@ -76,7 +81,7 @@ def test_every_template_routes_through_send():
         f"declared TEMPLATES and actual _send labels disagree: "
         f"only-declared={set(TEMPLATES) - named}, only-used={named - set(TEMPLATES)}"
     )
-    assert len(TEMPLATES) == 11
+    assert len(TEMPLATES) == 12
 
 
 # ── The recorder's two constraints ───────────────────────────────────

--- a/backend/tests/test_api_key_requests.py
+++ b/backend/tests/test_api_key_requests.py
@@ -15,6 +15,7 @@ from unittest.mock import patch
 
 import pytest
 from tests.source_text import code_only
+from db_rows import ROW_FACTORY
 
 LIVE_DB = os.getenv("DATABASE_URL")
 
@@ -86,7 +87,7 @@ def client_and_token():
     email = "funnel@apirequest.test"
     password = "Funnel!Passw0rd"
     import psycopg2
-    conn = psycopg2.connect(LIVE_DB)
+    conn = psycopg2.connect(LIVE_DB, cursor_factory=ROW_FACTORY)
     conn.autocommit = True
     with conn.cursor() as cur:
         cur.execute("DELETE FROM api_key_requests WHERE email = %s", ("dana@pacificcoastescrow.example",))
@@ -122,7 +123,7 @@ def test_request_is_stored_and_owner_is_notified(client_and_token):
     assert notify.called
 
     import psycopg2
-    conn = psycopg2.connect(LIVE_DB)
+    conn = psycopg2.connect(LIVE_DB, cursor_factory=ROW_FACTORY)
     with conn.cursor() as cur:
         cur.execute("""SELECT company_name, email, status, notified_at, notify_error
                        FROM api_key_requests WHERE id = %s""", (body["request_id"],))
@@ -151,11 +152,12 @@ def test_a_failed_email_still_keeps_the_request(client_and_token):
     assert "SENDGRID_API_KEY" in body["email_error"]
 
     import psycopg2
-    conn = psycopg2.connect(LIVE_DB)
+    conn = psycopg2.connect(LIVE_DB, cursor_factory=ROW_FACTORY)
     with conn.cursor() as cur:
         cur.execute("SELECT notified_at, notify_error FROM api_key_requests WHERE id = %s",
                     (body["request_id"],))
-        notified_at, notify_error = cur.fetchone()
+        _r = cur.fetchone()
+        notified_at, notify_error = _r['notified_at'], _r['notify_error']
     conn.close()
     assert notified_at is None
     assert "SENDGRID_API_KEY" in notify_error
@@ -173,7 +175,7 @@ def test_the_queue_lists_it_for_an_admin_only(client_and_token):
                       headers={"Authorization": f"Bearer {token}"}).status_code == 403
 
     import psycopg2
-    conn = psycopg2.connect(LIVE_DB)
+    conn = psycopg2.connect(LIVE_DB, cursor_factory=ROW_FACTORY)
     conn.autocommit = True
     with conn.cursor() as cur:
         cur.execute("UPDATE users SET role = 'admin' WHERE email = %s", ("funnel@apirequest.test",))
@@ -231,7 +233,7 @@ def test_anonymous_inquiry_is_stored_and_queued():
     from main import app
     import psycopg2
 
-    conn = psycopg2.connect(LIVE_DB)
+    conn = psycopg2.connect(LIVE_DB, cursor_factory=ROW_FACTORY)
     conn.autocommit = True
     with conn.cursor() as cur:
         cur.execute("DELETE FROM api_key_requests WHERE email = %s", ("ops@coastlinetitle.example",))
@@ -248,7 +250,7 @@ def test_anonymous_inquiry_is_stored_and_queued():
     assert "reach out" in body["message"].lower()
     assert notify.called
 
-    conn = psycopg2.connect(LIVE_DB)
+    conn = psycopg2.connect(LIVE_DB, cursor_factory=ROW_FACTORY)
     with conn.cursor() as cur:
         cur.execute("""SELECT user_id, company_name, email, status
                        FROM api_key_requests WHERE id = %s""", (body["request_id"],))

--- a/backend/tests/test_red_s2_artifact_durability.py
+++ b/backend/tests/test_red_s2_artifact_durability.py
@@ -30,6 +30,8 @@ import pytest
 BACKEND = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(BACKEND))
 
+from db_rows import ROW_FACTORY  # noqa: E402
+
 from services import artifact_store as store_mod  # noqa: E402
 from tests.source_text import code_only  # noqa: E402
 
@@ -152,7 +154,7 @@ def test_the_live_constraint_is_restrict():
     import psycopg2
     from database import create_tables
     create_tables()
-    c = psycopg2.connect(LIVE_DB, connect_timeout=10)
+    c = psycopg2.connect(LIVE_DB, cursor_factory=ROW_FACTORY, connect_timeout=10)
     try:
         with c.cursor() as cur:
             cur.execute("""
@@ -162,7 +164,8 @@ def test_the_live_constraint_is_restrict():
             """)
             rows = cur.fetchall()
         assert rows, "no foreign key found on deed_pdfs"
-        for (deltype,) in rows:
+        for _r in rows:
+            deltype = _r["confdeltype"]
             assert deltype == "r", f"expected RESTRICT, got confdeltype={deltype!r}"
     finally:
         c.close()
@@ -174,7 +177,7 @@ def test_deleting_a_deed_with_an_artifact_is_refused():
     from database import create_tables
     create_tables()
     tag = uuid.uuid4().hex[:10]
-    c = psycopg2.connect(LIVE_DB, connect_timeout=10)
+    c = psycopg2.connect(LIVE_DB, cursor_factory=ROW_FACTORY, connect_timeout=10)
     try:
         with c.cursor() as cur:
             cur.execute("INSERT INTO users (email, password_hash) VALUES (%s,%s) RETURNING id",

--- a/backend/tests/test_row_contract_positional.py
+++ b/backend/tests/test_row_contract_positional.py
@@ -1,0 +1,219 @@
+"""A database row is NEVER destructured positionally. Repo-wide.
+
+═══ WHY A PROPERTY AND NOT SIX FIXES ═══
+
+This defect has now appeared SIX times, in four years' worth of code
+written by different hands:
+
+    A1          the partner API's auth read a dict row as a tuple, so
+                `key_hash` became the literal string "key_hash" and every
+                valid API key 401'd — for months
+    ADMIN1.5    the admin serializers, same shape
+    TRIAL1      /users/upgrade            nobody could reach Checkout
+    TRIAL1      /users/verify-email/request  an unverified user was told
+                                          "Email already verified"
+    TRIAL1      shared-deed feedback      the deed's own owner got 403
+    TRIAL1      check_plan_limits         a limit check that always says
+                                          yes (uncalled, fixed anyway)
+
+Six independent authors did not each make a careless mistake. They wrote
+the obvious thing, and the obvious thing is wrong here for a reason that
+is invisible at the call site.
+
+═══ THE MECHANISM ═══
+
+`db_rows.HybridRow` is a `RealDictRow` subclass — a DICT — with integer
+indexing added:
+
+    def __getitem__(self, key):
+        if isinstance(key, int):
+            return list(self.values())[key]
+        return super().__getitem__(key)
+
+It overrides `__getitem__`. It does NOT override `__iter__`.
+
+So `row[0]` returns the first VALUE, and `a, b = row` — which iterates —
+returns the first two KEYS. Both spellings look like "read this row
+positionally"; one works and one silently yields column names. Every
+occurrence above is that gap.
+
+And the failure is always quiet, because a column name is a non-empty
+string: truthy, comparable, JSON-serialisable. `if not customer_id` took
+the wrong branch. `if verified` took the wrong branch. `owner != user_id`
+was permanently true. Nothing raised. Nothing logged.
+
+═══ WHY THE RULE IS ABSOLUTE, WITH NO ALLOWLIST ═══
+
+The tempting version of this pin allows positional destructuring in
+files that use a plain psycopg2 cursor, where it is genuinely correct.
+That version fails at the only moment it matters: a reader looking at
+`a, b = row` cannot tell which kind of cursor produced `row` without
+tracing the connection, and THAT AMBIGUITY IS THE BUG. An allowlist
+would encode the ambiguity as policy.
+
+So TRIAL1 converged the five plain-cursor sites that actually
+destructured (`migrations/fix_user5_password`,
+`scripts/backfill_plan_sync`, `scripts/init_db`, and two test helpers)
+onto `db_rows.ROW_FACTORY` and made them read by key. The rule is now
+sayable in one line with no exceptions — **read rows by name,
+everywhere**.
+
+═══ WHAT THIS PIN DOES NOT CLAIM ═══
+
+Stated because the first draft of this file over-reached and asserted it.
+
+Roughly 25 scripts and test helpers still open their own
+`psycopg2.connect(...)` with no cursor factory, and their rows really
+are plain tuples. NONE of them destructure — verified — so none are
+broken, and converging all 25 is not this ticket.
+
+That leaves one honest wrinkle: in those files `a, b = cur.fetchone()`
+would WORK, and this pin forbids it anyway. Deliberate. The whole defect
+is that `a, b = row` is right or wrong depending on a cursor factory
+chosen in another file, and no reader can tell which by looking. A rule
+with an "unless the cursor is plain" carve-out reproduces exactly the
+ambiguity that produced six bugs. The way to comply in such a file is to
+give it `ROW_FACTORY` — the direction we want anyway.
+"""
+import ast
+import re
+import sys
+from pathlib import Path
+
+BACKEND = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(BACKEND))
+
+import pytest
+
+FETCH = re.compile(r"^fetch(one|all|many)$")
+
+
+def _is_fetch_call(node) -> bool:
+    return (isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and bool(FETCH.match(node.func.attr)))
+
+
+def _python_files():
+    for path in sorted(BACKEND.rglob("*.py")):
+        if "__pycache__" in str(path):
+            continue
+        yield path
+
+
+def _offenders(path: Path):
+    """Every tuple/list destructure whose source is a database row.
+
+    Catches three shapes, because the first cut of this sweep caught only
+    the first and reported 8 sites when there were 11:
+
+        a, b = cur.fetchone()          direct
+        row = cur.fetchone(); a, b = row   via a variable
+        for a, b in cur.fetchall():    loops and comprehensions
+    """
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return []
+
+    row_vars = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and _is_fetch_call(node.value):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    row_vars[target.id] = node.lineno
+
+    found = []
+    for node in ast.walk(tree):
+        target = value = None
+        if isinstance(node, ast.Assign):
+            tuples = [t for t in node.targets if isinstance(t, (ast.Tuple, ast.List))]
+            if tuples:
+                target, value = tuples[0], node.value
+        elif isinstance(node, (ast.For, ast.comprehension)):
+            if isinstance(node.target, (ast.Tuple, ast.List)):
+                target, value = node.target, node.iter
+        if target is None:
+            continue
+        from_row = _is_fetch_call(value) or (
+            isinstance(value, ast.Name) and value.id in row_vars)
+        if from_row:
+            found.append((getattr(node, "lineno", 0), ast.unparse(target)))
+    return found
+
+
+def test_no_database_row_is_destructured_positionally():
+    """THE pin. Not "these six call sites are fixed" — "this shape does
+    not exist in the repository"."""
+    offenders = []
+    for path in _python_files():
+        for lineno, target in _offenders(path):
+            offenders.append(f"{path.relative_to(BACKEND)}:{lineno}  {target} = <row>")
+
+    assert offenders == [], (
+        "a database row is being destructured positionally — it yields "
+        "COLUMN NAMES, not values (db_rows.HybridRow overrides "
+        "__getitem__ but not __iter__). Read by key:\n  "
+        + "\n  ".join(offenders))
+
+
+def test_the_sweep_can_actually_see_all_three_shapes():
+    """A detector that finds nothing proves nothing until you know it can
+    find something. Each shape is fed to it explicitly, because the first
+    version of this sweep silently missed loops and under-reported by
+    three sites."""
+    import tempfile
+
+    samples = {
+        "direct": "a, b = cur.fetchone()\n",
+        "via variable": "row = cur.fetchone()\na, b = row\n",
+        "for loop": "for a, b in cur.fetchall():\n    pass\n",
+        "comprehension": "x = [a for a, b in cur.fetchall()]\n",
+    }
+    for label, src in samples.items():
+        with tempfile.NamedTemporaryFile("w", suffix=".py", delete=False) as fh:
+            fh.write(src)
+            tmp = Path(fh.name)
+        try:
+            assert _offenders(tmp), f"the sweep cannot see the {label} shape"
+        finally:
+            tmp.unlink()
+
+
+def test_reading_by_index_still_works_and_is_not_what_this_forbids():
+    """`row[0]` is correct — HybridRow overrides __getitem__ for ints on
+    purpose, to keep ~66 legacy call sites working. The forbidden thing
+    is specifically ITERATION, which was never overridden."""
+    from db_rows import HybridRow
+
+    row = HybridRow([("stripe_customer_id", None), ("email", "a@b.test")])
+    assert row[0] is None
+    assert row["email"] == "a@b.test"
+    # And the trap itself, asserted so the reason is executable:
+    assert list(row) == ["stripe_customer_id", "email"], (
+        "if this ever returns VALUES, HybridRow gained an __iter__ and "
+        "this whole pin can be retired")
+
+
+def test_the_two_application_helpers_share_one_factory():
+    """This pin only means something while the APP has one row type.
+
+    Scoped to the two helpers every request goes through — `db.py` and
+    `database.py`. Those are what PR #107 unified after two factories
+    401'd every API key for months. Scripts opening their own connection
+    are outside this claim (see the docstring); the destructure ban above
+    covers them, and covers them absolutely.
+    """
+    from db_rows import ROW_FACTORY, HybridCursor
+    from tests.source_text import code_only
+
+    assert ROW_FACTORY is HybridCursor
+
+    for name in ("db.py", "database.py"):
+        src = code_only(BACKEND / name)
+        connects = re.findall(r"psycopg2\.connect\(([^)]*)", src)
+        assert connects, f"{name} no longer opens connections — re-scope this pin"
+        for args in connects:
+            assert "ROW_FACTORY" in args, (
+                f"{name} opens a connection off the one row contract: "
+                f"psycopg2.connect({args.strip()}...)")

--- a/backend/tests/test_trial1_paid_path.py
+++ b/backend/tests/test_trial1_paid_path.py
@@ -1,0 +1,316 @@
+"""TRIAL1 — a user can actually pay us.
+
+Before this ticket the paid path was dead at step one and nothing said
+so. `/users/upgrade` destructured a HybridRow, `customer_id` became the
+string 'stripe_customer_id' (truthy), so the Stripe customer was never
+created and Checkout was called with `customer='stripe_customer_id'`.
+Every upgrade attempt returned 400. The webhook half was sound and
+unreachable — BILL1's pins were green the whole time, because they start
+at the webhook and the break was upstream of it.
+
+That is the shape this file exists to prevent: two correct halves with
+nothing pinning the join. So the load-bearing test here runs the WHOLE
+path — upgrade call → checkout session → webhook → plan on the row.
+"""
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+BACKEND = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(BACKEND))
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+from tests.source_text import code_only  # noqa: E402
+
+REPO = BACKEND.parent
+LIVE_DB = os.getenv("DATABASE_URL")
+needs_db = pytest.mark.skipif(not LIVE_DB, reason="needs a database")
+
+TEST_EMAIL = "trial1@paidpath.test"
+CUSTOMER_ID = "cus_trial1_created"
+
+
+# ── 1. The trial exists, and its length is not two numbers ───────────
+
+def test_the_checkout_session_carries_a_trial():
+    src = code_only(BACKEND / "routers" / "users_auth.py")
+    assert "trial_period_days" in src
+    assert "subscription_data" in src
+
+
+def test_the_advertised_trial_length_matches_the_one_we_charge_on():
+    """THE mirror. A "14-day trial" in the copy and a 7-day trial on the
+    session is a promise the customer discovers is broken on day 8 — by
+    being charged. Same class as the DTT rate mirror: two numbers that
+    must be one number.
+    """
+    from routers.users_auth import TRIAL_PERIOD_DAYS
+
+    import re
+    page = (REPO / "frontend" / "src" / "app" / "page.tsx").read_text(encoding="utf-8")
+    claimed = {int(n) for n in re.findall(r"(\d+)[\s-]day trial", page, re.I)}
+    assert claimed, "the marketing page no longer states a trial length"
+    assert claimed == {TRIAL_PERIOD_DAYS}, (
+        f"the page advertises {sorted(claimed)}-day trial(s); the server "
+        f"opens Checkout with trial_period_days={TRIAL_PERIOD_DAYS}")
+
+
+def test_the_trial_can_be_turned_off_without_a_deploy():
+    src = code_only(BACKEND / "routers" / "users_auth.py")
+    assert "STRIPE_TRIAL_PERIOD_DAYS" in src
+    assert "if trial_days > 0 else {}" in src
+
+
+# ── 2. One plan vocabulary ───────────────────────────────────────────
+
+def _quoted_values(src: str, key: str):
+    """Every `key: "value"` / `key="value"` literal in a TSX file.
+
+    STRUCTURAL ON PURPOSE, and this is the ninth and tenth trip of the
+    family the code_only docs describe — walked into while implementing
+    the note about it, which is the most honest possible demonstration
+    that the rule is not obvious.
+
+    Both this test and the "5 deeds/month" one below first read the TSX
+    RAW and failed on the comments explaining the removals. The Python
+    `code_only` cannot help: it tokenizes PYTHON, and a `//` comment in a
+    .tsx file is not a Python comment, so passing TS source through it
+    changes nothing.
+
+    So neither test asks "does this string appear in the file". They ask
+    what the VALUES are — prose cannot forge a `key: "..."` literal, and
+    the next person to write an explanatory comment here will not have to
+    rediscover any of this.
+    """
+    import re
+    return re.findall(rf'{key}\s*[:=]\s*[\'"]([^\'"]+)[\'"]', src)
+
+
+def test_the_free_plan_has_exactly_one_name():
+    """'free' is what the database stores; 'starter' lived only in the
+    billing UI and matched nothing, so every free user's plan card
+    rendered a blank name over a blank price."""
+    from routers.users_auth import FREE_PLAN, PAID_PLANS
+    assert FREE_PLAN == "free"
+
+    billing = (REPO / "frontend" / "src" / "app" / "account-settings" /
+               "page.tsx").read_text(encoding="utf-8")
+    # Scoped to the PLANS array. A first cut read `key:` across the whole
+    # file and swept up React `key={...}` props and notification
+    # preference keys — a pin that reports 'marketing' as a pricing tier
+    # is noise, and noise is how a real failure gets skimmed past.
+    import re
+    block = re.search(r"const plans = \[(.*?)\n  \]", billing, re.S)
+    assert block, "the plans array moved — re-scope this pin"
+    keys = set(_quoted_values(block.group(1), "key"))
+    assert keys == {FREE_PLAN, *PAID_PLANS}, (
+        f"the billing tab offers plan keys the product does not know: {keys}")
+
+    admin = (REPO / "frontend" / "src" / "app" / "admin" / "users" / "[id]" /
+             "page.tsx").read_text(encoding="utf-8")
+    options = set(_quoted_values(admin, "value"))
+    assert "starter" not in options, (
+        "an admin can still set a plan key nothing else recognises")
+
+
+def test_the_billing_tab_can_find_the_plan_the_database_stores():
+    """The exact break: `currentPlan` defaulted to "starter", the guard
+    read `!== "starter"`, and `plans.find(key === 'free')` was undefined."""
+    src = code_only((REPO / "frontend" / "src" / "app" / "account-settings" /
+                     "page.tsx").read_text(encoding="utf-8"))
+    assert 'userProfile?.plan || "free"' in src
+    assert 'key: "free"' in src
+
+
+# ── 3. Dunning runs on the renewal event ─────────────────────────────
+
+def test_the_renewal_failure_event_is_handled_at_all():
+    """`payment_intent.payment_failed` is the wrong event for a
+    subscription — it wrote a payment_history row with user_id NULL and
+    told nobody. `invoice.payment_failed` carries the customer."""
+    src = code_only(BACKEND / "phase23_billing" / "router_webhook.py")
+    assert 'etype == "invoice.payment_failed"' in src
+
+
+def test_the_handler_resolves_a_real_user_and_emails_through_the_one_transport():
+    src = code_only(BACKEND / "phase23_billing" / "router_webhook.py")
+    handler = src[src.index('etype == "invoice.payment_failed"'):
+                  src.index('etype == "payment_intent.payment_failed"')]
+    assert "_resolve_user_id" in handler, "a failure nobody can attribute"
+    assert "send_payment_failed_with_reason" in handler
+    assert ":uid" in handler, "the payment_history row must carry the user"
+
+
+def test_notifying_never_makes_stripe_retry_an_event_we_recorded():
+    src = code_only(BACKEND / "phase23_billing" / "router_webhook.py")
+    handler = src[src.index('etype == "invoice.payment_failed"'):
+                  src.index('etype == "payment_intent.payment_failed"')]
+    assert "except Exception" in handler
+
+
+def test_the_template_goes_through_the_e1_choke_point():
+    from utils.notifications import TEMPLATES
+    assert "payment_failed" in TEMPLATES
+    src = code_only(BACKEND / "utils" / "notifications.py")
+    assert '_send("payment_failed"' in src
+
+
+def test_the_email_does_not_threaten_an_account_that_is_still_live():
+    """Stripe retries. At this point the account is untouched, and an
+    email implying otherwise turns an expired card into a support call."""
+    from utils import email_templates
+    subject, html, textbody = email_templates.payment_failed(
+        "Dana", " of $29.00", "https://example.test/account-settings")
+    assert "unaffected" in textbody
+    for word in ("suspended", "cancelled", "canceled", "terminated", "deleted"):
+        assert word not in textbody.lower(), word
+
+
+# ── 4. Feature claims are gated like compliance claims ───────────────
+
+@pytest.mark.parametrize("claim", [
+    "SSO/SAML", "single sign-on", "Custom branding", "white-label",
+    "team management",
+])
+def test_the_banned_claims_gate_now_covers_feature_claims(claim, tmp_path):
+    """The gate shipped guarding certifications, so a pricing page could
+    say "SSO/SAML" — zero files implement it — and pass cleanly while
+    "SOC 2" failed. Both are things a buyer pays for and does not
+    receive; the rule had been drawn around the examples that prompted
+    it rather than around the property."""
+    sys.path.insert(0, str(REPO / "scripts"))
+    import importlib
+    mod = importlib.import_module("check_banned_claims")
+    hits = [r.name for r in mod.RULES if r.rx.search(claim)]
+    assert hits, f"{claim!r} passes the gate"
+
+
+def test_the_claims_are_actually_absent_from_the_product():
+    """A gate is only honest if the thing it forbids is also gone."""
+    import re
+    page = (REPO / "frontend" / "src" / "app" / "page.tsx").read_text(encoding="utf-8")
+    listed = []
+    for block in re.findall(r"features:\s*\[(.*?)\]", page, re.S):
+        listed += re.findall(r"[\'\"]([^\'\"]+)[\'\"]", block)
+    assert listed, "no feature lists found on the marketing page"
+    for claim in ("SSO", "SAML", "custom branding", "deeds/month"):
+        hits = [f for f in listed if claim.lower() in f.lower()]
+        assert hits == [], f"still advertised: {hits}"
+
+
+def test_the_unenforced_limit_is_gone_from_both_purchase_surfaces():
+    """`check_plan_limits` has zero call sites and `plan_limits` is never
+    seeded at boot, so "5 deeds/month" was never enforced. An unenforced
+    limit on a purchase surface is a promise we are not keeping — in our
+    favour, which is the harmless direction and still not something to
+    leave written down."""
+    import re
+    for rel in (("app", "page.tsx"), ("app", "account-settings", "page.tsx")):
+        src = (REPO / "frontend" / "src").joinpath(*rel).read_text(encoding="utf-8")
+        # The FEATURE LISTS, not the file — see _quoted_values above for
+        # why these tests read values rather than text.
+        for block in re.findall(r"features:\s*\[(.*?)\]", src, re.S):
+            listed = re.findall(r"[\'\"]([^\'\"]+)[\'\"]", block)
+            offenders = [f for f in listed if re.search(r"deeds\s*/\s*month", f, re.I)]
+            assert offenders == [], f"{rel[-1]} still advertises {offenders}"
+
+
+# ── 5. END TO END: the join BILL1's pins could not see ───────────────
+
+@needs_db
+def test_a_user_reaches_checkout_with_a_real_customer_id_and_the_webhook_upgrades_them():
+    """THE test. Upgrade → session → webhook → plan on the row.
+
+    Stripe is stubbed at the SDK boundary and nowhere else: the real
+    endpoint runs, the real row is read, the real webhook handler
+    executes against the real table. What is asserted is what Stripe was
+    ASKED for — because the bug was entirely in the asking.
+    """
+    from phase23_billing.deps import SessionLocal
+    from phase23_billing.router_webhook import router as webhook_router
+    from routers.users_auth import TRIAL_PERIOD_DAYS
+
+    session = SessionLocal()
+    session.execute(text("DELETE FROM users WHERE email = :e"), {"e": TEST_EMAIL})
+    session.execute(text("""
+        INSERT INTO users (email, password_hash, full_name, role, state, plan)
+        VALUES (:e, 'x', 'Trial Tester', 'escrow_officer', 'CA', 'free')
+    """), {"e": TEST_EMAIL})
+    session.commit()
+    uid = session.execute(text("SELECT id FROM users WHERE email = :e"),
+                          {"e": TEST_EMAIL}).scalar()
+
+    # ── the upgrade call ──
+    import routers.users_auth as ua
+    from auth import get_current_user_id
+
+    captured = {}
+
+    def _session_create(**kwargs):
+        captured.update(kwargs)
+        return MagicMock(url="https://checkout.stripe.test/s/x", id="cs_trial1")
+
+    app = FastAPI()
+    app.include_router(ua.router)
+    app.dependency_overrides[get_current_user_id] = lambda: uid
+    client = TestClient(app)
+
+    with patch.object(ua.stripe.Customer, "create",
+                      return_value=MagicMock(id=CUSTOMER_ID)) as mk_cust, \
+         patch.object(ua.stripe.checkout.Session, "create", side_effect=_session_create), \
+         patch.dict(os.environ, {"STRIPE_PROFESSIONAL_PRICE_ID": "price_test_pro"}):
+        resp = client.post("/users/upgrade", json={"plan": "professional"})
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["session_url"].startswith("https://checkout.stripe.test")
+
+    # The customer was CREATED — the branch the unpack bug skipped.
+    assert mk_cust.called, (
+        "no Stripe customer was created; `if not customer_id` took the "
+        "wrong branch, which is exactly the original defect")
+
+    # And Checkout was asked for a real customer, not a column name.
+    assert captured["customer"] == CUSTOMER_ID
+    assert captured["customer"] != "stripe_customer_id"
+    assert captured["client_reference_id"] == str(uid)
+    assert captured["metadata"]["plan"] == "professional"
+    assert captured["subscription_data"]["trial_period_days"] == TRIAL_PERIOD_DAYS
+
+    # And it was persisted, so the portal and the webhook can find them.
+    stored = session.execute(
+        text("SELECT stripe_customer_id FROM users WHERE id = :i"), {"i": uid}).scalar()
+    assert stored == CUSTOMER_ID
+
+    # ── the webhook half ──
+    event = {"type": "checkout.session.completed", "data": {"object": {
+        "client_reference_id": str(uid),
+        "metadata": {"plan": "professional", "user_id": str(uid)},
+        "customer": CUSTOMER_ID,
+        "subscription": "sub_trial1",
+    }}}
+    stub = MagicMock()
+    stub.Webhook.construct_event.return_value = event
+
+    wapp = FastAPI()
+    wapp.include_router(webhook_router)
+    wapp.dependency_overrides[
+        __import__("phase23_billing.deps", fromlist=["get_db"]).get_db] = lambda: session
+    with patch("phase23_billing.router_webhook.init_stripe", return_value=stub):
+        wr = TestClient(wapp).post("/payments/webhook", json={},
+                                   headers={"stripe-signature": "t=1,v1=stub"})
+    assert wr.status_code == 200, wr.text
+
+    plan = session.execute(text("SELECT plan FROM users WHERE id = :i"),
+                           {"i": uid}).scalar()
+    assert plan == "professional", (
+        "the webhook did not upgrade the user — the half BILL1 pinned "
+        "was fine; this asserts the join")
+
+    session.execute(text("DELETE FROM users WHERE email = :e"), {"e": TEST_EMAIL})
+    session.commit()
+    session.close()

--- a/backend/utils/email_templates.py
+++ b/backend/utils/email_templates.py
@@ -279,6 +279,34 @@ def password_changed(full_name) -> Rendered:
     return subject, _base("Password changed on your account", content, False), text
 
 
+def payment_failed(full_name, amount_text, attempt_url) -> Rendered:
+    """TRIAL1 — the renewal failed and the customer does not know.
+
+    Deliberately NOT a threat. A card expires; that is the ordinary
+    reason this fires, and the ordinary fix is thirty seconds in the
+    billing portal. What it must NOT do is imply the account is already
+    gone, because at this point it is not: Stripe retries, and the
+    account is untouched until it stops.
+    """
+    subject = "Your DeedPro payment didn't go through"
+    content = (
+        _p(f"Hi {_esc(full_name) or 'there'},")
+        + _p(f"We couldn't process your subscription payment{_esc(amount_text)}. "
+             "This is usually an expired or replaced card.")
+        + _p("Your account and your documents are unaffected. Update your "
+             "card and the payment will retry automatically.")
+        + _button(attempt_url, "Update payment method")
+        + _p('<span style="font-size:13px;color:#8a94a0;">If you have already '
+             "updated it, you can ignore this.</span>")
+    )
+    text = (
+        f"We couldn't process your DeedPro subscription payment{amount_text}. "
+        "This is usually an expired or replaced card. Your account and your "
+        f"documents are unaffected. Update your card here: {attempt_url}"
+    )
+    return subject, _base("Payment failed — your account is unaffected", content, False), text
+
+
 def welcome(full_name) -> Rendered:
     subject = "Welcome to DeedPro"
     url = _frontend_url()

--- a/backend/utils/notifications.py
+++ b/backend/utils/notifications.py
@@ -23,6 +23,8 @@ TEMPLATES = (
     "share_invite", "share_reminder", "share_approved", "share_rejected",
     "deed_completed", "password_reset", "verify_email", "password_changed",
     "welcome", "admin_api_key_request", "admin_new_user",
+    # TRIAL1 — renewal failure. The event dunning actually runs on.
+    "payment_failed",
 )
 
 
@@ -170,6 +172,21 @@ def send_verify_email_with_reason(user_email: str, full_name: str,
 def send_password_changed_with_reason(user_email: str, full_name: str) -> SendResult:
     return _send("password_changed", user_email,
                  email_templates.password_changed(full_name))
+
+
+def send_payment_failed_with_reason(user_email: str, full_name: str,
+                                    amount_text: str, billing_url: str,
+                                    user_id: Optional[int] = None) -> SendResult:
+    """TRIAL1 — tell the customer their renewal failed.
+
+    Goes through the one transport like every other send, so the attempt
+    lands in `email_log` whether or not it reaches them. A dunning email
+    nobody can prove we sent is the same problem ADMIN3 fixed for the
+    other ten templates.
+    """
+    return _send("payment_failed", user_email,
+                 email_templates.payment_failed(full_name, amount_text, billing_url),
+                 user_id=user_id)
 
 
 def send_welcome_with_reason(user_email: str, full_name: str) -> SendResult:

--- a/frontend/src/app/account-settings/page.tsx
+++ b/frontend/src/app/account-settings/page.tsx
@@ -343,14 +343,26 @@ function BillingTab({
   onManageSubscription: () => void
   saving: boolean
 }) {
-  const currentPlan = userProfile?.plan || "starter"
+  // ONE VOCABULARY (TRIAL1). This read `|| "starter"` while the database
+  // stores 'free', so every free user fell through every comparison
+  // below: `currentPlan !== "starter"` was true, the "Current Plan"
+  // card rendered, and `plans.find(p => p.key === 'free')` was
+  // undefined — a blank name over a blank price, above a Manage
+  // Subscription button that 404s because they have no Stripe customer.
+  const currentPlan = userProfile?.plan || "free"
 
   const plans = [
     {
-      key: "starter",
-      name: "Starter",
-      price: "Free",
-      features: ["5 deeds/month", "Basic AI assistance", "Standard templates", "Email support"],
+      key: "free",
+      name: "Free",
+      price: "$0",
+      // TRIAL1: "5 deeds/month" removed. check_plan_limits is never
+      // called and plan_limits is never seeded, so the limit was never
+      // enforced. An unenforced limit written on a purchase surface is a
+      // promise we are not keeping — in our favour, which is the
+      // harmless direction, and still not something to leave written
+      // down.
+      features: ["All deed types", "Basic AI assistance", "Standard templates", "Email support"],
     },
     {
       key: "professional",
@@ -375,7 +387,7 @@ function BillingTab({
   return (
     <div className="space-y-8">
       {/* Current Plan Status */}
-      {currentPlan !== "starter" && (
+      {currentPlan !== "free" && (
         <div className="bg-slate-50 border border-[#7C4DFF]/30 rounded-xl p-6">
           <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
             <div>
@@ -455,7 +467,7 @@ function BillingTab({
       {/* Payment Methods */}
       <div>
         <h3 className="text-xl font-bold text-slate-800 mb-6">Payment Methods</h3>
-        {currentPlan === "starter" ? (
+        {currentPlan === "free" ? (
           <div className="bg-slate-50 border border-slate-200 rounded-xl p-6 text-center">
             <CreditCard className="w-12 h-12 mx-auto mb-3 text-slate-400" />
             <p className="text-slate-600 mb-4">No payment method on file</p>
@@ -489,7 +501,7 @@ function BillingTab({
       {/* Billing History */}
       <div>
         <h3 className="text-xl font-bold text-slate-800 mb-6">Billing History</h3>
-        {currentPlan === "starter" ? (
+        {currentPlan === "free" ? (
           <div className="bg-slate-50 border border-slate-200 rounded-xl p-6 text-center">
             <p className="text-slate-600">No billing history yet.</p>
             <p className="text-sm text-slate-500 mt-1">Your invoices will appear here once you upgrade to a paid plan.</p>

--- a/frontend/src/app/admin/users/[id]/page.tsx
+++ b/frontend/src/app/admin/users/[id]/page.tsx
@@ -286,8 +286,12 @@ export default function UserDetailPage() {
                   value={formData.plan || 'free'} 
                   onChange={e => setFormData({...formData, plan: e.target.value})}
                 >
+                  {/* TRIAL1: 'starter' removed. It was a fourth plan key
+                      nothing else in the product recognised — an admin
+                      setting it would have put the user in a state the
+                      billing tab, the webhook and plan_limits all read as
+                      unknown. */}
                   <option value="free">Free</option>
-                  <option value="starter">Starter</option>
                   <option value="professional">Professional</option>
                   <option value="enterprise">Enterprise</option>
                 </select>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -794,7 +794,7 @@ Content-Type: application/json
                   name: "Starter",
                   price: "$0",
                   period: "forever",
-                  features: ["5 deeds/month", "Email support", "Basic templates", "All deed types"],
+                  features: ["Email support", "Basic templates", "All deed types"],
                   cta: "Start Free",
                   popular: false,
                 },
@@ -806,7 +806,6 @@ Content-Type: application/json
                     "Unlimited deeds",
                     "Priority support",
                     "API access",
-                    "Custom branding",
                   ],
                   cta: "Start 14-day trial",
                   popular: true,
@@ -818,8 +817,7 @@ Content-Type: application/json
                   features: [
                     "Volume pricing",
                     "Dedicated support",
-                    "SSO/SAML",
-                    "SLA guarantee",
+
                     "White-glove onboarding",
                   ],
                   cta: "Contact Sales",

--- a/scripts/check_banned_claims.py
+++ b/scripts/check_banned_claims.py
@@ -95,6 +95,30 @@ RULES = [
          "no webhook handler, no field mapping, not a stub. Naming one as a "
          "feature is the single claim most likely to drive a purchase and "
          "then be discovered false on the customer's first file."),
+
+    # ── TRIAL1: FEATURE claims, not just compliance claims ────────────
+    #
+    # The gate shipped covering certifications and security postures, and
+    # that framing was one category too narrow. A pricing page listing
+    # "SSO/SAML" and "Custom branding" passed cleanly — zero files
+    # implement either — while a page saying "SOC 2" failed. Both are
+    # things a buyer pays for and then does not receive; only one was
+    # guarded.
+    #
+    # Same blind spot RED0 found in the compliance sweep, one category
+    # over: the rule was drawn around the EXAMPLES that prompted it
+    # rather than around the property (a claim on a purchase surface
+    # that nothing implements).
+    Rule("SSO / SAML", r"\b(?:SSO|SAML|single[\s\-]sign[\s\-]on)\b",
+         "No SSO or SAML implementation exists — zero files, not a stub. "
+         "It appeared on the Enterprise tier of the pricing page, which "
+         "is a surface people buy from."),
+    Rule("custom branding / white-label", r"\b(?:custom branding|white[\s\-]label(?:ed|ing)?)\b",
+         "Nothing in the product themes a deed, an email or a portal per "
+         "customer. Listed on the Professional tier until TRIAL1."),
+    Rule("team management / seats", r"\b(?:team management|multi[\s\-]user seats?|user seats?)\b",
+         "`deeds` carries one user_id and every query is scoped to it. "
+         "There is no team model to manage (RED-S5, deferred by decision)."),
 ]
 
 


### PR DESCRIPTION
Two commits — the sweep first, reported separately as ruled.

---

# Commit 1 — the sweep (`562a5c4`)

**The ticket called this the third appearance. It is the sixth, and four of them were live.**

| | site | consequence |
|---|---|---|
| A1 | partner API auth | every valid API key 401'd, for months |
| ADMIN1.5 | admin serializers | same shape |
| **LIVE** | `/users/upgrade` | **nobody could reach Stripe Checkout** |
| **LIVE** | `/users/verify-email/request` | an **unverified** user was told *"Email already verified"* and never got a link |
| **LIVE** | `GET /shared-deeds/{id}/feedback` | `owner_user_id` compared against the string `'owner_user_id'` — the deed's **own owner** got a permanent 403 |
| **LIVE** | `POST /admin/update-price` | Stripe asked to create a price on product `'stripe_product_id'` |
| dead | `check_plan_limits` | `'max_deeds_per_month' > 0` → TypeError → swallowed → *"allowing action"*. A limit check that always says yes |

All four live ones **proven against a real `HybridRow`** before being touched, not read off the page.

**The mechanism, once.** `HybridRow` is a `RealDictRow` — a dict — with integer indexing added. It overrides `__getitem__`. It does **not** override `__iter__`. So `row[0]` is the first *value* and `a, b = row` is the first two *keys*. Both spellings read as "positional"; one works. The failure is always silent, because a column name is a non-empty string: truthy, comparable, serialisable. `if not customer_id` took the wrong branch. `if verified` took the wrong branch. `owner != user_id` was permanently true.

**The property, not the instances.** `test_row_contract_positional.py` walks every `.py` in the backend and fails on **any** positional destructure of a `fetch*` result — direct, via a variable, in a `for` loop, in a comprehension. **Zero allowlist**, and that's the point: the tempting version permits it where the cursor is plain, which fails exactly where it matters, because a reader looking at `a, b = row` can't tell which cursor produced it without tracing the connection — *and that ambiguity is the bug*. So the five plain-cursor sites that destructured were converged onto `ROW_FACTORY` and read by key.

The pin is honest about two things in its own docstring: ~25 scripts still open raw connections whose rows really are tuples (none destructure, none broken, converging them isn't this ticket), and in those files the forbidden shape *would* work — forbidden anyway, because a carve-out reproduces the ambiguity.

The detector is itself tested against all four shapes, because my first cut silently missed loops and reported 8 sites when there were 11.

Login's `isinstance(user, dict)` guard is deleted: it branched on a second cursor factory that no longer exists, so the tuple arm was unreachable — and unreachable is the worst place for this pattern, because it reads as proof that destructuring is supported.

---

# Commit 2 — TRIAL1 (`6e7cc39`)

**2. One plan vocabulary.** `free` wins — it's what `users.plan` defaults to, what registration writes, what the webhook downgrades to. `starter` existed only in the billing UI, so `currentPlan` defaulted to a key nothing matched: the Current Plan card rendered with a blank name over a blank price, above a Manage Subscription button that 404s. The admin selector's fourth option is gone too.

**3. Trial.** `subscription_data.trial_period_days`, `TRIAL_PERIOD_DAYS = 14`, `STRIPE_TRIAL_PERIOD_DAYS` to change without a deploy, `0` to switch off. Stripe owns the clock. The advertised length and the charged length are **mirrored and pinned** — a 14-day promise on a 7-day session is discovered by the customer, on day 8, by being charged.

**4. Dunning.** `invoice.payment_failed` now handled. `payment_intent.payment_failed` is the wrong event for a subscription: it wrote a row with `user_id NULL` and told nobody, so an expired card meant full access silently, forever. The new handler resolves a real `user_id`, writes an attributable row, and emails through the E1 choke point so the attempt lands in `email_log` either way — wrapped, because an exception would make Stripe retry an event we already recorded. The copy is deliberately not a threat: Stripe retries, the account is untouched.

**5. Unenforced promises.** "5 deeds/month" deleted from both purchase surfaces (`check_plan_limits` has zero call sites; `plan_limits` is never seeded). And the banned-claims gate extended from **compliance** claims to **feature** claims — a page could say "SSO/SAML" and "Custom branding" (zero files each) and pass cleanly while "SOC 2" failed. Same blind spot RED0 found, one category over: the rule was drawn around the examples that prompted it rather than around the property. Three rules added; both claims removed.

**End to end** — the join nobody was watching: upgrade call → Stripe asked for a **real** customer id → customer persisted → `checkout.session.completed` → `users.plan` updated. Stripe stubbed at the SDK boundary and nowhere else. Verified to bite: reintroducing the unpack fails the end-to-end **and** the property pin, independently.

**Ninth and tenth trip**, worth recording for *when* it happened: two of these pins first read TSX raw and failed on the comments explaining the removals — while I was implementing your note about exactly that. The Python `code_only` can't help across languages (a `//` comment isn't a Python comment), so both now read **values** instead of text — quoted literals inside the plans array and the features arrays. Prose can't forge a `key: "..."`.

## Gates

pytest **814** · jest **588** · tsc **94** (unchanged) · six-flow ✔ · API baseline ✔ · banned-claims clean (13 rules)

## Owner-side, still required for this to work in production

Neither is code, and the path stays broken without them:

- `STRIPE_PROFESSIONAL_PRICE_ID` / `STRIPE_ENTERPRISE_PRICE_ID` — currently defaulting to the literal strings `price_professional_default` / `price_enterprise_default`, which are not valid Stripe price IDs.
- Confirm the real prices in Stripe. The homepage said **$149** and the billing tab **$29** for the same plan; the billing tab is unchanged by this PR and still says $29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_