### PR TITLE
PRICING1: one price, $99, and only what we can deliver is for sale

### DIFF
--- a/backend/db.py
+++ b/backend/db.py
@@ -233,6 +233,12 @@ def _active():
     return _standalone_connection()
 
 
+# What a real connection looks like. Used to tell "you are using the
+# database outside a request" (loud) from "you are asking whether this
+# object has a `_is_coroutine`" (it does not).
+from psycopg2.extensions import connection as _psycopg2_connection
+
+
 class _ConnectionProxy:
     """`db.conn`, resolving per request.
 
@@ -247,6 +253,38 @@ class _ConnectionProxy:
         return _active() is not None
 
     def __getattr__(self, name):
+        # PRICING1 — dunder probes get AttributeError, not a 500.
+        #
+        # This raised HTTPException for EVERY attribute name, including
+        # the special-method lookups library code performs routinely.
+        # `unittest.mock.patch.object` calls `hasattr(original,
+        # '__func__')` before patching; `hasattr` only swallows
+        # AttributeError, so an HTTP exception escaped from a
+        # introspection call and `patch.object(db, "conn")` failed with
+        # "Database connection not available" — from a line that was not
+        # touching the database.
+        #
+        # It cost a red CI run that was green locally, because whether it
+        # fires depends on whether an earlier test in the same session
+        # happened to leave a connection in the contextvar. A failure
+        # that depends on test ORDER is worse than a loud one.
+        #
+        # The loud behaviour is kept for real attributes — using `db.conn`
+        # outside a request is still a 500, which is the whole point of
+        # the proxy. Dunders are not that; they are Python asking what
+        # kind of object this is.
+        # A first cut special-cased dunders. That was the shape of the
+        # examples (`__func__`), not the property — `_is_coroutine` has
+        # one underscore and went straight through, which is the same
+        # enumerate-the-spellings mistake this codebase keeps making.
+        #
+        # The property: a name the real connection does not have is
+        # ABSENT, and absent is AttributeError whatever the connection
+        # state. A name it does have is a genuine use, and using
+        # `db.conn` outside a request is still a loud 500 — the entire
+        # point of the proxy, unchanged.
+        if not hasattr(_psycopg2_connection, name):
+            raise AttributeError(name)
         target = _active()
         if target is None:
             raise HTTPException(status_code=500,

--- a/backend/phase23_billing/router_webhook.py
+++ b/backend/phase23_billing/router_webhook.py
@@ -174,6 +174,29 @@ async def stripe_webhook(request: Request, db: Session = Depends(get_db)):
             db.execute(text(
                 "UPDATE users SET plan = :plan, updated_at = now() WHERE id = :uid"
             ), {"plan": plan, "uid": uid})
+        elif uid is not None and not plan:
+            # PRICING1 — THE FOUNDING-RATE TRAP, made loud.
+            #
+            # A Stripe PAYMENT LINK carries `client_reference_id` if you
+            # set one, but it carries `metadata.plan` only if you set
+            # that TOO. With the reference alone this branch used to fall
+            # through and return {"ok": true}: Stripe recorded a
+            # successful payment, the customer was charged, the plan
+            # stayed 'free', and nothing anywhere said so.
+            #
+            # Verified against the live handler before this was written —
+            # client_reference_id alone gives HTTP 200 and plan
+            # unchanged.
+            #
+            # We do NOT guess the plan from the price. Inferring which
+            # product somebody bought is the same class of move the whole
+            # doctrine refuses, and a founding-rate price ID would not
+            # match the standard one anyway. So: refuse silently to
+            # guess, and refuse loudly to be quiet.
+            print(f"[billing] PAID BUT NOT UPGRADED: checkout completed for "
+                  f"user {uid} with no metadata.plan — the Payment Link or "
+                  f"Checkout session must set metadata={{'plan': '<key>'}}. "
+                  f"The customer has been charged and their plan is unchanged.")
         # BILL1: a subscription checkout must leave a subscription row.
         # Previously nothing here or downstream ever inserted one.
         #

--- a/backend/routers/users_auth.py
+++ b/backend/routers/users_auth.py
@@ -445,7 +445,13 @@ TRIAL_PERIOD_DAYS = 14
 # A fourth key ('starter') lived only in the billing UI and matched
 # nothing, which is why every free user saw a blank plan card.
 FREE_PLAN = 'free'
-PAID_PLANS = ('professional', 'enterprise')
+# PRICING1: Enterprise deleted. Its differentiators were SSO/SAML and
+# custom branding — zero files each, and now banned outright by the
+# claims gate. `business` is priced and visible on the pricing surfaces
+# and is NOT here, because it is not purchasable until the org model
+# (RED-S5) exists: a plan key the checkout accepts is a plan somebody
+# can buy.
+PAID_PLANS = ('professional',)
 
 
 @router.post("/users/upgrade")
@@ -500,14 +506,35 @@ async def upgrade_plan(req: UpgradeRequest, user_id: int = Depends(get_current_u
         # 7-day trial on the session is a promise broken on day 8.
         trial_days = int(os.getenv('STRIPE_TRIAL_PERIOD_DAYS', str(TRIAL_PERIOD_DAYS)))
 
-        # Map plans to Stripe price IDs (create these in your Stripe dashboard)
-        price_map = {
-            'professional': os.getenv('STRIPE_PROFESSIONAL_PRICE_ID', 'price_professional_default'),
-            'enterprise': os.getenv('STRIPE_ENTERPRISE_PRICE_ID', 'price_enterprise_default')
-        }
+        # PRICING1 — NO PLACEHOLDER FALLBACK.
+        #
+        # This read `os.getenv('STRIPE_PROFESSIONAL_PRICE_ID',
+        # 'price_professional_default')`. With the env var unset it
+        # handed Stripe the literal string 'price_professional_default',
+        # which is not a price ID, and Checkout failed with a Stripe
+        # error the officer saw as "Upgrade failed".
+        #
+        # That was the SECOND independent break in the paid path — the
+        # first was the row unpack (TRIAL1) — and it had the same
+        # quality: a default that made an unconfigured system look
+        # configured. An unconfigured service is an error, not a
+        # fabricated value. Same rule the AI endpoint follows for a
+        # missing OPENAI_API_KEY, and the same rule §4 states generally.
+        if req.plan not in PAID_PLANS:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid plan selection. Available: {list(PAID_PLANS)}")
 
-        if req.plan not in price_map:
-            raise HTTPException(status_code=400, detail="Invalid plan selection")
+        price_map = {'professional': os.getenv('STRIPE_PROFESSIONAL_PRICE_ID')}
+        price_id = price_map.get(req.plan)
+        if not price_id:
+            # NAMED reason. "Upgrade failed" sent an operator looking at
+            # Stripe; this sends them to the variable that is missing.
+            logger_detail = (
+                f"Billing is not configured for the {req.plan} plan "
+                f"(STRIPE_{req.plan.upper()}_PRICE_ID is not set).")
+            print(f"[billing] {logger_detail}")
+            raise HTTPException(status_code=503, detail=logger_detail)
 
         # Create Stripe Checkout session
         session = stripe.checkout.Session.create(
@@ -516,7 +543,7 @@ async def upgrade_plan(req: UpgradeRequest, user_id: int = Depends(get_current_u
             metadata={'plan': req.plan, 'user_id': str(user_id)},
             payment_method_types=['card'],
             line_items=[{
-                'price': price_map[req.plan],
+                'price': price_id,
                 'quantity': 1
             }],
             mode='subscription',
@@ -529,6 +556,16 @@ async def upgrade_plan(req: UpgradeRequest, user_id: int = Depends(get_current_u
 
         return {"session_url": session.url, "session_id": session.id}
 
+    except HTTPException:
+        # PRICING1: the broad handler below was re-wrapping our OWN
+        # HTTPExceptions into 500s — so the deliberate, named
+        # "STRIPE_PROFESSIONAL_PRICE_ID is not set" 503 reached the
+        # officer as "Upgrade failed: 503: ..." with a 500 status.
+        #
+        # Found by this ticket's own test, not by reading. A precise
+        # error message is worthless if the layer above flattens it, and
+        # doctrine §4 is about the message the human actually sees.
+        raise
     except stripe.error.StripeError as e:
         raise HTTPException(status_code=400, detail=f"Stripe error: {str(e)}")
     except Exception as e:

--- a/backend/scripts/backfill_plan_sync.py
+++ b/backend/scripts/backfill_plan_sync.py
@@ -46,12 +46,16 @@ def main():
     if not db_url or not stripe.api_key:
         sys.exit("DATABASE_URL and STRIPE_SECRET_KEY are required")
 
+    # PRICING1: 'enterprise' retired with the tier. Kept as a RECOGNISED
+    # token, not an offered one — a reconciliation script that stopped
+    # recognising a plan real subscriptions were sold under would report
+    # those customers as unmapped, which is a false alarm about revenue.
+    # What is sellable lives in users_auth.PAID_PLANS; this is history.
     KNOWN_PLANS = ("professional", "enterprise")
 
-    # Optional env override, same vars /users/upgrade uses — fine if absent.
+    # Optional env override, same var /users/upgrade uses — fine if absent.
     price_to_plan = {}
-    for env_var, plan in (("STRIPE_PROFESSIONAL_PRICE_ID", "professional"),
-                          ("STRIPE_ENTERPRISE_PRICE_ID", "enterprise")):
+    for env_var, plan in (("STRIPE_PROFESSIONAL_PRICE_ID", "professional"),):
         price_id = os.getenv(env_var)
         if price_id:
             price_to_plan[price_id] = plan

--- a/backend/tests/test_pricing1_one_price.py
+++ b/backend/tests/test_pricing1_one_price.py
@@ -1,0 +1,364 @@
+"""PRICING1 — one price, and only things we can deliver are for sale.
+
+═══ WHAT WAS TRUE BEFORE ═══
+
+The same plan was advertised at two prices at the same time: the
+marketing page said Professional **$149/month**, the billing tab said
+**$29**. Neither was what Stripe would charge, because the amount billed
+comes from a price ID in an environment variable that had no
+relationship to either number.
+
+Three sources of truth for one price is a structure, not a typo, and the
+structure produces a customer quoted one figure and charged another. So
+the surfaces now derive from `frontend/src/lib/pricing.ts` and this file
+asserts no second hardcoded price survives.
+"""
+import re
+import sys
+from pathlib import Path
+
+BACKEND = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(BACKEND))
+
+import pytest
+
+REPO = BACKEND.parent
+CONFIG = REPO / "frontend" / "src" / "lib" / "pricing.ts"
+SURFACES = [
+    REPO / "frontend" / "src" / "app" / "page.tsx",
+    REPO / "frontend" / "src" / "app" / "account-settings" / "page.tsx",
+]
+
+
+def _config() -> str:
+    """The config WITHOUT its prose.
+
+    Eleventh trip: `test_enterprise_is_gone` first read this raw and
+    failed on the docstring explaining why Enterprise was deleted. The
+    file that documents a removal necessarily names the thing removed.
+    """
+    return _strip_ts_comments(CONFIG.read_text(encoding="utf-8"))
+
+
+def _strip_ts_comments(src: str) -> str:
+    """Block and line comments out of TSX.
+
+    The Python `code_only` tokenizes PYTHON and cannot help here — the
+    lesson TRIAL1 learned twice. Prices are quoted in the comments
+    explaining their removal ("Professional at $149 while the billing tab
+    said $29"), and a price pin that reads those is the eleventh trip of
+    the same family.
+    """
+    src = re.sub(r"/\*.*?\*/", "", src, flags=re.DOTALL)
+    src = re.sub(r"^[^\S\n]*//.*$", "", src, flags=re.MULTILINE)
+    return src
+
+
+# ── 1. One price, everywhere ─────────────────────────────────────────
+
+def test_the_pricing_config_exists_and_is_the_only_place_a_price_is_written():
+    assert CONFIG.exists()
+    src = _config()
+    assert "priceMonthly: 99" in src, "Professional is not $99"
+
+
+@pytest.mark.parametrize("surface", SURFACES, ids=lambda p: p.name)
+def test_no_surface_hardcodes_a_price(surface):
+    """THE pin. Not "the two numbers currently agree" — "there is no
+    second number to disagree with"."""
+    code = _strip_ts_comments(surface.read_text(encoding="utf-8"))
+    literals = re.findall(r"[\"'`]\$\d[\d,]*(?:\.\d+)?[\"'`/]", code)
+    assert literals == [], (
+        f"{surface.name} spells a price itself: {literals}. Prices come "
+        f"from lib/pricing.ts — that is the whole ticket.")
+
+
+@pytest.mark.parametrize("surface", SURFACES, ids=lambda p: p.name)
+def test_every_surface_reads_the_config(surface):
+    code = _strip_ts_comments(surface.read_text(encoding="utf-8"))
+    assert "@/lib/pricing" in code
+
+
+# A dollar figure is only a PLAN PRICE when it is one. The first cut of
+# the sweep below flagged `"transfer_tax": {"amount": "$825.00"}` and
+# "County rate: $1.10 per $1,000" in the API documentation — real
+# numbers, correct where they are, with nothing to do with what we
+# charge. A pin that cries about documentary transfer tax is a pin
+# people learn to ignore.
+#
+# So the property is narrowed to what it always meant: a dollar figure
+# presented as a SUBSCRIPTION price — assigned to a price-ish key, or
+# sitting next to a billing cadence.
+_PLAN_PRICE = re.compile(
+    r"""(?:price\w*\s*[:=]\s*[\"'`]?\$?\d)"""
+    r"""|(?:\$\d[\d,]*(?:\.\d+)?[^\n]{0,40}?"""
+    # No leading \b: the cadence often follows markup ("</span>/month"),
+    # where there is no word character to anchor against. Self-tested
+    # below, because this exact boundary silently made the sweep blind.
+    r"""(?:\bper\s+(?:user\s+)?month\b|/\s*month\b|/\s*mo\b|\ba\s+month\b|\bmonthly\b))""",
+    re.IGNORECASE)
+
+
+def test_no_plan_price_is_written_anywhere_but_the_config():
+    """Counted across the whole frontend, not just the two surfaces: a
+    third screen quoting a price is the same defect arriving later."""
+    hits = []
+    for path in (REPO / "frontend" / "src").rglob("*.tsx"):
+        if "node_modules" in str(path):
+            continue
+        code = _strip_ts_comments(path.read_text(encoding="utf-8"))
+        for m in _PLAN_PRICE.finditer(code):
+            hits.append(f"{path.relative_to(REPO)}: {m.group(0)[:60]}")
+    assert hits == [], f"plan-price literals outside the config: {hits}"
+
+
+def test_the_sweep_would_catch_the_defect_it_was_written_for():
+    """The two prices that actually shipped, and the two documentation
+    figures that must NOT trip it."""
+    assert _PLAN_PRICE.search('price: "$149",')
+    assert _PLAN_PRICE.search("<span>$99</span><span>/month</span>")
+    assert _PLAN_PRICE.search("$249 per user month")
+    assert not _PLAN_PRICE.search('"transfer_tax": { "amount": "$825.00" }')
+    assert not _PLAN_PRICE.search("County rate: $1.10 per $1,000 (R&T 11911).")
+
+
+# ── 2. Tier structure, honestly ──────────────────────────────────────
+
+def test_the_three_tiers_are_free_professional_business():
+    keys = re.findall(r"key:\s*'([a-z]+)'", _config())
+    assert keys == ["free", "professional", "business"]
+
+
+def test_enterprise_is_gone_from_the_product():
+    """Deleted, not hidden. Its differentiators were SSO/SAML and custom
+    branding — zero files each."""
+    assert "enterprise" not in _config().lower()
+
+    from routers.users_auth import PAID_PLANS
+    assert "enterprise" not in PAID_PLANS
+
+    for surface in SURFACES:
+        code = _strip_ts_comments(surface.read_text(encoding="utf-8"))
+        assert "Enterprise" not in code, surface.name
+
+
+def test_business_is_visible_and_not_purchasable():
+    """Priced and shown so the ladder is legible; unsellable because the
+    multi-user org model it implies (RED-S5) does not exist. `deeds`
+    carries one user_id and every query is scoped to it."""
+    src = _config()
+    business = src[src.index("key: 'business'"):]
+    assert "purchasable: false" in business[:400]
+    assert "Coming soon" in business[:600]
+
+
+def test_an_unpurchasable_tier_is_not_a_valid_checkout_plan():
+    """The pin that matters more than the badge: a plan key checkout
+    accepts is a plan somebody can buy."""
+    from routers.users_auth import PAID_PLANS
+    assert "business" not in PAID_PLANS
+    assert PAID_PLANS == ("professional",)
+
+
+@pytest.mark.parametrize("surface", SURFACES, ids=lambda p: p.name)
+def test_no_surface_renders_a_buy_control_for_an_unpurchasable_tier(surface):
+    code = _strip_ts_comments(surface.read_text(encoding="utf-8"))
+    assert "purchasable" in code, (
+        f"{surface.name} renders tiers without consulting `purchasable` — "
+        f"it will offer Business for sale")
+
+
+# ── 3. A missing price ID fails loudly, never falls back ─────────────
+
+def test_there_is_no_placeholder_price_id():
+    """The SECOND independent break the trial audit found: an unset env
+    var handed Stripe the literal 'price_professional_default'. A default
+    that makes an unconfigured system look configured."""
+    from tests.source_text import code_only
+    src = code_only(BACKEND / "routers" / "users_auth.py")
+    assert "price_professional_default" not in src
+    assert "price_enterprise_default" not in src
+    assert "STRIPE_ENTERPRISE_PRICE_ID" not in src
+
+
+def test_a_missing_price_id_names_the_variable():
+    from tests.source_text import code_only
+    src = code_only(BACKEND / "routers" / "users_auth.py")
+    block = src[src.index("price_map = {"):src.index("session = stripe.checkout")]
+    assert "503" in block, "an unconfigured service is unavailable, not a bad request"
+    assert "PRICE_ID is not set" in block or "_PRICE_ID" in block
+
+
+def test_the_upgrade_endpoint_refuses_when_billing_is_unconfigured():
+    """Executable, not read off the page."""
+    import os
+    from unittest.mock import patch
+    from fastapi import FastAPI, HTTPException
+    from fastapi.testclient import TestClient
+
+    import routers.users_auth as ua
+    from auth import get_current_user_id
+
+    app = FastAPI()
+    app.include_router(ua.router)
+    app.dependency_overrides[get_current_user_id] = lambda: 1
+    client = TestClient(app, raise_server_exceptions=False)
+
+    env = {k: v for k, v in os.environ.items() if k != "STRIPE_PROFESSIONAL_PRICE_ID"}
+    with patch.dict(os.environ, env, clear=True):
+        # Reach the price lookup without needing a database row.
+        with patch.object(ua.db, "conn") as conn:
+            conn.cursor.return_value.__enter__.return_value.fetchone.return_value = {
+                "stripe_customer_id": "cus_x", "email": "a@b.test", "full_name": "A"}
+            resp = client.post("/users/upgrade", json={"plan": "professional"})
+
+    assert resp.status_code == 503, resp.text
+    assert "PRICE_ID" in resp.json()["detail"]
+
+
+def test_an_unknown_plan_is_refused_before_stripe_is_touched():
+    from tests.source_text import code_only
+    src = code_only(BACKEND / "routers" / "users_auth.py")
+    assert "if req.plan not in PAID_PLANS" in src
+
+
+# ── 4. The instrument count is checked against the registry ──────────
+
+def test_the_advertised_instrument_count_matches_the_catalog():
+    """"21 recordable instruments" is a claim on a purchase surface. It
+    is counted from the registry rather than by hand, because a number
+    that drifts on a pricing page is discovered by a customer."""
+    from services.form_families import FAMILY_BY_DEED_TYPE
+
+    # Legacy slug aliases are the same instrument under an older name.
+    aliases = {"grant_deed", "quitclaim"}
+    actual = len([k for k in FAMILY_BY_DEED_TYPE if k not in aliases])
+
+    claimed = int(re.search(r"INSTRUMENT_COUNT\s*=\s*(\d+)", _config()).group(1))
+    assert claimed == actual, (
+        f"the pricing surfaces advertise {claimed} instruments; the "
+        f"registry has {actual}")
+
+
+# ── 5. Copy states what is true ──────────────────────────────────────
+
+def test_the_copy_claims_only_things_the_product_does():
+    src = _config()
+    for truth in ("PCOR", "hash-stamped", "lineage", "confirmed by you"):
+        assert truth in src, truth
+
+
+def test_no_sla_uptime_or_phantom_integration_survives_in_the_pricing_config():
+    """The red team called the integration line items the single most
+    credible objection in the audit.
+
+    SCOPED TO THE CONFIG, and the reason is worth writing down: a first
+    cut ran the rule patterns over the marketing page too and failed on
+    the FAQ entry "Does it connect to SoftPro, Qualia, or ResWare?" —
+    which carries an explicit `banned-claims: allow` escape because
+    naming the systems is what makes the truthful "no" useful.
+
+    That was my test re-implementing rule application and skipping the
+    escape handling the real gate has. The surfaces are already covered
+    by `scripts/check_banned_claims.py` in CI, honestly, escapes and all.
+    What is added here is the new file that gate did not exist to guard.
+    """
+    sys.path.insert(0, str(REPO / "scripts"))
+    import importlib
+    gate = importlib.import_module("check_banned_claims")
+
+    hits = [r.name for r in gate.RULES if r.rx.search(_config())]
+    assert hits == [], f"the pricing config claims: {hits}"
+
+
+def test_the_real_gate_passes_over_the_whole_product():
+    """And the surfaces, through the gate's own logic rather than a
+    lookalike of it."""
+    import subprocess
+    result = subprocess.run([sys.executable, "scripts/check_banned_claims.py"],
+                            cwd=str(REPO), capture_output=True, text=True)
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+# ── 6. The founding-rate path: Stripe Payment Links ──────────────────
+#
+# Item 4 of the ticket assumed no code was needed — "BILL1's webhook
+# already handles checkout.session.completed correctly" with
+# client_reference_id set. Checked against the live handler, and the
+# assumption is half right: the reference resolves the USER, but the
+# handler also needs `metadata.plan` to know what they bought.
+#
+# Without it: HTTP 200, plan unchanged, customer charged, nobody told.
+# That is the founding-rate flow's silent failure mode, so it is pinned
+# from both directions and made loud in the handler.
+
+import os
+import pytest as _pytest
+
+needs_db = _pytest.mark.skipif(not os.getenv("DATABASE_URL"), reason="needs a database")
+
+
+def _fire_checkout(session_obj):
+    from unittest.mock import MagicMock, patch
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from sqlalchemy import text
+    from phase23_billing.deps import SessionLocal, get_db
+    from phase23_billing.router_webhook import router
+
+    se = SessionLocal()
+    se.execute(text("DELETE FROM users WHERE email = 'founding@pricing1.test'"))
+    se.execute(text(
+        "INSERT INTO users (email, password_hash, full_name, role, state, plan) "
+        "VALUES ('founding@pricing1.test','x','Founding','escrow_officer','CA','free')"))
+    se.commit()
+    uid = se.execute(text(
+        "SELECT id FROM users WHERE email = 'founding@pricing1.test'")).scalar()
+
+    obj = dict(session_obj)
+    obj["client_reference_id"] = str(uid)
+    stub = MagicMock()
+    stub.Webhook.construct_event.return_value = {
+        "type": "checkout.session.completed", "data": {"object": obj}}
+
+    app = FastAPI()
+    app.include_router(router)
+    app.dependency_overrides[get_db] = lambda: se
+    with patch("phase23_billing.router_webhook.init_stripe", return_value=stub):
+        resp = TestClient(app).post("/payments/webhook", json={},
+                                    headers={"stripe-signature": "t=1,v1=stub"})
+    plan = se.execute(text("SELECT plan FROM users WHERE id = :i"), {"i": uid}).scalar()
+    se.execute(text("DELETE FROM users WHERE id = :i"), {"i": uid})
+    se.commit()
+    se.close()
+    return resp, plan
+
+
+@needs_db
+def test_a_payment_link_with_metadata_upgrades_the_user():
+    """THE founding-rate path, as it must be configured. A $79 link with
+    client_reference_id AND metadata.plan works through the existing
+    handler — no code needed, exactly as the ticket expected."""
+    resp, plan = _fire_checkout({
+        "customer": "cus_founding", "subscription": "sub_founding",
+        "metadata": {"plan": "professional"},
+    })
+    assert resp.status_code == 200
+    assert plan == "professional"
+
+
+@needs_db
+def test_a_payment_link_without_metadata_does_not_silently_upgrade(capfd):
+    """And the trap. The reference alone resolves the user but not the
+    product, so the plan cannot change — and the one thing that must not
+    happen is for that to be quiet, because the customer has paid."""
+    resp, plan = _fire_checkout({
+        "customer": "cus_founding", "subscription": "sub_founding",
+        "metadata": {},
+    })
+    assert resp.status_code == 200, "Stripe must not retry a well-formed event"
+    assert plan == "free", "we do not guess which product somebody bought"
+
+    out = capfd.readouterr().out
+    assert "PAID BUT NOT UPGRADED" in out
+    assert "metadata" in out, "the log must name the fix, not just the symptom"

--- a/backend/tests/test_pricing1_one_price.py
+++ b/backend/tests/test_pricing1_one_price.py
@@ -204,12 +204,17 @@ def test_the_upgrade_endpoint_refuses_when_billing_is_unconfigured():
     app.dependency_overrides[get_current_user_id] = lambda: 1
     client = TestClient(app, raise_server_exceptions=False)
 
+    from unittest.mock import MagicMock
+    conn = MagicMock()
+    conn.cursor.return_value.__enter__.return_value.fetchone.return_value = {
+        "stripe_customer_id": "cus_x", "email": "a@b.test", "full_name": "A"}
+
     env = {k: v for k, v in os.environ.items() if k != "STRIPE_PROFESSIONAL_PRICE_ID"}
     with patch.dict(os.environ, env, clear=True):
-        # Reach the price lookup without needing a database row.
-        with patch.object(ua.db, "conn") as conn:
-            conn.cursor.return_value.__enter__.return_value.fetchone.return_value = {
-                "stripe_customer_id": "cus_x", "email": "a@b.test", "full_name": "A"}
+        # `new=` explicitly: patch.object without it introspects the
+        # original, and `db.conn` is a proxy whose whole job is to react
+        # to attribute access. See test_the_connection_proxy_* below.
+        with patch.object(ua.db, "conn", new=conn):
             resp = client.post("/users/upgrade", json={"plan": "professional"})
 
     assert resp.status_code == 503, resp.text
@@ -362,3 +367,132 @@ def test_a_payment_link_without_metadata_does_not_silently_upgrade(capfd):
     out = capfd.readouterr().out
     assert "PAID BUT NOT UPGRADED" in out
     assert "metadata" in out, "the log must name the fix, not just the symptom"
+
+
+# ── 7. The proxy answers introspection without raising HTTP ──────────
+
+def test_the_connection_proxy_reports_absent_attributes_as_absent():
+    """`db.conn` used to raise HTTPException for EVERY attribute name, so
+    any library asking "what kind of object is this?" got an HTTP 500
+    from a line that never touched a database.
+
+    `hasattr` only swallows AttributeError, so the exception escaped:
+    `unittest.mock.patch.object(db, "conn")` probes `__func__` and then
+    `_is_coroutine` and blew up with "Database connection not
+    available". It cost a CI run that was green locally — and green
+    locally only because an earlier test had left a connection in the
+    contextvar, which makes it a failure that depends on test order.
+    """
+    import db as db_module
+
+    for probe in ("__func__", "_is_coroutine", "__await__", "not_a_real_attr"):
+        assert not hasattr(db_module.conn, probe), probe
+
+
+def test_a_real_attribute_still_resolves_or_fails_loudly(monkeypatch):
+    """The half that must NOT be softened — stated as the contract
+    actually is, rather than as I first assumed it.
+
+    My first version asserted that touching `db.conn.cursor` outside a
+    request always raises 500. It passed without a database and failed
+    with one, because `_active()` deliberately falls back to a
+    STANDALONE connection when DB_URL is set — that is how scripts and
+    the six-flow harness use the module. Asserting a contract I had not
+    read is the same error as a pin that guards a spelling.
+
+    The real contract, both halves:
+
+      DB_URL set    a real attribute resolves (standalone fallback)
+      DB_URL unset  a real attribute is a loud 500
+
+    Either way an ABSENT attribute is AttributeError, which is the
+    change this ticket made and the one the tests above pin.
+    """
+    from fastapi import HTTPException
+    import db as db_module
+
+    # `_active` is the one function the proxy consults, so simulating
+    # "no connection" means patching that — NOT the ContextVar's `get`,
+    # which a first cut tried and which leaked out of the test and broke
+    # six unrelated ones. A test that damages its neighbours is worse
+    # than the assertion it was making.
+    monkeypatch.setattr(db_module, "_active", lambda: None)
+    for real in ("cursor", "commit", "rollback"):
+        with pytest.raises(HTTPException) as excinfo:
+            getattr(db_module.conn, real)
+        assert excinfo.value.status_code == 500, real
+
+
+def test_patch_object_works_on_the_proxy_both_ways():
+    """The thing that actually broke. Pinned in both spellings, because
+    the one that failed is the one people reach for first."""
+    from unittest.mock import MagicMock, patch
+    import db as db_module
+
+    with patch.object(db_module, "conn", new=MagicMock()):
+        assert db_module.conn
+    with patch.object(db_module, "conn"):
+        assert db_module.conn
+
+
+# ── 8. The gate asserts the property, not the spellings ──────────────
+
+def _gate():
+    sys.path.insert(0, str(REPO / "scripts"))
+    import importlib
+    return importlib.import_module("check_banned_claims")
+
+
+@pytest.mark.parametrize("claim", [
+    # The two that were enumerated...
+    "bank-level security",
+    "military-grade encryption",
+    # ...the third that walked past both and prompted the ruling...
+    "Enterprise-grade security",
+    # ...and the ones nobody has written yet, which is the point.
+    "government-grade protection",
+    "hospital-grade privacy",
+    "industry-leading security",
+    "world-class infrastructure",
+    "carrier-class reliability",
+])
+def test_one_rule_covers_every_spelling_of_the_unearned_grade(claim):
+    """Owner-ruled after the enterprise-grade catch: assert the property
+    (unearned security framing), not a list of phrasings. Three
+    spellings of one claim with two of them enumerated is the pin
+    guarding a spelling while the property walks past."""
+    assert any(r.rx.search(claim) for r in _gate().RULES), claim
+
+
+@pytest.mark.parametrize("claim", [
+    "security certified by a third party",
+    "independently audited security",
+    "accredited privacy program",
+])
+def test_the_audit_half_of_the_property_is_covered_too(claim):
+    assert any(r.rx.search(claim) for r in _gate().RULES), claim
+
+
+@pytest.mark.parametrize("innocent", [
+    # Real vocabulary in this domain. A gate that cried about these is a
+    # gate people learn to skip.
+    "a certified copy of the recorded instrument",
+    "Certification of Trust under Probate Code 18100.5",
+    "commercial-grade paper stock",
+    "the county recorder certified the document",
+    "professional liability coverage",
+])
+def test_the_property_rule_does_not_swallow_real_domain_language(innocent):
+    hits = [r.name for r in _gate().RULES if r.rx.search(innocent)]
+    assert hits == [], f"{innocent!r} tripped {hits}"
+
+
+def test_the_enumerated_spellings_were_replaced_not_merely_supplemented():
+    """The ruling was to assert the property RATHER THAN enumerate. If
+    the old per-phrase rules were still here, the next contributor would
+    add a fourth phrase instead of trusting the shape."""
+    names = {r.name for r in _gate().RULES}
+    assert "bank-level security" not in names
+    assert "military-grade" not in names
+    assert "enterprise-grade" not in names
+    assert "unearned security grade" in names

--- a/backend/tests/test_trial1_paid_path.py
+++ b/backend/tests/test_trial1_paid_path.py
@@ -53,7 +53,11 @@ def test_the_advertised_trial_length_matches_the_one_we_charge_on():
 
     import re
     page = (REPO / "frontend" / "src" / "app" / "page.tsx").read_text(encoding="utf-8")
-    claimed = {int(n) for n in re.findall(r"(\d+)[\s-]day trial", page, re.I)}
+    # PRICING1 moved the copy to `Start {TRIAL_DAYS}-day trial`, so the
+    # page states the number once as a constant instead of twice as
+    # prose. Read the constant — that IS the claim now.
+    claimed = {int(n) for n in re.findall(r"const TRIAL_DAYS\s*=\s*(\d+)", page)}
+    claimed |= {int(n) for n in re.findall(r"(\d+)[\s-]day trial", page, re.I)}
     assert claimed, "the marketing page no longer states a trial length"
     assert claimed == {TRIAL_PERIOD_DAYS}, (
         f"the page advertises {sorted(claimed)}-day trial(s); the server "
@@ -91,6 +95,23 @@ def _quoted_values(src: str, key: str):
     return re.findall(rf'{key}\s*[:=]\s*[\'"]([^\'"]+)[\'"]', src)
 
 
+def _advertised_features():
+    """Every feature bullet on any purchase surface.
+
+    One function because PRICING1 gave the surfaces one source: features
+    live in `lib/pricing.ts` and both the marketing page and the billing
+    tab render them. Asking each screen separately was how the two came
+    to disagree about the price in the first place.
+    """
+    import re
+    config = (REPO / "frontend" / "src" / "lib" / "pricing.ts").read_text(encoding="utf-8")
+    out = []
+    for block in re.findall(r"(?:features|TRUE_OF_EVERY_TIER)[^\[]*\[(.*?)\]", config, re.S):
+        out += re.findall(r"[\'\"`]([^\'\"`]+)[\'\"`]", block)
+    assert out, "no feature bullets found in the pricing config"
+    return out
+
+
 def test_the_free_plan_has_exactly_one_name():
     """'free' is what the database stores; 'starter' lived only in the
     billing UI and matched nothing, so every free user's plan card
@@ -98,18 +119,14 @@ def test_the_free_plan_has_exactly_one_name():
     from routers.users_auth import FREE_PLAN, PAID_PLANS
     assert FREE_PLAN == "free"
 
-    billing = (REPO / "frontend" / "src" / "app" / "account-settings" /
-               "page.tsx").read_text(encoding="utf-8")
-    # Scoped to the PLANS array. A first cut read `key:` across the whole
-    # file and swept up React `key={...}` props and notification
-    # preference keys — a pin that reports 'marketing' as a pricing tier
-    # is noise, and noise is how a real failure gets skimmed past.
-    import re
-    block = re.search(r"const plans = \[(.*?)\n  \]", billing, re.S)
-    assert block, "the plans array moved — re-scope this pin"
-    keys = set(_quoted_values(block.group(1), "key"))
-    assert keys == {FREE_PLAN, *PAID_PLANS}, (
-        f"the billing tab offers plan keys the product does not know: {keys}")
+    # PRICING1 gave both surfaces ONE source, so this reads the config
+    # rather than the screen. Stronger, not weaker: before, two surfaces
+    # could disagree and only one was pinned.
+    config = (REPO / "frontend" / "src" / "lib" / "pricing.ts").read_text(encoding="utf-8")
+    keys = set(_quoted_values(config, "key"))
+    assert FREE_PLAN in keys
+    assert set(PAID_PLANS) <= keys, (
+        f"a purchasable plan is missing from the pricing config: {keys}")
 
     admin = (REPO / "frontend" / "src" / "app" / "admin" / "users" / "[id]" /
              "page.tsx").read_text(encoding="utf-8")
@@ -121,10 +138,11 @@ def test_the_free_plan_has_exactly_one_name():
 def test_the_billing_tab_can_find_the_plan_the_database_stores():
     """The exact break: `currentPlan` defaulted to "starter", the guard
     read `!== "starter"`, and `plans.find(key === 'free')` was undefined."""
-    src = code_only((REPO / "frontend" / "src" / "app" / "account-settings" /
-                     "page.tsx").read_text(encoding="utf-8"))
+    src = (REPO / "frontend" / "src" / "app" / "account-settings" /
+           "page.tsx").read_text(encoding="utf-8")
     assert 'userProfile?.plan || "free"' in src
-    assert 'key: "free"' in src
+    config = (REPO / "frontend" / "src" / "lib" / "pricing.ts").read_text(encoding="utf-8")
+    assert "'free'" in config or '"free"' in config
 
 
 # ── 3. Dunning runs on the renewal event ─────────────────────────────
@@ -192,12 +210,7 @@ def test_the_banned_claims_gate_now_covers_feature_claims(claim, tmp_path):
 
 def test_the_claims_are_actually_absent_from_the_product():
     """A gate is only honest if the thing it forbids is also gone."""
-    import re
-    page = (REPO / "frontend" / "src" / "app" / "page.tsx").read_text(encoding="utf-8")
-    listed = []
-    for block in re.findall(r"features:\s*\[(.*?)\]", page, re.S):
-        listed += re.findall(r"[\'\"]([^\'\"]+)[\'\"]", block)
-    assert listed, "no feature lists found on the marketing page"
+    listed = _advertised_features()
     for claim in ("SSO", "SAML", "custom branding", "deeds/month"):
         hits = [f for f in listed if claim.lower() in f.lower()]
         assert hits == [], f"still advertised: {hits}"
@@ -210,14 +223,8 @@ def test_the_unenforced_limit_is_gone_from_both_purchase_surfaces():
     favour, which is the harmless direction and still not something to
     leave written down."""
     import re
-    for rel in (("app", "page.tsx"), ("app", "account-settings", "page.tsx")):
-        src = (REPO / "frontend" / "src").joinpath(*rel).read_text(encoding="utf-8")
-        # The FEATURE LISTS, not the file — see _quoted_values above for
-        # why these tests read values rather than text.
-        for block in re.findall(r"features:\s*\[(.*?)\]", src, re.S):
-            listed = re.findall(r"[\'\"]([^\'\"]+)[\'\"]", block)
-            offenders = [f for f in listed if re.search(r"deeds\s*/\s*month", f, re.I)]
-            assert offenders == [], f"{rel[-1]} still advertises {offenders}"
+    for feature in _advertised_features():
+        assert not re.search(r"deeds\s*/\s*month", feature, re.I), feature
 
 
 # ── 5. END TO END: the join BILL1's pins could not see ───────────────

--- a/frontend/src/__tests__/homepageLinks.test.ts
+++ b/frontend/src/__tests__/homepageLinks.test.ts
@@ -11,6 +11,7 @@
 import { describe, expect, it } from '@jest/globals';
 import * as fs from 'fs';
 import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
 
 const APP_DIR = path.join(__dirname, '..', 'app');
 
@@ -99,9 +100,33 @@ describe('HM1 — dead promises stay dead', () => {
     expect(ALL).not.toContain('href="/security"');
   });
 
-  it('Contact Sales is owner-gated — hidden until an address exists', () => {
-    expect(PAGE).toContain('CONTACT_SALES_EMAIL');
-    expect(PAGE).toContain('Contact information coming soon');
+  it('there is no Contact Sales path at all — the tier it belonged to is gone', () => {
+    /*
+     * RETIRED BY PRICING1, in the diff that cured its condition.
+     *
+     * This asserted that Contact Sales was GATED on an address that had
+     * never been set, so the button rendered "Contact information coming
+     * soon" — a holding position, and an honest one while an Enterprise
+     * tier existed.
+     *
+     * PRICING1 deleted that tier: its differentiators were SSO/SAML and
+     * custom branding, zero files each. A CTA for a tier that does not
+     * exist cannot be honestly gated, only removed — and removing it
+     * satisfies the original intent (a dead promise is not presented as
+     * live) more completely than gating ever did.
+     *
+     * The pin now asserts the stronger fact. Left as a gate assertion it
+     * would have demanded the machinery for a button with nothing behind
+     * it, and the next contributor would have restored the button to go
+     * green.
+     */
+    // codeOnly, because the comment recording the removal necessarily
+    // names the thing removed — the twelfth trip of that family, and the
+    // helper exists precisely so it costs one import instead of a
+    // debugging session.
+    const code = codeOnly(PAGE);
+    expect(code).not.toContain('Contact Sales');
+    expect(code).not.toContain('CONTACT_SALES_EMAIL');
   });
 });
 

--- a/frontend/src/app/account-settings/page.tsx
+++ b/frontend/src/app/account-settings/page.tsx
@@ -2,11 +2,11 @@
 import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import Sidebar from "@/components/Sidebar"
-import { User, CreditCard, Bell, Lock, Code, Check, Copy, Loader2 } from "lucide-react"
+import { User, CreditCard, Bell, Lock, Check, Loader2 } from "lucide-react"
 import { toast } from "sonner"
 import { TIERS, priceLabel } from "@/lib/pricing"
 
-type Tab = "profile" | "billing" | "notifications" | "security" | "widget"
+type Tab = "profile" | "billing" | "notifications" | "security"
 
 interface UserProfile {
   first_name?: string
@@ -20,6 +20,15 @@ interface UserProfile {
   zip_code?: string
   plan?: string
   plan_limits?: any
+  /* PRICING1: the Widget Add-on TAB is deleted (owner-ruled). It priced
+     an unimplemented product at $49/month and handed the customer a
+     script tag for https://deedpro.com/widget.js — no such file, no
+     /embed route, no handler. A dead marketing component with a payment
+     button attached.
+
+     The FLAG stays: users.widget_addon is real data an admin may have
+     set, and dropping a column is not a UI ticket. It returns when
+     DX0's widget work actually ships. */
   widget_addon?: boolean
   embed_key?: string
 }
@@ -120,36 +129,12 @@ export default function AccountSettingsPageV0() {
     }
   }
 
-  /**
-   * PRICING1 — this handed the customer a script tag for a file that
-   * does not exist.
-   *
-   * The snippet pointed at `https://deedpro.com/widget.js` and
-   * `/embed/<key>`. There is no widget.js in `frontend/public`, no
-   * `/embed/` route in the backend, and no embed handler anywhere. The
-   * add-on was priced at $49/month on the screen above.
-   *
-   * Same class as the SSO/SAML and custom-branding claims this ticket
-   * deletes, and worse in one respect: those were bullet points, this
-   * had a price and a Copy button, so a customer could pay and then
-   * paste a broken tag into their own site.
-   *
-   * Copying is disabled rather than the tab deleted — removing a product
-   * surface is the owner's call, and this is the honest holding
-   * position. Flagged in the PRICING1 report.
-   */
-  const copySnippet = () => {
-    toast.error(
-      "The embeddable widget is not available yet — there is nothing to embed."
-    )
-  }
 
   const tabs = [
     { id: "profile" as Tab, label: "Profile", icon: User },
     { id: "billing" as Tab, label: "Billing", icon: CreditCard },
     { id: "notifications" as Tab, label: "Notifications", icon: Bell },
     { id: "security" as Tab, label: "Security", icon: Lock },
-    { id: "widget" as Tab, label: "Widget Add-on", icon: Code },
   ]
 
   if (loading) {
@@ -213,7 +198,6 @@ export default function AccountSettingsPageV0() {
               )}
               {activeTab === "notifications" && <NotificationsTab />}
               {activeTab === "security" && <SecurityTab />}
-              {activeTab === "widget" && <WidgetTab userProfile={userProfile} onCopySnippet={copySnippet} />}
             </div>
           </div>
         </div>
@@ -652,77 +636,3 @@ function SecurityTab() {
 }
 
 // Widget Tab Component
-function WidgetTab({
-  userProfile,
-  onCopySnippet,
-}: {
-  userProfile: UserProfile | null
-  onCopySnippet: () => void
-}) {
-  const widgetEnabled = userProfile?.widget_addon || false
-  const embedKey = userProfile?.embed_key || "YOUR_EMBED_KEY"
-
-  return (
-    <div className="space-y-8">
-      {/* Widget Status */}
-      <div
-        className={`rounded-xl p-6 border-2 ${
-          widgetEnabled ? "border-green-500 bg-green-50" : "border-slate-200 bg-slate-50"
-        }`}
-      >
-        <div className="flex items-center justify-between">
-          <div>
-            <h3 className="text-2xl font-bold text-slate-800 mb-2">{widgetEnabled ? "✅ Enabled" : "❌ Disabled"}</h3>
-            <p className="text-slate-600">Widget Add-On Status</p>
-          </div>
-          <div className="text-right">
-            {/* PRICING1: the $49 was a second hardcoded price, and it
-                priced something that does not exist — see the note on
-                copySnippet. No figure until there is a product to
-                attach it to. */}
-            <div className="text-3xl font-bold text-slate-400">—</div>
-          </div>
-        </div>
-      </div>
-
-      {widgetEnabled ? (
-        <>
-          {/* Embed Key */}
-          <div className="bg-white border-2 border-green-500 rounded-xl p-6">
-            <h3 className="text-xl font-bold text-slate-800 mb-4">🔑 Your Embed Key</h3>
-            <div className="bg-slate-800 rounded-lg p-4 mb-4">
-              <code className="text-green-400 font-mono text-sm break-all">{embedKey}</code>
-            </div>
-            <button
-              onClick={onCopySnippet}
-              className="flex items-center gap-2 px-6 py-3 bg-blue-500 hover:bg-blue-600 text-white font-medium rounded-lg transition-colors"
-            >
-              <Copy className="w-4 h-4" />📋 Copy Embed Snippet
-            </button>
-          </div>
-
-          {/* Usage Instructions */}
-          <div className="bg-slate-50 rounded-xl p-6">
-            <h4 className="text-lg font-bold text-slate-800 mb-3">Usage Instructions</h4>
-            <ol className="list-decimal list-inside space-y-2 text-slate-700">
-              <li>Copy the embed snippet above</li>
-              <li>Paste it into your website's HTML</li>
-              <li>The widget will appear automatically</li>
-              <li>Customize styling via the widget dashboard</li>
-            </ol>
-          </div>
-        </>
-      ) : (
-        <div className="bg-blue-50 rounded-xl p-8 text-center">
-          <div className="text-6xl mb-4">🔧</div>
-          <h3 className="text-2xl font-bold text-slate-800 mb-3">Widget Add-On Not Enabled</h3>
-          <p className="text-slate-600 mb-6">Contact your administrator to enable the widget add-on for your account</p>
-          {/* PRICING1: the price came off with the product. There is no
-              widget.js and no /embed route — quoting a monthly figure for
-              it was the same defect as the SSO line this ticket deletes. */}
-        </div>
-      )}
-    </div>
-  )
-}
-

--- a/frontend/src/app/account-settings/page.tsx
+++ b/frontend/src/app/account-settings/page.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation"
 import Sidebar from "@/components/Sidebar"
 import { User, CreditCard, Bell, Lock, Code, Check, Copy, Loader2 } from "lucide-react"
 import { toast } from "sonner"
+import { TIERS, priceLabel } from "@/lib/pricing"
 
 type Tab = "profile" | "billing" | "notifications" | "security" | "widget"
 
@@ -119,13 +120,28 @@ export default function AccountSettingsPageV0() {
     }
   }
 
+  /**
+   * PRICING1 — this handed the customer a script tag for a file that
+   * does not exist.
+   *
+   * The snippet pointed at `https://deedpro.com/widget.js` and
+   * `/embed/<key>`. There is no widget.js in `frontend/public`, no
+   * `/embed/` route in the backend, and no embed handler anywhere. The
+   * add-on was priced at $49/month on the screen above.
+   *
+   * Same class as the SSO/SAML and custom-branding claims this ticket
+   * deletes, and worse in one respect: those were bullet points, this
+   * had a price and a Copy button, so a customer could pay and then
+   * paste a broken tag into their own site.
+   *
+   * Copying is disabled rather than the tab deleted — removing a product
+   * surface is the owner's call, and this is the honest holding
+   * position. Flagged in the PRICING1 report.
+   */
   const copySnippet = () => {
-    const embedKey = userProfile?.embed_key || "YOUR_EMBED_KEY"
-    const snippet = `<script src="https://deedpro.com/widget.js" data-key="${embedKey}"></script>
-<iframe src="https://deedpro.com/embed/${embedKey}" width="100%" height="600"></iframe>`
-
-    navigator.clipboard.writeText(snippet)
-    toast.success("Embed snippet copied to clipboard!")
+    toast.error(
+      "The embeddable widget is not available yet — there is nothing to embed."
+    )
   }
 
   const tabs = [
@@ -351,38 +367,10 @@ function BillingTab({
   // Subscription button that 404s because they have no Stripe customer.
   const currentPlan = userProfile?.plan || "free"
 
-  const plans = [
-    {
-      key: "free",
-      name: "Free",
-      price: "$0",
-      // TRIAL1: "5 deeds/month" removed. check_plan_limits is never
-      // called and plan_limits is never seeded, so the limit was never
-      // enforced. An unenforced limit written on a purchase surface is a
-      // promise we are not keeping — in our favour, which is the
-      // harmless direction, and still not something to leave written
-      // down.
-      features: ["All deed types", "Basic AI assistance", "Standard templates", "Email support"],
-    },
-    {
-      key: "professional",
-      name: "Professional",
-      price: "$29",
-      // RED-H1.1: "SoftPro integration" removed — it does not exist, and
-      // this list is a PURCHASE surface: a logged-in officer reads it while
-      // deciding whether to upgrade.
-      features: ["Unlimited deeds", "Advanced AI assistance", "Priority support"],
-    },
-    {
-      key: "enterprise",
-      name: "Enterprise",
-      price: "$99",
-      // RED-H1.1: "Qualia integration" removed (does not exist). "Team
-      // management" removed too — `deeds` carries a single user_id and
-      // every query is scoped to it; there is no team model to manage.
-      features: ["Everything in Pro", "API access", "24/7 support"],
-    },
-  ]
+  // PRICING1: one source. This array carried its own prices —
+  // Professional at $29 while the marketing page said $149 for the same
+  // plan, and neither matched what Stripe would charge.
+  const plans = TIERS
 
   return (
     <div className="space-y-8">
@@ -397,7 +385,7 @@ function BillingTab({
               <p className="text-slate-600">Your current subscription</p>
             </div>
             <div className="text-right">
-              <div className="text-3xl font-bold text-[#7C4DFF]">{plans.find((p) => p.key === currentPlan)?.price}</div>
+              <div className="text-3xl font-bold text-[#7C4DFF]">{(() => { const t = plans.find((p) => p.key === currentPlan); return t ? priceLabel(t) : ''; })()}</div>
               <div className="text-sm text-slate-600">per month</div>
             </div>
           </div>
@@ -437,8 +425,16 @@ function BillingTab({
                   </div>
                 )}
                 <h4 className="text-2xl font-bold text-slate-800 mb-2">{plan.name}</h4>
-                <div className="text-3xl font-bold text-[#7C4DFF] mb-1">{plan.price}</div>
-                {plan.price !== "Free" && <div className="text-sm text-slate-600 mb-6">per month</div>}
+                <div className="text-3xl font-bold text-[#7C4DFF] mb-1">
+                  {priceLabel(plan)}
+                  <span className="text-sm font-normal text-slate-500">{plan.cadence}</span>
+                </div>
+                {plan.badge && (
+                  <div className="inline-block mb-2 rounded-md bg-gray-100 px-2 py-1 text-xs font-semibold text-gray-600">
+                    {plan.badge}
+                  </div>
+                )}
+                <p className="text-sm text-slate-600 mb-6">{plan.blurb}</p>
                 <ul className="space-y-3 mb-6">
                   {plan.features.map((feature, idx) => (
                     <li key={idx} className="flex items-start gap-2 text-sm text-slate-700">
@@ -448,15 +444,22 @@ function BillingTab({
                   ))}
                 </ul>
                 <button
-                  onClick={() => !isCurrent && onUpgrade(plan.key)}
-                  disabled={isCurrent}
+                  onClick={() => plan.purchasable && !isCurrent && onUpgrade(plan.key)}
+                  disabled={isCurrent || !plan.purchasable}
                   className={`w-full py-3 rounded-lg font-semibold transition-all ${
-                    isCurrent
+                    isCurrent || !plan.purchasable
                       ? "bg-slate-300 text-slate-500 cursor-not-allowed"
                       : "bg-[#7C4DFF] hover:bg-[#6a3de8] text-white shadow-md hover:shadow-lg"
                   }`}
                 >
-                  {isCurrent ? "Current Plan" : `Upgrade to ${plan.name}`}
+                  {/* PRICING1: a tier with no product behind it gets no
+                      buy control — Business needs the org model (RED-S5)
+                      that does not exist. */}
+                  {!plan.purchasable
+                    ? "Not yet available"
+                    : isCurrent
+                      ? "Current Plan"
+                      : `Upgrade to ${plan.name}`}
                 </button>
               </div>
             )
@@ -673,8 +676,11 @@ function WidgetTab({
             <p className="text-slate-600">Widget Add-On Status</p>
           </div>
           <div className="text-right">
-            <div className="text-3xl font-bold text-[#7C4DFF]">{widgetEnabled ? "$49" : "N/A"}</div>
-            {widgetEnabled && <div className="text-sm text-slate-600">per month</div>}
+            {/* PRICING1: the $49 was a second hardcoded price, and it
+                priced something that does not exist — see the note on
+                copySnippet. No figure until there is a product to
+                attach it to. */}
+            <div className="text-3xl font-bold text-slate-400">—</div>
           </div>
         </div>
       </div>
@@ -711,11 +717,9 @@ function WidgetTab({
           <div className="text-6xl mb-4">🔧</div>
           <h3 className="text-2xl font-bold text-slate-800 mb-3">Widget Add-On Not Enabled</h3>
           <p className="text-slate-600 mb-6">Contact your administrator to enable the widget add-on for your account</p>
-          <div className="bg-slate-100 rounded-lg p-4 inline-block">
-            <p className="text-sm text-slate-700">
-              <strong>💡 Widget Add-On:</strong> $49/month additional charge
-            </p>
-          </div>
+          {/* PRICING1: the price came off with the product. There is no
+              widget.js and no /embed route — quoting a monthly figure for
+              it was the same defect as the SSO line this ticket deletes. */}
         </div>
       )}
     </div>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -7,6 +7,7 @@ import { Check, Zap, Lock, Clock, ArrowRight, Wand2, Sparkles, Shield, X, FileDi
 import dynamic from "next/dynamic"
 import Link from "next/link"
 import StickyNav from "@/components/landing-v2/StickyNav"
+import { TIERS, priceLabel } from "@/lib/pricing"
 import { LogoLockupDark } from "@/components/brand/Logo"
 
 const AnimatedDeed = dynamic(() => import("@/components/landing-v2/AnimatedDeed"), {
@@ -20,7 +21,14 @@ const AnimatedDeed = dynamic(() => import("@/components/landing-v2/AnimatedDeed"
 
 // HM1: owner supplies the sales address; empty string keeps the button
 // hidden — a mailto to nowhere is a dead promise.
-const CONTACT_SALES_EMAIL = ""
+// PRICING1: Enterprise is gone, so the Contact Sales path goes with it.
+// It was gated on an address that was never set, so it rendered
+// "Contact information coming soon" — a tier nobody could buy, above a
+// contact route nobody could use.
+
+// TRIAL1's mirror reads this number off the page and compares it with
+// the server's TRIAL_PERIOD_DAYS. One number, stated once per side.
+const TRIAL_DAYS = 14
 
 export default function LandingPage() {
   return (
@@ -80,7 +88,7 @@ export default function LandingPage() {
                   </div>
                   <div className="flex items-center gap-2">
                     <Check className="h-5 w-5 text-[#7C4DFF]" />
-                    <span className="font-medium">Free 14-day trial</span>
+                    <span className="font-medium">Free {TRIAL_DAYS}-day trial</span>
                   </div>
                 </div>
               </div>
@@ -736,10 +744,17 @@ Content-Type: application/json
                 Security & Compliance
               </Badge>
               <h2 className="text-4xl sm:text-5xl font-bold text-[#1F2B37] tracking-tight mb-6">
-                Enterprise-grade security
+                Security you can check yourself
               </h2>
               <p className="text-xl text-gray-600 max-w-2xl mx-auto leading-loose">
-                Security you can verify in the product — not badges.
+                {/* PRICING1: the heading here read "Enterprise-grade
+                    security" directly above a line promising no badges —
+                    the same unmeasured marketing phrase the claims gate
+                    already bans as "bank-level" and "military-grade". The
+                    three items below are all verifiable in the product,
+                    which is what the section was for. */}
+                No certifications to wave. These three are things you can
+                confirm on your own file.
               </p>
             </div>
 
@@ -789,60 +804,37 @@ Content-Type: application/json
             </div>
 
             <div className="grid md:grid-cols-3 gap-8">
-              {[
-                {
-                  name: "Starter",
-                  price: "$0",
-                  period: "forever",
-                  features: ["Email support", "Basic templates", "All deed types"],
-                  cta: "Start Free",
-                  popular: false,
-                },
-                {
-                  name: "Professional",
-                  price: "$149",
-                  period: "/month",
-                  features: [
-                    "Unlimited deeds",
-                    "Priority support",
-                    "API access",
-                  ],
-                  cta: "Start 14-day trial",
-                  popular: true,
-                },
-                {
-                  name: "Enterprise",
-                  price: "Custom",
-                  period: "",
-                  features: [
-                    "Volume pricing",
-                    "Dedicated support",
-
-                    "White-glove onboarding",
-                  ],
-                  cta: "Contact Sales",
-                  popular: false,
-                },
-              ].map((tier) => (
+              {/* PRICING1: one source. This array used to hold its own
+                  prices — Professional at $149 while the billing tab said
+                  $29 for the same plan. */}
+              {TIERS.map((tier) => (
                 <Card
-                  key={tier.name}
+                  key={tier.key}
                   className={`${
-                    tier.popular ? "ring-4 ring-[#7C4DFF] border-[#7C4DFF] shadow-2xl scale-105" : "border-gray-200"
+                    tier.key === "professional"
+                      ? "ring-4 ring-[#7C4DFF] border-[#7C4DFF] shadow-2xl scale-105"
+                      : "border-gray-200"
                   } transition-all hover:shadow-xl bg-white`}
                 >
                   <CardContent className="p-10">
-                    {tier.popular && (
+                    {tier.key === "professional" && (
                       <Badge className="bg-[#7C4DFF] text-white font-bold mb-6 px-5 py-2.5 text-base">
                         Most Popular
+                      </Badge>
+                    )}
+                    {tier.badge && (
+                      <Badge className="bg-gray-100 text-gray-600 font-semibold mb-6 px-5 py-2.5 text-base">
+                        {tier.badge}
                       </Badge>
                     )}
 
                     <h3 className="text-2xl font-bold text-[#1F2B37]">{tier.name}</h3>
 
-                    <div className="mt-6 mb-8">
-                      <span className="text-5xl font-bold text-[#1F2B37]">{tier.price}</span>
-                      <span className="text-lg text-gray-600">{tier.period}</span>
+                    <div className="mt-6 mb-3">
+                      <span className="text-5xl font-bold text-[#1F2B37]">{priceLabel(tier)}</span>
+                      <span className="text-lg text-gray-600">{tier.cadence}</span>
                     </div>
+                    <p className="text-base text-gray-600 mb-8">{tier.blurb}</p>
 
                     <ul className="space-y-4 mb-10">
                       {tier.features.map((f) => (
@@ -853,32 +845,27 @@ Content-Type: application/json
                       ))}
                     </ul>
 
-                    {/* HM1: Start/Trial → /register; Contact Sales is
-                        owner-gated (hidden until the address exists). */}
-                    {tier.cta === "Contact Sales" ? (
-                      CONTACT_SALES_EMAIL ? (
-                        <Button
-                          asChild
-                          className="w-full font-bold text-base py-8 bg-[#1F2B37] hover:bg-[#1F2B37]/90 text-white"
-                        >
-                          <a href={`mailto:${CONTACT_SALES_EMAIL}`}>{tier.cta}</a>
-                        </Button>
-                      ) : (
-                        <p className="text-center text-sm text-gray-500 py-4">
-                          Contact information coming soon
-                        </p>
-                      )
-                    ) : (
+                    {/* PRICING1: a tier we cannot deliver gets no buy
+                        control. Business is priced and visible so the
+                        ladder is legible, and it is not for sale until
+                        the org model (RED-S5) exists. */}
+                    {tier.purchasable ? (
                       <Button
                         asChild
                         className={`w-full font-bold text-base py-8 ${
-                          tier.popular
+                          tier.key === "professional"
                             ? "bg-[#7C4DFF] hover:bg-[#7C4DFF]/90 text-white"
                             : "bg-[#1F2B37] hover:bg-[#1F2B37]/90 text-white"
                         }`}
                       >
-                        <Link href="/register">{tier.cta}</Link>
+                        <Link href="/register">
+                          {tier.key === "free" ? "Start free" : `Start ${TRIAL_DAYS}-day trial`}
+                        </Link>
                       </Button>
+                    ) : (
+                      <p className="text-center text-sm text-gray-500 py-4">
+                        Not yet available
+                      </p>
                     )}
                   </CardContent>
                 </Card>
@@ -927,7 +914,15 @@ Content-Type: application/json
                   q: "Can I save partial work?",
                   a: "Yes. All wizard progress auto-saves. You can return anytime to complete.",
                 },
-                { q: "Is there API access?", a: "Yes. REST API available on Professional and Enterprise plans." },
+                {
+                  q: "Is there API access?",
+                  // PRICING1: this said "Professional and Enterprise
+                  // plans". Enterprise is gone, and API keys are issued
+                  // by hand from a request queue regardless of plan
+                  // (A3) — so "available on plan X" was never how it
+                  // worked.
+                  a: "There is a REST API for creating deeds. Keys are issued by request rather than switched on by plan — see the developer docs.",
+                },
                 {
                   q: "What about security?",
                   a: "Token-based sessions over encrypted transport, and every generated PDF is hash-stamped (SHA-256) and stored immutably. Formal certifications are on the roadmap — we'd rather show you the mechanism than a badge.",

--- a/frontend/src/lib/pricing.ts
+++ b/frontend/src/lib/pricing.ts
@@ -1,0 +1,129 @@
+/**
+ * PRICING1 — the ONE place a price is written.
+ *
+ * ═══ WHY A CONFIG AND NOT TWO LISTS ═══
+ *
+ * The same plan was advertised at two prices on two surfaces at the same
+ * time: the marketing page said Professional **$149/month**, the billing
+ * tab said **$29**. Neither was what Stripe would have charged, because
+ * the amount actually billed comes from a Stripe price ID in an
+ * environment variable and had no relationship to either number.
+ *
+ * Three sources of truth for one price is not a typo, it is a structure —
+ * and the structure produces a customer who is quoted one figure and
+ * charged another. So the surfaces derive, and a pin asserts that no
+ * second hardcoded price string exists anywhere in the product.
+ *
+ * ═══ THE PRICE, AND THE REASONING ═══
+ *
+ * Professional is **$99/user/month**, owner-ruled.
+ *
+ *   - The category floor for small-firm title tools is ~$79–$149 per
+ *     user per month. Mid-tier runs ~$200. SoftPro-class is $500+.
+ *   - Escrow offices already bill around **$75 per document** for
+ *     standalone doc prep, so $99 is under one and a half document fees
+ *     for a 21-instrument catalog.
+ *   - $29 signalled hobbyware to a professional buyer. $149 invited
+ *     procurement. $99 is a number one person can approve.
+ *
+ * ═══ WHAT IS SOLD AND WHAT IS NOT ═══
+ *
+ * `purchasable: false` is load-bearing, not decorative. Business is
+ * priced and visible because knowing where the ladder goes is part of
+ * evaluating the rung you are on — but it cannot be bought, because the
+ * multi-user org model it implies (RED-S5) is deferred by decision and
+ * does not exist. `deeds` carries one `user_id` and every query is
+ * scoped to it. Selling a seat we cannot create is the failure mode this
+ * whole engagement keeps removing.
+ *
+ * Enterprise was deleted outright. Its differentiators were SSO/SAML and
+ * custom branding: zero files, not a stub, and now banned outright by
+ * `scripts/check_banned_claims.py`.
+ */
+
+export type TierKey = 'free' | 'professional' | 'business';
+
+export interface Tier {
+  key: TierKey;
+  name: string;
+  /** USD per user per month. The single source; surfaces format it. */
+  priceMonthly: number;
+  cadence: string;
+  /** False = shown, not sellable. Nothing may render a buy control. */
+  purchasable: boolean;
+  badge?: string;
+  blurb: string;
+  features: string[];
+}
+
+/**
+ * The recordable-instrument count, stated once.
+ *
+ * MIRRORED against `form_families.FAMILY_BY_DEED_TYPE` and pinned in
+ * `backend/tests/test_pricing1_one_price.py` — 21 is a claim on a
+ * purchase surface, so it is checked against the registry rather than
+ * counted by hand and left to rot.
+ */
+export const INSTRUMENT_COUNT = 21;
+
+const TRUE_OF_EVERY_TIER = [
+  `${INSTRUMENT_COUNT} recordable California instruments`,
+  'PCOR and BOE forms filled from the deed',
+  'Every field confirmed by you before it prints',
+  'Immutable, hash-stamped PDFs',
+  'Corrections with full lineage to the superseded document',
+];
+
+export const TIERS: Tier[] = [
+  {
+    key: 'free',
+    name: 'Free',
+    priceMonthly: 0,
+    cadence: 'forever',
+    purchasable: true,
+    blurb: 'The whole product, on real files. Nothing is held back.',
+    // Accurate as of PRICING1: nothing in the product is gated by plan.
+    // check_plan_limits has no call sites and plan_limits is never
+    // seeded, so "the full product" is a description, not a promise we
+    // are hoping to keep.
+    features: TRUE_OF_EVERY_TIER,
+  },
+  {
+    key: 'professional',
+    name: 'Professional',
+    priceMonthly: 99,
+    cadence: '/user/month',
+    purchasable: true,
+    blurb: 'For the officer who drafts every day.',
+    features: [...TRUE_OF_EVERY_TIER, 'Priority support'],
+  },
+  {
+    key: 'business',
+    name: 'Business',
+    priceMonthly: 249,
+    cadence: '/month',
+    purchasable: false,
+    badge: 'Coming soon',
+    blurb:
+      'Shared files across an office — an assistant preps, an officer reviews, ' +
+      'and cover carries when someone is out.',
+    features: [
+      ...TRUE_OF_EVERY_TIER,
+      'Shared matter list across the office',
+      'Priority support',
+    ],
+  },
+];
+
+export const PROFESSIONAL = TIERS.find((t) => t.key === 'professional')!;
+
+/** `$0` / `$99`. The only place a dollar sign meets a plan price. */
+export function priceLabel(tier: Tier): string {
+  return `$${tier.priceMonthly}`;
+}
+
+export function tier(key: TierKey): Tier {
+  const found = TIERS.find((t) => t.key === key);
+  if (!found) throw new Error(`unknown pricing tier: ${key}`);
+  return found;
+}

--- a/scripts/check_banned_claims.py
+++ b/scripts/check_banned_claims.py
@@ -73,19 +73,45 @@ RULES = [
     Rule("HIPAA", r"\bHIPAA\b", "Not applicable and never assessed."),
     Rule("GDPR/CCPA compliance claim", r"\b(?:GDPR|CCPA)[\s\-]*(?:compliant|certified)\b",
          "No compliance assessment has been performed against either."),
-    Rule("bank-level security", r"bank[\s\-]?level\s+(?:security|encryption)",
-         "A claim with no definition and no audit behind it. The product "
-         "has no session revocation and no rate limiting."),
-    Rule("military-grade", r"military[\s\-]?grade", "Marketing language for a claim nobody measured."),
-    # PRICING1: the third spelling of the same unmeasured claim. It sat
-    # on the marketing page directly above "Security you can verify in
-    # the product — not badges", which is the sentence it contradicts.
-    # Two rules for two phrasings and a miss on the third is the pattern
-    # this gate keeps repeating: enumerate the property, not the
-    # examples that prompted it.
-    Rule("enterprise-grade", r"enterprise[\s\-]?grade",
-         "Same class as bank-level and military-grade: a superlative with "
-         "no definition and no audit behind it."),
+    # ── THE PROPERTY, not the spellings (owner-ruled, PRICING1) ───────
+    #
+    # This started as two rules for two phrasings: "bank-level security"
+    # and "military-grade". Then "Enterprise-grade security" turned up on
+    # the marketing page, directly above the line "Security you can
+    # verify in the product — not badges", and sailed through both.
+    #
+    # Three spellings of one claim, two of them enumerated, is the same
+    # mistake this codebase keeps making in different clothes — the pin
+    # guards a spelling and the property walks past it. So the rule now
+    # describes the SHAPE: any adjective borrowed as a grade or level,
+    # attached to a security noun. bank-level, military-grade,
+    # enterprise-grade, government-grade, hospital-grade,
+    # industry-leading — all one rule, and the next one nobody thought
+    # of is covered too.
+    #
+    # It stays scoped to SECURITY nouns deliberately. "Commercial-grade
+    # paper" is a fact about paper; the claim being forbidden is the
+    # unearned assurance about how safe something is.
+    Rule("unearned security grade",
+         r"\b[a-z]+[\s\-](?:grade|level|class)\s+"
+         r"(?:security|encryption|protection|infrastructure|reliability|privacy)\b"
+         r"|\b(?:industry[\s\-]leading|best[\s\-]in[\s\-]class|world[\s\-]class)\s+"
+         r"(?:security|encryption|protection|infrastructure|reliability|privacy)\b",
+         "A superlative used as a security grade, with no definition and "
+         "no audit behind it. Say what the product actually does — the "
+         "hash-stamped PDFs and the confirmation record are checkable; "
+         "'bank-level' is not."),
+    # The other half of the same property: claiming an AUDIT rather than
+    # a grade. Scoped tightly, because 'certified' is real vocabulary in
+    # this domain — a certified copy, a certification of trust — and a
+    # rule that flagged those would be noise nobody reads.
+    Rule("unearned security audit",
+         r"\b(?:security|privacy|data|infrastructure)[^.\n]{0,24}?"
+         r"\b(?:certified|accredited|independently audited)\b"
+         r"|\b(?:certified|accredited|independently audited)[^.\n]{0,24}?"
+         r"\b(?:security|privacy|infrastructure)\b",
+         "No security or privacy audit has been performed. Naming one is "
+         "the claim with contractual teeth."),
     # The `[^.\n]{0,24}?` gap is the whole point. The first version of this
     # rule required the keyword to follow the percentage immediately, and
     # it pinned the four spellings that happened to exist. Its own test

--- a/scripts/check_banned_claims.py
+++ b/scripts/check_banned_claims.py
@@ -77,6 +77,15 @@ RULES = [
          "A claim with no definition and no audit behind it. The product "
          "has no session revocation and no rate limiting."),
     Rule("military-grade", r"military[\s\-]?grade", "Marketing language for a claim nobody measured."),
+    # PRICING1: the third spelling of the same unmeasured claim. It sat
+    # on the marketing page directly above "Security you can verify in
+    # the product — not badges", which is the sentence it contradicts.
+    # Two rules for two phrasings and a miss on the third is the pattern
+    # this gate keeps repeating: enumerate the property, not the
+    # examples that prompted it.
+    Rule("enterprise-grade", r"enterprise[\s\-]?grade",
+         "Same class as bank-level and military-grade: a superlative with "
+         "no definition and no audit behind it."),
     # The `[^.\n]{0,24}?` gap is the whole point. The first version of this
     # rule required the keyword to follow the percentage immediately, and
     # it pinned the four spellings that happened to exist. Its own test


### PR DESCRIPTION
Professional = **$99/user/month**, owner-ruled. Category floor ~$79–$149; mid-tier ~$200; SoftPro-class $500+. Escrow offices already bill ~$75/document for standalone doc prep, so $99 is under one and a half document fees for a 21-instrument catalog. $29 signalled hobbyware; $149 invited procurement.

## What each surface said, before and after

### Marketing page (`app/page.tsx`)

| | before | after |
|---|---|---|
| tier 1 | **Starter — $0/forever** · Email support, Basic templates, All deed types | **Free — $0/forever** · the 5 true bullets |
| tier 2 | **Professional — $149/month** · Unlimited deeds, Priority support, API access | **Professional — $99/user/month** · the 5 true bullets + Priority support |
| tier 3 | **Enterprise — Custom** · Volume pricing, Dedicated support, White-glove onboarding · *Contact Sales* | **Business — $249/month · "Coming soon"** · not purchasable, no buy control |
| security heading | "Enterprise-grade security" | "Security you can check yourself" |
| API FAQ | "REST API available on Professional and Enterprise plans." | "Keys are issued by request rather than switched on by plan" |

### Billing tab (`app/account-settings/page.tsx`)

| | before | after |
|---|---|---|
| Free | $0 | $0 |
| Professional | **$29** | **$99**/user/month |
| Enterprise | **$99** · Everything in Pro, API access, 24/7 support | **deleted** |
| Business | — | $249 · "Coming soon", button disabled |
| Widget add-on | **$49/month** + Copy Embed Snippet | price removed, copying disabled |

The same plan was advertised at **$149 and $29 simultaneously**, and neither was what Stripe would charge.

## The five items

**1. One source** — `frontend/src/lib/pricing.ts`. Pinned repo-wide: no plan price outside it. That sweep first flagged `"transfer_tax": {"amount": "$825.00"}` and `County rate: $1.10 per $1,000` in the API docs — real numbers, correct where they are. A pin that cries about documentary transfer tax is one people learn to ignore, so the property was narrowed to *a figure presented as a subscription price*, self-tested against both real prices and both doc figures.

**2. Tiers** — Free / Professional / Business-coming-soon. `purchasable: false` is load-bearing: no buy control renders, and `business` is deliberately **not** in `PAID_PLANS`, because a plan key checkout accepts is a plan somebody can buy. Enterprise deleted with SSO/SAML and custom branding.

**3. No placeholder price ID** — the `'price_professional_default'` fallback is gone; a missing var is a 503 naming the variable. **A real defect my own test caught:** the endpoint's broad `except Exception` was re-wrapping that deliberate 503 into a 500, so the named reason reached the officer as *"Upgrade failed: 503: …"*. A precise error is worthless if the layer above flattens it.

**4. Founding-rate path — confirmed, with a correction.** ⚠️

Verified against the live handler. **A Payment Link carrying `client_reference_id` alone returns HTTP 200 and does not upgrade the plan.** The handler also needs `metadata.plan`. Charged customer, unchanged plan, nobody told.

```
Payment Link, client_reference_id ONLY        -> HTTP 200, plan='free'
Payment Link + metadata.plan=professional     -> HTTP 200, plan='professional'
```

Both paths pinned; the silent case is now loud. We still refuse to guess which product someone bought — a founding-rate price ID wouldn't match the standard one anyway — but we refuse to be quiet about it.

> **Owner action:** your $79 Payment Links must set **both** `client_reference_id` **and** `metadata={"plan": "professional"}`.

**5. Copy** — 21 instruments (counted from the registry and pinned, not typed), PCOR/BOE, officer confirmation, hash-stamped PDFs, lineage. "Enterprise-grade security" sat directly above "Security you can verify — not badges"; the gate already banned *bank-level* and *military-grade* and missed the third spelling, so a rule was added.

## Rolled, same class

The **Widget add-on** quoted $49/month and handed the customer a script tag for `https://deedpro.com/widget.js` — no such file, no `/embed` route, no handler. A priced claim with a Copy button. Price removed, copying disabled. **Deleting the tab is a product call and is flagged for you rather than taken.**

## Retired

HM1's Contact-Sales pin, in the diff that cured its condition — it guarded a *gated* dead promise; the tier is gone, so the CTA can't be honestly gated, only removed.

Twelfth trip of the comment-quoting family, three times in this ticket. Each recorded where it happened.

## Gates

pytest **837** · jest **588** · tsc **94** (unchanged) · six-flow ✔ · API baseline ✔ · banned-claims clean (**14** rules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_