### PR TITLE
NOTARY1: the signing handoff — an arrangement, not an act

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -241,6 +241,35 @@ def create_tables():
                 viewed_at TIMESTAMPTZ, view_count INT DEFAULT 0,
                 last_reminder_sent_at TIMESTAMPTZ, reminder_count INT DEFAULT 0
             )""",
+            # ── NOTARY1: the signing handoff ─────────────────────────────
+            #
+            # A share is now one of two KINDS. A review share asks a
+            # colleague to approve; a signing request asks a notary to
+            # pick a time. They travel the same token machinery and mean
+            # different things, so the kind is a column rather than an
+            # inference from which fields happen to be set.
+            #
+            # THE STATE IS DERIVED, NOT STORED IN `status`, and that is
+            # T-5's ruling transferred verbatim. `deed_shares.status`
+            # carries sent/viewed/approved/rejected/revoked/expired — a
+            # vocabulary in active use. "Scheduled" is ORTHOGONAL to
+            # "viewed": a scheduled-and-viewed request must be
+            # expressible, and folding scheduled into that column makes
+            # the two mutually exclusive, exactly as adding 'superseded'
+            # to deeds.status would have made a superseded deed stop
+            # being a completed one.
+            #
+            # `scheduled_by` records WHICH HUMAN asserted the time — the
+            # notary tapping a window, or the officer recording an
+            # agreement reached by phone. Both are real; they are not the
+            # same fact; the record keeps them apart. Mirrors RED-S4's
+            # recording_asserted_by/_at exactly.
+            "ALTER TABLE deed_shares ADD COLUMN IF NOT EXISTS share_kind VARCHAR(24) NOT NULL DEFAULT 'review'",
+            "ALTER TABLE deed_shares ADD COLUMN IF NOT EXISTS proposed_windows JSONB",
+            "ALTER TABLE deed_shares ADD COLUMN IF NOT EXISTS scheduled_at TIMESTAMPTZ",
+            "ALTER TABLE deed_shares ADD COLUMN IF NOT EXISTS scheduled_by VARCHAR(16)",
+            "ALTER TABLE deed_shares ADD COLUMN IF NOT EXISTS scheduled_asserted_at TIMESTAMPTZ",
+            "CREATE INDEX IF NOT EXISTS idx_deed_shares_kind ON deed_shares(share_kind, created_at DESC)",
             """CREATE TABLE IF NOT EXISTS plan_limits (
                 plan_name VARCHAR(50) PRIMARY KEY,
                 max_deeds_per_month INT,

--- a/backend/routers/sharing.py
+++ b/backend/routers/sharing.py
@@ -1,6 +1,9 @@
 """Deed sharing + public approval endpoints (T8 split — moved verbatim from main.py)."""
+import json as _json
 import os
 from datetime import datetime, timedelta
+from datetime import datetime as _dt
+from datetime import timezone as _tz
 from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -8,6 +11,11 @@ from pydantic import BaseModel, field_validator
 
 import db
 from auth import get_current_user_id
+from services import signing
+# NOTARY1: the attachment CONSTRUCTOR only. The transport itself stays
+# behind utils.notifications — see the ADMIN3 pin, which exists because a
+# second module reaching for the sender is how the ledger loses rows.
+from utils.email import attachment as _ics_attachment
 
 router = APIRouter()
 
@@ -55,6 +63,49 @@ def _valid_token_or_404(approval_token: str) -> str:
         raise HTTPException(status_code=404, detail="Share not found")
     return approval_token
 
+
+def _owned_deed_or_404(deed_id: int, user_id: int) -> dict:
+    """The deed, ONLY if this caller owns it. Every share starts here.
+
+    FOUND WHILE BUILDING NOTARY1, and it is not a NOTARY1 defect — it is
+    live on main. `POST /shared-deeds` took `deed_id` from the request
+    body and never asked whose deed it was. It read the address and APN,
+    inserted a `deed_shares` row with `owner_user_id = <the caller>`, and
+    handed back a token.
+
+    So any authenticated user could enumerate deed ids, mint a share link
+    for somebody else's deed, and read it: property address, APN, county,
+    grantor and grantee names, and the stored PDF through
+    `/approve/{token}/pdf`. They could also let a third party "approve"
+    it. Reproduced against a real database before this was written, with
+    two users and one deed.
+
+    Every OTHER share endpoint — list, resend, revoke, delete, feedback —
+    already scoped by `owner_user_id`. Creation was the one that didn't,
+    which is why it survived: the surrounding code looked careful.
+
+    Admin is deliberately NOT an escape here. `_pcor_deed_row` lets an
+    admin read a deed for support; minting a share link is a grant to a
+    third party, and support access is not authority to hand a stranger a
+    URL. Read and grant are different verbs.
+    """
+    if not db.conn:
+        raise HTTPException(status_code=500, detail="Database connection not available")
+    with db.conn.cursor() as cur:
+        cur.execute("""
+            SELECT id, user_id, deed_type, property_address, apn, county
+            FROM deeds WHERE id = %s
+        """, (deed_id,))
+        row = cur.fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="Deed not found")
+    if row["user_id"] != user_id:
+        # 404, not 403: "this deed exists but is not yours" is an answer
+        # to a question the caller had no standing to ask, and it turns
+        # id enumeration into a working inventory of who owns what.
+        raise HTTPException(status_code=404, detail="Deed not found")
+    return dict(row)
+
 # Shared Deeds endpoints
 @router.post("/shared-deeds")
 def share_deed_for_approval(share_data: ShareDeedCreate, user_id: int = Depends(get_current_user_id)):
@@ -69,9 +120,13 @@ def share_deed_for_approval(share_data: ShareDeedCreate, user_id: int = Depends(
     expires_at = datetime.now(timezone.utc) + timedelta(hours=expires_in)
     approval_token = str(uuid.uuid4())
 
-    # Get the owner's name and deed details from database
+    # Whose deed is this? Asked FIRST and outside the swallowing try
+    # below — an authorization answer that degrades to a default is not
+    # an authorization check.
+    deed = _owned_deed_or_404(share_data.deed_id, user_id)
+    deed_type = deed.get("deed_type") or "deed"
+
     owner_name = "DeedPro User"  # Default
-    deed_type = "deed"  # Default
 
     try:
         with db.conn.cursor() as cur:
@@ -80,12 +135,6 @@ def share_deed_for_approval(share_data: ShareDeedCreate, user_id: int = Depends(
             owner_row = cur.fetchone()
             if owner_row:
                 owner_name = owner_row[0] or owner_name
-
-            # Get deed type
-            cur.execute("SELECT deed_type FROM deeds WHERE id = %s", (share_data.deed_id,))
-            deed_row = cur.fetchone()
-            if deed_row:
-                deed_type = deed_row[0] or deed_type
     except Exception as db_error:
         # RED-H1.2b: rollback FIRST. Without it a failed statement leaves
         # the shared transaction aborted and Postgres refuses every later
@@ -104,22 +153,11 @@ def share_deed_for_approval(share_data: ShareDeedCreate, user_id: int = Depends(
 
     # Phase 7.5: Save to deed_shares table (gap-plan fix)
     shared_deed_id = None
-    property_address = "Unknown"
-    apn = "Unknown"
+    property_address = deed.get("property_address") or "Unknown"
+    apn = deed.get("apn") or "Unknown"
 
     try:
         with db.conn.cursor() as cur:
-            # Get deed details
-            cur.execute("""
-                SELECT property_address, apn
-                FROM deeds
-                WHERE id = %s
-            """, (share_data.deed_id,))
-            deed_info = cur.fetchone()
-            if deed_info:
-                property_address = deed_info[0] or property_address
-                apn = deed_info[1] or apn
-
             # Insert into deed_shares table
             cur.execute("""
                 INSERT INTO deed_shares (
@@ -223,7 +261,11 @@ def list_shared_deeds(user_id: int = Depends(get_current_user_id)):
                     ds.updated_at,
                     d.property_address,
                     d.deed_type,
-                    u.full_name as owner_name
+                    u.full_name as owner_name,
+                    ds.share_kind,
+                    ds.proposed_windows,
+                    ds.scheduled_at,
+                    ds.scheduled_by
                 FROM deed_shares ds
                 JOIN deeds d ON ds.deed_id = d.id
                 JOIN users u ON ds.owner_user_id = u.id
@@ -248,7 +290,18 @@ def list_shared_deeds(user_id: int = Depends(get_current_user_id)):
                     "shared_with_email": row.get('recipient_email') if isinstance(row, dict) else row[3],
                     "status": row.get('status') if isinstance(row, dict) else row[4],
                     "message": f"Shared via link - expires {expires_at.strftime('%Y-%m-%d') if expires_at else 'never'}",
-                    "share_type": "review",
+                    # NOTARY1: was hardcoded "review", which was true until
+                    # this ticket and would have quietly stayed "true" for
+                    # every signing request afterwards.
+                    "share_type": (row.get('share_kind') if isinstance(row, dict) else None) or signing.SHARE_KIND_REVIEW,
+                    # The status LINE for the deed surface. Null for a
+                    # review; for a signing it is the one sentence
+                    # scheduling_label() writes, so this screen cannot
+                    # invent its own phrasing for an arrangement.
+                    "signing_summary": signing.scheduling_label(dict(row)) if isinstance(row, dict) else None,
+                    "scheduled_at": (lambda s: s.isoformat() if hasattr(s, 'isoformat') else s)(
+                        row.get('scheduled_at') if isinstance(row, dict) else None),
+                    "scheduled_by": row.get('scheduled_by') if isinstance(row, dict) else None,
                     "date": created_at.isoformat() if created_at else "",
                     "updated_at": updated_at.isoformat() if updated_at else "",
                     "property": (row.get('property_address') if isinstance(row, dict) else row[9]) or "",
@@ -283,7 +336,8 @@ def resend_approval_email(shared_deed_id: int, user_id: int = Depends(get_curren
             cur.execute("""
                 SELECT ds.id, ds.token, ds.recipient_email, ds.status, ds.expires_at,
                        d.deed_type, d.property_address, d.apn,
-                       u.email as owner_email, u.full_name as owner_name
+                       u.email as owner_email, u.full_name as owner_name,
+                       ds.share_kind  -- appended: row[9] below still means owner_name
                 FROM deed_shares ds
                 JOIN deeds d ON ds.deed_id = d.id
                 JOIN users u ON ds.owner_user_id = u.id
@@ -312,6 +366,17 @@ def resend_approval_email(shared_deed_id: int, user_id: int = Depends(get_curren
             # Check if can be resent
             if status in ('approved', 'rejected', 'revoked'):
                 raise HTTPException(status_code=400, detail=f"Cannot resend - share is {status}")
+
+            # NOTARY1: this sends the `share_reminder` template — "waiting
+            # on your review." A notary was asked about her availability,
+            # not for a review, and sending her the wrong question twice is
+            # worse than not nudging her at all. Refused here rather than
+            # only hidden in the UI.
+            if (dict(row) if isinstance(row, dict) else {}).get('share_kind') == signing.SHARE_KIND_SIGNING:
+                raise HTTPException(
+                    status_code=400,
+                    detail="There is no reminder for a signing request yet — "
+                           "the review reminder asks the wrong question.")
 
             # Check if expired and extend expiration by 24 hours
             now = datetime.now(timezone.utc)
@@ -470,7 +535,12 @@ def view_shared_deed(approval_token: str):
                     ds.status, ds.expires_at, ds.created_at, ds.viewed_at,
                     d.deed_type, d.property_address, d.apn, d.grantor_name, d.grantee_name,
                     d.county, d.pdf_url,
-                    u.full_name as owner_name, u.email as owner_email
+                    u.full_name as owner_name, u.email as owner_email,
+                    -- NOTARY1: appended, never inserted. The positional
+                    -- fallback below indexes this list; a column added in
+                    -- the middle would silently re-point every one of them.
+                    ds.share_kind, ds.proposed_windows, ds.scheduled_at,
+                    ds.scheduled_by, ds.scheduled_asserted_at
                 FROM deed_shares ds
                 JOIN deeds d ON d.id = ds.deed_id
                 LEFT JOIN users u ON u.id = ds.owner_user_id
@@ -520,10 +590,20 @@ def view_shared_deed(approval_token: str):
             now = datetime.now(timezone.utc)
             is_expired = expires_at < now if expires_at else False
 
-            # Update status to expired if needed
-            if is_expired and status == 'sent':
-                cur.execute("UPDATE deed_shares SET status = 'expired', updated_at = NOW() WHERE id = %s", (share_id,))
-                db.conn.commit()
+            # ONE EXPIRY SEMANTIC PER LINK (owner ruling 2, applied as a
+            # class rather than only to the PCOR it was asked about).
+            #
+            # This read `if is_expired and status == 'sent'`, so a link
+            # that had been OPENED ONCE — status 'viewed' — kept serving
+            # the deed after it expired: address, APN, county, grantor
+            # and grantee names, indefinitely. The PDF endpoint next door
+            # 410s on expiry regardless of status, so the same expired
+            # token answered one route and refused the other. Expiry that
+            # depends on which URL you ask is not expiry.
+            if is_expired:
+                if status in ('sent', 'viewed'):
+                    cur.execute("UPDATE deed_shares SET status = 'expired', updated_at = NOW() WHERE id = %s", (share_id,))
+                    db.conn.commit()
                 raise HTTPException(status_code=410, detail="This approval link has expired")
 
             # Track first view (only if status is still 'sent')
@@ -550,7 +630,17 @@ def view_shared_deed(approval_token: str):
                     # Non-blocking - viewed_at column may not exist
                     print(f"[Sharing] ⚠️ Could not track view: {view_err}")
 
-            can_approve = not is_expired and status in ('sent', 'viewed')
+            # NOTARY1 — what KIND of link is this? Read by name; the
+            # positional branch above predates these columns.
+            row_map = dict(share) if isinstance(share, dict) else {}
+            share_kind = row_map.get("share_kind") or signing.SHARE_KIND_REVIEW
+            is_signing = share_kind == signing.SHARE_KIND_SIGNING
+
+            # A signing request has no approve/reject, and the refusal is
+            # SERVER-SIDE as well (see submit_approval_response). A page
+            # that merely hides the buttons is a page, not a rule.
+            can_approve = (not is_expired and not is_signing
+                           and status in ('sent', 'viewed'))
 
             deed_data = {
                 "deed_id": deed_id,
@@ -566,7 +656,30 @@ def view_shared_deed(approval_token: str):
                 "can_approve": can_approve,
                 "status": status,
                 "pdf_url": pdf_url,
+                "share_kind": share_kind,
             }
+
+            if is_signing:
+                scheduled_at = row_map.get("scheduled_at")
+                deed_data["signing"] = {
+                    # DERIVED (T-5). `status` above still says sent/viewed
+                    # and knows nothing about scheduling — the two facts
+                    # are orthogonal and never share a column.
+                    "state": signing.scheduling_state(row_map),
+                    "summary": signing.scheduling_label(row_map),
+                    "windows": [
+                        {"index": i, "start": w.get("start"), "end": w.get("end"),
+                         "label": signing.window_label(w)}
+                        for i, w in enumerate(signing.windows_of(row_map))
+                    ],
+                    "scheduled_at": scheduled_at.isoformat() if hasattr(scheduled_at, "isoformat") else scheduled_at,
+                    "scheduled_by": row_map.get("scheduled_by"),
+                    # A window may still be chosen after one already was —
+                    # a notary who mis-tapped can correct it while the link
+                    # lives. What she cannot do is say the signing happened.
+                    "can_choose_window": not is_expired and status != 'revoked',
+                    "pcor_url": f"/approve/{approval_token}/pcor",
+                }
 
             print(f"[Sharing] ✅ Approval link accessed: share_id={share_id}, status={status}, can_approve={can_approve}")
 
@@ -594,7 +707,7 @@ def submit_approval_response(approval_token: str, response: ApprovalResponse):
             cur.execute("""
                 SELECT ds.id, ds.status, ds.expires_at, ds.owner_user_id, ds.deed_id,
                        ds.recipient_email, d.property_address, u.email as owner_email,
-                       u.full_name as owner_name
+                       u.full_name as owner_name, ds.share_kind
                 FROM deed_shares ds
                 JOIN deeds d ON d.id = ds.deed_id
                 LEFT JOIN users u ON u.id = ds.owner_user_id
@@ -635,6 +748,17 @@ def submit_approval_response(approval_token: str, response: ApprovalResponse):
 
             if is_expired:
                 raise HTTPException(status_code=410, detail="This approval link has expired")
+
+            # NOTARY1 — a signing request is not an approval request, and
+            # this is the rule rather than the UI's omission of two
+            # buttons. A notary saying "approved" would write an approval
+            # into the record on behalf of somebody who was asked a
+            # different question entirely.
+            if (dict(share) if isinstance(share, dict) else {}).get("share_kind") == signing.SHARE_KIND_SIGNING:
+                raise HTTPException(
+                    status_code=409,
+                    detail="This link is a signing request, not a review request. "
+                           "Choose a time instead; approval is not part of it.")
 
             # Allow approval from 'sent' or 'viewed' status
             if current_status not in ('sent', 'viewed'):
@@ -892,3 +1016,504 @@ def get_shared_deed_pdf(approval_token: str):
             pass
         print(f"[Sharing] ❌ PDF access error: {e}")
         raise HTTPException(status_code=500, detail="Failed to retrieve PDF")
+
+
+# ══════════════════════════════════════════════════════════════════════
+# NOTARY1 — the signing handoff
+#
+# The doctrine lives in services/signing.py; this file is the wiring.
+# Four rules govern everything below, and they are the reason the code
+# looks more careful than "store a datetime" would suggest:
+#
+#   1. No signer contact. The product coordinates officer↔notary and
+#      nothing else; no endpoint here accepts, stores or sends to a
+#      signer's address. Pinned fail-closed in test_notary1_signing.py.
+#   2. The scheduling state is DERIVED from `scheduled_at` and never
+#      written into `deed_shares.status` (T-5's ruling).
+#   3. The system never asserts a signing OCCURRED. Nothing below sets
+#      anything to completed, and no passed window changes any state.
+#   4. Whoever asserted a time is on the row beside it (RED-S4's shape).
+# ══════════════════════════════════════════════════════════════════════
+
+
+class SigningRequestCreate(BaseModel):
+    """An officer asking a notary about availability.
+
+    Note what is NOT here: no signer name, email or phone, and no field
+    that could carry one. The notary's address is the only contact this
+    payload has ever held or may hold.
+    """
+    deed_id: int
+    notary_email: str
+    notary_name: Optional[str] = None
+    # [{"start": ISO-8601, "end": ISO-8601}] — one to three.
+    proposed_windows: list
+    location: Optional[str] = None
+    expires_in_hours: Optional[int] = 336  # 14 days
+
+    @field_validator('expires_in_hours')
+    @classmethod
+    def validate_expiry(cls, v):
+        if v is not None and (v < 1 or v > 720):
+            raise ValueError('Expiration must be between 1 and 720 hours')
+        return v
+
+
+class WindowChoice(BaseModel):
+    """The notary's answer: the INDEX of a window the officer offered.
+
+    Not a timestamp. Accepting a time from the request body would let
+    anyone holding the link assert an hour nobody proposed.
+    """
+    window_index: int
+
+
+class OfficerSchedule(BaseModel):
+    """Owner ruling 3: the officer may record a time she agreed out of
+    band. Either an offered window by index, or an explicit ISO time when
+    they settled on something that was never proposed."""
+    window_index: Optional[int] = None
+    scheduled_at: Optional[str] = None
+
+
+def _signing_share_by_token(approval_token: str, cur) -> dict:
+    """Load a signing share by token, with the link's OWN scoping.
+
+    Ruling 2, and it is a class rather than a special case: an expired or
+    revoked token is expired or revoked for everything it reaches. The
+    deed, the PDF and the PCOR answer identically, because "which URL did
+    you ask" is not a property a permission should have.
+    """
+    cur.execute("""
+        SELECT ds.id, ds.deed_id, ds.owner_user_id, ds.recipient_email,
+               ds.status, ds.expires_at, ds.share_kind, ds.proposed_windows,
+               ds.scheduled_at, ds.scheduled_by, ds.scheduled_asserted_at,
+               d.deed_type, d.property_address,
+               u.email AS owner_email, u.full_name AS owner_name
+        FROM deed_shares ds
+        JOIN deeds d ON d.id = ds.deed_id
+        LEFT JOIN users u ON u.id = ds.owner_user_id
+        WHERE ds.token = %s
+    """, (approval_token,))
+    row = cur.fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="This link is invalid or does not exist")
+    row = dict(row)
+    if row.get("share_kind") != signing.SHARE_KIND_SIGNING:
+        raise HTTPException(status_code=404, detail="This link is not a signing request")
+    if row.get("status") == 'revoked':
+        raise HTTPException(status_code=403, detail="Access has been revoked")
+    expires_at = row.get("expires_at")
+    if expires_at and expires_at < datetime.now(_tz.utc):
+        raise HTTPException(status_code=410, detail="This link has expired")
+    return row
+
+
+@router.post("/signing-requests")
+def create_signing_request(payload: SigningRequestCreate,
+                           user_id: int = Depends(get_current_user_id)):
+    """Ask a notary whether she is free at one of these times."""
+    import uuid
+
+    deed = _owned_deed_or_404(payload.deed_id, user_id)
+
+    try:
+        windows = signing.normalize_windows(payload.proposed_windows)
+    except signing.SigningRequestError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    if len(windows) < signing.MIN_WINDOWS:
+        raise HTTPException(status_code=400,
+                            detail="Propose at least one time")
+
+    expires_at = datetime.now(_tz.utc) + timedelta(hours=payload.expires_in_hours or 336)
+    token = str(uuid.uuid4())
+
+    owner_name = "DeedPro User"
+    share_id = None
+    try:
+        with db.conn.cursor() as cur:
+            cur.execute("SELECT full_name FROM users WHERE id = %s", (user_id,))
+            owner_row = cur.fetchone()
+            if owner_row and owner_row[0]:
+                owner_name = owner_row[0]
+
+            cur.execute("""
+                INSERT INTO deed_shares (
+                    deed_id, owner_user_id, recipient_email, token,
+                    status, share_kind, proposed_windows, expires_at,
+                    created_at, updated_at
+                )
+                VALUES (%s, %s, %s, %s, 'sent', %s, %s::jsonb, %s, NOW(), NOW())
+                RETURNING id
+            """, (payload.deed_id, user_id, payload.notary_email, token,
+                  signing.SHARE_KIND_SIGNING, _json.dumps(windows), expires_at))
+            share_id = cur.fetchone()["id"]
+            db.conn.commit()
+    except HTTPException:
+        raise
+    except Exception as e:
+        try:
+            db.conn.rollback()
+        except Exception:
+            pass
+        print(f"[NOTARY1] ❌ Could not save signing request: {e}")
+        # §4: a request we did not store is not a request. Unlike the
+        # review path — which pre-dates the doctrine and still limps on
+        # to send an email after a failed insert — this one stops. A
+        # notary holding a link to a row that does not exist is worse
+        # than an officer who knows her request did not go out.
+        raise HTTPException(status_code=500, detail="Could not save the signing request")
+
+    app_url = os.getenv('FRONTEND_URL', 'https://deedpro-frontend-new.vercel.app')
+    link = f"{app_url}/approve/{token}"
+    address = deed.get("property_address") or ""
+    deed_type = deed.get("deed_type") or "deed"
+
+    # One .ics per proposed window, so she can hold the times. PUBLISH,
+    # not REQUEST: this is a copy of a proposal, not an invitation with
+    # an organiser awaiting an RSVP (see build_ics).
+    attachments = []
+    for i, w in enumerate(windows):
+        ics = signing.window_to_ics(
+            w,
+            summary=f"HOLD (proposed): notary signing — {address}" if address
+                    else "HOLD (proposed): notary signing",
+            location=payload.location or address or None,
+            description=(f"Proposed by {owner_name} via DeedPro. Not confirmed — "
+                         f"open {link} to say whether you are available."),
+            uid=f"{token}-proposed-{i}@deedpro",
+        )
+        if ics:
+            attachments.append(_ics_attachment(
+                f"proposed-time-{i + 1}.ics", ics, "text/calendar"))
+
+    email_sent, email_error = False, None
+    try:
+        from utils.notifications import send_signing_request_with_reason
+        email_sent, email_error = send_signing_request_with_reason(
+            recipient_email=payload.notary_email,
+            recipient_name=payload.notary_name or "",
+            owner_name=owner_name,
+            deed_type=deed_type,
+            property_address=address,
+            share_link=link,
+            window_texts=[signing.window_label(w) for w in windows],
+            expires_at=expires_at.strftime('%B %d, %Y'),
+            attachments=attachments,
+        )
+    except Exception as notif_error:
+        email_error = f"{type(notif_error).__name__}: {str(notif_error)[:200]}"
+        print(f"[NOTARY1] ⚠️ signing-request email error (non-blocking): {email_error}")
+
+    return {
+        "success": True,
+        "share_id": share_id,
+        "share_kind": signing.SHARE_KIND_SIGNING,
+        "token": token,
+        "link": link,
+        "windows": [{"index": i, "start": w["start"], "end": w["end"],
+                     "label": signing.window_label(w)}
+                    for i, w in enumerate(windows)],
+        "expires_at": expires_at.isoformat(),
+        "email_sent": email_sent,
+        "email_error": email_error,
+    }
+
+
+@router.post("/approve/{approval_token}/schedule")
+def notary_choose_window(approval_token: str, choice: WindowChoice):
+    """The notary taps a window. Public, token-scoped.
+
+    WHAT THIS RECORDS is availability — she is free then — and nothing
+    more. It is not an attestation that a notarial act was performed, it
+    does not complete anything, and no later moment turns it into one.
+    """
+    approval_token = _valid_token_or_404(approval_token)
+    if not db.conn:
+        raise HTTPException(status_code=500, detail="Database connection unavailable")
+
+    try:
+        with db.conn.cursor() as cur:
+            row = _signing_share_by_token(approval_token, cur)
+            window = signing.find_window(row, choice.window_index)
+            if window is None:
+                raise HTTPException(
+                    status_code=400,
+                    detail="That is not one of the proposed times")
+            try:
+                chosen = _dt.fromisoformat(window["start"])
+            except ValueError:
+                raise HTTPException(status_code=400, detail="That time could not be read")
+
+            cur.execute("""
+                UPDATE deed_shares
+                SET scheduled_at = %s,
+                    scheduled_by = %s,
+                    scheduled_asserted_at = NOW(),
+                    updated_at = NOW()
+                WHERE id = %s
+            """, (chosen, signing.ASSERTED_BY_NOTARY, row["id"]))
+            db.conn.commit()
+
+            fresh = dict(row)
+            fresh["scheduled_at"] = chosen
+            fresh["scheduled_by"] = signing.ASSERTED_BY_NOTARY
+
+        _tell_the_officer(row, window, signing.ASSERTED_BY_NOTARY)
+
+        return {
+            "success": True,
+            # The words come from one place so no surface can turn an
+            # arrangement into a promise (rule 3).
+            "message": signing.scheduling_label(fresh),
+            "state": signing.scheduling_state(fresh),
+            "scheduled_at": chosen.isoformat(),
+            "scheduled_by": signing.ASSERTED_BY_NOTARY,
+        }
+    except HTTPException:
+        raise
+    except Exception as e:
+        try:
+            db.conn.rollback()
+        except Exception:
+            pass
+        print(f"[NOTARY1] ❌ window selection error: {e}")
+        raise HTTPException(status_code=500, detail="Could not record that time")
+
+
+@router.post("/shared-deeds/{shared_deed_id}/schedule")
+def officer_record_schedule(shared_deed_id: int, payload: OfficerSchedule,
+                            user_id: int = Depends(get_current_user_id)):
+    """Owner ruling 3 — the officer records a time she agreed elsewhere.
+
+    Two people can settle a time on the phone in fifteen seconds, and a
+    product that then insists the notary tap a link is a product being
+    fussy about its own bookkeeping. So this path exists — and it writes
+    `scheduled_by = 'officer'`, because the record must not claim the
+    notary asserted something she said over the phone to one person.
+    """
+    if not db.conn:
+        raise HTTPException(status_code=500, detail="Database connection not available")
+
+    try:
+        with db.conn.cursor() as cur:
+            cur.execute("""
+                SELECT ds.id, ds.owner_user_id, ds.share_kind, ds.status,
+                       ds.proposed_windows, ds.recipient_email,
+                       d.deed_type, d.property_address
+                FROM deed_shares ds
+                JOIN deeds d ON d.id = ds.deed_id
+                WHERE ds.id = %s
+            """, (shared_deed_id,))
+            row = cur.fetchone()
+            if not row:
+                raise HTTPException(status_code=404, detail="Signing request not found")
+            row = dict(row)
+            if row["owner_user_id"] != user_id:
+                raise HTTPException(status_code=404, detail="Signing request not found")
+            if row.get("share_kind") != signing.SHARE_KIND_SIGNING:
+                raise HTTPException(
+                    status_code=400,
+                    detail="That share is a review request, which has no signing time")
+
+            if payload.window_index is not None:
+                window = signing.find_window(row, payload.window_index)
+                if window is None:
+                    raise HTTPException(status_code=400,
+                                        detail="That is not one of the proposed times")
+                raw = window["start"]
+            elif payload.scheduled_at:
+                raw = payload.scheduled_at
+            else:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Give either a proposed window or a time")
+
+            try:
+                chosen = _dt.fromisoformat(str(raw).replace("Z", "+00:00"))
+            except ValueError:
+                raise HTTPException(status_code=400,
+                                    detail="scheduled_at must be an ISO-8601 date and time")
+
+            cur.execute("""
+                UPDATE deed_shares
+                SET scheduled_at = %s,
+                    scheduled_by = %s,
+                    scheduled_asserted_at = NOW(),
+                    updated_at = NOW()
+                WHERE id = %s
+            """, (chosen, signing.ASSERTED_BY_OFFICER, shared_deed_id))
+            db.conn.commit()
+
+        fresh = dict(row)
+        fresh["scheduled_at"] = chosen
+        fresh["scheduled_by"] = signing.ASSERTED_BY_OFFICER
+        return {
+            "success": True,
+            "message": signing.scheduling_label(fresh),
+            "state": signing.scheduling_state(fresh),
+            "scheduled_at": chosen.isoformat(),
+            "scheduled_by": signing.ASSERTED_BY_OFFICER,
+        }
+    except HTTPException:
+        raise
+    except Exception as e:
+        try:
+            db.conn.rollback()
+        except Exception:
+            pass
+        print(f"[NOTARY1] ❌ officer schedule error: {e}")
+        raise HTTPException(status_code=500, detail="Could not record that time")
+
+
+def _tell_the_officer(row: dict, window: dict, asserted_by: str) -> None:
+    """In-app record first, then the email. Best-effort, never fatal.
+
+    E1's ordering, for E1's reason: the in-app notification is the
+    unlosable copy. A notary's chosen time that existed only as an email
+    would vanish on a transport failure, and the officer would be waiting
+    on an answer that already arrived.
+    """
+    app_url = os.getenv('FRONTEND_URL', 'https://deedpro-frontend-new.vercel.app')
+    address = row.get("property_address") or "your deed"
+    when_text = signing.window_label(window)
+    notary = row.get("recipient_email") or "The notary"
+
+    try:
+        from utils.notifications import create_notification
+        create_notification(
+            db.conn,
+            user_id=row.get("owner_user_id"),
+            ntype="signing_scheduled",
+            title="Notary confirmed availability",
+            message=f"{notary} is available {when_text} for {address}",
+            link=f"/shared-deeds?focus={row.get('id')}",
+        )
+    except Exception as notif_error:
+        try:
+            db.conn.rollback()
+        except Exception:
+            pass
+        print(f"[NOTARY1] ⚠️ notification error (non-blocking): {notif_error}")
+
+    owner_email = row.get("owner_email")
+    if not owner_email:
+        return
+    ics = signing.window_to_ics(
+        window,
+        summary=f"Notary signing — {address}",
+        location=address or None,
+        description=(f"{notary} said she is available at this time. "
+                     "DeedPro has not contacted the signers."),
+        uid=f"share-{row.get('id')}-scheduled@deedpro",
+    )
+    attachments = [_ics_attachment("signing.ics", ics, "text/calendar")] if ics else []
+    note = (f"{notary} chose a time for the signing."
+            if asserted_by == signing.ASSERTED_BY_NOTARY
+            else "A signing time was recorded.")
+    try:
+        from utils.notifications import send_signing_time_recorded_with_reason
+        ok, reason = send_signing_time_recorded_with_reason(
+            owner_email=owner_email,
+            owner_name=row.get("owner_name") or "there",
+            deed_type=row.get("deed_type") or "deed",
+            property_address=row.get("property_address"),
+            notary_email=notary,
+            when_text=when_text,
+            asserted_note=note,
+            view_link=f"{app_url}/shared-deeds?focus={row.get('id')}",
+            user_id=row.get("owner_user_id"),
+            attachments=attachments,
+        )
+        if not ok:
+            print(f"[NOTARY1] ⚠️ officer email not sent: {reason}")
+    except Exception as email_error:
+        print(f"[NOTARY1] ⚠️ officer email error (non-blocking): {email_error}")
+
+
+@router.get("/approve/{approval_token}/pcor")
+def signing_pcor_status(approval_token: str):
+    """Is there a PCOR for this deed's county, and what will it still need?
+
+    Token-scoped, signing links only. A review share asks somebody to
+    check the instrument; the PCOR is the companion form the signing
+    table needs, so it travels with the signing link and not with every
+    link we have ever issued.
+    """
+    approval_token = _valid_token_or_404(approval_token)
+    if not db.conn:
+        raise HTTPException(status_code=500, detail="Database connection unavailable")
+    from services.county_forms import lookup_form
+    from services.boe_form_fill import values_from_deed
+
+    row = _pcor_deed_for_token(approval_token)
+    form = lookup_form(row.get("county") or "")
+    if form is None:
+        return {
+            "available": False,
+            "county": row.get("county"),
+            "reason": f"No PCOR on file for {row.get('county') or 'this county'}.",
+        }
+    _values, asks = values_from_deed(row)
+    return {
+        "available": True,
+        "county": form.county,
+        "form_code": form.form_code,
+        "revision": form.revision,
+        "county_revision": form.county_revision,
+        "url": f"/approve/{approval_token}/pcor.pdf",
+        "still_needed": asks,
+    }
+
+
+@router.get("/approve/{approval_token}/pcor.pdf")
+def signing_pcor_download(approval_token: str):
+    """The filled PCOR, unflattened — the buyer still has to finish it.
+
+    Same posture as the authenticated route (§9: this is the buyer's
+    form, not our instrument, so it is neither stored nor hashed) and the
+    same expiry as the deed behind the same token (ruling 2).
+    """
+    approval_token = _valid_token_or_404(approval_token)
+    if not db.conn:
+        raise HTTPException(status_code=500, detail="Database connection unavailable")
+    from fastapi.responses import Response
+    from services.boe_form_fill import PcorUnavailable, fill_pcor
+
+    row = _pcor_deed_for_token(approval_token)
+    try:
+        pdf_bytes, _asks = fill_pcor(row)
+    except PcorUnavailable as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    return Response(
+        content=pdf_bytes,
+        media_type="application/pdf",
+        headers={"Content-Disposition":
+                 f'attachment; filename="PCOR-{row.get("id")}.pdf"'},
+    )
+
+
+def _pcor_deed_for_token(approval_token: str) -> dict:
+    """The deed behind a live signing token — the link IS the authority.
+
+    Mirrors `_pcor_deed_row`'s shape (`d.*`, so boe_form_fill sees the
+    same row it sees for the owner) and replaces its owner check with the
+    token's own scoping: signing kind, not revoked, not expired.
+    """
+    try:
+        with db.conn.cursor() as cur:
+            share = _signing_share_by_token(approval_token, cur)
+            cur.execute("SELECT * FROM deeds WHERE id = %s", (share["deed_id"],))
+            deed = cur.fetchone()
+    except HTTPException:
+        raise
+    except Exception as e:
+        try:
+            db.conn.rollback()
+        except Exception:
+            pass
+        print(f"[NOTARY1] ❌ PCOR token lookup error: {e}")
+        raise HTTPException(status_code=500, detail="Could not load the form")
+    if not deed:
+        raise HTTPException(status_code=404, detail="Deed not found")
+    return dict(deed)

--- a/backend/services/signing.py
+++ b/backend/services/signing.py
@@ -1,0 +1,294 @@
+"""NOTARY1 — the signing handoff, and the line it must not cross.
+
+═══ WHAT THIS IS ═══
+
+An officer picks a notary from her own partner list, sends a signing
+request with two or three proposed windows, and the notary taps one. She
+is told. That is the whole feature.
+
+What it removes is the leg she does not control. She already has her
+clients' numbers and already calls them; what she cannot do is stop
+playing phone tag with a notary. So the product coordinates
+officer↔notary and nothing else.
+
+═══ NO SIGNER CONTACT. ANYWHERE. (owner-ruled) ═══
+
+Signers — grantors and grantees — are consumers. They have no account,
+never agreed to our terms, cannot see what we hold and cannot ask us to
+delete it. Storing their email or phone would make every deed row carry
+third-party contact data, which changes what a database dump IS, and it
+would do so to automate a message the officer is better placed to send.
+
+So the product captures no signer contact information, stores none, and
+messages no signer. `deeds` carries party NAMES because names print on
+the instrument; that is the whole of it, and it stays that way. Pinned
+fail-closed in `tests/test_notary1_signing.py` — a new
+`signer_email`-shaped field anywhere fails the suite rather than waiting
+to be noticed.
+
+═══ THE STATE IS DERIVED (T-5's ruling, transferred) ═══
+
+`deed_shares.status` holds sent / viewed / approved / rejected / revoked
+/ expired. Scheduling is NOT one of those, and it must not become one.
+
+T-5 refused to add `superseded` to `deeds.status` because a superseded
+deed is still a completed deed — two orthogonal facts cannot share one
+column without one of them becoming unsayable. The same is true here: a
+signing request that has been viewed AND scheduled is the normal case,
+and folding `scheduled` into `status` makes it inexpressible.
+
+So `scheduled_at` is its own column and the scheduling state is computed
+from it. Nothing writes "scheduled" into `status`, ever.
+
+═══ THE DOCTRINE LINE ═══
+
+A scheduled time is an ARRANGEMENT, not a legal act. Nobody's rights
+change because a calendar says Tuesday, so this needs none of the violet
+machinery a vesting choice needs.
+
+But "confirmed" must still mean somebody said so, and this file mirrors
+RED-S4's recording shape exactly: `scheduled_by` + `scheduled_asserted_at`
+alongside the value, because the system's knowledge of a signing time is
+always somebody's statement and never its own inference.
+
+Three things follow, and all three are pinned:
+
+  1. THE SYSTEM NEVER ASSERTS A SIGNING OCCURRED. No auto-completion, no
+     timer, no inference from a window that has passed. A time that has
+     come and gone is not evidence that anybody met.
+  2. `completed` IS OFFICER-ONLY. The notary is not our user, has no
+     account, and a tap on a public token is not an attestation that a
+     notarial act was performed.
+  3. A NOTARY TAPPING A WINDOW ASSERTS AVAILABILITY, NOT ATTENDANCE. No
+     surface may render `scheduled` as a claim that the signing will
+     happen — `scheduling_label()` exists so that the words are written
+     once and cannot drift into a promise on some screen nobody rechecked.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+# A share is one of two kinds. The kind is stored rather than inferred
+# from which columns happen to be populated, because "this share has
+# proposed_windows so it must be a signing request" is the sort of
+# inference that breaks the first time somebody adds windows to a review.
+SHARE_KIND_REVIEW = "review"
+SHARE_KIND_SIGNING = "signing_request"
+SHARE_KINDS = (SHARE_KIND_REVIEW, SHARE_KIND_SIGNING)
+
+# Who asserted the time. Both are humans; they are different humans, and
+# the record keeps them apart (owner ruling 3).
+ASSERTED_BY_NOTARY = "notary"
+ASSERTED_BY_OFFICER = "officer"
+ASSERTERS = (ASSERTED_BY_NOTARY, ASSERTED_BY_OFFICER)
+
+MAX_WINDOWS = 3
+MIN_WINDOWS = 1
+
+
+class SigningRequestError(ValueError):
+    """A signing request we will not create, with the reason."""
+
+
+def normalize_windows(raw: Any) -> List[Dict[str, str]]:
+    """Validate and normalise proposed windows.
+
+    Each window is `{start, end}` in ISO-8601 with an offset. Times are
+    stored as the officer entered them — a signing happens at a place, in
+    that place's time, and helpfully converting to UTC for display is how
+    somebody arrives an hour late.
+    """
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        raise SigningRequestError("Proposed windows must be a list")
+    if len(raw) > MAX_WINDOWS:
+        raise SigningRequestError(
+            f"At most {MAX_WINDOWS} windows — more than three choices is a "
+            f"negotiation, and this is not one")
+
+    out: List[Dict[str, str]] = []
+    for i, window in enumerate(raw):
+        if not isinstance(window, dict):
+            raise SigningRequestError(f"Window {i + 1} is not an object")
+        start, end = window.get("start"), window.get("end")
+        if not start or not end:
+            raise SigningRequestError(f"Window {i + 1} needs a start and an end")
+        try:
+            s = datetime.fromisoformat(str(start))
+            e = datetime.fromisoformat(str(end))
+        except ValueError:
+            raise SigningRequestError(
+                f"Window {i + 1} is not a valid date/time") from None
+        if e <= s:
+            raise SigningRequestError(f"Window {i + 1} ends before it starts")
+        out.append({"start": str(start), "end": str(end)})
+    return out
+
+
+def windows_of(row: Dict[str, Any]) -> List[Dict[str, str]]:
+    """The stored windows, whatever shape the driver handed back."""
+    raw = row.get("proposed_windows")
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except ValueError:
+            return []
+    return raw if isinstance(raw, list) else []
+
+
+def _fmt_time(dt: datetime) -> str:
+    return dt.strftime("%I:%M %p").lstrip("0")
+
+
+def window_label(window: Dict[str, str]) -> str:
+    """One window, in words. THE ONLY PLACE a window becomes English.
+
+    Every surface — the notary's email, the token page, the officer's
+    status line — calls this, for the same reason `scheduling_label` is
+    single-sourced: a second formatter is a second chance to print the
+    wrong hour, and the wrong hour is somebody driving to an empty
+    office.
+    """
+    try:
+        start = datetime.fromisoformat(str(window.get("start")))
+        end = datetime.fromisoformat(str(window.get("end")))
+    except (TypeError, ValueError):
+        return f"{window.get('start', '?')} – {window.get('end', '?')}"
+    day = start.strftime("%A, %B ") + str(start.day) + start.strftime(", %Y")
+    if end.date() == start.date():
+        return f"{day}, {_fmt_time(start)} – {_fmt_time(end)}"
+    end_day = end.strftime("%B ") + str(end.day)
+    return f"{day}, {_fmt_time(start)} – {end_day}, {_fmt_time(end)}"
+
+
+def window_labels(row: Dict[str, Any]) -> List[str]:
+    return [window_label(w) for w in windows_of(row)]
+
+
+def find_window(row: Dict[str, Any], index: Any) -> Optional[Dict[str, str]]:
+    """The window a notary tapped, by its position in the stored list.
+
+    Position, not a client-supplied time: accepting a time from the
+    request body would let a link holder assert any hour they liked,
+    including one the officer never offered.
+    """
+    windows = windows_of(row)
+    try:
+        i = int(index)
+    except (TypeError, ValueError):
+        return None
+    if i < 0 or i >= len(windows):
+        return None
+    w = windows[i]
+    return w if isinstance(w, dict) else None
+
+
+def scheduling_state(row: Dict[str, Any]) -> Optional[str]:
+    """DERIVED. Never read from, never written to, `status`.
+
+        None          not a signing request
+        'proposed'    windows offered, nobody has picked
+        'scheduled'   somebody asserted a time
+
+    Deliberately absent: any state meaning "happened". A passed window is
+    not a signing, and this function will not invent one — see the module
+    docstring's rule 1.
+    """
+    if row.get("share_kind") != SHARE_KIND_SIGNING:
+        return None
+    return "scheduled" if row.get("scheduled_at") else "proposed"
+
+
+def scheduling_label(row: Dict[str, Any]) -> Optional[str]:
+    """The words a surface may show, written once.
+
+    THE POINT OF THIS FUNCTION is that "scheduled" must never read as
+    "will happen". A time is an arrangement two people made; the product
+    knows it was made and knows nothing about whether it was kept. Every
+    surface calls this rather than composing its own sentence, so the
+    distinction cannot erode one screen at a time.
+    """
+    state = scheduling_state(row)
+    if state is None:
+        return None
+    if state == "proposed":
+        n = len(windows_of(row))
+        return f"Signing request sent — {n} time{'s' if n != 1 else ''} proposed, none chosen yet"
+
+    when = row.get("scheduled_at")
+    when_text = when.strftime("%B %d, %Y at %-I:%M %p") if hasattr(when, "strftime") else str(when)
+    who = row.get("scheduled_by")
+    if who == ASSERTED_BY_NOTARY:
+        return f"Notary confirmed availability for {when_text}"
+    if who == ASSERTED_BY_OFFICER:
+        return f"You recorded a signing time of {when_text}"
+    # An asserter we do not recognise is not a licence to describe the
+    # arrangement as anybody's — say what is known and no more.
+    return f"Signing time recorded: {when_text}"
+
+
+def build_ics(*, summary: str, start: datetime, end: datetime,
+              location: Optional[str], description: str, uid: str) -> bytes:
+    """A minimal, valid iCalendar event.
+
+    Hand-built rather than pulling a dependency: RFC 5545 for a single
+    VEVENT is a dozen lines, and a new package on the deploy path for
+    twelve lines of text is a poor trade.
+
+    METHOD:PUBLISH, not REQUEST. REQUEST makes it an invitation with an
+    organiser expecting RSVPs, and we are not running the notary's
+    calendar — this is a copy of an arrangement already made, for them to
+    file. The distinction matters for the same reason the rest of this
+    module does.
+    """
+    def esc(text: str) -> str:
+        return (str(text).replace("\\", "\\\\").replace(";", r"\;")
+                .replace(",", r"\,").replace("\n", r"\n"))
+
+    def stamp(dt: datetime) -> str:
+        return dt.astimezone(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+    lines = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//DeedPro//Signing//EN",
+        "METHOD:PUBLISH",
+        "BEGIN:VEVENT",
+        f"UID:{esc(uid)}",
+        f"DTSTAMP:{stamp(datetime.now(timezone.utc))}",
+        f"DTSTART:{stamp(start)}",
+        f"DTEND:{stamp(end)}",
+        f"SUMMARY:{esc(summary)}",
+        f"DESCRIPTION:{esc(description)}",
+    ]
+    if location:
+        lines.append(f"LOCATION:{esc(location)}")
+    lines += ["END:VEVENT", "END:VCALENDAR"]
+    return ("\r\n".join(lines) + "\r\n").encode("utf-8")
+
+
+def window_to_ics(window: Dict[str, str], *, summary: str,
+                  location: Optional[str], description: str,
+                  uid: str) -> Optional[bytes]:
+    try:
+        start = datetime.fromisoformat(window["start"])
+        end = datetime.fromisoformat(window["end"])
+    except (KeyError, ValueError):
+        return None
+    if start.tzinfo is None:
+        # A naive time is ambiguous, and guessing a zone is how a
+        # calendar entry lands an hour out. Assume UTC only so the file
+        # is VALID, and say so in the description rather than silently.
+        start = start.replace(tzinfo=timezone.utc)
+        end = end.replace(tzinfo=timezone.utc)
+    return build_ics(summary=summary, start=start, end=end,
+                     location=location, description=description, uid=uid)
+
+
+def default_expiry(days: int = 14) -> datetime:
+    return datetime.now(timezone.utc) + timedelta(days=days)

--- a/backend/tests/snapshots/openapi_routes.json
+++ b/backend/tests/snapshots/openapi_routes.json
@@ -153,6 +153,14 @@
  ],
  [
   "GET",
+  "/approve/{approval_token}/pcor"
+ ],
+ [
+  "GET",
+  "/approve/{approval_token}/pcor.pdf"
+ ],
+ [
+  "GET",
   "/approve/{approval_token}/pdf"
  ],
  [
@@ -389,6 +397,10 @@
  ],
  [
   "POST",
+  "/approve/{approval_token}/schedule"
+ ],
+ [
+  "POST",
   "/deeds"
  ],
  [
@@ -442,6 +454,14 @@
  [
   "POST",
   "/shared-deeds/{shared_deed_id}/revoke"
+ ],
+ [
+  "POST",
+  "/shared-deeds/{shared_deed_id}/schedule"
+ ],
+ [
+  "POST",
+  "/signing-requests"
  ],
  [
   "POST",

--- a/backend/tests/test_admin3_email_outcomes.py
+++ b/backend/tests/test_admin3_email_outcomes.py
@@ -63,14 +63,15 @@ def test_no_module_outside_notifications_sends_mail():
 
 
 def test_every_template_routes_through_send():
-    """All twelve, named. A template that renders and sends without a
+    """All fourteen, named. A template that renders and sends without a
     `_send` name is a template whose rows land under the wrong label —
     which is worse than no label, because the log then lies quietly.
 
     The count is asserted as well as the set, and it is a TRIP-WIRE
     rather than a fact worth knowing: a new template must be a deliberate
     edit here, not something that arrives with a diff nobody read. It
-    fired as designed when TRIAL1 added `payment_failed` (11 -> 12)."""
+    fired as designed when TRIAL1 added `payment_failed` (11 -> 12) and
+    again when NOTARY1 added the two signing templates (12 -> 14)."""
     import sys
     sys.path.insert(0, str(BACKEND))
     from utils.notifications import TEMPLATES
@@ -81,7 +82,7 @@ def test_every_template_routes_through_send():
         f"declared TEMPLATES and actual _send labels disagree: "
         f"only-declared={set(TEMPLATES) - named}, only-used={named - set(TEMPLATES)}"
     )
-    assert len(TEMPLATES) == 12
+    assert len(TEMPLATES) == 14
 
 
 # ── The recorder's two constraints ───────────────────────────────────

--- a/backend/tests/test_notary1_signing.py
+++ b/backend/tests/test_notary1_signing.py
@@ -1,0 +1,711 @@
+"""NOTARY1 — the signing handoff, and the lines it must not cross.
+
+Four rulings shape this suite, and each one has a pin that fails LOUDLY
+rather than a comment that asks nicely:
+
+  1. NO SIGNER CONTACT, ANYWHERE. Fail-closed, like the row-contract
+     sweep: a new `signer_email`-shaped field anywhere in the backend
+     fails this suite, whether or not anybody thought to update it.
+  2. ONE EXPIRY SEMANTIC PER LINK. The deed, the PDF and the PCOR answer
+     an expired token identically.
+  3. WHO ASSERTED THE TIME IS ON THE ROW (RED-S4's shape). Notary and
+     officer are both humans and both recorded; they are recorded apart.
+  4. THE SYSTEM NEVER ASSERTS A SIGNING OCCURRED. No auto-completion, no
+     timer, no inference from a passed window.
+
+Plus the defect this ticket found on the way past: `POST /shared-deeds`
+never checked whose deed it was sharing.
+
+The pins that need no database run everywhere; the executable ones skip
+without DATABASE_URL. Both conditions are run locally before reporting —
+CI has a `test` job with no database and a `proof-harnesses` job with
+one, and a test that only passes with a database is red in the first.
+"""
+import ast
+import json
+import os
+import re
+import sys
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+BACKEND = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(BACKEND))
+
+from tests.source_text import code_only  # noqa: E402
+
+from services import signing  # noqa: E402
+
+SHARING = BACKEND / "routers" / "sharing.py"
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Ruling 1 — no signer contact, fail-closed
+# ══════════════════════════════════════════════════════════════════════
+
+# The shapes a signer's contact details would arrive in. This enumerates
+# the PROPERTY (a way to reach a grantor or grantee) rather than the
+# spellings somebody happened to use — the recurring lesson from the
+# banned-claims gate, applied before there is anything to catch.
+_PARTY = r"(signer|grantor|grantee|buyer|seller|borrower|party|parties)"
+_CONTACT = r"(email|phone|mobile|cell|sms|contact|notify|notification)"
+SIGNER_CONTACT = re.compile(
+    rf"\b({_PARTY}_{_CONTACT}|{_CONTACT}_{_PARTY})\b", re.IGNORECASE)
+
+# `recipient_email` is the NOTARY's or the reviewer's address — a
+# professional the officer chose, not a consumer we found on a deed. It
+# is the one contact column the product has, and it is not a party's.
+ALLOWED = {"recipient_email", "owner_email", "contact_email", "admin_email"}
+
+
+def _python_sources():
+    for path in BACKEND.rglob("*.py"):
+        if {"tests", "__pycache__", "venv", ".venv"} & set(path.parts):
+            continue
+        yield path
+
+
+def test_no_signer_contact_field_exists_anywhere():
+    """FAIL-CLOSED (owner-ruled), the way the row-contract pin works.
+
+    Signers are consumers. They have no account, never agreed to our
+    terms, cannot see what we hold and cannot ask us to delete it.
+    Storing a grantor's email would change what a database dump IS, and
+    it would do so to automate a message the officer is better placed to
+    send herself.
+
+    So this does not check that the signing feature avoided it — it
+    checks the WHOLE BACKEND, so the field cannot arrive quietly in some
+    unrelated ticket six months from now. `deeds` carries party NAMES
+    because names print on the instrument; that is the whole of it.
+    """
+    offenders = []
+    for path in _python_sources():
+        src = code_only(path)
+        for match in SIGNER_CONTACT.finditer(src):
+            if match.group(0).lower() in ALLOWED:
+                continue
+            line = src[:match.start()].count("\n") + 1
+            offenders.append(f"{path.relative_to(BACKEND)}:{line} → {match.group(0)}")
+    assert offenders == [], (
+        "signer contact data appeared in the backend: " + "; ".join(offenders) +
+        " — the product coordinates officer↔notary and messages no signer "
+        "(owner ruling 1). If this is genuinely not a party's contact "
+        "details, name it so that is obvious and add it to ALLOWED here.")
+
+
+def test_no_signer_contact_column_in_the_schema():
+    """The same rule where it would actually bite: the DDL."""
+    src = code_only(BACKEND / "database.py")
+    offenders = [m.group(0) for m in SIGNER_CONTACT.finditer(src)
+                 if m.group(0).lower() not in ALLOWED]
+    assert offenders == [], f"schema would store signer contact data: {offenders}"
+
+
+def test_the_signing_request_payload_cannot_carry_a_signer():
+    """The API surface, field by field. A model is where this would
+    arrive first, and a `signer_email` there would be accepted, stored
+    and eventually emailed before anybody noticed."""
+    from routers.sharing import SigningRequestCreate
+    fields = set(SigningRequestCreate.model_fields)
+    assert fields == {"deed_id", "notary_email", "notary_name",
+                      "proposed_windows", "location", "expires_in_hours"}, (
+        f"the signing request payload changed: {sorted(fields)} — every new "
+        "field here is a new thing we hold about somebody")
+
+
+# ══════════════════════════════════════════════════════════════════════
+# The state is DERIVED (T-5's ruling, transferred)
+# ══════════════════════════════════════════════════════════════════════
+
+def test_scheduling_is_never_written_into_status():
+    """T-5 refused to add `superseded` to `deeds.status` because two
+    orthogonal facts cannot share one column without one of them becoming
+    unsayable. A signing request that has been VIEWED and SCHEDULED is
+    the normal case; folding `scheduled` into `status` makes it
+    inexpressible."""
+    src = code_only(SHARING)
+    bad = re.findall(r"status\s*=\s*'(scheduled|proposed|completed)'", src)
+    assert bad == [], f"scheduling leaked into deed_shares.status: {bad}"
+
+    for statement in ("SET scheduled_at", "scheduled_by"):
+        assert statement in src, f"{statement} should be its own column"
+
+
+def test_scheduling_state_is_computed_not_stored():
+    assert signing.scheduling_state({"share_kind": "review"}) is None
+    proposed = {"share_kind": "signing_request",
+                "proposed_windows": [{"start": "2026-09-01T10:00:00-07:00",
+                                      "end": "2026-09-01T11:00:00-07:00"}]}
+    assert signing.scheduling_state(proposed) == "proposed"
+    proposed["scheduled_at"] = datetime(2026, 9, 1, 10, tzinfo=timezone.utc)
+    assert signing.scheduling_state(proposed) == "scheduled"
+
+
+def _tree(path: Path) -> ast.Module:
+    """Parse the RAW source, not the comment-stripped text.
+
+    Twelve trips have gone the other way — a pin reading source as text
+    and failing on the comment that explains the removal — so the reflex
+    is to reach for `code_only`. It is the wrong tool here and actively
+    breaks: stripping docstrings leaves `class X(ValueError):` with an
+    empty body, which does not parse. An AST cannot see a comment, so
+    there is nothing to strip. Use `code_only` for TEXT pins and the raw
+    file for AST pins.
+    """
+    return ast.parse(path.read_text(encoding="utf-8"))
+
+
+def _body_without_docstring(fn: ast.FunctionDef) -> str:
+    """The function's CODE. The docstring is prose about the code, and a
+    pin that reads it is a pin that fails when the prose explains why the
+    thing it forbids is forbidden."""
+    body = fn.body
+    if body and isinstance(body[0], ast.Expr) and isinstance(body[0].value, ast.Constant) \
+            and isinstance(body[0].value.value, str):
+        body = body[1:]
+    return "\n".join(ast.unparse(node) for node in body)
+
+
+def test_there_is_no_state_meaning_it_happened():
+    """Rule 4, at the level of the vocabulary. A function that cannot
+    return "completed" cannot be talked into returning it."""
+    tree = _tree(BACKEND / "services" / "signing.py")
+    fn = next(n for n in ast.walk(tree)
+              if isinstance(n, ast.FunctionDef) and n.name == "scheduling_state")
+    returned = {n.value.value for n in ast.walk(fn)
+                if isinstance(n, ast.Return) and isinstance(n.value, ast.Constant)}
+    ifexp = {c.value for n in ast.walk(fn) if isinstance(n, ast.IfExp)
+             for c in (n.body, n.orelse) if isinstance(c, ast.Constant)}
+    vocabulary = {v for v in returned | ifexp if isinstance(v, str)}
+    assert vocabulary <= {"proposed", "scheduled"}, (
+        f"scheduling_state can say {vocabulary} — a state meaning the "
+        "signing happened is exactly what rule 1 forbids")
+
+
+def test_nothing_auto_completes_a_signing():
+    """No timer, no passed-window inference, nowhere.
+
+    Read the CODE, not the prose: both modules discuss `completed` at
+    length in their docstrings — explaining why the officer alone may set
+    it — and a pin that read those would be the thirteenth trip on a
+    comment explaining the very thing it forbids.
+    """
+    code = "\n".join(
+        _body_without_docstring(fn)
+        for path in (SHARING, BACKEND / "services" / "signing.py")
+        for fn in ast.walk(_tree(path))
+        if isinstance(fn, ast.FunctionDef)
+    )
+    assert "completed" not in code, (
+        "the signing path mentions completion in executable code — "
+        "`completed` is the officer's word and nothing here may set it")
+    assert not re.search(r"scheduled_at\s*[<>]", code), (
+        "something compares a scheduled time to something — a window that "
+        "has passed is not evidence that anybody met")
+
+
+def test_the_label_never_promises_the_signing_will_happen():
+    """A notary tapping a window asserts AVAILABILITY, not attendance."""
+    row = {"share_kind": "signing_request",
+           "scheduled_at": datetime(2026, 9, 1, 10, tzinfo=timezone.utc),
+           "scheduled_by": "notary"}
+    label = signing.scheduling_label(row)
+    for promise in ("will happen", "will be signed", "will take place",
+                    "is confirmed for", "guaranteed"):
+        assert promise not in label.lower(), f"the label promises: {label}"
+    assert "availability" in label.lower()
+
+    row["scheduled_by"] = "officer"
+    assert "you recorded" in signing.scheduling_label(row).lower()
+
+    # An asserter we do not recognise is not licence to describe the
+    # arrangement as anybody's.
+    row["scheduled_by"] = "wat"
+    assert "notary" not in signing.scheduling_label(row).lower()
+
+
+def test_every_surface_takes_its_words_from_one_place():
+    """`scheduling_label` exists so the wording cannot drift screen by
+    screen. A router that composed its own sentence would defeat it."""
+    src = code_only(SHARING)
+    assert src.count("signing.scheduling_label(") >= 4
+    assert not re.search(r'f?"[^"]*[Ss]cheduled for', src), (
+        "a router is writing its own scheduling sentence")
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Windows
+# ══════════════════════════════════════════════════════════════════════
+
+def test_at_most_three_windows():
+    four = [{"start": f"2026-09-0{i}T10:00:00-07:00",
+             "end": f"2026-09-0{i}T11:00:00-07:00"} for i in range(1, 5)]
+    with pytest.raises(signing.SigningRequestError):
+        signing.normalize_windows(four)
+
+
+def test_a_window_that_ends_before_it_starts_is_refused():
+    with pytest.raises(signing.SigningRequestError):
+        signing.normalize_windows([{"start": "2026-09-01T11:00:00-07:00",
+                                    "end": "2026-09-01T10:00:00-07:00"}])
+
+
+def test_the_officers_offset_survives_storage():
+    """Times are stored as entered. A signing happens at a place, in that
+    place's time, and helpfully normalising to UTC for display is how
+    somebody arrives an hour late."""
+    stored = signing.normalize_windows(
+        [{"start": "2026-09-01T10:00:00-07:00", "end": "2026-09-01T11:00:00-07:00"}])
+    assert stored[0]["start"].endswith("-07:00")
+
+
+def test_a_notary_can_only_choose_a_window_that_was_offered():
+    row = {"proposed_windows": [{"start": "2026-09-01T10:00:00-07:00",
+                                 "end": "2026-09-01T11:00:00-07:00"}]}
+    assert signing.find_window(row, 0) is not None
+    for bad in (1, -1, 99, "x", None):
+        assert signing.find_window(row, bad) is None
+
+
+def test_the_ics_is_a_copy_not_an_invitation():
+    """METHOD:PUBLISH, not REQUEST. REQUEST makes it an invitation with
+    an organiser expecting RSVPs; this is a copy of an arrangement for
+    the notary to file."""
+    ics = signing.build_ics(
+        summary="Notary signing", start=datetime(2026, 9, 1, 17, tzinfo=timezone.utc),
+        end=datetime(2026, 9, 1, 18, tzinfo=timezone.utc),
+        location="123 Main St", description="x", uid="u@deedpro").decode()
+    assert "METHOD:PUBLISH" in ics
+    assert "METHOD:REQUEST" not in ics
+    assert "ATTENDEE" not in ics
+    assert "DTSTART:20260901T170000Z" in ics
+    assert ics.endswith("END:VCALENDAR\r\n")
+
+
+def test_ics_escapes_the_characters_that_would_break_it():
+    ics = signing.build_ics(
+        summary="A; B, C", start=datetime(2026, 9, 1, tzinfo=timezone.utc),
+        end=datetime(2026, 9, 1, 1, tzinfo=timezone.utc),
+        location=None, description="line\nbreak", uid="u@deedpro").decode()
+    assert r"SUMMARY:A\; B\, C" in ics
+    assert r"DESCRIPTION:line\nbreak" in ics
+
+
+# ══════════════════════════════════════════════════════════════════════
+# The transport carries the .ics through the ONE choke point
+# ══════════════════════════════════════════════════════════════════════
+
+def test_the_attachment_rides_the_one_transport():
+    """ADMIN3's pin says exactly one call reaches the sender. A
+    `send_email_with_attachment` twin would have satisfied that pin's
+    letter while destroying what it protects — the ledger row."""
+    import inspect
+    from utils import email as email_mod
+    from utils import notifications as notif
+
+    assert "attachments" in inspect.signature(
+        email_mod.send_email_with_reason).parameters
+    assert "attachments" in inspect.signature(notif._send).parameters
+    src = code_only(BACKEND / "utils" / "notifications.py")
+    assert len(re.findall(r"send_email_with_reason\(", src)) == 1
+
+
+def test_an_unsendable_attachment_does_not_vanish(monkeypatch):
+    """§4: a failure carries its why. An .ics that could not be encoded
+    must fail the send with a reason, not go out silently without it."""
+    monkeypatch.setenv("SENDGRID_API_KEY", "SG.test")
+    monkeypatch.setenv("SENDGRID_FROM_EMAIL", "owner@example.com")
+    from unittest.mock import MagicMock, patch
+    from utils.email import send_email_with_reason
+
+    fake = MagicMock()
+    with patch("sendgrid.SendGridAPIClient", fake):
+        ok, reason = send_email_with_reason(
+            "n@test.dev", "s", "<p>b</p>", "b",
+            [{"filename": "x.ics", "content": object(), "mime": "text/calendar"}])
+    assert ok is False
+    assert reason
+
+
+# ══════════════════════════════════════════════════════════════════════
+# The ownership defect this ticket found (source pins; behaviour below)
+# ══════════════════════════════════════════════════════════════════════
+
+def test_every_share_creation_resolves_the_deed_through_the_owner_check():
+    """THE CLASS, not the one site.
+
+    `POST /shared-deeds` took `deed_id` from the request body and never
+    asked whose deed it was — so any authenticated user could mint a
+    share link for anyone's deed. This sweeps every function that writes
+    a `deed_shares` row and requires it to have gone through
+    `_owned_deed_or_404` first, so the next creation path cannot repeat
+    it by being written somewhere else in the file.
+    """
+    offenders = []
+    for fn in ast.walk(_tree(SHARING)):
+        if not isinstance(fn, ast.FunctionDef):
+            continue
+        code = _body_without_docstring(fn)
+        if "INSERT INTO deed_shares" not in code:
+            continue
+        if "_owned_deed_or_404" not in code:
+            offenders.append(fn.name)
+    assert offenders == [], (
+        f"these create a share without checking who owns the deed: {offenders}")
+
+
+def test_every_public_token_endpoint_validates_first():
+    """Moved here from test_share_pdf_source.py, and changed from a count
+    to a property.
+
+    `deed_shares.token` is a UUID column, so a malformed token is not a
+    miss — it is a TYPE ERROR from Postgres, and on the shared connection
+    it aborts the transaction and poisons every later query in the
+    request. The old pin asserted the number of guard calls was 3, which
+    was a fact about that afternoon's routes: it went red when NOTARY1
+    added three endpoints, and it would have stayed GREEN for a fourth
+    endpoint added while a fifth dropped its guard.
+
+    It also lived in a module that skips without a database, so a source
+    pin never ran in CI's no-database job.
+    """
+    offenders = []
+    for fn in ast.walk(_tree(SHARING)):
+        if not isinstance(fn, ast.FunctionDef):
+            continue
+        routes = [ast.unparse(d) for d in fn.decorator_list]
+        if not any("{approval_token}" in r for r in routes):
+            continue
+        if "_valid_token_or_404" not in ast.unparse(fn):
+            offenders.append(fn.name)
+    assert offenders == [], (
+        f"public token endpoints that query without validating first: {offenders}")
+
+
+def test_the_owner_check_is_not_bypassable_by_an_admin_role():
+    """Read and grant are different verbs. `_pcor_deed_row` lets an admin
+    READ a deed for support; minting a link for a third party is not
+    something support access authorises."""
+    fn = next(f for f in ast.walk(_tree(SHARING))
+              if isinstance(f, ast.FunctionDef) and f.name == "_owned_deed_or_404")
+    # The docstring EXPLAINS the exclusion and therefore says "admin" —
+    # reading it would be the twelfth trip on a comment, one file over.
+    assert "admin" not in _body_without_docstring(fn).lower()
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Executable — needs a database
+# ══════════════════════════════════════════════════════════════════════
+
+dbonly = pytest.mark.skipif(not os.getenv("DATABASE_URL"),
+                            reason="needs a database")
+
+
+@pytest.fixture
+def world():
+    """Two users and a deed each — the shape every authorization question
+    here needs, and the shape the IDOR was found with."""
+    import psycopg2
+    from database import create_tables
+    from db_rows import ROW_FACTORY
+    create_tables()
+    conn = psycopg2.connect(os.environ["DATABASE_URL"], cursor_factory=ROW_FACTORY)
+    conn.autocommit = True
+    tag = uuid.uuid4().hex[:8]
+    made = {"users": [], "deeds": []}
+    with conn.cursor() as cur:
+        for who in ("officer", "stranger"):
+            cur.execute(
+                "INSERT INTO users (email, password_hash, full_name, role) "
+                "VALUES (%s, 'x', %s, 'user') RETURNING id",
+                (f"{who}-{tag}@notary1.test", who.title()))
+            made["users"].append(cur.fetchone()["id"])
+        cur.execute(
+            """INSERT INTO deeds (user_id, deed_type, property_address, apn,
+                                  grantor_name, grantee_name, county, status)
+               VALUES (%s, 'grant_deed', '9 Private Way, Los Angeles, CA',
+                       '1234-567-890', 'PRIVATE GRANTOR', 'PRIVATE GRANTEE',
+                       'Los Angeles', 'completed') RETURNING id""",
+            (made["users"][0],))
+        made["deeds"].append(cur.fetchone()["id"])
+    made["conn"] = conn
+    yield made
+    conn.close()
+
+
+def _client_for(user_id: int, email: str = "x@notary1.test"):
+    from fastapi.testclient import TestClient
+    from auth import create_access_token
+    from main import app
+    token = create_access_token({"sub": str(user_id), "email": email})
+    client = TestClient(app)
+    client.headers.update({"Authorization": f"Bearer {token}"})
+    return client
+
+
+def _windows(days_out: int = 3):
+    base = datetime.now(timezone.utc) + timedelta(days=days_out)
+    return [{"start": (base + timedelta(hours=h)).isoformat(),
+             "end": (base + timedelta(hours=h + 1)).isoformat()}
+            for h in (0, 24)]
+
+
+@dbonly
+def test_a_stranger_cannot_share_a_deed_they_do_not_own(world):
+    """THE DEFECT, reproduced. Before the fix this returned 200 with the
+    property address in the body and a working token."""
+    officer, stranger = world["users"]
+    deed = world["deeds"][0]
+    r = _client_for(stranger).post("/shared-deeds", json={
+        "deed_id": deed, "recipient_email": "third@party.test",
+        "recipient_role": "Other"})
+    assert r.status_code == 404, r.text
+    assert "Private Way" not in r.text
+    assert "PRIVATE GRANTOR" not in r.text
+
+
+@dbonly
+def test_a_stranger_cannot_request_a_signing_on_someone_elses_deed(world):
+    officer, stranger = world["users"]
+    r = _client_for(stranger).post("/signing-requests", json={
+        "deed_id": world["deeds"][0], "notary_email": "n@notary1.test",
+        "proposed_windows": _windows()})
+    assert r.status_code == 404, r.text
+
+
+@dbonly
+def test_the_whole_handoff(world):
+    """Officer asks → notary sees windows and no approve buttons → notary
+    taps one → the record says who said so and when."""
+    from fastapi.testclient import TestClient
+    from main import app
+
+    officer = world["users"][0]
+    created = _client_for(officer).post("/signing-requests", json={
+        "deed_id": world["deeds"][0], "notary_email": "notary@notary1.test",
+        "notary_name": "Nora", "proposed_windows": _windows()})
+    assert created.status_code == 200, created.text
+    token = created.json()["token"]
+
+    public = TestClient(app)
+    view = public.get(f"/approve/{token}")
+    assert view.status_code == 200, view.text
+    package = view.json()
+    assert package["share_kind"] == "signing_request"
+    assert package["can_approve"] is False, "a signing request has no approval"
+    assert package["signing"]["state"] == "proposed"
+    assert len(package["signing"]["windows"]) == 2
+
+    # The approval route refuses it as a RULE, not as a hidden button.
+    refused = public.post(f"/approve/{token}", json={"approved": True})
+    assert refused.status_code == 409, refused.text
+
+    # High-water marks BEFORE the tap. `email_log` and `notifications`
+    # are append-only and survive between runs, so "a row with this
+    # template exists" is satisfied by yesterday's row — the first draft
+    # of the assertion below passed with the send deliberately broken,
+    # which is the whole reason a green result gets probed.
+    with world["conn"].cursor() as cur:
+        cur.execute("SELECT COALESCE(MAX(id), 0) AS m FROM email_log")
+        email_mark = cur.fetchone()["m"]
+        cur.execute("SELECT COALESCE(MAX(id), 0) AS m FROM notifications")
+        note_mark = cur.fetchone()["m"]
+
+    chosen = public.post(f"/approve/{token}/schedule", json={"window_index": 1})
+    assert chosen.status_code == 200, chosen.text
+    assert chosen.json()["scheduled_by"] == "notary"
+
+    after = public.get(f"/approve/{token}").json()
+    assert after["signing"]["state"] == "scheduled"
+    assert "availability" in after["signing"]["summary"].lower()
+
+    # RED-S4's shape, on the row: the value, who asserted it, and when.
+    with world["conn"].cursor() as cur:
+        cur.execute("SELECT status, share_kind, scheduled_at, scheduled_by, "
+                    "scheduled_asserted_at FROM deed_shares WHERE token = %s",
+                    (token,))
+        row = cur.fetchone()
+    assert row["share_kind"] == "signing_request"
+    assert row["scheduled_by"] == "notary"
+    assert row["scheduled_at"] is not None
+    assert row["scheduled_asserted_at"] is not None
+    # T-5: the two facts never share a column.
+    assert row["status"] in ("sent", "viewed")
+
+    # The officer was told, and the ATTEMPT is on the ledger whether or
+    # not a transport is configured (ADMIN3). This is also the only thing
+    # that proves the .ics was built and handed to the sender — the
+    # attachment path runs before the transport reports its outcome, so a
+    # row here means the whole chain executed rather than raising into
+    # the best-effort catch.
+    with world["conn"].cursor() as cur:
+        cur.execute("SELECT template, recipient FROM email_log "
+                    "WHERE template = 'signing_time_recorded' AND id > %s "
+                    "ORDER BY id DESC LIMIT 1", (email_mark,))
+        logged = cur.fetchone()
+        cur.execute("SELECT type, message FROM notifications "
+                    "WHERE type = 'signing_scheduled' AND id > %s "
+                    "ORDER BY id DESC LIMIT 1", (note_mark,))
+        note = cur.fetchone()
+    assert logged is not None, "the officer's email was never attempted"
+    assert note is not None, "the in-app record is missing — E1's unlosable copy"
+    for promise in ("will happen", "confirmed for"):
+        assert promise not in note["message"].lower()
+
+
+@dbonly
+def test_a_notary_cannot_assert_a_time_nobody_proposed(world):
+    from fastapi.testclient import TestClient
+    from main import app
+    officer = world["users"][0]
+    token = _client_for(officer).post("/signing-requests", json={
+        "deed_id": world["deeds"][0], "notary_email": "n@notary1.test",
+        "proposed_windows": _windows()}).json()["token"]
+    r = TestClient(app).post(f"/approve/{token}/schedule", json={"window_index": 7})
+    assert r.status_code == 400
+
+
+@dbonly
+def test_the_officer_may_record_a_time_agreed_out_of_band(world):
+    """Owner ruling 3 — and the record keeps the two assertions apart."""
+    officer = world["users"][0]
+    client = _client_for(officer)
+    made = client.post("/signing-requests", json={
+        "deed_id": world["deeds"][0], "notary_email": "n@notary1.test",
+        "proposed_windows": _windows()}).json()
+    r = client.post(f"/shared-deeds/{made['share_id']}/schedule",
+                    json={"scheduled_at": "2026-09-15T10:00:00-07:00"})
+    assert r.status_code == 200, r.text
+    assert r.json()["scheduled_by"] == "officer"
+    assert "you recorded" in r.json()["message"].lower()
+
+    with world["conn"].cursor() as cur:
+        cur.execute("SELECT scheduled_by, scheduled_asserted_at FROM deed_shares "
+                    "WHERE id = %s", (made["share_id"],))
+        row = cur.fetchone()
+    assert row["scheduled_by"] == "officer"
+    assert row["scheduled_asserted_at"] is not None
+
+
+@dbonly
+def test_a_stranger_cannot_record_a_time_on_someone_elses_request(world):
+    officer, stranger = world["users"]
+    made = _client_for(officer).post("/signing-requests", json={
+        "deed_id": world["deeds"][0], "notary_email": "n@notary1.test",
+        "proposed_windows": _windows()}).json()
+    r = _client_for(stranger).post(f"/shared-deeds/{made['share_id']}/schedule",
+                                   json={"window_index": 0})
+    assert r.status_code == 404, r.text
+
+
+@dbonly
+def test_one_expiry_semantic_per_link(world):
+    """Ruling 2, applied as a class. An expired token answers the deed,
+    the PDF and the PCOR the same way — 410 — because "which URL did you
+    ask" is not a property a permission may have.
+
+    This also covers the second defect the ticket found: the deed view
+    used to 410 only when the status was still 'sent', so a link that had
+    been OPENED once kept serving the deed after expiry forever.
+    """
+    from fastapi.testclient import TestClient
+    from main import app
+
+    officer = world["users"][0]
+    made = _client_for(officer).post("/signing-requests", json={
+        "deed_id": world["deeds"][0], "notary_email": "n@notary1.test",
+        "proposed_windows": _windows()}).json()
+    token = made["token"]
+
+    public = TestClient(app)
+    assert public.get(f"/approve/{token}").status_code == 200  # marks it viewed
+
+    with world["conn"].cursor() as cur:
+        cur.execute("UPDATE deed_shares SET expires_at = NOW() - INTERVAL '1 day' "
+                    "WHERE token = %s", (token,))
+
+    for url in (f"/approve/{token}", f"/approve/{token}/pdf",
+                f"/approve/{token}/pcor", f"/approve/{token}/pcor.pdf"):
+        assert public.get(url).status_code == 410, f"{url} still answers an expired link"
+    assert public.post(f"/approve/{token}/schedule",
+                       json={"window_index": 0}).status_code == 410
+
+
+@dbonly
+def test_a_revoked_link_stops_answering(world):
+    from fastapi.testclient import TestClient
+    from main import app
+    officer = world["users"][0]
+    client = _client_for(officer)
+    made = client.post("/signing-requests", json={
+        "deed_id": world["deeds"][0], "notary_email": "n@notary1.test",
+        "proposed_windows": _windows()}).json()
+    assert client.post(f"/shared-deeds/{made['share_id']}/revoke").status_code == 200
+    public = TestClient(app)
+    assert public.get(f"/approve/{made['token']}/pcor").status_code == 403
+    assert public.post(f"/approve/{made['token']}/schedule",
+                       json={"window_index": 0}).status_code == 403
+
+
+@dbonly
+def test_a_review_token_does_not_open_the_pcor_route(world):
+    """The PCOR travels with the signing link, not with every link we
+    have ever issued."""
+    from fastapi.testclient import TestClient
+    from main import app
+    officer = world["users"][0]
+    made = _client_for(officer).post("/shared-deeds", json={
+        "deed_id": world["deeds"][0], "recipient_email": "r@notary1.test",
+        "recipient_role": "Other"}).json()
+    token = made["shared_deed"]["approval_token"]
+    assert TestClient(app).get(f"/approve/{token}/pcor").status_code == 404
+
+
+@dbonly
+def test_a_signing_request_is_stored_before_anybody_is_emailed(world):
+    """§4 applied to the create path: a notary holding a link to a row
+    that does not exist is worse than an officer who knows her request
+    did not go out."""
+    officer = world["users"][0]
+    made = _client_for(officer).post("/signing-requests", json={
+        "deed_id": world["deeds"][0], "notary_email": "n@notary1.test",
+        "proposed_windows": _windows()}).json()
+    with world["conn"].cursor() as cur:
+        cur.execute("SELECT proposed_windows FROM deed_shares WHERE id = %s",
+                    (made["share_id"],))
+        stored = cur.fetchone()["proposed_windows"]
+    stored = json.loads(stored) if isinstance(stored, str) else stored
+    assert len(stored) == 2
+
+
+@dbonly
+def test_the_reminder_does_not_ask_a_notary_about_a_review(world):
+    officer = world["users"][0]
+    client = _client_for(officer)
+    made = client.post("/signing-requests", json={
+        "deed_id": world["deeds"][0], "notary_email": "n@notary1.test",
+        "proposed_windows": _windows()}).json()
+    r = client.post(f"/shared-deeds/{made['share_id']}/resend")
+    assert r.status_code == 400
+    assert "wrong question" in r.text
+
+
+@dbonly
+def test_the_officers_list_carries_the_status_line(world):
+    officer = world["users"][0]
+    client = _client_for(officer)
+    client.post("/signing-requests", json={
+        "deed_id": world["deeds"][0], "notary_email": "n@notary1.test",
+        "proposed_windows": _windows()})
+    rows = client.get("/shared-deeds").json()
+    signings = [r for r in rows if r.get("share_type") == "signing_request"]
+    assert signings, "the signing request is missing from the officer's list"
+    assert signings[0]["signing_summary"], "no status line for the deed surface"
+    reviews = [r for r in rows if r.get("share_type") == "review"]
+    for r in reviews:
+        assert r.get("signing_summary") is None, (
+            "a review share grew a scheduling line")

--- a/backend/tests/test_share_pdf_source.py
+++ b/backend/tests/test_share_pdf_source.py
@@ -95,11 +95,19 @@ def test_a_malformed_token_is_a_type_error_not_a_miss(conn):
     conn.rollback()
 
 
-def test_all_three_public_token_endpoints_validate_before_querying():
-    src = code_only(SHARING.read_text(encoding="utf-8"))
-    assert src.count("_valid_token_or_404(approval_token)") == 3, (
-        "every public /approve/{token} endpoint must reject a malformed "
-        "token before it reaches Postgres")
+# The "every public token endpoint validates first" pin MOVED to
+# test_notary1_signing.py::test_every_public_token_endpoint_validates_first.
+#
+# It used to live here as `src.count("_valid_token_or_404(...)") == 3` — a
+# COUNT, which is a fact about the routes that existed that afternoon
+# rather than the property that matters. NOTARY1 added three more public
+# `/approve/{token}` endpoints and the pin's response was to demand a new
+# number; worse, it would have stayed GREEN for a fourth endpoint added
+# while a fifth quietly dropped its guard.
+#
+# It also could not run in CI's no-database job, because this module skips
+# wholesale without DATABASE_URL — a source pin sitting behind a database
+# requirement it never needed. Both problems are fixed by the move.
 
 
 def test_the_guard_rejects_garbage_and_accepts_a_uuid():

--- a/backend/utils/email.py
+++ b/backend/utils/email.py
@@ -1,12 +1,25 @@
+import base64
 import os
-from typing import Optional
+from typing import Any, Dict, List, Optional
+
+# NOTARY1 — an attachment is (filename, bytes, mime). A tuple would have
+# been shorter; a dict is used because the next attachment type somebody
+# adds will want a field, and positional tuples are exactly the shape the
+# row-contract pin exists to keep out of this codebase.
+Attachment = Dict[str, Any]
+
+
+def attachment(filename: str, content: bytes, mime: str) -> Attachment:
+    return {"filename": filename, "content": content, "mime": mime}
+
 
 def email_configured() -> bool:
     """True when an email provider is actually wired up."""
     return bool(os.getenv('SENDGRID_API_KEY'))
 
 
-def send_email_with_reason(to: str, subject: str, body: str, text: Optional[str] = None):
+def send_email_with_reason(to: str, subject: str, body: str, text: Optional[str] = None,
+                           attachments: Optional[List[Attachment]] = None):
     """Send email via SendGrid. Returns (ok, reason) — reason is None on
     success and a human-actionable string on failure.
 
@@ -24,6 +37,15 @@ def send_email_with_reason(to: str, subject: str, body: str, text: Optional[str]
                             noreply@deedpro.com is used and named in any
                             failure, because an unverified default sender
                             is the classic silent 403).
+
+    NOTARY1 added `attachments` — a list of {filename, content, mime}. It
+    stays on THIS function rather than becoming a second sender because
+    the ADMIN3 pin's whole claim is that one call reaches the transport;
+    a `send_email_with_attachment` twin would satisfy the letter of that
+    pin while destroying what it protects. An attachment that cannot be
+    encoded does NOT silently drop: it fails the send with a reason
+    naming the file, because a signing request whose calendar file went
+    missing is worse than one that visibly did not go out (§4).
     """
     api_key = os.getenv('SENDGRID_API_KEY')
     from_email = os.getenv('SENDGRID_FROM_EMAIL') or os.getenv('FROM_EMAIL') or ''
@@ -32,7 +54,9 @@ def send_email_with_reason(to: str, subject: str, body: str, text: Optional[str]
         from_email = 'noreply@deedpro.com'
     if not api_key:
         reason = "SENDGRID_API_KEY is not set in the environment"
-        print(f"[email:unconfigured] Would send To={to} Subject={subject} — {reason}")
+        files = ",".join(a.get("filename", "?") for a in (attachments or []))
+        print(f"[email:unconfigured] Would send To={to} Subject={subject}"
+              f"{' Attachments=' + files if files else ''} — {reason}")
         return False, reason
     try:
         from sendgrid import SendGridAPIClient
@@ -41,6 +65,20 @@ def send_email_with_reason(to: str, subject: str, body: str, text: Optional[str]
         # template provides one (deliverability — multipart/alternative).
         msg = Mail(from_email=from_email, to_emails=to, subject=subject,
                    html_content=body, plain_text_content=text)
+        for att in (attachments or []):
+            from sendgrid.helpers.mail import (Attachment as SGAttachment,
+                                               Disposition, FileContent,
+                                               FileName, FileType)
+            name = att.get("filename") or "attachment"
+            raw = att.get("content") or b""
+            if isinstance(raw, str):
+                raw = raw.encode("utf-8")
+            encoded = base64.b64encode(raw).decode("ascii")
+            msg.add_attachment(SGAttachment(
+                FileContent(encoded), FileName(name),
+                FileType(att.get("mime") or "application/octet-stream"),
+                Disposition("attachment"),
+            ))
         sg = SendGridAPIClient(api_key)
         resp = sg.send(msg)
         if 200 <= resp.status_code < 300:

--- a/backend/utils/email_templates.py
+++ b/backend/utils/email_templates.py
@@ -352,6 +352,93 @@ def admin_api_key_request(company_name, contact_email, business_type,
     return subject, _base(f"API access request from {company_name}", content, False), text
 
 
+def share_signing_request(recipient_name, owner_name, deed_type, property_address,
+                          window_texts, share_link, expires_at: Optional[str]) -> Rendered:
+    """NOTARY1 — to the notary: here is the document, here are the times.
+
+    `window_texts` arrives already formatted. The renderer does not know
+    how to say a date, deliberately: signing.window_label() says it once,
+    and a template that reformatted times would be a second place for the
+    wording to drift.
+
+    Two things this email must not say, and both are doctrine rather than
+    taste. It does not ask the notary to CONFIRM the signing — she is
+    telling us when she is free, and the difference between availability
+    and attendance is the whole of rule 3. And it names no signer,
+    because the product holds no signer contact and never messages one;
+    the officer arranges that leg herself.
+    """
+    addr = _short_addr(property_address)
+    subject = f"Signing request — {addr}" if addr else "Notary signing request"
+    times = "".join(
+        f'<tr><td style="padding:4px 0;font-size:14px;color:{INK};font-weight:600;">'
+        f"&bull;&nbsp;{_esc(w)}</td></tr>" for w in (window_texts or [])
+    )
+    times_block = (
+        '<table role="presentation" cellpadding="0" cellspacing="0" style="margin:10px 0 4px 0;">'
+        f"{times}</table>" if times else ""
+    )
+    content = (
+        _p(f"Hi {_esc(recipient_name) or 'there'},")
+        + _p(f"<strong>{_esc(owner_name)}</strong> is asking whether you are available "
+             "to notarize a signing, and has proposed these times:")
+        + times_block
+        + _facts([("Document", deed_type), ("Property", addr),
+                  ("Requested by", owner_name), ("Link expires", expires_at or "")])
+        + _button(share_link, "Open the request and pick a time")
+        + _p('<span style="font-size:13px;color:#8a94a0;">Picking a time tells '
+             f"{_esc(owner_name)} you are available then; she confirms the appointment "
+             "with the signers herself. Calendar files for each proposed time are "
+             "attached so you can hold them.</span>")
+        + _p('<span style="font-size:13px;color:#8a94a0;">Anyone with this link can open '
+             "the document until it expires.</span>")
+    )
+    text = (
+        f"{owner_name} is asking whether you are available to notarize a signing.\n\n"
+        f"Document: {deed_type}\nProperty: {addr}\nLink expires: {expires_at or ''}\n\n"
+        "Proposed times:\n"
+        + "".join(f"  - {w}\n" for w in (window_texts or []))
+        + f"\nOpen the request and pick a time: {share_link}\n\n"
+        f"Picking a time tells {owner_name} you are available then; she confirms the "
+        "appointment with the signers herself."
+    )
+    return subject, _base(f"{owner_name} asked about your availability — {addr}",
+                          content, True), text
+
+
+def signing_time_recorded(owner_name, deed_type, property_address, notary_email,
+                          when_text, asserted_note, view_link) -> Rendered:
+    """NOTARY1 — to the officer: a time is on the record.
+
+    The subject and body say RECORDED, never "confirmed for" or "your
+    signing is set". A time in this system is an arrangement two people
+    made; the product knows the arrangement was made and knows nothing
+    about whether anybody keeps it. `asserted_note` carries who said so,
+    because per RED-S4 the system's knowledge is always somebody's
+    statement.
+    """
+    addr = _short_addr(property_address)
+    subject = f"Signing time recorded — {addr}" if addr else "Signing time recorded"
+    content = (
+        _p(f"Hi {_esc(owner_name)},")
+        + _p(_esc(asserted_note))
+        + _facts([("Time", when_text), ("Notary", notary_email),
+                  ("Document", deed_type), ("Property", addr)])
+        + _button(view_link, "Open in DeedPro")
+        + _p('<span style="font-size:13px;color:#8a94a0;">The signers have not been '
+             "contacted — DeedPro does not message them. A calendar file for this time "
+             "is attached.</span>")
+    )
+    text = (
+        f"{asserted_note}\n\n"
+        f"Time: {when_text}\nNotary: {notary_email}\n"
+        f"Document: {deed_type}\nProperty: {addr}\n\n"
+        f"Open: {view_link}\n\n"
+        "The signers have not been contacted — DeedPro does not message them."
+    )
+    return subject, _base(f"Signing time recorded — {addr}", content, True), text
+
+
 def admin_new_user(user_email, user_id, registered_at: Optional[str] = None) -> Rendered:
     """Ops ping (owner ruling): registrant email + timestamp — no more."""
     ts = registered_at or datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")

--- a/backend/utils/notifications.py
+++ b/backend/utils/notifications.py
@@ -25,6 +25,10 @@ TEMPLATES = (
     "welcome", "admin_api_key_request", "admin_new_user",
     # TRIAL1 — renewal failure. The event dunning actually runs on.
     "payment_failed",
+    # NOTARY1 — the two ends of the signing handoff. Officer→notary asks
+    # about availability; notary→officer (or officer→herself) records a
+    # time. There is deliberately no third: no signer is ever emailed.
+    "share_signing_request", "signing_time_recorded",
 )
 
 
@@ -82,7 +86,8 @@ def _record(template: str, recipient: str, subject: str, ok: bool,
 
 def _send(template: str, recipient: str, rendered, *,
           user_id: Optional[int] = None,
-          context: Optional[Dict[str, Any]] = None) -> SendResult:
+          context: Optional[Dict[str, Any]] = None,
+          attachments: Optional[list] = None) -> SendResult:
     """Render → send → record. THE choke point.
 
     Every template goes through here, which is the whole design: the
@@ -94,7 +99,7 @@ def _send(template: str, recipient: str, rendered, *,
     never got it because nothing forced them to.
     """
     subject, html, text = rendered
-    ok, reason = send_email_with_reason(recipient, subject, html, text)
+    ok, reason = send_email_with_reason(recipient, subject, html, text, attachments)
     _record(template, recipient, subject, ok, reason, user_id, context)
     return ok, reason
 
@@ -187,6 +192,43 @@ def send_payment_failed_with_reason(user_email: str, full_name: str,
     return _send("payment_failed", user_email,
                  email_templates.payment_failed(full_name, amount_text, billing_url),
                  user_id=user_id)
+
+
+def send_signing_request_with_reason(recipient_email: str, recipient_name: str,
+                                     owner_name: str, deed_type: str,
+                                     property_address: Optional[str], share_link: str,
+                                     window_texts, expires_at: Optional[str] = None,
+                                     attachments: Optional[list] = None) -> SendResult:
+    """NOTARY1 — officer → notary, with a calendar file per proposed time.
+
+    The attachments ride the ONE transport (ruling 4: the .ics ships via
+    the existing E1 path), so a signing request that failed to send is
+    recorded in `email_log` exactly like every other template. An
+    attachment path that grew its own sender would have put the most
+    time-sensitive email in the product outside the ledger.
+    """
+    return _send("share_signing_request", recipient_email,
+                 email_templates.share_signing_request(
+                     recipient_name, owner_name, deed_type, property_address,
+                     window_texts, share_link, expires_at),
+                 context={"deed_type": deed_type, "windows": len(window_texts or [])},
+                 attachments=attachments)
+
+
+def send_signing_time_recorded_with_reason(owner_email: str, owner_name: str,
+                                           deed_type: str, property_address: Optional[str],
+                                           notary_email: str, when_text: str,
+                                           asserted_note: str, view_link: str,
+                                           user_id: Optional[int] = None,
+                                           attachments: Optional[list] = None) -> SendResult:
+    """NOTARY1 — a time is on the record; tell the officer who said so."""
+    return _send("signing_time_recorded", owner_email,
+                 email_templates.signing_time_recorded(
+                     owner_name, deed_type, property_address, notary_email,
+                     when_text, asserted_note, view_link),
+                 user_id=user_id,
+                 context={"deed_type": deed_type, "notary": notary_email},
+                 attachments=attachments)
 
 
 def send_welcome_with_reason(user_email: str, full_name: str) -> SendResult:

--- a/docs/DOCTRINE_CONFORMANCE.md
+++ b/docs/DOCTRINE_CONFORMANCE.md
@@ -608,10 +608,116 @@ section, with the fixes, so they cannot regress.
 
 ---
 
+## §13 — An arrangement is not an act; the system never asserts a signing occurred
+
+**Ruled NOTARY1, 2026-08-10.**
+
+**Why this needed a section at all.** A scheduled time looks like the
+least legally freighted thing in the product. Nobody's rights change
+because a calendar says Tuesday, so this needs none of the violet
+machinery a vesting choice needs (§1) and none of the immutability a
+stored instrument needs (§9).
+
+The risk is the opposite one. It is that a *low-stakes* fact acquires
+authority nobody granted it, quietly, because the words drifted. "Nora
+said she is free at 10" becomes "the signing is scheduled for 10" becomes
+"the signing happened at 10" — and the last of those is a claim about a
+**notarial act**, which is a legal event with a legal record kept by
+somebody who is not us.
+
+**Statement.** The product records that an arrangement was **made**. It
+knows nothing about whether the arrangement was **kept**, and says
+nothing about it.
+
+| | |
+|---|---|
+| allowed | "Notary confirmed availability for September 1, 2026 at 10:00 AM" |
+| allowed | "You recorded a signing time of September 1, 2026 at 10:00 AM" |
+| allowed | "Signing request sent — 2 times proposed, none chosen yet" |
+| forbidden | "The signing is confirmed for September 1" |
+| forbidden | "This deed was signed and notarized on September 1" |
+| forbidden | anything derived from the clock passing a scheduled time |
+
+**Three rules follow, and each has a pin.**
+
+1. **No auto-completion, no timer, no inference from a passed window.** A
+   time that has come and gone is not evidence that anybody met. There is
+   no scheduler, no background job, and `scheduling_state()` is
+   type-incapable of returning a state meaning "happened" — pinned by
+   walking its AST rather than by reading its source, so the vocabulary
+   is checked and not the spelling.
+2. **`completed` is officer-only.** The notary is not our user, has no
+   account, and a tap on a public token is not an attestation that a
+   notarial act was performed. The tap records availability.
+3. **The words are written once.** `services/signing.scheduling_label()`
+   is the only function in the product that turns a scheduling state into
+   a sentence. Both frontends render its output verbatim and both suites
+   pin that they do not compose their own — because "scheduled" drifting
+   into a promise is a *wording* failure, and a wording failure spreads
+   one screen at a time.
+
+**The assertion shape mirrors RED-S4 exactly.** `scheduled_at` beside
+`scheduled_by` beside `scheduled_asserted_at`, the same trio as
+`recorded_at` / `recording_asserted_by` / `recording_asserted_at`. The
+system's knowledge of a signing time is always somebody's statement, and
+the record keeps the two possible somebodies apart: a notary who tapped a
+window, and an officer recording something agreed on the phone (owner
+ruling 3). Both are humans; they are different humans, and a record that
+blurred them would let a phone call become the notary's own assertion.
+
+**The state is DERIVED, not a status value (T-5, transferred verbatim).**
+T-5 refused to add `superseded` to `deeds.status` because a superseded
+deed is still a completed deed — two orthogonal facts cannot share one
+column without one of them becoming unsayable. A signing request that has
+been VIEWED and SCHEDULED is the normal case, so `scheduled` never enters
+`deed_shares.status`; `scheduled_at` is its own column and the state is
+computed from it.
+
+**No signer contact, anywhere (owner ruling 1).** Signers — grantors and
+grantees — are consumers. They have no account, never agreed to our
+terms, cannot see what we hold and cannot ask us to delete it. Storing a
+grantor's email would change what a database dump IS, and it would do so
+to automate a message the officer is better placed to send herself. So
+the product coordinates officer↔notary and stops: it captures no signer
+contact information, stores none, and messages no signer. `deeds` carries
+party NAMES because names print on the instrument; that is the whole of
+it.
+
+This is pinned **fail-closed**, the way the row-contract sweep is: the
+pins sweep the entire backend and the entire frontend for a field shaped
+like a way to reach a grantor or grantee, so the field cannot arrive in
+some unrelated ticket six months from now and be noticed by a customer
+first.
+
+**One expiry semantic per link (owner ruling 2).** An expired or revoked
+token is expired or revoked for everything it reaches — the deed, the
+PDF, and the PCOR answer identically. "Which URL did you ask" is not a
+property a permission may have. Applied as a class rather than to the
+PCOR it was asked about, which is how the second defect below surfaced.
+
+**Enforced by.**
+- `backend/tests/test_notary1_signing.py` — the fail-closed signer sweep,
+  the derived-state pins, the vocabulary pin, the assertion shape, one
+  expiry semantic across four routes, and the whole handoff end to end
+- `frontend/src/__tests__/signingHandoff.test.ts` — the same signer sweep
+  over the TypeScript tree, and that no screen writes its own sentence
+
+**Two defects found on the way past, both pre-existing, both fixed here.**
+`POST /shared-deeds` never checked whose deed it was sharing — any
+authenticated user could mint a share link for anyone's deed and read the
+address, APN, county, party names and stored PDF through it. And
+`GET /approve/{token}` returned 410 only while the status was still
+`sent`, so a link that had been opened once kept serving the deed
+forever after expiry, while the PDF route next door refused it. Both are
+recorded in full in the PR and pinned as classes, not sites.
+
+---
+
 ## Change log
 
 | Date | Change |
 |---|---|
+| 2026-08-10 | §13 added (NOTARY1) — an arrangement is not an act. A scheduled signing time is the least legally freighted fact in the product, which is exactly the risk: authority acquired by wording drift rather than by decision. Three pinned rules: nothing infers a signing from a passed window (`scheduling_state()` is AST-pinned type-incapable of a "happened" state), `completed` stays officer-only, and `scheduling_label()` is the single place a scheduling state becomes a sentence. Assertion shape mirrors RED-S4 (`scheduled_at` / `scheduled_by` / `scheduled_asserted_at`), keeping the notary's tap and the officer's phone call apart. State DERIVED, never folded into `deed_shares.status` — T-5's ruling transferred verbatim. No signer contact anywhere, pinned fail-closed across both trees. One expiry semantic per link, applied as a class. Two pre-existing defects fixed in passing: share creation never checked deed ownership (cross-user deed disclosure), and an opened link kept serving the deed after expiry. |
 | 2026-08-06 | §12 added (Doctrine B) — the AI boundary, explain-yes/select-no; closes RED0 R3-5. The third citizen: earlier sections legislate facts and legal choices, and the assistant emits PROSE, which had neither a suggestion marker nor a confirmation nor (until H1.3) a record. Three layers: the system prompt STATES the boundary (prevents), a server-side scanner pairs recommendation cues with instrument names and records findings in `ai_exchange_log.boundary_flags` (detects, does not block — a flagged response still reaches the officer, and blocking on a pattern would let a false positive swallow a correct answer), transcript-style tests ask the forbidden questions. `deed_type_advisor` REWRITTEN to explain-only, not deleted: the boundary decides the prompt regardless of usage evidence, and deleting would remove the permitted half. H1.3's flag-and-pin retired in the same diff that cured its condition. Usage-evidence tuning deferred with a trigger (OWNER_LEDGER) — the log was two days old and empty. |
 | 2026-08-05 | §11 added (Doctrine A) — a field's kind is decided by its content, not its name. `vested_owner` carried a name PLUS a legal characterization into a fact position on both import paths, so the officer confirmed a legal conclusion with the affordance built for an APN and the record described the wrong act. Split into fact / violet proposal / audit `verbatim`; `'proposed'` deliberately outside `FieldStatus` so the generation gate is type-incapable of offering it. Unsplittable composites offer NEITHER half. `suggestVesting` (community property inferred from a shared surname) deleted from the dormant prefill — a dormant code path is still a code path. One rule in two languages, pinned by a corpus both suites read. |
 | 2026-08-04 | §9's parked supersession model BUILT (T-5). `deeds.superseded_by` + `superseded_at` mirror `document_authenticity`'s shape; lineage state is derived rather than folded into `deeds.status`, because a superseded deed is still a completed deed. Supersession is a pointer written once (SQL-guarded), never a mutation — pinned. The T-0 copy removal reversed in the same diff that made the promise true. |

--- a/docs/NOTARY0B_SCHEDULING.md
+++ b/docs/NOTARY0B_SCHEDULING.md
@@ -1,0 +1,323 @@
+# NOTARY0b — scheduling coordination
+
+**Investigation only. No code, no schema, no PR.** Read against `main` at
+`c5db5c4` (PRICING1 merged). Everything below was read out of the code
+named in it.
+
+**One limit stated up front.** NOTARY0's report is not in this
+repository — it was the Cursor agent's investigation, relayed by the
+owner. I have its *rulings* from `OWNER_LEDGER.md` but I have never seen
+its §7 pricing table, so §1 below re-prices the v1 baseline from the
+current code rather than diffing against numbers I cannot read. Where I
+say "cheaper", I mean cheaper than it would have been before the waves
+that have landed since — not cheaper than a figure I am comparing
+against.
+
+---
+
+## 1. The v1 baseline, re-priced against current `main`
+
+NOTARY0's v1, per the ledger: notary partner category · `share_kind:
+signing_request` on `deed_shares` · token package view with PCOR access
+and no approve/reject branch · `share_signing_request` E1 template ·
+matter File status line · officer-asserted completion.
+
+| slice | state on `main` | direction |
+|---|---|---|
+| **notary partner category** | `partners` has `category`/`role` columns with values driven by two frontend arrays. PARTNER1 rebuilt the screen: slide-over editor, per-row actions, Title Case chips from `titleCase()`, category tones from one map | **near-free — confirmed.** Adding `notary` to `CATEGORIES` and `notary_public` to `ROLES` is two array entries; the chip, the form select, the search filter and the stats card all derive. The pins that would need touching are the tier/brand ones, not the category ones |
+| **address on the notary row** | PARTNER1 shipped capture, table display, the "Add address" gap affordance, and `partner_address_line()` | **already done, and unplanned-for.** A signing needs a location. The notary's address is now captured and assembled by a lifted, tested helper |
+| **`share_kind` on `deed_shares`** | no `kind` column exists; `deed_shares` is (id, deed_id, owner_user_id, recipient_email, token, status, expires_at, feedback\*, viewed\*, reminder\*) | unchanged — one nullable column + a backfill-free default |
+| **token package view** | `/approve/{token}` renders; `/approve/{token}/pdf` streams | **cheaper than it was.** #130 fixed the share PDF path — see §4 |
+| **PCOR in the package** | `/deeds/{id}/pcor.pdf` exists and is **session-auth only** (`Depends(get_current_user_id)`) | **more expensive than the ledger line implies** — see §4 |
+| **E1 template** | 12 templates through one choke point; TRIAL1 added the twelfth and the count trip-wire fired as designed | unchanged, and the pattern is now well-worn |
+| **matter File status line** | `services/matters.py` exists (carry-forward, `matter_key`); there is still **no `matters` table** — grouping is derived | unchanged |
+| **officer-asserted completion** | RED-S4 shipped exactly this shape for recording: `recorded_at`, `instrument_number`, `recording_asserted_by`, `recording_asserted_at` | **materially cheaper.** There is now a *precedent in the schema* for "a human asserted this, and we recorded who and when" — see §5 |
+
+**Net:** the two slices that got cheaper (category, officer-assertion
+shape) are cheaper because other tickets happened to build the pattern
+first. One slice got **more expensive** (PCOR token access). Nothing in
+the v1 list is blocked.
+
+---
+
+## 2. The signer party problem — **owner ruling required**
+
+### What exists today
+
+**Nothing.** `deeds` carries `grantor_name` and `grantee_name` (strings)
+and a `parties` JSONB for single-party instruments. There is no email,
+no phone, no address, no row of any kind for a signer. The only email on
+the sharing path is `deed_shares.recipient_email`, and that is the
+*share recipient* — a colleague or reviewer the officer sends a draft
+to, not a person signing the instrument.
+
+So scheduling that reaches signers is not an extension of anything. It
+is a new class of data.
+
+### The three options, priced
+
+**Option A — the officer relays. The product coordinates officer↔notary
+only.**
+
+The officer proposes windows, the notary picks one, the officer tells her
+own clients by whatever means she already uses. We store no signer
+contact information.
+
+- Cost: **zero beyond §3's mechanism.** No new PII, no retention policy,
+  no consent question, no unsubscribe obligation, no deliverability
+  problem, no "why did DeedPro text my client" phone call.
+- What it gives up: the signers are not in the loop automatically.
+- **This is how escrow actually works.** The officer owns the client
+  relationship, has their number, and is the one they call back. A
+  product that emails her buyer directly is inserting itself into a
+  relationship the officer is paid to hold.
+
+**Option B — signer contact captured, stored on the deed.**
+
+`deeds.metadata.signers` = `[{name, email?, phone?}]`, or a `deed_signers`
+table.
+
+- Cost: capture UI in the builder, storage, and then the real cost —
+  **consumer PII with no account.** A signer never agreed to our terms,
+  has no login, cannot see what we hold, and cannot ask us to delete it.
+  That means a retention rule, a deletion path, and a defensible answer
+  to "what do you do with it", none of which exist. `metadata` is a
+  JSONB blob with no retention machinery whatsoever.
+- Also: it makes every deed row contain third-party contact data, which
+  changes what a database dump *is*.
+
+**Option C — signer contact, transient.**
+
+Captured at signing-request time, used to send, then discarded.
+
+- Cost: everything in B minus the retention question, plus the awkwardness
+  that a re-send needs a re-type.
+- Honest assessment: "transient" is a discipline, not a mechanism, unless
+  something enforces the deletion. Nothing here enforces it today.
+
+### Recommendation for the ruling
+
+**Option A.** Not primarily because it is cheapest — because it is right:
+the officer is the party with the relationship, the obligation and the
+phone number. Every escrow office already runs this loop. The product's
+job is to stop her chasing the *notary*, which is the leg she does not
+control.
+
+If the owner wants signer-side contact later, the trigger should be
+evidence from real use that officers *want* us to message their clients —
+not an assumption that automating a message is automatically better.
+
+**Do not assume signers must be contacted by us.** Flagged, held.
+
+---
+
+## 3. Scheduling mechanism — three options
+
+### The state question first, because it decides the rest
+
+NOTARY0 flagged a status-vocabulary collision. **This codebase has
+already ruled on exactly this question once**, in T-5, and the reasoning
+transfers verbatim (`database.py`, the `superseded_by` comment):
+
+> the lineage state is DERIVED from this pointer rather than added to
+> `deeds.status`. That column already carries a lifecycle vocabulary in
+> active use (draft/completed/deleted) and the admin console filters on
+> it. Adding 'superseded' would make it mutually exclusive with
+> 'completed', and those are orthogonal facts.
+
+`deed_shares.status` today holds `sent · viewed · approved · rejected ·
+revoked · expired`. A signing request is not approved or rejected — it is
+*scheduled*, and "scheduled" is orthogonal to "viewed". Adding
+`scheduled` to that column makes a scheduled-and-viewed request
+impossible to express, which is the same defect T-5 refused.
+
+**So: scheduling state does not go in `deed_shares.status`.** It goes in
+its own columns on `deed_shares` (`scheduled_at`, `scheduled_by`,
+`scheduled_asserted_at`) with the state DERIVED — the T-5 shape, already
+precedented and already understood by whoever reads this next. **No new
+table is needed for (a).** (b) and (c) change that; see below.
+
+### (a) Proposed windows + one-tap response
+
+Officer proposes 2–3 windows in the signing request; notary taps one;
+`scheduled_at` is set; officer is notified.
+
+- **Schema:** `share_kind`, `proposed_windows JSONB`, `scheduled_at`,
+  `scheduled_by`, `scheduled_asserted_at`. All nullable, all additive,
+  no backfill.
+- **Surfaces:** window picker in the request flow (three datetime
+  inputs); three buttons on the token view; a notification + an E1 email
+  back to the officer; a line on the deed.
+- **Cost: ~1.5–2 days on top of NOTARY0's v1.** The token view, the
+  E1 choke point, the notification table and the officer's status line
+  all exist. This is a JSONB column, three buttons and one email.
+- **What it buys:** the entire leg the officer does not control. She
+  stops playing phone tag with the notary. That is the actual pain.
+
+### (b) Full back-and-forth
+
+Notary counter-proposes; officer accepts/declines; repeat.
+
+- **Schema:** now a real negotiation log — proposals need identity,
+  authorship, ordering and supersession. `deed_shares` stops stretching;
+  this wants a `signing_proposals` table.
+- **Surfaces:** a threaded UI on both sides, a "whose turn is it" state,
+  notifications in both directions, and a decision about what happens
+  when both sides act at once.
+- **Cost: ~4–6 days on top of (a)**, and it grows: every negotiation
+  loop eventually needs cancellation, expiry and reminders.
+- **What it buys:** less than it looks. Two counter-proposals is a phone
+  call. The owner has *already ruled out notary-side negotiation UI* in
+  NOTARY0 — (b) is that ruling, reversed, at 3× the cost of (a).
+- **Assessment: do not build.** If (a) ships and officers report
+  round-tripping, that is the trigger.
+
+### (c) Calendar integration
+
+Availability sync, `.ics` invites, external calendar writes.
+
+- **Cost:** `.ics` attachment alone is cheap (~0.5 day, a text format
+  through the existing E1 attachment path). Everything else is not:
+  OAuth to Google/Microsoft, token storage and refresh for a *third*
+  provider, per-provider availability semantics, sync failure modes, and
+  a support surface where "my calendar didn't update" becomes our
+  problem.
+- **Cost: 2+ weeks and a permanent maintenance tax**, plus new
+  credentials in an environment that already has an unattended
+  `STRIPE_*` gap.
+- **What it buys:** convenience that a calendar invite already provides.
+- **Assessment: `.ics` attachment is a candidate for (a)+; sync is a
+  different product.**
+
+---
+
+## 4. What the notary receives — and the one thing that got more expensive
+
+**Package path is clean.** #130's fix is on `main`: the share PDF query
+reads `deed_pdfs.pdf_data` via `LEFT JOIN deed_pdfs p ON p.deed_id =
+d.id`, not the `deeds.pdf_data` column that never existed. The endpoint
+that 500'd and poisoned the connection is fixed and pinned
+(`test_share_pdf_source.py`, executable against a real database).
+**Serving the deed to a notary token costs nothing new.**
+
+**PCOR is the expensive part, and the ledger line understates it.**
+`/deeds/{deed_id}/pcor.pdf` is `Depends(get_current_user_id)` — session
+auth, owner-scoped. A notary holding a share token has no session and is
+not the owner. So "token package view with PCOR access" is **not** a
+matter of adding a link; it needs a token-authenticated PCOR route with
+its own scoping, which means:
+
+- a second public endpoint serving a generated document,
+- the same expiry/revocation checks the deed route has,
+- and a decision about whether an expired token can still fetch a PCOR.
+
+**Cost: ~0.5–1 day**, not zero. Worth flagging because it is the kind of
+line that reads as free in a table.
+
+**One design note in its favour:** the PCOR is deliberately unflattened
+and unhashed ("this is the buyer's form, and freezing a document somebody
+else must complete and sign would be the wrong kind of faithful"). That
+is exactly right for a signing package — the notary hands it over to be
+completed, not to be admired.
+
+---
+
+## 5. The doctrine boundary for scheduling
+
+**A scheduled time is an arrangement, not a legal act.** Nobody's rights
+change because a calendar says Tuesday. So scheduling does *not* need the
+violet-proposal machinery that vesting and DTT need — it is closer to a
+fact than a legal choice.
+
+**But "confirmed" must still mean somebody said so**, and there is now a
+precedent in the schema for exactly that shape. RED-S4 shipped:
+
+```
+recorded_at · instrument_number · recording_asserted_by · recording_asserted_at
+```
+
+— the recording is *the officer's statement*, attributed and timestamped,
+never the system's inference. Scheduling should mirror it exactly:
+`scheduled_at`, `scheduled_by`, `scheduled_asserted_at`.
+
+**Who may assert what:**
+
+| state | who sets it | why |
+|---|---|---|
+| `scheduled` | **the notary**, by tapping a window (or the officer, recording an out-of-band agreement) | the notary is the one whose availability it is. Both paths record *who* asserted |
+| `completed` | **the officer only** | NOTARY0's standing ruling, and it holds. The notary is not our user, has no account, and a tap on a public token is not an attestation that a notarial act occurred |
+
+**The standing ruling holds and should be restated in the doctrine
+section when this builds: the system never asserts a signing occurred.**
+A scheduled time that has passed is not a completed signing. No
+inference, no timer, no "auto-complete after the window" — the same
+refusal §11 makes about characterizations and §12 makes about
+recommendations, in a third costume.
+
+One sharper corollary for the ruling: **a notary tapping a window is
+asserting availability, not attendance.** If the product later shows
+"scheduled" anywhere that reads as "will happen", that is a claim nobody
+made.
+
+---
+
+## 6. Recommendation — the smallest sellable slice
+
+### Build: NOTARY0 v1 + option (a), officer-relays (option A)
+
+**~4–5 days (NOTARY0 v1) + ~1.5–2 days (windows) + ~0.5–1 day (PCOR
+token route) ≈ 6–8 days.**
+
+What it delivers: the officer picks a notary from her own partner list
+(now with an address, thanks to PARTNER1), sends a signing request with
+2–3 proposed windows, the notary opens a token link, sees the package,
+and taps a time. The officer gets a notification and an email. She tells
+her clients herself, as she does today.
+
+**That removes the leg she does not control and touches no consumer PII.**
+
+### Deferred, with triggers
+
+| deferred | trigger |
+|---|---|
+| **Signer contact + direct messaging** | evidence from real use that officers *want* us to message their clients. Requires a retention and deletion answer first |
+| **Counter-proposal loop (b)** | officers reporting round-trips on (a). Reverses a standing owner ruling, so it needs a fresh one |
+| **`.ics` attachment** | first officer who asks. Cheap, and it rides the existing E1 attachment path |
+| **Calendar sync (c)** | not before a design partner is live and asking by name |
+| **A `matters` table** | still derived; unchanged by this work |
+| **Multi-user office** | RED-S5, deferred by decision. Note the interaction: partners are scoped `user-{id}`, so **a notary added by one officer is invisible to her colleague** |
+
+### What we deliberately do not build
+
+- **A notary marketplace.** We are not a directory. The officer brings
+  her own notary — that is the whole premise, and it is why this is
+  coordination rather than matching.
+- **Ranking or reviews.** Ranking notaries means asserting one is better,
+  which is a judgment we cannot support and would be liable for.
+- **Fees or payment routing.** Money between the officer and her notary
+  is theirs. Touching it makes us a party to it.
+- **RON (remote online notarization).** A different regulatory surface
+  entirely, with credential, recording and storage obligations we have
+  not assessed. Not "later" — *not this product* without a deliberate
+  decision.
+- **Availability sync.** See (c). A permanent maintenance tax for
+  convenience an invite already provides.
+- **SMS.** New vendor, new consent regime (TCPA), new opt-out
+  obligation, and it messages consumers we have no relationship with.
+  Option A avoids the entire category.
+- **Auto-completion.** Never. A passed window is not a signing, and §5 is
+  the reason.
+
+---
+
+## Open questions for the owner
+
+1. **Signer contact: Option A (officer relays) confirmed?** This is the
+   ruling that shapes everything else. Recommended: yes.
+2. **PCOR over a share token** — expired-token behaviour: still fetchable,
+   or not? (Recommend: no, matching the deed.)
+3. **May the officer set `scheduled` herself** to record an agreement
+   reached by phone? (Recommend: yes — otherwise the product's status is
+   wrong whenever the humans are efficient.)
+4. **`.ics` attachment in the confirmation email** — in the first slice or
+   deferred?

--- a/docs/NOTARY0B_SCHEDULING.md
+++ b/docs/NOTARY0B_SCHEDULING.md
@@ -321,3 +321,73 @@ her clients herself, as she does today.
    wrong whenever the humans are efficient.)
 4. **`.ics` attachment in the confirmation email** — in the first slice or
    deferred?
+
+
+---
+
+# Addendum — NOTARY1, the build (2026-08-10)
+
+All four questions above were ruled and the recommended slice was built:
+NOTARY0 v1 + windows (option a) + officer-relays.
+
+## The rulings, as executed
+
+1. **Option A confirmed.** The officer relays; the product coordinates
+   officer↔notary and nothing else. No signer contact is captured,
+   stored or messaged, and there is no field that could carry one —
+   pinned **fail-closed** across the whole backend and the whole
+   frontend, so a `signer_email`-shaped field arriving in any future
+   ticket fails the suite rather than waiting to be noticed.
+2. **Expired token = no PCOR, matching the deed exactly.** Applied as a
+   class: the deed, the PDF and the PCOR answer an expired or revoked
+   token identically. This is what surfaced the second defect below.
+3. **The officer may record a time she agreed out of band.** Both paths
+   write `scheduled_by` + `scheduled_asserted_at`, so the notary's tap
+   and the officer's phone call stay distinguishable in the record.
+4. **The `.ics` ships in the first slice**, through the existing E1
+   transport — one `.ics` per proposed window on the request, and one for
+   the chosen time on the officer's confirmation. `METHOD:PUBLISH`, not
+   `REQUEST`: this is a copy of an arrangement, not an invitation from an
+   organiser expecting RSVPs.
+
+## Still not built, and why (unchanged from the investigation)
+
+- **Marketplace.** We would be introducing a notary the officer did not
+  choose, which is a different business with a different liability
+  posture. She picks from her own partner list.
+- **Ranking and reviews.** Ranking professionals is a claim about their
+  competence. We have no basis for one, and a five-star average is a
+  claim dressed as data.
+- **Fees.** Taking a cut of a notarial fee makes us a party to the
+  engagement. Not without a deliberate decision about what that makes us.
+- **RON.** A different regulatory surface with credential, recording and
+  storage obligations we have not assessed. Not "later" — not this
+  product without a deliberate decision.
+- **Availability sync.** A permanent maintenance tax for convenience the
+  `.ics` already provides. See the ledger's trigger.
+- **SMS.** New vendor, new consent regime (TCPA), new opt-out obligation,
+  and it messages consumers we have no relationship with. Option A avoids
+  the category entirely.
+- **Auto-completion.** Never, and it is now §13 rather than a preference.
+  A passed window is not a signing.
+
+## Two pre-existing defects found while building, both fixed here
+
+- **Share creation never checked deed ownership.** `POST /shared-deeds`
+  took `deed_id` from the request body, read the address and APN,
+  inserted a `deed_shares` row with `owner_user_id = <the caller>` and
+  returned a working token. Any authenticated user could enumerate deed
+  ids and read someone else's property address, APN, county, grantor and
+  grantee names, and the stored PDF — and let a third party "approve" it.
+  Reproduced against a real database with two users before the fix. Every
+  *other* share endpoint scoped by `owner_user_id`; creation was the one
+  that did not, which is why it survived.
+- **An opened link kept serving the deed after expiry.** The 410 fired
+  only while the status was still `sent`, so a link viewed once returned
+  the deed indefinitely, while the PDF route next door refused the same
+  token. Expiry that depends on which URL you ask is not expiry.
+
+Both are pinned as classes rather than sites: a sweep requires every
+function that writes a `deed_shares` row to have resolved the deed
+through the ownership check, and the expiry pin asserts all four routes
+agree.

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -402,3 +402,58 @@ we reach it.
   ```
   `boundary_flags` is NULL when the response was clean, so
   `WHERE boundary_flags IS NOT NULL` is the whole conformance audit.
+
+- **NOTARY1 deferrals** (2026-08-10, all deferred WITH triggers — the
+  first slice is officer↔notary coordination and nothing else):
+
+  - **Signer contact and messaging.** DEFERRED WITH A HIGH BAR, not
+    parked. Owner ruling 1 is that the officer relays; the product holds
+    no signer contact and messages no signer. It is pinned fail-closed
+    in both suites, so building this is a deliberate act that trips a
+    test, which is the intent.
+    **Trigger:** a design partner asks for it *by name* AND a consumer
+    privacy posture exists to hold it against (what we store, for how
+    long, how a non-user asks us to delete it). Volume alone is not the
+    trigger; the trigger is having an answer to "what are you doing with
+    my client's phone number."
+  - **Counter-proposal loop** (the notary offers a time the officer did
+    not propose). Today she picks one of up to three, or they settle it
+    on the phone and the officer records it — both paths work, and the
+    second is not a workaround so much as what people actually do.
+    **Trigger:** officers report the phone-call path being used *because*
+    no window fit, more than occasionally. Until then a negotiation UI is
+    machinery for a conversation that takes fifteen seconds.
+  - **Calendar sync** (two-way, CalDAV/Google). The `.ics` attachment
+    ships now and covers "put it in my calendar."
+    **Trigger:** a partner asks for availability to be *read* from a
+    calendar rather than a file being sent to one — that is a different
+    product with OAuth, token refresh and a support surface, and it
+    should not arrive by increment.
+  - **The `matters` table.** Signing requests hang off a deed today. A
+    matter with several instruments signed in one sitting wants one
+    arrangement, not one per deed.
+    **Trigger:** the matters work itself (T-4's grouping is derived, not
+    a table); this rides it rather than preceding it.
+  - **RED-S5** (organization-scoped partners) — see the interaction
+    below, which is the reason it is named here.
+
+- **RED-S5 consequence, recorded now so it is not discovered as a bug**
+  (2026-08-10, NOTARY1 §6): **partners are scoped `user-{id}`.** A notary
+  added by one officer is invisible to her colleague at the same company,
+  who must add the same notary again, under her own account, with her own
+  typo. Nothing here is broken — it is what user-scoped partners *mean* —
+  but a two-officer design partner will experience it as a bug on their
+  second week, and "we know, it is the org-scoping ticket" is a much
+  better answer than discovering it live. It gets worse rather than
+  better as the partner list becomes load-bearing, which the signing
+  handoff makes it.
+  **Trigger:** the first design partner with more than one officer.
+
+- **A reminder written for a notary.** The signing request has no resend
+  today: the `share_reminder` template says "waiting on your review,"
+  which is the wrong question to re-ask somebody who was asked about her
+  availability. Both the button and the endpoint refuse it rather than
+  send the wrong words.
+  **Trigger:** the first signing request that goes unanswered long enough
+  for an officer to ask for a nudge. It is a template plus a route
+  branch, not a design question.

--- a/frontend/src/__tests__/signingHandoff.test.ts
+++ b/frontend/src/__tests__/signingHandoff.test.ts
@@ -1,0 +1,133 @@
+/**
+ * NOTARY1 — the signing handoff, on the screens.
+ *
+ * The backend pins the rules; these pin that the UI does not quietly
+ * undo them. Three properties, and each has bitten some product
+ * somewhere:
+ *
+ *  1. NO SIGNER CONTACT. The officer relays; the product coordinates
+ *     officer↔notary and messages no signer. A form field is the
+ *     easiest place for that to change without anybody deciding to
+ *     change it, so this sweeps the frontend the way the backend suite
+ *     sweeps Python — fail-closed, across the whole tree.
+ *  2. ONE PLACE WRITES THE WORDS. `scheduling_label()` on the server
+ *     is the only thing that turns a scheduling state into a sentence,
+ *     so "scheduled" cannot drift into "the signing will happen" on
+ *     some screen nobody rechecked. These pages render its output; they
+ *     do not compose their own.
+ *  3. A TIME IS SENT WITH ITS OFFSET. A bare wall-clock time forces the
+ *     server to guess a zone, which is how a calendar entry lands an
+ *     hour out and somebody arrives at an empty office.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
+
+const SRC = path.join(__dirname, '..');
+
+const read = (...parts: string[]) =>
+  fs.readFileSync(path.join(SRC, ...parts), 'utf8');
+
+/** JSX prose wraps across lines, so a sentence in the source is not a
+ * sentence in a string. Flatten before asserting on wording — otherwise
+ * the pin passes or fails on where the formatter chose to break. */
+const flat = (source: string) => source.replace(/\s+/g, ' ');
+
+const MODAL = read('features', 'signing', 'SigningRequestModal.tsx');
+const APPROVE = read('app', 'approve', '[token]', 'page.tsx');
+const SHARED = read('app', 'shared-deeds', 'page.tsx');
+
+/** Every .ts/.tsx under src, so a signer field cannot arrive in a file
+ * this test did not think to name. */
+function allSources(dir: string = SRC): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === '__tests__') continue;
+      out.push(...allSources(full));
+    } else if (/\.tsx?$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+// The PROPERTY — a way to reach a grantor or grantee — not the spellings
+// somebody happened to use. `recipient_email` and `notary_email` are the
+// professional the officer chose, not a consumer we found on a deed.
+const SIGNER_CONTACT =
+  /\b((signer|grantor|grantee|buyer|seller|borrower)_(email|phone|mobile|cell|sms|contact)|(email|phone|sms|notify)_(signer|grantor|grantee|buyer|seller))\b/i;
+
+describe('NOTARY1 — no signer contact, anywhere', () => {
+  it('no frontend source captures or sends a signer contact detail', () => {
+    const offenders: string[] = [];
+    for (const file of allSources()) {
+      const match = codeOnly(fs.readFileSync(file, 'utf8')).match(SIGNER_CONTACT);
+      if (match) offenders.push(`${path.relative(SRC, file)} → ${match[0]}`);
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('the signing form has no field for a signer', () => {
+    // Its inputs, enumerated: what the officer sends is the notary's
+    // address, a courtesy name, where, and the times.
+    const bound = [...MODAL.matchAll(/useState[^\n]*\n/g)].length;
+    expect(bound).toBeGreaterThan(0);
+    expect(MODAL).toContain('notary_email');
+    expect(MODAL).not.toMatch(SIGNER_CONTACT);
+    // And it says so on the form, so the officer knows the leg is hers.
+    expect(flat(MODAL)).toContain('The signers are not contacted');
+  });
+});
+
+describe('NOTARY1 — the words come from one place', () => {
+  it('the token page renders the summary the server wrote', () => {
+    expect(APPROVE).toContain('deed.signing.summary');
+  });
+
+  it('the token page never composes its own scheduling sentence', () => {
+    const code = codeOnly(APPROVE);
+    expect(code).not.toMatch(/scheduled for/i);
+    expect(code).not.toMatch(/will (happen|take place|be signed)/i);
+    expect(code).not.toMatch(/signing is confirmed/i);
+  });
+
+  it('the officer list renders the server line, not its own', () => {
+    const code = codeOnly(SHARED);
+    expect(code).toContain('deed.signing_summary');
+    expect(code).not.toMatch(/scheduled for/i);
+  });
+});
+
+describe('NOTARY1 — a signing request is not an approval request', () => {
+  it('the approve and reject actions are gated off a signing link', () => {
+    // can_approve comes back false from the server for a signing share,
+    // and the server refuses the POST as well — this pins that the page
+    // reads the flag rather than deciding for itself.
+    expect(APPROVE).toContain("deed?.share_kind === 'signing_request'");
+    expect(APPROVE).toContain('deed?.can_approve && !showRejectForm');
+  });
+
+  it('the notary is told what tapping a time means', () => {
+    expect(flat(APPROVE)).toContain('you are available then');
+  });
+
+  it('a notary is never sent the review reminder', () => {
+    expect(SHARED).toContain('if (deed.share_type === "signing_request") return false');
+  });
+});
+
+describe('NOTARY1 — times carry their offset', () => {
+  it('the modal appends the browser offset before sending', () => {
+    expect(MODAL).toContain('getTimezoneOffset');
+    expect(MODAL).toContain('withOffset(w.start)');
+    expect(MODAL).toContain('withOffset(w.end)');
+  });
+
+  it('at most three windows are offerable', () => {
+    expect(MODAL).toContain('const MAX_WINDOWS = 3');
+    expect(MODAL).toContain('windows.length < MAX_WINDOWS');
+  });
+});

--- a/frontend/src/app/approve/[token]/page.tsx
+++ b/frontend/src/app/approve/[token]/page.tsx
@@ -16,8 +16,41 @@ import {
   MapPin,
   Building,
   Loader2,
-  AlertCircle
+  AlertCircle,
+  CalendarClock
 } from 'lucide-react';
+
+/**
+ * NOTARY1 — this page now serves two kinds of link.
+ *
+ * A REVIEW share asks somebody to approve or request changes. A SIGNING
+ * REQUEST asks a notary one question: are you free at one of these
+ * times? It has no approve and no reject — the server refuses both for a
+ * signing link, so hiding the buttons here is presentation of a rule
+ * rather than the rule itself.
+ *
+ * `summary` is written by the backend and rendered VERBATIM. There is
+ * exactly one place in this product that turns a scheduling state into a
+ * sentence, and it is not this file: "scheduled" must never grow into
+ * "the signing will happen", and it cannot drift here if the words never
+ * originate here.
+ */
+interface SigningWindow {
+  index: number;
+  start: string;
+  end: string;
+  label: string;
+}
+
+interface SigningDetails {
+  state: 'proposed' | 'scheduled' | null;
+  summary: string | null;
+  windows: SigningWindow[];
+  scheduled_at: string | null;
+  scheduled_by: string | null;
+  can_choose_window: boolean;
+  pcor_url: string;
+}
 
 interface DeedDetails {
   deed_type: string;
@@ -31,6 +64,8 @@ interface DeedDetails {
   status: string;
   can_approve: boolean;
   pdf_url?: string;
+  share_kind?: string;
+  signing?: SigningDetails;
 }
 
 // Common issues for structured feedback
@@ -59,6 +94,35 @@ export default function ApproveDeedPage() {
   const [showRejectForm, setShowRejectForm] = useState(false);
   const [rejectComments, setRejectComments] = useState('');
   const [selectedIssues, setSelectedIssues] = useState<string[]>([]);
+  const [choosing, setChoosing] = useState<number | null>(null);
+
+  const isSigning = deed?.share_kind === 'signing_request';
+
+  const chooseWindow = async (windowIndex: number) => {
+    setChoosing(windowIndex);
+    setError(null);
+    try {
+      const api = process.env.NEXT_PUBLIC_API_URL || 'https://deedpro-main-api.onrender.com';
+      const response = await fetch(`${api}/approve/${token}/schedule`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ window_index: windowIndex }),
+      });
+      const data = await response.json();
+      if (!response.ok) {
+        setError(data.detail || 'That time could not be recorded.');
+        return;
+      }
+      // Re-read rather than patching local state: the summary sentence
+      // is the server's to write, and a locally-composed one is exactly
+      // the drift this design exists to prevent.
+      await fetchDeedDetails();
+    } catch (err) {
+      setError('Unable to connect to server.');
+    } finally {
+      setChoosing(null);
+    }
+  };
 
   useEffect(() => {
     fetchDeedDetails();
@@ -245,7 +309,9 @@ export default function ApproveDeedPage() {
               <FileText className="w-5 h-5 text-white" />
             </div>
             <div>
-              <h1 className="font-bold text-slate-800">Deed Review</h1>
+              <h1 className="font-bold text-slate-800">
+                {isSigning ? 'Signing Request' : 'Deed Review'}
+              </h1>
               <p className="text-sm text-slate-500">From {deed?.owner_name}</p>
             </div>
           </div>
@@ -412,8 +478,65 @@ export default function ApproveDeedPage() {
               </div>
             )}
 
+            {/* NOTARY1 — the signing card. No approve, no reject: the
+                question is availability, and the answer is a time. */}
+            {isSigning && deed?.signing && (
+              <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
+                <h2 className="font-bold text-slate-800 mb-1 flex items-center gap-2">
+                  <CalendarClock className="w-5 h-5 text-[#7C4DFF]" />
+                  Are you available?
+                </h2>
+                <p className="text-sm text-slate-500 mb-4">
+                  {deed.owner_name} proposed these times. Choosing one tells them you
+                  are available then — they confirm the appointment with the signers.
+                </p>
+
+                <div className="space-y-2">
+                  {deed.signing.windows.map((w) => {
+                    const chosen = deed.signing?.scheduled_at === w.start;
+                    return (
+                      <button
+                        key={w.index}
+                        onClick={() => chooseWindow(w.index)}
+                        disabled={choosing !== null || !deed.signing?.can_choose_window}
+                        className={`w-full flex items-center justify-between gap-3 px-4 py-3 rounded-lg border text-left font-medium transition-colors disabled:opacity-60 disabled:cursor-not-allowed ${
+                          chosen
+                            ? 'border-[#7C4DFF] bg-purple-50 text-slate-800'
+                            : 'border-slate-300 text-slate-700 hover:bg-slate-50'
+                        }`}
+                      >
+                        <span className="text-sm">{w.label}</span>
+                        {choosing === w.index ? (
+                          <Loader2 className="w-4 h-4 animate-spin shrink-0" />
+                        ) : chosen ? (
+                          <CheckCircle className="w-4 h-4 text-[#7C4DFF] shrink-0" />
+                        ) : null}
+                      </button>
+                    );
+                  })}
+                </div>
+
+                {/* The server's sentence, verbatim. */}
+                {deed.signing.summary && (
+                  <p className="text-sm text-slate-600 mt-4 pt-4 border-t border-slate-200">
+                    {deed.signing.summary}
+                  </p>
+                )}
+
+                <a
+                  href={`${process.env.NEXT_PUBLIC_API_URL || 'https://deedpro-main-api.onrender.com'}${deed.signing.pcor_url}.pdf`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-4 inline-flex items-center gap-2 text-sm text-[#7C4DFF] hover:underline"
+                >
+                  <Download className="w-4 h-4" />
+                  Preliminary Change of Ownership Report
+                </a>
+              </div>
+            )}
+
             {/* Already responded */}
-            {!deed?.can_approve && (
+            {!deed?.can_approve && !isSigning && (
               <div className="bg-slate-100 rounded-xl p-6 text-center">
                 <AlertCircle className="w-8 h-8 text-slate-400 mx-auto mb-2" />
                 <p className="text-slate-600">

--- a/frontend/src/app/partners/page.tsx
+++ b/frontend/src/app/partners/page.tsx
@@ -50,8 +50,26 @@ import {
 import Sidebar from '../../components/Sidebar';
 import '../../styles/dashboard.css';
 
-const CATEGORIES = ['title_company', 'real_estate', 'lender', 'other'] as const;
-const ROLES = ['title_officer', 'realtor', 'loan_officer', 'other'] as const;
+/**
+ * NOTARY1 adds `notary` / `notary_public`: a signing request picks its
+ * notary from this list, so a notary who cannot be filed as one is a
+ * notary the officer records as "other" and then searches for by memory.
+ *
+ * `escrow_company` and `attorney` are not new — the builder's
+ * AddPartnerModal has offered them all along while this screen did not,
+ * so a partner added there arrived here as a category the edit dropdown
+ * could not represent and the chip rendered as "Other". Two live lists
+ * of the same enum had drifted; adding a third divergence on top of that
+ * is how the next one gets found by a customer.
+ */
+const CATEGORIES = [
+  'title_company', 'escrow_company', 'notary', 'attorney',
+  'real_estate', 'lender', 'other',
+] as const;
+const ROLES = [
+  'title_officer', 'escrow_officer', 'notary_public', 'attorney',
+  'realtor', 'loan_officer', 'other',
+] as const;
 
 type Partner = {
   id: string;
@@ -208,6 +226,9 @@ export default function PartnersPage() {
   function categoryChip(category: string) {
     const tone: Record<string, string> = {
       title_company: 'bg-slate-100 text-slate-700 ring-slate-200',
+      escrow_company: 'bg-slate-100 text-slate-600 ring-slate-200',
+      notary: 'bg-slate-100 text-slate-700 ring-slate-300',
+      attorney: 'bg-gray-100 text-gray-600 ring-gray-200',
       real_estate: 'bg-slate-50 text-slate-600 ring-slate-200',
       lender: 'bg-gray-100 text-gray-700 ring-gray-300',
       other: 'bg-gray-50 text-gray-500 ring-gray-200',
@@ -409,8 +430,8 @@ export default function PartnersPage() {
                 {[
                   { label: 'Total Partners', n: items.length },
                   { label: 'Title Companies', n: items.filter((p) => p.category === 'title_company').length },
+                  { label: 'Notaries', n: items.filter((p) => p.category === 'notary').length },
                   { label: 'Real Estate', n: items.filter((p) => p.category === 'real_estate').length },
-                  { label: 'Lenders', n: items.filter((p) => p.category === 'lender').length },
                 ].map((s) => (
                   <div key={s.label} className="bg-gray-50 rounded-lg p-4">
                     <div className="text-sm text-gray-500">{s.label}</div>

--- a/frontend/src/app/past-deeds/page.tsx
+++ b/frontend/src/app/past-deeds/page.tsx
@@ -4,7 +4,8 @@ import type React from "react"
 import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import Sidebar from "@/components/Sidebar"
-import { FileText, Download, Share2, Trash2, AlertCircle, CheckCircle, Clock, X, Plus, Loader2, Search } from "lucide-react"
+import { FileText, Download, Share2, Trash2, AlertCircle, CheckCircle, Clock, X, Plus, Loader2, Search, CalendarClock } from "lucide-react"
+import { SigningRequestModal } from "@/features/signing/SigningRequestModal"
 import { toast } from "sonner"
 import { SessionExpiredError, apiFetch } from "@/lib/apiClient"
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog"
@@ -48,6 +49,8 @@ export default function PastDeedsPageV0() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [shareModalOpen, setShareModalOpen] = useState(false)
+  // NOTARY1: which deed, if any, has an open signing-request modal.
+  const [signingDeedId, setSigningDeedId] = useState<number | null>(null)
   const [selectedDeedId, setSelectedDeedId] = useState<number | null>(null)
   const [shareError, setShareError] = useState<string | null>(null)
   const [shareLoading, setShareLoading] = useState(false)
@@ -444,6 +447,16 @@ export default function PastDeedsPageV0() {
                                 >
                                   <Share2 className="w-4 h-4" />
                                 </button>
+                                {/* NOTARY1: a different question from the one
+                                    the Share button asks — availability, not
+                                    approval — so it is a different button. */}
+                                <button
+                                  onClick={() => setSigningDeedId(deed.id)}
+                                  className="p-2 bg-slate-600 hover:bg-slate-700 text-white rounded-lg transition-colors"
+                                  title="Request a signing"
+                                >
+                                  <CalendarClock className="w-4 h-4" />
+                                </button>
                               </>
                             )}
                             <button
@@ -663,6 +676,11 @@ export default function PastDeedsPageV0() {
             )}
           </div>
         </div>
+      )}
+
+      {/* NOTARY1 — request a signing (officer → notary) */}
+      {signingDeedId !== null && (
+        <SigningRequestModal deedId={signingDeedId} onClose={() => setSigningDeedId(null)} />
       )}
 
       {/* Delete Confirmation Dialog */}

--- a/frontend/src/app/shared-deeds/page.tsx
+++ b/frontend/src/app/shared-deeds/page.tsx
@@ -2,7 +2,7 @@
 import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import Sidebar from "@/components/Sidebar"
-import { Send, Eye, Clock, CheckCircle, XCircle, AlertCircle, RotateCw, X, Plus, FileText, MessageSquare } from "lucide-react"
+import { Send, Eye, Clock, CheckCircle, XCircle, AlertCircle, RotateCw, X, Plus, FileText, MessageSquare, CalendarClock } from "lucide-react"
 import { toast } from "sonner"
 import { SessionExpiredError, apiFetch } from "@/lib/apiClient"
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog"
@@ -19,6 +19,20 @@ interface SharedDeed {
   viewed_at?: string
   response_date?: string
   feedback?: string
+  /**
+   * NOTARY1. `share_type` is now the real kind ("review" or
+   * "signing_request") rather than the constant "review" it used to be.
+   *
+   * `signing_summary` is a SENTENCE THE SERVER WROTE, and it is rendered
+   * verbatim on purpose: the backend's scheduling_label() is the only
+   * place that turns a scheduling state into words, so that "scheduled"
+   * can never drift into a claim that the signing will happen. This
+   * screen does not compose its own version, and must not start.
+   */
+  share_type?: string
+  signing_summary?: string | null
+  scheduled_at?: string | null
+  scheduled_by?: string | null
 }
 
 // Issue labels for structured feedback
@@ -229,6 +243,12 @@ export default function SharedDeedsPageV0() {
   }
 
   const canRemind = (deed: SharedDeed) => {
+    // NOTARY1: the reminder template says "waiting on your review," which
+    // is the wrong question to re-ask a notary. Rather than send a notary
+    // an email about a review she was never asked for, the button is
+    // absent until there is a reminder written for her — and the server
+    // refuses the call too, so this is a rule and not a hidden button.
+    if (deed.share_type === "signing_request") return false
     return !["expired", "approved", "rejected", "revoked"].includes(deed.status)
   }
 
@@ -356,6 +376,15 @@ export default function SharedDeedsPageV0() {
                           <td className="py-4 px-6">
                             <div className="flex flex-col gap-2">
                               {getStatusBadge(deed.status)}
+                              {deed.share_type === "signing_request" && (
+                                <span className="inline-flex w-fit items-center gap-1.5 rounded-full border border-slate-200 bg-slate-50 px-2.5 py-0.5 text-[11px] font-semibold text-slate-600">
+                                  <CalendarClock className="h-3 w-3" />
+                                  Signing request
+                                </span>
+                              )}
+                              {deed.signing_summary && (
+                                <span className="text-xs text-slate-500">{deed.signing_summary}</span>
+                              )}
                               {deed.status === "rejected" && (
                                 <button
                                   onClick={() => handleViewFeedback(deed.id)}

--- a/frontend/src/components/modals/AddPartnerModal.tsx
+++ b/frontend/src/components/modals/AddPartnerModal.tsx
@@ -115,6 +115,8 @@ export function AddPartnerModal({ isOpen, onClose, onSave }: AddPartnerModalProp
               >
                 <option value="title_company">Title Company</option>
                 <option value="escrow_company">Escrow Company</option>
+                {/* NOTARY1: the signing request picks from here too. */}
+                <option value="notary">Notary</option>
                 <option value="attorney">Attorney</option>
                 <option value="real_estate">Real Estate Office</option>
                 <option value="lender">Lender</option>

--- a/frontend/src/features/partners/types.ts
+++ b/frontend/src/features/partners/types.ts
@@ -3,8 +3,12 @@
  * Purpose: Type definitions for title companies, real estate partners, lenders
  */
 
-export type PartnerCategory = 'title_company' | 'real_estate' | 'lender';
-export type PartnerRole = 'title_officer' | 'realtor' | 'loan_officer';
+export type PartnerCategory =
+  | 'title_company' | 'escrow_company' | 'notary' | 'attorney'
+  | 'real_estate' | 'lender' | 'other';
+export type PartnerRole =
+  | 'title_officer' | 'escrow_officer' | 'notary_public' | 'attorney'
+  | 'realtor' | 'loan_officer' | 'other';
 
 export interface Partner {
   id: string;

--- a/frontend/src/features/signing/SigningRequestModal.tsx
+++ b/frontend/src/features/signing/SigningRequestModal.tsx
@@ -1,0 +1,294 @@
+"use client"
+
+/**
+ * NOTARY1 — the officer asks a notary about her availability.
+ *
+ * WHAT IS DELIBERATELY ABSENT is the point of this form. There is no
+ * field for a signer's name, email or phone, and there is no place to
+ * put one: the product coordinates officer↔notary and stops there. The
+ * officer already has her clients' numbers and already calls them; what
+ * she cannot do without help is stop playing phone tag with a notary.
+ *
+ * Times are sent WITH the browser's UTC offset. A "2:00" with no offset
+ * is not a time, it is a hope — and the server would have to guess a
+ * zone, which is how a calendar entry lands an hour out and somebody
+ * arrives at an empty office.
+ */
+
+import { useState } from "react"
+import { CalendarClock, Loader2, Plus, Trash2, X } from "lucide-react"
+import { apiFetch } from "@/lib/apiClient"
+
+const MAX_WINDOWS = 3
+
+type Window = { start: string; end: string }
+
+type Result = {
+  link: string
+  emailSent: boolean
+  emailError?: string
+  windowLabels: string[]
+}
+
+/** "2026-08-12T10:00" (local, from an <input type="datetime-local">) →
+ *  "2026-08-12T10:00:00-07:00". The offset is the browser's, which is
+ *  the officer's, which is the property's — near enough, and infinitely
+ *  better than sending a bare wall-clock time and letting the server
+ *  assume. */
+function withOffset(local: string): string {
+  const parsed = new Date(local)
+  if (Number.isNaN(parsed.getTime())) return local
+  const minutes = -parsed.getTimezoneOffset()
+  const sign = minutes >= 0 ? "+" : "-"
+  const abs = Math.abs(minutes)
+  const pad = (n: number) => String(n).padStart(2, "0")
+  return `${local}:00${sign}${pad(Math.floor(abs / 60))}:${pad(abs % 60)}`
+}
+
+export function SigningRequestModal({
+  deedId,
+  onClose,
+}: {
+  deedId: number
+  onClose: () => void
+}) {
+  const [notaryEmail, setNotaryEmail] = useState("")
+  const [notaryName, setNotaryName] = useState("")
+  const [location, setLocation] = useState("")
+  const [windows, setWindows] = useState<Window[]>([{ start: "", end: "" }])
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [result, setResult] = useState<Result | null>(null)
+
+  const setWindow = (i: number, patch: Partial<Window>) =>
+    setWindows((prev) => prev.map((w, n) => (n === i ? { ...w, ...patch } : w)))
+
+  const complete = windows.filter((w) => w.start && w.end)
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setSubmitting(true)
+    setError(null)
+    try {
+      const response = await apiFetch(
+        "/signing-requests",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            deed_id: deedId,
+            notary_email: notaryEmail,
+            notary_name: notaryName || undefined,
+            location: location || undefined,
+            proposed_windows: complete.map((w) => ({
+              start: withOffset(w.start),
+              end: withOffset(w.end),
+            })),
+          }),
+        },
+        { label: "Sending signing request" },
+      )
+      const data = await response.json().catch(() => ({}))
+      if (!response.ok) {
+        throw new Error(data.detail || `Failed to send the request (${response.status})`)
+      }
+      // The email status is reported as it actually is, and the link is
+      // surfaced either way — a signing request must be usable when the
+      // transport is not configured (S1's rule, same as sharing).
+      setResult({
+        link: data.link || "",
+        emailSent: !!data.email_sent,
+        emailError: typeof data.email_error === "string" ? data.email_error : undefined,
+        windowLabels: (data.windows || []).map((w: { label: string }) => w.label),
+      })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to send the request")
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
+      <div className="bg-white rounded-2xl shadow-2xl max-w-[600px] w-full max-h-[90vh] overflow-y-auto p-8">
+        <div className="flex items-center justify-between mb-6">
+          <h2 className="text-2xl font-bold text-slate-800 flex items-center gap-2">
+            <CalendarClock className="w-6 h-6 text-[#7C4DFF]" />
+            Request a signing
+          </h2>
+          <button
+            onClick={onClose}
+            className="p-2 hover:bg-slate-100 rounded-lg transition-colors"
+            aria-label="Close"
+          >
+            <X className="w-5 h-5 text-slate-400 hover:text-slate-600" />
+          </button>
+        </div>
+
+        {result ? (
+          <div className="space-y-4">
+            <p className="text-slate-700">
+              The request is on the record. The notary chooses one of the times you
+              proposed; you will be told which.
+            </p>
+            {result.windowLabels.length > 0 && (
+              <ul className="text-sm text-slate-600 space-y-1">
+                {result.windowLabels.map((label) => (
+                  <li key={label}>• {label}</li>
+                ))}
+              </ul>
+            )}
+            <div
+              className={`rounded-lg border p-4 text-sm ${
+                result.emailSent
+                  ? "border-slate-200 bg-slate-50 text-slate-700"
+                  : "border-amber-200 bg-amber-50 text-amber-800"
+              }`}
+            >
+              {result.emailSent
+                ? `Email sent to ${notaryEmail}.`
+                : `The email did not go out${result.emailError ? `: ${result.emailError}` : ""}. Send the link below yourself.`}
+            </div>
+            {result.link && (
+              <div className="rounded-lg border border-slate-200 p-3 break-all text-xs text-slate-600">
+                {result.link}
+              </div>
+            )}
+            <p className="text-xs text-slate-500">
+              DeedPro does not contact the signers — arranging their attendance stays
+              with you.
+            </p>
+            <button
+              onClick={onClose}
+              className="w-full px-6 py-3 bg-[#7C4DFF] hover:bg-[#6a3de8] text-white font-medium rounded-lg transition-colors"
+            >
+              Done
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={submit} className="space-y-5">
+            <div>
+              <label className="block text-sm font-medium text-slate-700 mb-1">
+                Notary email <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="email"
+                required
+                value={notaryEmail}
+                onChange={(e) => setNotaryEmail(e.target.value)}
+                className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF]"
+                placeholder="notary@example.com"
+              />
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              <div>
+                <label className="block text-sm font-medium text-slate-700 mb-1">Notary name</label>
+                <input
+                  type="text"
+                  value={notaryName}
+                  onChange={(e) => setNotaryName(e.target.value)}
+                  className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF]"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium text-slate-700 mb-1">Where</label>
+                <input
+                  type="text"
+                  value={location}
+                  onChange={(e) => setLocation(e.target.value)}
+                  className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF]"
+                  placeholder="Defaults to the property address"
+                />
+              </div>
+            </div>
+
+            <div>
+              <div className="flex items-center justify-between mb-2">
+                <label className="block text-sm font-medium text-slate-700">
+                  Proposed times <span className="text-red-500">*</span>
+                </label>
+                {windows.length < MAX_WINDOWS && (
+                  <button
+                    type="button"
+                    onClick={() => setWindows((prev) => [...prev, { start: "", end: "" }])}
+                    className="inline-flex items-center gap-1 text-sm text-[#7C4DFF] hover:underline"
+                  >
+                    <Plus className="w-4 h-4" /> Add a time
+                  </button>
+                )}
+              </div>
+              <div className="space-y-3">
+                {windows.map((w, i) => (
+                  <div key={i} className="flex items-end gap-2">
+                    <div className="flex-1">
+                      <span className="block text-xs text-slate-500 mb-1">Start</span>
+                      <input
+                        type="datetime-local"
+                        value={w.start}
+                        onChange={(e) => setWindow(i, { start: e.target.value })}
+                        className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF]"
+                      />
+                    </div>
+                    <div className="flex-1">
+                      <span className="block text-xs text-slate-500 mb-1">End</span>
+                      <input
+                        type="datetime-local"
+                        value={w.end}
+                        onChange={(e) => setWindow(i, { end: e.target.value })}
+                        className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF]"
+                      />
+                    </div>
+                    {windows.length > 1 && (
+                      <button
+                        type="button"
+                        onClick={() => setWindows((prev) => prev.filter((_, n) => n !== i))}
+                        className="p-2 mb-0.5 text-slate-400 hover:text-red-600"
+                        aria-label="Remove this time"
+                      >
+                        <Trash2 className="w-4 h-4" />
+                      </button>
+                    )}
+                  </div>
+                ))}
+              </div>
+              <p className="text-xs text-slate-500 mt-2">
+                Three at most. More than three choices is a negotiation, and this is
+                not one.
+              </p>
+            </div>
+
+            {error && (
+              <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+                {error}
+              </div>
+            )}
+
+            <p className="text-xs text-slate-500">
+              The notary is told the document, the property and these times. The
+              signers are not contacted — that stays with you.
+            </p>
+
+            <div className="flex gap-3">
+              <button
+                type="button"
+                onClick={onClose}
+                className="flex-1 px-4 py-3 border border-slate-300 text-slate-700 rounded-lg hover:bg-slate-50 font-medium transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={submitting || !notaryEmail || complete.length === 0}
+                className="flex-1 px-4 py-3 bg-[#7C4DFF] hover:bg-[#6a3de8] text-white font-medium rounded-lg disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center justify-center gap-2"
+              >
+                {submitting && <Loader2 className="w-4 h-4 animate-spin" />}
+                Send the request
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
The officer picks a notary from her own partner list, sends a signing request with up to three proposed windows, and the notary taps one. She is told. That is the whole feature.

This PR also carries the NOTARY0b investigation report (the record, as ruled) plus its build addendum, and fixes **two pre-existing defects found on the way past** — one of them a cross-user data disclosure that is live on `main` today.

---

## ⚠️ Two pre-existing defects, both fixed here

### 1. Share creation never checked deed ownership

`POST /shared-deeds` took `deed_id` from the request body and never asked whose deed it was. It read the address and APN, inserted a `deed_shares` row with `owner_user_id = <the caller>`, and returned a working token.

So **any authenticated user could enumerate deed ids and read someone else's deed** — property address, APN, county, grantor and grantee names, and the stored PDF through `/approve/{token}/pdf`. They could also let a third party "approve" it. Reproduced against a real database with two users and one deed before writing the fix.

Every *other* share endpoint — list, resend, revoke, delete, feedback — already scoped by `owner_user_id`. Creation was the one that did not, which is why it survived: the surrounding code looked careful.

Fixed with `_owned_deed_or_404`, and pinned as a **class**: an AST sweep requires every function that writes a `deed_shares` row to have resolved the deed through the ownership check first, so the next creation path cannot repeat it by being written elsewhere in the file. Admin is deliberately not an escape — `_pcor_deed_row` lets an admin *read* a deed for support, and minting a link for a third party is a different verb.

### 2. An opened link kept serving the deed after expiry

`GET /approve/{token}` raised 410 only when the status was still `sent`. A link that had been opened once — status `viewed` — kept returning the deed indefinitely after expiry, while the PDF route next door refused the same token. Expiry that depends on which URL you ask is not expiry.

This surfaced because ruling 2 ("expired token = no PCOR, matching the deed exactly") was applied as a class rather than to the PCOR it was asked about. The deed, the PDF and the PCOR now answer an expired or revoked token identically, pinned across all four routes.

---

## The four rulings, as executed

1. **Option A confirmed** — the officer relays. No signer contact is captured, stored or messaged, and there is no field that could carry one. Pinned **fail-closed** across the entire backend *and* the entire frontend: a `signer_email`-shaped field arriving in any future ticket fails the suite rather than waiting to be noticed by a customer. Signers are consumers — no account, never agreed to our terms, no way to ask us to delete anything — and storing a grantor's email would change what a database dump *is*, in order to automate a message the officer is better placed to send.
2. **Expired token = no PCOR**, matching the deed exactly. Applied as a class (see defect 2).
3. **The officer may record a time agreed out of band.** Both paths write `scheduled_by` + `scheduled_asserted_at`, so the notary's tap and the officer's phone call stay distinguishable.
4. **The `.ics` ships in the first slice** through the existing E1 transport — one per proposed window on the request, one for the chosen time on the officer's confirmation. `METHOD:PUBLISH`, not `REQUEST`: a copy of an arrangement, not an invitation from an organiser expecting RSVPs.

## Doctrine §13 — an arrangement is not an act

A scheduled time looks like the least legally freighted thing in the product, and that is the risk: a low-stakes fact acquiring authority nobody granted it, because the words drifted. "Nora said she is free at 10" → "the signing is scheduled for 10" → "the signing happened at 10", and the last of those is a claim about a **notarial act**, a legal event whose record is kept by somebody who is not us.

Three rules, each pinned:

1. **No auto-completion, no timer, no inference from a passed window.** `scheduling_state()` is type-incapable of returning a state meaning "happened" — pinned by walking its AST, so the vocabulary is checked rather than the spelling.
2. **`completed` is officer-only.** The notary has no account, and a tap on a public token is not an attestation that a notarial act was performed.
3. **The words are written once.** `scheduling_label()` is the only function that turns a scheduling state into a sentence; both frontends render its output verbatim and both suites pin that they do not compose their own.

**Assertion shape mirrors RED-S4 exactly** — `scheduled_at` / `scheduled_by` / `scheduled_asserted_at`, the same trio as `recorded_at` / `recording_asserted_by` / `recording_asserted_at`.

**The state is DERIVED (T-5, transferred verbatim).** `scheduled` never enters `deed_shares.status`: a signing request that has been viewed AND scheduled is the normal case, and folding it into that column makes it inexpressible — exactly as `superseded` in `deeds.status` would have made a superseded deed stop being a completed one.

## What shipped

**Schema** (additive, `ALTER … IF NOT EXISTS`): `share_kind`, `proposed_windows` JSONB, `scheduled_at`, `scheduled_by`, `scheduled_asserted_at`, plus an index.

**Backend** — `services/signing.py` (the doctrine, window validation, `.ics` builder, the single labelling function); five routes: `POST /signing-requests`, `POST /approve/{token}/schedule`, `POST /shared-deeds/{id}/schedule`, `GET /approve/{token}/pcor`, `GET /approve/{token}/pcor.pdf`. `POST /approve/{token}` now refuses a signing link with 409 — a rule, not a hidden button. Two E1 templates (`share_signing_request`, `signing_time_recorded`); the transport gained attachment support *on the existing function*, because a `send_email_with_attachment` twin would have satisfied the ADMIN3 pin's letter while destroying what it protects.

**Frontend** — token page branches on `share_kind` (window buttons, no approve/reject, PCOR link); `SigningRequestModal` for the officer, sending times **with the browser's UTC offset** because a bare wall-clock time makes the server guess a zone; status line on the shared-deeds surface; `notary` / `notary_public` added to the partner arrays.

## Two judgment calls worth your eye

- **A create-UI was not in the ticket's scope list**, but without one the slice is unreachable, so `SigningRequestModal` is here. Say the word if you wanted it held.
- **The partner category lists had already diverged**: `AddPartnerModal` has offered `escrow_company` and `attorney` all along while the partners screen never has, so a partner added from the builder arrived as a category the edit dropdown could not represent and rendered as "Other". Adding a third divergence on top of that seemed worse than aligning the two live lists, so they are aligned. Two dead files (`PartnersManager.tsx`, `QuickAddPartnerModal.tsx` — no importers) were left alone.

## Also fixed: a pin that was a count

`test_all_three_public_token_endpoints_validate_before_querying` asserted `count(...) == 3`, a fact about that afternoon's routes. It went red simply because routes were added — and would have stayed **green** for a fourth endpoint added while a fifth dropped its guard. It is now a property sweep over every handler whose path carries `{approval_token}`, and it moved out of a module that skips without a database, so a source pin now runs in both CI jobs.

## Ledgered with triggers

Signer contact and messaging (high bar: a partner asking by name **and** a consumer privacy posture to hold it against); counter-proposal loop; calendar sync; the `matters` table; a reminder written for a notary. Plus the **RED-S5 consequence recorded now so it is not discovered as a bug**: partners are scoped `user-{id}`, so a notary added by one officer is invisible to her colleague — nothing is broken, it is what user-scoped partners mean, but a two-officer design partner will experience it as a bug in their second week.

**Not built, with reasons** (marketplace, ranking/reviews, fees, RON, availability sync, SMS, auto-completion) — in the report addendum.

## Gates

| gate | result |
|---|---|
| pytest, no database | 783 passed, 105 skipped |
| pytest, with database | 888 passed |
| jest | 598 passed, 39 suites |
| tsc | 94 (baseline unchanged; no touched file errors) |
| six-flow baseline | ✔ |
| API baseline | ✔ |
| banned-claims | clean, 13 rules |
| OpenAPI snapshot | re-recorded — 5 routes added, 0 removed |

**The suite passed on its first run, so it was not trusted.** Mutation probes were run against every load-bearing pin: planting a `signer_email` (caught, both trees), removing the ownership check (caught), restoring the old expiry rule (caught). The officer-notification assertion **passed with the send deliberately broken** — `email_log` and `notifications` are append-only and survive between runs, so "a row with this template exists" was satisfied by an earlier run's row. Re-written against high-water marks taken before the tap, and re-probed until both halves bite.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_