### PR TITLE
PARTNER2: one partner registry, one phone rule — and the §13.1 reversal recorded

### DIFF
--- a/backend/services/partners.py
+++ b/backend/services/partners.py
@@ -3,6 +3,7 @@ Partners Service
 CRUD operations for Industry Partners (org-scoped)
 """
 
+from services.phone import normalize_phone
 from typing import List, Dict, Optional
 from database import get_db_connection
 
@@ -48,6 +49,14 @@ def normalize_partner_fields(data: Dict) -> Dict:
     # judgement about anyone's spelling.
     if "state" in out and out["state"]:
         out["state"] = " ".join(str(out["state"]).split()).upper() or None
+    # PARTNER2: E.164 for anything US-shaped, verbatim for everything
+    # else. The browser already does this before it posts; doing it here
+    # too means the column's shape is a property of the STORAGE rather
+    # than of which client happened to write the row. Unparseable input
+    # survives untouched — see services/phone.py for why that is the
+    # rule and not an oversight.
+    if "phone" in out:
+        out["phone"] = normalize_phone(out["phone"]) or None
     return out
 
 

--- a/backend/services/phone.py
+++ b/backend/services/phone.py
@@ -1,0 +1,94 @@
+"""PARTNER2 — phone normalization, server side.
+
+═══ WHY THIS EXISTS WHEN THE BROWSER ALREADY DOES IT ═══
+
+`frontend/src/lib/phone.ts` masks as she types and normalizes before it
+posts, which covers every surface a person uses. It does not cover the
+API, and "every current caller happens to be well-behaved" is a property
+of this afternoon rather than of the system. Column shape is a storage
+concern; it belongs where storage is.
+
+So the rule exists in two languages, which is a real risk — the one this
+codebase has been bitten by repeatedly (A2's third city list, the five
+partner-category copies this same ticket is deleting). The mitigation is
+the one Doctrine A established: a SHARED CORPUS, `phone_cases.json`, read
+by both suites, so the two implementations are checked against the same
+referee rather than against each other's reputation.
+
+═══ E.164 IN, REGIONAL OUT ═══
+
+Stored as `+1XXXXXXXXXX` because that is the representation that is a
+FACT: one number, one spelling, comparable and dial-able. Displayed
+regionally because that is how a person reads a phone number. Conflating
+the two is how `partners.phone` came to hold eleven punctuation styles
+that no search could match.
+
+═══ WHAT IT REFUSES TO DO ═══
+
+It does not validate that a number is reachable or assigned, and it does
+NOT discard what it cannot parse. An extension, a UK number, or "ask for
+Dana" is information the officer chose to record; dropping it to keep a
+column tidy would be the product deciding it knows better than the person
+using it. Unparseable input is returned trimmed and verbatim.
+"""
+from __future__ import annotations
+
+import re
+from typing import Optional
+
+_NON_DIGIT = re.compile(r"\D")
+
+
+def _digits(value: str) -> str:
+    return _NON_DIGIT.sub("", value or "")
+
+
+def _ten_digits(value: str) -> str:
+    """The ten significant digits, or '' when this is not US-shaped."""
+    d = _digits(value)
+    if len(d) == 10:
+        return d
+    if len(d) == 11 and d.startswith("1"):
+        return d[1:]
+    return ""
+
+
+def normalize_phone(value: Optional[str]) -> str:
+    """Storage form. `+1XXXXXXXXXX`, or the input verbatim if it is not a
+    US-shaped number. Idempotent — normalizing twice is normalizing once,
+    which matters because an update round-trips a stored value."""
+    raw = (value or "").strip()
+    if not raw:
+        return ""
+    ten = _ten_digits(raw)
+    if not ten:
+        return raw
+    return f"+1{ten}"
+
+
+def format_phone(value: Optional[str]) -> str:
+    """Display form, from whatever is stored — including the historical
+    mess written before this ticket."""
+    raw = (value or "").strip()
+    if not raw:
+        return ""
+    ten = _ten_digits(raw)
+    if not ten:
+        return raw
+    return f"({ten[:3]}) {ten[3:6]}-{ten[6:]}"
+
+
+def phone_search_key(value: Optional[str]) -> str:
+    """The comparable form: the TEN significant digits for a US-shaped
+    number, all digits otherwise.
+
+    The first draft returned every digit, which was wrong in a way the
+    test caught: a stored `+16265550134` keyed to `16265550134` while an
+    officer typing `6265550134` keyed to `6265550134`. Substring matching
+    happened to still work, so the screen would have looked fine — and
+    any comparison by equality, which is what a future "is this the same
+    number" check would use, would have said no. Dropping the country
+    code makes both sides reduce to the same key.
+    """
+    raw = value or ""
+    return _ten_digits(raw) or _digits(raw)

--- a/backend/services/phone_cases.json
+++ b/backend/services/phone_cases.json
@@ -1,0 +1,77 @@
+{
+  "_comment": "PARTNER2 — the phone normalization corpus, read by BOTH suites. One rule in two languages; the corpus is the referee. Doctrine A's pattern (services/vesting_cases.json) applied to a smaller problem: the officer types in the browser and the API can be posted to directly, so the rule exists twice and must not drift. `stored` is what the column must hold; `display` is what a human must read back.",
+  "cases": [
+    {
+      "why": "the ordinary case — as she types it",
+      "input": "(626) 555-0134",
+      "stored": "+16265550134",
+      "display": "(626) 555-0134"
+    },
+    {
+      "why": "bare digits",
+      "input": "6265550134",
+      "stored": "+16265550134",
+      "display": "(626) 555-0134"
+    },
+    {
+      "why": "hyphens — the most common thing already in the column",
+      "input": "626-555-0134",
+      "stored": "+16265550134",
+      "display": "(626) 555-0134"
+    },
+    {
+      "why": "dots",
+      "input": "626.555.0134",
+      "stored": "+16265550134",
+      "display": "(626) 555-0134"
+    },
+    {
+      "why": "leading 1",
+      "input": "1 (626) 555-0134",
+      "stored": "+16265550134",
+      "display": "(626) 555-0134"
+    },
+    {
+      "why": "already E.164 — normalizing must be idempotent",
+      "input": "+16265550134",
+      "stored": "+16265550134",
+      "display": "(626) 555-0134"
+    },
+    {
+      "why": "surrounding whitespace",
+      "input": "  626 555 0134  ",
+      "stored": "+16265550134",
+      "display": "(626) 555-0134"
+    },
+    {
+      "why": "empty is empty, not '+1'",
+      "input": "",
+      "stored": "",
+      "display": ""
+    },
+    {
+      "why": "an extension is INFORMATION — kept verbatim, never truncated to fit the column's preferred shape",
+      "input": "(626) 555-0134 x220",
+      "stored": "(626) 555-0134 x220",
+      "display": "(626) 555-0134 x220"
+    },
+    {
+      "why": "an international number is not ours to reformat",
+      "input": "+44 20 7946 0958",
+      "stored": "+44 20 7946 0958",
+      "display": "+44 20 7946 0958"
+    },
+    {
+      "why": "a note the officer left herself is still data — we do not discard what we cannot parse",
+      "input": "ask for Dana",
+      "stored": "ask for Dana",
+      "display": "ask for Dana"
+    },
+    {
+      "why": "too few digits to be a US number — left alone rather than padded or rejected",
+      "input": "555-0134",
+      "stored": "555-0134",
+      "display": "555-0134"
+    }
+  ]
+}

--- a/backend/tests/test_partner2_registry_phone.py
+++ b/backend/tests/test_partner2_registry_phone.py
@@ -1,0 +1,92 @@
+"""PARTNER2 — one phone rule in two languages, refereed by a corpus.
+
+The normalization rule exists in Python (`services/phone.py`, so the
+column's shape is a property of storage rather than of which client wrote
+the row) and in TypeScript (`lib/phone.ts`, so she sees her number
+formatted as she types it). Two implementations of one rule is exactly
+the divergence this ticket is deleting elsewhere, so it gets the Doctrine
+A treatment: a shared corpus both suites read, with the corpus as referee
+rather than either implementation.
+
+`frontend/src/__tests__/partnerRegistry.test.ts` reads the same file.
+"""
+import json
+import sys
+from pathlib import Path
+
+BACKEND = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(BACKEND))
+
+from services.phone import format_phone, normalize_phone, phone_search_key  # noqa: E402
+
+CASES = json.loads((BACKEND / "services" / "phone_cases.json").read_text())["cases"]
+
+
+def test_the_corpus_is_not_empty_and_covers_the_awkward_shapes():
+    """A corpus of only happy cases proves an implementation agrees with
+    itself. The ones that matter are the ones where the rule declines to
+    act — an extension, an international number, a note."""
+    assert len(CASES) >= 10
+    reasons = " ".join(c["why"] for c in CASES).lower()
+    for shape in ("extension", "international", "idempotent", "empty"):
+        assert shape in reasons, f"the corpus does not exercise the {shape} case"
+
+
+def test_every_case_normalizes_as_the_corpus_says():
+    for case in CASES:
+        assert normalize_phone(case["input"]) == case["stored"], case["why"]
+
+
+def test_every_case_displays_as_the_corpus_says():
+    for case in CASES:
+        assert format_phone(case["stored"]) == case["display"], case["why"]
+
+
+def test_normalizing_is_idempotent():
+    """An update round-trips a stored value, so a second pass must be a
+    no-op. A rule that is not idempotent turns `+16265550134` into
+    something else the second time somebody saves the row."""
+    for case in CASES:
+        once = normalize_phone(case["input"])
+        assert normalize_phone(once) == once, case["why"]
+
+
+def test_unparseable_input_survives_verbatim():
+    """We do not discard what we cannot parse.
+
+    An officer typing an extension, a UK number, or a note to herself has
+    recorded information. Dropping it to keep a column tidy would be the
+    product deciding it knows better than the person using it — and the
+    loss would be silent, which is the part §4 objects to.
+    """
+    for raw in ("ask for Dana", "+44 20 7946 0958", "(626) 555-0134 x220"):
+        assert normalize_phone(raw) == raw.strip()
+
+
+def test_search_finds_the_same_row_however_either_side_was_typed():
+    """The defect this closes: `partners.phone` was free text and the
+    partners screen matched it as a substring, so a row saved as
+    "626-555-0134" was invisible to somebody typing "(626) 555"."""
+    stored = normalize_phone("626-555-0134")
+    assert phone_search_key("(626) 555") in phone_search_key(stored)
+    assert phone_search_key("6265550134") == phone_search_key(stored)
+
+
+def test_the_write_path_normalizes_regardless_of_client():
+    """The reason this exists in Python at all. Every UI surface
+    normalizes before posting; the API does not have to."""
+    from services.partners import normalize_partner_fields
+    assert normalize_partner_fields({"phone": "626.555.0134"})["phone"] == "+16265550134"
+
+
+def test_a_key_that_is_absent_stays_absent():
+    """`update_partner` builds its SET clause from which keys exist, so
+    inventing `phone` here would blank a column the caller never
+    mentioned. PARTNER1's rule, and the phone step must respect it."""
+    from services.partners import normalize_partner_fields
+    assert "phone" not in normalize_partner_fields({"city": "Los Angeles"})
+
+
+def test_a_blank_phone_becomes_null_not_plus_one():
+    from services.partners import normalize_partner_fields
+    assert normalize_partner_fields({"phone": "   "})["phone"] is None

--- a/docs/DOCTRINE_CONFORMANCE.md
+++ b/docs/DOCTRINE_CONFORMANCE.md
@@ -673,7 +673,12 @@ been VIEWED and SCHEDULED is the normal case, so `scheduled` never enters
 `deed_shares.status`; `scheduled_at` is its own column and the state is
 computed from it.
 
-**No signer contact, anywhere (owner ruling 1).** Signers — grantors and
+**AMENDED 2026-08-11 (NOTARY2) — see the reversal below.** The paragraph
+that follows was the rule as NOTARY1 shipped it. It has been reversed by
+the owner and is kept verbatim, because a doctrine section that quietly
+rewrites its own history is worth less than one that shows its work.
+
+**No signer contact, anywhere (owner ruling 1, SUPERSEDED).** Signers — grantors and
 grantees — are consumers. They have no account, never agreed to our
 terms, cannot see what we hold and cannot ask us to delete it. Storing a
 grantor's email would change what a database dump IS, and it would do so
@@ -711,12 +716,68 @@ address, APN, county, party names and stored PDF through it. And
 forever after expiry, while the PDF route next door refused it. Both are
 recorded in full in the PR and pinned as classes, not sites.
 
+### §13.1 — The signer-contact reversal (2026-08-11, owner-ruled)
+
+**The ruling above is reversed.** Signers now participate directly: the
+notary posts availability, the signers pick or propose, and when they
+converge it is booked. The officer initiates and is notified; she does
+not gate the final time.
+
+**The owner's reasoning, recorded because a reversal without its argument
+is just churn:**
+
+> The signers are the scheduling constraint, so routing around them
+> recreated the phone tag the feature exists to kill.
+
+That is right, and it is worth being exact about how Option A came to
+look correct. Option A optimised for the cost it could SEE — data held
+about a non-user — and treated the officer's relaying as free. It is not
+free; it is the entire cost of the problem. A notary offers three
+windows, the officer phones two signers, one can do Tuesday and the other
+cannot, and she is back on the phone to the notary. The product had
+removed one leg of a three-leg negotiation and called it coordination.
+
+**What did NOT change.** Everything else in §13 stands. An arrangement is
+still not an act; booked is still not happened; there is still no
+auto-completion and no timer and no inference from a passed window;
+`completed` is still officer-asserted; no surface may render a booking as
+a claim that the signing will occur. The reversal is about *who may be
+contacted*, and nothing else.
+
+**What the pins become.** NOTARY1 pinned "no signer contact anywhere,"
+fail-closed across both trees, precisely so that adding it would be a
+deliberate act that trips a test rather than a diff nobody read. That pin
+did its job and is being ANSWERED, not deleted. It is retargeted to the
+narrower promise we can actually keep:
+
+| | |
+|---|---|
+| was | no signer contact exists anywhere in the product |
+| is | signer contact exists on ONE purgeable row, reaches no other table, and is deleted on a schedule by a mechanism with a test |
+
+Specifically, and pinned: no signer contact column on `deeds`, no
+contact-shaped key written into the `parties` JSONB, none on `users`,
+`partners`, or any other profile table, and exactly one table in the
+schema that holds it.
+
+**The obligation the reversal creates rather than removes.** NOTARY0b's
+argument against involving signers was that they "cannot see what we hold
+and cannot ask us to delete it." Reversing the ruling does not answer
+that objection — it converts it into a requirement. A retention rule
+(proposed: 90 days past completion or expiry) and a way for a non-user to
+ask for removal are now part of the feature, not adjacent to it, and the
+purge must be a MECHANISM rather than a discipline. Recorded in
+`OWNER_LEDGER.md` as an owner item, because what we tell a consumer about
+their data is not a machine decision.
+
+
 ---
 
 ## Change log
 
 | Date | Change |
 |---|---|
+| 2026-08-11 | §13.1 — the signer-contact ruling REVERSED (NOTARY2). Signers now participate directly; the notary posts availability, signers pick or propose, convergence books it, and the officer is notified rather than gating. Owner's reasoning recorded: the signers are the scheduling constraint, so routing around them recreated the phone tag the feature exists to kill — Option A had priced the officer's relaying at zero when it is the entire problem. The superseded paragraph is kept verbatim rather than rewritten. §13 otherwise stands unchanged: booked is still not happened. NOTARY1's fail-closed sweep is ANSWERED rather than deleted — retargeted from "no signer contact anywhere" to "one purgeable row, no other table, deleted by a mechanism with a test." The retention rule and a non-user's route to removal become part of the feature, ledgered as owner items. |
 | 2026-08-10 | §13 added (NOTARY1) — an arrangement is not an act. A scheduled signing time is the least legally freighted fact in the product, which is exactly the risk: authority acquired by wording drift rather than by decision. Three pinned rules: nothing infers a signing from a passed window (`scheduling_state()` is AST-pinned type-incapable of a "happened" state), `completed` stays officer-only, and `scheduling_label()` is the single place a scheduling state becomes a sentence. Assertion shape mirrors RED-S4 (`scheduled_at` / `scheduled_by` / `scheduled_asserted_at`), keeping the notary's tap and the officer's phone call apart. State DERIVED, never folded into `deed_shares.status` — T-5's ruling transferred verbatim. No signer contact anywhere, pinned fail-closed across both trees. One expiry semantic per link, applied as a class. Two pre-existing defects fixed in passing: share creation never checked deed ownership (cross-user deed disclosure), and an opened link kept serving the deed after expiry. |
 | 2026-08-06 | §12 added (Doctrine B) — the AI boundary, explain-yes/select-no; closes RED0 R3-5. The third citizen: earlier sections legislate facts and legal choices, and the assistant emits PROSE, which had neither a suggestion marker nor a confirmation nor (until H1.3) a record. Three layers: the system prompt STATES the boundary (prevents), a server-side scanner pairs recommendation cues with instrument names and records findings in `ai_exchange_log.boundary_flags` (detects, does not block — a flagged response still reaches the officer, and blocking on a pattern would let a false positive swallow a correct answer), transcript-style tests ask the forbidden questions. `deed_type_advisor` REWRITTEN to explain-only, not deleted: the boundary decides the prompt regardless of usage evidence, and deleting would remove the permitted half. H1.3's flag-and-pin retired in the same diff that cured its condition. Usage-evidence tuning deferred with a trigger (OWNER_LEDGER) — the log was two days old and empty. |
 | 2026-08-05 | §11 added (Doctrine A) — a field's kind is decided by its content, not its name. `vested_owner` carried a name PLUS a legal characterization into a fact position on both import paths, so the officer confirmed a legal conclusion with the affordance built for an APN and the record described the wrong act. Split into fact / violet proposal / audit `verbatim`; `'proposed'` deliberately outside `FieldStatus` so the generation gate is type-incapable of offering it. Unsplittable composites offer NEITHER half. `suggestVesting` (community property inferred from a shared surname) deleted from the dormant prefill — a dormant code path is still a code path. One rule in two languages, pinned by a corpus both suites read. |

--- a/docs/NOTARY2_PLAN.md
+++ b/docs/NOTARY2_PLAN.md
@@ -1,0 +1,385 @@
+# NOTARY2 — the coordination loop: build plan
+
+**Status: plan for owner review. No Part C code written.**
+Parts A (PARTNER2) and B (share entry points) ship separately and are
+not blocked on this.
+
+---
+
+## 0. The reversal, and why it is the right call
+
+NOTARY0b ruled **Option A**: the officer relays, the product coordinates
+officer↔notary only, no signer contact anywhere. NOTARY1 built exactly
+that, and pinned it fail-closed in both suites.
+
+The owner has reversed it. The reasoning, recorded because a reversal
+without its argument is just churn:
+
+> **The signers are the scheduling constraint.** Routing around them
+> recreated the phone tag the feature exists to kill.
+
+That is correct, and it is worth being precise about *why* Option A
+looked right and was not. Option A optimised for the thing we could see —
+the data we would hold about a non-user — and treated the officer's
+relaying as free. It is not free; it is the entire cost of the problem.
+A notary posts three windows, the officer phones two signers, one can do
+Tuesday, the other cannot, and the officer is back on the phone to the
+notary. The product had removed one leg of a three-leg negotiation and
+called it coordination.
+
+**What the reversal does NOT change.** §13 stands unchanged: an
+arrangement is not an act, booked ≠ happened, `completed` stays
+officer-asserted, nothing renders "scheduled" as a claim the signing will
+occur. What changes is a single sub-ruling — *who may be contacted* —
+and the pins that enforce it get **retargeted, not deleted**: from "no
+signer contact anywhere" to "no signer contact outside one purgeable
+row." That is a narrower promise, and it is the one we can keep.
+
+**The pins will fail on the first Part C commit, by design.** NOTARY1's
+sweep is fail-closed across both trees precisely so that adding signer
+contact is a deliberate act that trips a test. Part C's first change is
+to retarget it. Nothing about that is a workaround — it is the pin doing
+its job and being answered.
+
+---
+
+## 1. Schema
+
+### Why not extend `deed_shares`
+
+NOTARY1 put the signing request on `deed_shares` with `share_kind`,
+because one share = one recipient = one row, and there was one recipient.
+NOTARY2 has **one request with N participants**, each with their own
+token, their own view, and their own answers. That is an aggregate with
+children, and flattening it onto `deed_shares` means either N rows that
+have to be re-associated by convention, or JSONB blobs carrying identity
+and access — both of which put the token, the contact and the answers in
+a place nothing can constrain.
+
+So: `deed_shares` stays what it is (**review shares only**), and the
+signing request becomes its own small aggregate. NOTARY1's
+`share_kind`/`proposed_windows`/`scheduled_*` columns are migrated and
+then left in place, unused, rather than dropped — additive-only DDL is
+the house rule, and a column nobody reads costs nothing.
+
+### The four tables
+
+```sql
+signing_requests
+  id                  BIGSERIAL PRIMARY KEY
+  deed_id             INT NOT NULL REFERENCES deeds(id)
+  officer_user_id     INT NOT NULL REFERENCES users(id)
+  location            TEXT                    -- defaults to the property address
+  tz_name             VARCHAR(64) NOT NULL    -- IANA, e.g. 'America/Los_Angeles'
+  expires_at          TIMESTAMPTZ NOT NULL
+  cancelled_at        TIMESTAMPTZ             -- orthogonal fact, its own column
+  booked_at           TIMESTAMPTZ             -- the agreed instant
+  booked_by           VARCHAR(16)             -- 'convergence' | 'officer'
+  booked_asserted_at  TIMESTAMPTZ
+  signer_proposals    INT NOT NULL DEFAULT 0  -- the round-trip counter
+  contact_purged_at   TIMESTAMPTZ
+  created_at, updated_at TIMESTAMPTZ
+
+signing_participants
+  id                  BIGSERIAL PRIMARY KEY
+  signing_request_id  BIGINT NOT NULL REFERENCES signing_requests(id) ON DELETE CASCADE
+  party_role          VARCHAR(16) NOT NULL    -- 'notary' | 'signer'
+  display_name        VARCHAR(255)
+  email               VARCHAR(320)            -- PURGEABLE for signers
+  phone               VARCHAR(32)             -- PURGEABLE for signers
+  partner_id          UUID                    -- set for the notary; NULL for signers
+  token               UUID NOT NULL UNIQUE
+  expires_at          TIMESTAMPTZ NOT NULL
+  revoked_at          TIMESTAMPTZ
+  last_viewed_at      TIMESTAMPTZ
+  reminders_sent      INT NOT NULL DEFAULT 0
+  contact_purged_at   TIMESTAMPTZ
+  created_at, updated_at TIMESTAMPTZ
+
+signing_windows
+  id                  BIGSERIAL PRIMARY KEY
+  signing_request_id  BIGINT NOT NULL REFERENCES signing_requests(id) ON DELETE CASCADE
+  starts_at           TIMESTAMPTZ NOT NULL
+  ends_at             TIMESTAMPTZ NOT NULL
+  origin              VARCHAR(16) NOT NULL    -- 'notary' | 'signer_proposal' | 'officer'
+  proposed_by         BIGINT NOT NULL REFERENCES signing_participants(id)
+  declined_at         TIMESTAMPTZ
+  created_at          TIMESTAMPTZ
+
+signing_responses
+  id                  BIGSERIAL PRIMARY KEY
+  window_id           BIGINT NOT NULL REFERENCES signing_windows(id) ON DELETE CASCADE
+  participant_id      BIGINT NOT NULL REFERENCES signing_participants(id) ON DELETE CASCADE
+  answer              VARCHAR(16) NOT NULL    -- 'available' | 'unavailable'
+  asserted_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+  UNIQUE (window_id, participant_id)          -- changing your mind is an UPDATE
+```
+
+### Three schema decisions worth arguing
+
+**(a) There is no `status` column, and that is deliberate.** The four
+states the owner named are all derivable and none of them is a fact:
+
+| state | derivation |
+|---|---|
+| requested | no rows in `signing_windows` |
+| windows posted | windows exist, nobody has converged |
+| partially agreed | ≥1 `available` response, not a full set |
+| booked | `booked_at IS NOT NULL` |
+
+T-5's ruling, third application: orthogonal facts do not share a column.
+`cancelled_at` is its own column for the same reason — a cancelled
+request that had been partially agreed must stay expressible.
+
+**(b) `booked_at` is WRITTEN, not derived — and that is not a
+contradiction.** Convergence is computable, so deriving it is tempting.
+It is wrong for two reasons. An agreement is an **event with a moment**,
+and the moment is the last party's answer, not the moment somebody
+happened to run the query. And the officer's override must be able to
+disagree with the computation (owner ruling: she retains an override); a
+derived value has nothing for an override to disagree *with*. So it is
+written once, SQL-guarded (`WHERE booked_at IS NULL`) exactly like T-5's
+supersession pointer, and it carries the RED-S4 trio:
+`booked_at` / `booked_by` / `booked_asserted_at`. `booked_by` is
+`'convergence'` or `'officer'`, so the record never claims the parties
+agreed to a time the officer set.
+
+**(c) One timezone per request, named, not per-window offsets.** NOTARY1
+stored ISO strings with offsets in JSONB and assumed UTC for naive times
+— a latent hour-out bug in the `.ics`. A signing happens at **one place**,
+so the request carries one IANA zone, every window is a `TIMESTAMPTZ`,
+and every surface renders in that zone. This fixes a NOTARY1 weakness
+rather than porting it.
+
+### Migration off NOTARY1's model
+
+One transform: every `deed_shares` row with `share_kind='signing_request'`
+becomes a `signing_requests` row + one `notary` participant (carrying the
+existing token, so live links keep working) + one window per entry in
+`proposed_windows` + an `available` response if `scheduled_at` was set.
+Idempotent, guarded on a `migrated_from_share_id` column. Expected row
+count in production today: **zero or near it** — NOTARY1 merged hours
+ago and there is no design partner yet — but the transform is written and
+tested rather than assumed, because "there is probably no data" is how
+data gets lost.
+
+---
+
+## 2. Token-surface inventory
+
+This is the part of the plan I would most like challenged, because the
+signer surface is **the first consumer surface this product has ever
+had** and the cost of getting it wrong is not a bug report.
+
+Each surface is an **allowlist pinned by exact key-set equality**, not a
+denylist of excluded fields. A denylist enumerates the examples somebody
+thought of; an allowlist enumerates the property, and a new field cannot
+leak in without failing the pin.
+
+### Officer (session-authenticated, no token)
+
+Everything she already sees, plus the request detail and the scheduling
+page. No change to what an authenticated owner may read about her own
+deed. She sees participant names and emails **she herself typed**.
+
+### Notary token — `GET /signing/{token}`
+
+| field | why |
+|---|---|
+| property address (full), county | she is going to that address |
+| deed type | she is notarising this instrument |
+| officer name + company + email | who engaged her; she must be able to reply |
+| signer **display names** | she checks their ID at the table |
+| windows: her own, plus signer proposals awaiting accept/decline | the job |
+| booked time, if any | the job |
+| expiry | so she knows the link dies |
+| the deed PDF + the PCOR | NOTARY1 already gives her the package; she needs it |
+
+**Not present:** signer emails, signer phones, other partners, anything
+about the officer's other files.
+
+### Signer token — `GET /signing/{token}` — MINIMUM SURFACE
+
+| field | why |
+|---|---|
+| property **street address** (first comma segment only) | so they know which signing this is |
+| coordinating officer: name + company | who is asking, and who to contact |
+| notary display name | *proposed — see the open question below* |
+| windows offered + their own current answer | the task |
+| expiry | so they know the link dies |
+
+**Excluded, and pinned by the allowlist rather than by name:** APN,
+county, legal description, deed type, grantor/grantee names, vesting,
+transfer tax or any figure, the deed PDF, the PCOR, any other signer's
+name, and every participant's email and phone including the notary's.
+
+**Open question for the owner:** the notary's *display name* on the
+signer view. Argument for: a consumer being asked to meet a stranger
+should know who. Argument against: it is another party's information on
+the minimum surface, and "a notary will meet you at the time you pick" is
+sufficient. I have it in the allowlist above; say the word and it comes
+out. This is the only item on the signer surface I am not certain about,
+and it is exactly the kind of call I would rather flag than decide.
+
+**Abuse surface.** These are unauthenticated consumer endpoints, so they
+get `utils/throttle.py` per-token and per-IP on view, respond and
+propose — the RED-H1.2 treatment. A token that is enumerated is a
+property address disclosed.
+
+---
+
+## 3. Convergence, and the round-trip cap
+
+**A window books when** it is not declined, the notary answered
+`available`, and **every** non-revoked signer answered `available`.
+Checked after every response write, inside the same transaction, and the
+booking is the SQL-guarded single write described above.
+
+**A signer proposing a time outside the notary's windows creates a
+proposal, not a booking.** It lands as a `signing_windows` row with
+`origin='signer_proposal'` and an implicit `available` response from its
+proposer. The notary accepts (answers `available` — which may
+immediately converge) or declines (`declined_at`, which removes it from
+every surface and tells the proposer).
+
+**The cap: 3 signer proposals per request, aggregate.** Not per signer —
+two signers alternating twice each is six emails and the same deadlock.
+At the cap the propose action is refused with an honest sentence ("these
+haven't converged — {officer} will call you"), the officer is notified,
+and picking from the notary's existing windows still works. An
+unbounded thread is how a scheduling tool becomes a chat app nobody
+moderates, and the graceful degradation is the phone call that already
+works.
+
+---
+
+## 4. The purge — and the one thing that needs an owner decision
+
+The owner's ruling: *the purge is a mechanism, not a discipline — a real
+job with a real test.* Agreed, and here is the problem.
+
+**There is no scheduler in this deployment.** No cron, no worker, no
+APScheduler, no Celery. `render.yaml` defines web services only. I
+checked before designing around it.
+
+So the purge is built in two halves:
+
+1. **`services/signing_purge.py::purge_signer_contact()`** — idempotent,
+   batched, returns a count. Finds signer participants whose request is
+   terminal (booked and past, or expired, or cancelled) by more than
+   **90 days** (proposed default, configurable), NULLs `email` and
+   `phone`, stamps `contact_purged_at`. **`display_name` survives** — a
+   name is not contact information, and the record of who agreed to what
+   must outlive the ability to contact them.
+2. **Two invocations, same function.**
+   - `backend/scripts/purge_signer_contact.py`, ready for a Render Cron
+     Job. **Creating that cron service is a deploy-topology change,
+     which is Tier 3 — owner-only, not delegated.** It is the durable
+     answer and I am flagging it rather than building toward it.
+   - Until then: an **in-request sweep**, throttled to at most once an
+     hour via a `system_jobs(job_name, last_run_at)` row taken with
+     `FOR UPDATE SKIP LOCKED`, called from the signing router. No
+     topology change, genuinely a mechanism, and testable.
+
+**The honest caveat, stated because it will matter later:** the
+in-request sweep runs only if somebody uses the product. For a retention
+deadline that lags gracefully, that is acceptable. It is **not**
+acceptable as the backing for a promise of deletion within a stated
+window. If the privacy language ever says "within 90 days," the cron
+service stops being optional.
+
+**Tests:** contact is gone after the window; `display_name` and the
+responses survive; a request still inside the window is untouched;
+running twice changes nothing the second time; the throttle actually
+throttles.
+
+---
+
+## 5. What ships around the loop
+
+**Emails (5 new templates, all through the one E1 transport with the
+ADMIN3 ledger):** notary invited; signer invited; windows posted (to
+signers); proposal received (to notary); **booked** (to everyone, with
+the `.ics`). Signer-facing copy gets its own review pass — it is the
+first email this product sends to somebody who did not sign up.
+
+**Reminders:** officer-triggered only in v1, per the ruling, capped at 3
+per participant. A consumer surface with an uncapped send button is a
+spam vector pointed at our own customers' clients.
+
+**`.ics` to everyone on booking**, `METHOD:PUBLISH`, one zone, per §13's
+existing treatment.
+
+---
+
+## 6. Part D — the scheduling page
+
+Read-only aggregation over `signing_requests` for the officer: date/time,
+property, notary, derived state. Month grid + week/list toggle as
+specified. No new state, no availability engine, no external sync.
+
+---
+
+## 7. Honest estimate — and this does not fit two weeks
+
+| part | estimate |
+|---|---|
+| A — PARTNER2 (phone masking, role registry) | 0.5 d |
+| B — share entry points split | 1 d |
+| C — schema + services + convergence | 2 d |
+| C — three token surfaces + officer multi-signer create flow | 2 d |
+| C — 5 templates + `.ics` + notifications | 1 d |
+| C — purge mechanism + job + tests | 0.5 d |
+| C — reminders | 0.5 d |
+| C — tests, doctrine, pin retargeting, NOTARY1 migration | 2 d |
+| D — calendar month grid + week/list | 2 d |
+| **total** | **11.5 days** |
+
+**That is past ~2 weeks once anything goes wrong, and something always
+does.** Flagging it now, as instructed, so the cut is deliberate.
+
+### The cut I recommend
+
+**Cut Part D's month grid; ship a sorted agenda/list view in v1.**
+Saves ~1 day and lands the total near 10.5. A list sorted by date
+answers "what is coming up and what is stuck" completely; the month grid
+is the attractive version of the same information, and it is the only
+item on this list that no workflow depends on.
+
+### The cut I recommend AGAINST
+
+**Do not cut the signer counter-proposal loop**, even though it is the
+second-largest saving (~1.5 days with its cap, the notary's
+accept/decline, and its template). Cutting it means signers may only
+pick from windows the notary posted, and when none work the officer is
+back on the phone — which is **precisely the hole this reversal was made
+to close**. Cutting it would spend two weeks rebuilding Option A with
+more steps.
+
+### If more must come out
+
+In order, least damaging first: reminders → v1.1 (the officer can resend
+from the request page, ~0.5 d); then the notary's PCOR on the signing
+token (~0.25 d, she can get it from the officer). Both degrade into an
+existing manual path. Neither touches the coordination itself.
+
+---
+
+## 8. Owner items this raises (not code, and not mine to decide)
+
+1. **A privacy statement covering non-users.** NOTARY0b's own argument
+   against Option B was that signers "cannot see what we hold and cannot
+   ask us to delete it." The reversal does not answer that objection — it
+   converts it into a requirement. What we hold (name, email, optional
+   phone, their answers), for how long (90 days proposed), and how a
+   non-user asks for removal, should ship **with** Part C rather than
+   after it.
+2. **Transactional email to consumers.** These are transactional, not
+   marketing, but somebody who never signed up will receive mail from a
+   brand they do not know. Worth a look before the first send.
+3. **The Render Cron Job** for the purge — Tier 3, and the difference
+   between a retention practice and a retention promise.
+4. **The signer surface's notary-name question** in §2 above.
+
+None of these blocks Parts A or B, and none blocks *starting* C. Item 1
+should land before the first real signer email goes out.

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -457,3 +457,63 @@ we reach it.
   **Trigger:** the first signing request that goes unanswered long enough
   for an officer to ask for a nudge. It is a template plus a route
   branch, not a design question.
+
+## NOTARY2 — the reversal, and what it obliges (2026-08-11)
+
+- **The signer-contact ruling is REVERSED.** Signers participate
+  directly; recorded in DOCTRINE_CONFORMANCE §13.1 with the owner's
+  reasoning ("the signers are the scheduling constraint, so routing
+  around them recreated the phone tag the feature exists to kill"), and
+  with NOTARY0b's superseded paragraph kept verbatim rather than
+  rewritten. §13 otherwise stands: booked is not happened.
+
+- **OWNER ITEM — a privacy statement covering non-users.** NOTARY0b's
+  own argument against involving signers was that they "cannot see what
+  we hold and cannot ask us to delete it." The reversal does not answer
+  that objection; it converts it into a requirement. What we hold about
+  a signer (name, email, optional phone, their answers), for how long
+  (90 days past completion or expiry, proposed), and how a non-user asks
+  for removal. **Should ship WITH NOTARY2's build, not after it** — the
+  first real signer email is the deadline. Not a machine decision.
+
+- **OWNER ITEM — transactional email to consumers.** Signer invitations
+  are transactional rather than marketing, but they reach somebody who
+  never signed up, from a brand they do not know. Worth a look before
+  the first send.
+
+- **OWNER ITEM (Tier 3) — a Render Cron Job for the purge.** There is
+  **no scheduler in this deployment**: no cron, no worker, no
+  APScheduler, no Celery; `render.yaml` defines web services only.
+  NOTARY2 will ship the purge as a function with two invocations — a
+  script ready for a cron service, and a throttled in-request sweep that
+  needs no topology change. The sweep is a real mechanism and it is
+  tested, but it runs only when somebody uses the product, so it LAGS
+  gracefully rather than failing. That is acceptable for a retention
+  practice and **not** acceptable as the backing for a stated deletion
+  window. If the privacy language says "within 90 days," the cron
+  service stops being optional. Creating it is a deploy-topology change,
+  which is Tier 3.
+
+- **OPEN QUESTION for the owner** — the notary's display name on the
+  signer token view. A consumer asked to meet a stranger arguably should
+  know who; equally it is another party's information on a surface whose
+  whole point is minimum. Currently proposed IN the allowlist. See
+  `docs/NOTARY2_PLAN.md` §2.
+
+- **SCOPE FLAG — NOTARY2 as specified is ~11.5 working days**, which is
+  past two weeks once anything goes wrong. Recommended cut: Part D's
+  month grid becomes a sorted agenda list in v1 (~1 day, and no workflow
+  depends on the grid). Recommended AGAINST cutting: the signer
+  counter-proposal loop, which is the second-largest saving and is
+  precisely the hole the reversal was made to close — cutting it spends
+  two weeks rebuilding Option A with extra steps.
+
+- **PARTNER2 note (2026-08-11): the fifth partner-category copy is gone.**
+  PARTNER1 aligned two lists by hand and said hand-alignment has a shelf
+  life; it did. A third copy in `QuickAddPartnerModal` had `realtor` as a
+  CATEGORY while everywhere else it is a role belonging to
+  `real_estate` — one word, two positions in the model, in one product.
+  There is now one registry (`lib/partnerRegistry.ts`), every surface
+  derives from it, and a pin fails if any surface grows its own list.
+  `QuickAddPartnerModal` had no importers at the time; it was aligned
+  anyway rather than left dead, because NOTARY2 Part B revives it.

--- a/frontend/src/__tests__/partnerRegistry.test.ts
+++ b/frontend/src/__tests__/partnerRegistry.test.ts
@@ -1,0 +1,226 @@
+/**
+ * PARTNER2 — one registry, one phone rule, and pins against the copies.
+ *
+ * ═══ WHAT WENT WRONG BEFORE, WHICH IS WHY THESE EXIST ═══
+ *
+ * The partner category list had been copied into five files and had
+ * diverged twice:
+ *
+ *  - the partners screen offered four categories; the builder's
+ *    AddPartnerModal offered six. A partner added in the builder arrived
+ *    on the partners screen as a category the edit dropdown could not
+ *    represent, and rendered as "Other".
+ *  - QuickAddPartnerModal had a third list in which `realtor` was a
+ *    CATEGORY, while everywhere else `realtor` is a role belonging to
+ *    `real_estate`. One word, two positions in the model.
+ *
+ * PARTNER1 aligned the first two by hand and said so; hand-alignment has
+ * a shelf life, and this is what replaces it. The pin below sweeps for
+ * category keys appearing as literals in any surface — the copies are
+ * the defect, so the pin is against copying rather than against any
+ * particular wrong list.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
+import {
+  ALL_ROLE_KEYS,
+  CATEGORY_KEYS,
+  PARTNER_CATEGORIES,
+  categoryLabel,
+  defaultRoleFor,
+  roleBelongsTo,
+  roleLabel,
+  rolesFor,
+} from '../lib/partnerRegistry';
+import { formatPhone, maskUS, normalizePhone, phoneSearchKey } from '../lib/phone';
+
+const SRC = path.join(__dirname, '..');
+const read = (...p: string[]) => fs.readFileSync(path.join(SRC, ...p), 'utf8');
+
+/** The corpus the BACKEND suite also reads — same referee, two languages. */
+const CASES = JSON.parse(
+  fs.readFileSync(
+    path.join(SRC, '..', '..', 'backend', 'services', 'phone_cases.json'),
+    'utf8',
+  ),
+).cases as Array<{ why: string; input: string; stored: string; display: string }>;
+
+/** Every partner-facing surface. If a sixth appears it belongs here. */
+const SURFACES = [
+  ['app', 'partners', 'page.tsx'],
+  ['components', 'modals', 'AddPartnerModal.tsx'],
+  ['features', 'partners', 'QuickAddPartnerModal.tsx'],
+];
+
+describe('PARTNER2 — the registry is the single source', () => {
+  it('carries the seven categories, each with at least one role', () => {
+    expect(PARTNER_CATEGORIES.length).toBe(7);
+    for (const c of PARTNER_CATEGORIES) {
+      expect(c.roles.length).toBeGreaterThan(0);
+      expect(c.label).toBeTruthy();
+      expect(c.pluralLabel).toBeTruthy();
+    }
+  });
+
+  it('notary is a category and notary_public is one of its roles', () => {
+    expect(CATEGORY_KEYS).toContain('notary');
+    expect(rolesFor('notary').map((r) => r.key)).toEqual(
+      expect.arrayContaining(['notary_public', 'mobile_notary']),
+    );
+  });
+
+  it('realtor is a ROLE of real_estate, never a category', () => {
+    // The QuickAddPartnerModal divergence, pinned so it cannot return.
+    expect(CATEGORY_KEYS).not.toContain('realtor');
+    expect(rolesFor('real_estate').map((r) => r.key)).toContain('realtor');
+  });
+
+  it('category keys are unique and role keys are unique within a category', () => {
+    expect(new Set(CATEGORY_KEYS).size).toBe(CATEGORY_KEYS.length);
+    for (const c of PARTNER_CATEGORIES) {
+      const keys = c.roles.map((r) => r.key);
+      expect(new Set(keys).size).toBe(keys.length);
+    }
+  });
+
+  it('no surface hard-codes its own category list', () => {
+    // The PROPERTY: a category key appearing as a string literal in a
+    // surface means that surface is keeping its own copy. Deriving from
+    // the registry produces no literals at all.
+    //
+    // `title_company` is exempt as a single-value DEFAULT — several
+    // surfaces seed a new partner with it, which is a starting value and
+    // not a list. A default is one decision; a list is a copy.
+    const EXEMPT = new Set(['title_company', 'other']);
+    const offenders: string[] = [];
+    for (const surface of SURFACES) {
+      const code = codeOnly(read(...surface));
+      const found = CATEGORY_KEYS.filter(
+        (k) => !EXEMPT.has(k) && (code.includes(`'${k}'`) || code.includes(`"${k}"`)),
+      );
+      if (found.length) offenders.push(`${surface.join('/')} → ${found.join(', ')}`);
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('every surface imports the registry', () => {
+    for (const surface of SURFACES) {
+      expect(read(...surface)).toContain('partnerRegistry');
+    }
+  });
+});
+
+describe('PARTNER2 — the registry is UI metadata and nothing more', () => {
+  it('carries no field that could decide anything', () => {
+    // The same constraint the FORMS registry lives under (§1). A registry
+    // that grew a default, an auto-apply, a fee or a characterization of
+    // what a partner may DO would be making a choice on somebody's
+    // behalf. Comments stripped first — the doctrine note ABOUT
+    // auto-apply must not trip the scan for auto-apply.
+    const src = codeOnly(read('lib', 'partnerRegistry.ts'));
+    expect(src).not.toMatch(/auto[_-]?apply/i);
+    expect(src).not.toMatch(/\blicens/i);
+    expect(src).not.toMatch(/\bauthorit/i);
+    expect(src).not.toMatch(/\bpermitted\b/i);
+    expect(src).not.toMatch(/\bfee\b/i);
+
+    const allowed = new Set(['key', 'label', 'pluralLabel', 'roles']);
+    for (const c of PARTNER_CATEGORIES) {
+      for (const field of Object.keys(c)) expect(allowed.has(field)).toBe(true);
+      for (const r of c.roles) {
+        expect(Object.keys(r).sort()).toEqual(['key', 'label']);
+      }
+    }
+  });
+});
+
+describe('PARTNER2 — roles derive from category', () => {
+  it('each category defaults to its first role', () => {
+    for (const c of PARTNER_CATEGORIES) {
+      expect(defaultRoleFor(c.key)).toBe(c.roles[0].key);
+    }
+  });
+
+  it('roleBelongsTo answers honestly across categories', () => {
+    expect(roleBelongsTo('notary', 'notary_public')).toBe(true);
+    expect(roleBelongsTo('notary', 'loan_officer')).toBe(false);
+    expect(roleBelongsTo(undefined, 'anything')).toBe(false);
+  });
+
+  it('an unknown key is displayed, not silently relabelled', () => {
+    // A partner filed under a category we later remove should read as
+    // what the officer chose, not as though she chose nothing.
+    expect(categoryLabel('escrow_company')).toBe('Escrow Company');
+    expect(categoryLabel('legacy_thing')).toBe('Legacy Thing');
+    expect(roleLabel('legacy_role')).toBe('Legacy Role');
+  });
+
+  it('a stored role stays readable after a re-categorisation', () => {
+    // ALL_ROLE_KEYS is the validation set, not one category's list —
+    // moving a partner between categories must not make their recorded
+    // role unreadable.
+    expect(ALL_ROLE_KEYS).toContain('loan_officer');
+    expect(ALL_ROLE_KEYS).toContain('notary_public');
+  });
+});
+
+describe('PARTNER2 — the phone rule, against the shared corpus', () => {
+  it('normalizes every case as the corpus says', () => {
+    for (const c of CASES) expect(normalizePhone(c.input)).toBe(c.stored);
+  });
+
+  it('displays every case as the corpus says', () => {
+    for (const c of CASES) expect(formatPhone(c.stored)).toBe(c.display);
+  });
+
+  it('normalizing is idempotent', () => {
+    for (const c of CASES) {
+      const once = normalizePhone(c.input);
+      expect(normalizePhone(once)).toBe(once);
+    }
+  });
+
+  it('unparseable input survives verbatim', () => {
+    for (const raw of ['ask for Dana', '+44 20 7946 0958', '(626) 555-0134 x220']) {
+      expect(normalizePhone(raw)).toBe(raw.trim());
+    }
+  });
+
+  it('search finds the row however either side was typed', () => {
+    const stored = normalizePhone('626-555-0134');
+    expect(phoneSearchKey(stored)).toContain(phoneSearchKey('(626) 555'));
+  });
+});
+
+describe('PARTNER2 — masking as she types', () => {
+  it('formats progressively without jumping ahead of her', () => {
+    expect(maskUS('6')).toBe('6');
+    expect(maskUS('62')).toBe('62');
+    // The paren appears only once the area code is complete — wrapping a
+    // single digit as "(6" pushes the cursor past a character she did
+    // not type.
+    expect(maskUS('626')).toBe('(626) ');
+    expect(maskUS('6265')).toBe('(626) 5');
+    expect(maskUS('626555')).toBe('(626) 555');
+    expect(maskUS('6265550134')).toBe('(626) 555-0134');
+  });
+
+  it('is stable under its own output', () => {
+    // Called on every keystroke against its own previous result. A mask
+    // that is not idempotent fights the cursor.
+    for (const input of ['626', '6265', '626555', '6265550134', '16265550134']) {
+      const once = maskUS(input);
+      expect(maskUS(once)).toBe(once);
+    }
+  });
+
+  it('keeps its hands off an international number', () => {
+    expect(maskUS('+44 20 7946 0958')).toBe('+44 20 7946 0958');
+  });
+
+  it('stops formatting rather than mangling something too long', () => {
+    expect(maskUS('12345678901234')).toBe('12345678901234');
+  });
+});

--- a/frontend/src/app/partners/page.tsx
+++ b/frontend/src/app/partners/page.tsx
@@ -48,28 +48,21 @@ import {
   Plus, Pencil, Trash2, X, Save, Search, Users, MapPin, Mail, Loader2,
 } from 'lucide-react';
 import Sidebar from '../../components/Sidebar';
+import {
+  PARTNER_CATEGORIES, categoryLabel, defaultRoleFor, roleBelongsTo,
+  roleLabel, rolesFor,
+} from '../../lib/partnerRegistry';
+import { formatPhone, maskUS, normalizePhone, phoneSearchKey } from '../../lib/phone';
 import '../../styles/dashboard.css';
 
 /**
- * NOTARY1 adds `notary` / `notary_public`: a signing request picks its
- * notary from this list, so a notary who cannot be filed as one is a
- * notary the officer records as "other" and then searches for by memory.
- *
- * `escrow_company` and `attorney` are not new — the builder's
- * AddPartnerModal has offered them all along while this screen did not,
- * so a partner added there arrived here as a category the edit dropdown
- * could not represent and the chip rendered as "Other". Two live lists
- * of the same enum had drifted; adding a third divergence on top of that
- * is how the next one gets found by a customer.
+ * PARTNER2: the two hand-kept arrays are gone. They had already diverged
+ * from the builder's list once (PARTNER1 aligned them by hand and noted
+ * that hand-alignment has a shelf life), and a third copy in
+ * QuickAddPartnerModal disagreed with both about whether `realtor` is a
+ * category or a role. Every surface now derives from `lib/partnerRegistry`,
+ * and a pin fails if any of them grows its own list again.
  */
-const CATEGORIES = [
-  'title_company', 'escrow_company', 'notary', 'attorney',
-  'real_estate', 'lender', 'other',
-] as const;
-const ROLES = [
-  'title_officer', 'escrow_officer', 'notary_public', 'attorney',
-  'realtor', 'loan_officer', 'other',
-] as const;
 
 type Partner = {
   id: string;
@@ -163,6 +156,15 @@ export default function PartnersPage() {
     };
   }
 
+  /** Open the editor on a stored row. The phone comes back as E.164 and
+   * is masked for reading — an officer opening a partner should not be
+   * shown "+16265550134" and asked to recognise her own entry. */
+  function edit(p: Partner) {
+    setEditing({ ...p, phone: formatPhone(p.phone) });
+    setFormError(null);
+    setShowForm(true);
+  }
+
   function save(it: Partial<Partner>) {
     if (!(it.company_name || '').trim()) {
       setFormError('Company name is required.');
@@ -181,7 +183,9 @@ export default function PartnersPage() {
         ...(t ? { Authorization: `Bearer ${t}` } : {}),
       },
       credentials: 'include',
-      body: JSON.stringify(it),
+      // Masked for her eyes, E.164 on the wire. The column has held
+      // eleven punctuation styles until now, none of them searchable.
+      body: JSON.stringify({ ...it, phone: normalizePhone(it.phone) }),
     })
       .then(async (r) => {
         if (!r.ok) {
@@ -237,7 +241,7 @@ export default function PartnersPage() {
       <span
         className={`inline-block whitespace-nowrap rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset ${tone[category] || tone.other}`}
       >
-        {titleCase(category)}
+        {categoryLabel(category)}
       </span>
     );
   }
@@ -246,7 +250,9 @@ export default function PartnersPage() {
     const q = query.trim().toLowerCase();
     if (!q) return items;
     return items.filter((p) =>
-      [p.company_name, p.contact_name, p.email, p.phone, p.city, p.address_line1]
+      // phoneSearchKey so "(626) 555" finds a row stored as +16265550134.
+      // The raw substring match could not, whichever way either was typed.
+      [p.company_name, p.contact_name, p.email, phoneSearchKey(p.phone), p.city, p.address_line1]
         .some((f) => (f || '').toLowerCase().includes(q))
     );
   }, [items, query]);
@@ -376,7 +382,7 @@ export default function PartnersPage() {
                         {address || (
                           /* An editable gap, never a silent blank. */
                           <button
-                            onClick={() => { setEditing(p); setFormError(null); setShowForm(true); }}
+                            onClick={() => edit(p)}
                             className="inline-flex items-center gap-1 text-brand-600 hover:text-brand-700 hover:underline"
                           >
                             <MapPin className="w-3.5 h-3.5" /> Add address
@@ -401,7 +407,7 @@ export default function PartnersPage() {
                             aria-label={`Edit ${p.company_name}`}
                             title="Edit"
                             className="p-2 rounded-md text-gray-500 hover:text-brand-600 hover:bg-brand-50 transition-colors"
-                            onClick={() => { setEditing(p); setFormError(null); setShowForm(true); }}
+                            onClick={() => edit(p)}
                           >
                             <Pencil className="w-4 h-4" />
                           </button>
@@ -429,9 +435,17 @@ export default function PartnersPage() {
               <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
                 {[
                   { label: 'Total Partners', n: items.length },
-                  { label: 'Title Companies', n: items.filter((p) => p.category === 'title_company').length },
-                  { label: 'Notaries', n: items.filter((p) => p.category === 'notary').length },
-                  { label: 'Real Estate', n: items.filter((p) => p.category === 'real_estate').length },
+                  // Derived from the registry rather than four hand-written
+                  // filters: adding a category should not require anybody
+                  // to remember this tile row exists.
+                  ...PARTNER_CATEGORIES
+                    .filter((c) => c.key !== 'other')
+                    .map((c) => ({
+                      label: c.pluralLabel,
+                      n: items.filter((p) => p.category === c.key).length,
+                    }))
+                    .filter((tile) => tile.n > 0)
+                    .slice(0, 3),
                 ].map((s) => (
                   <div key={s.label} className="bg-gray-50 rounded-lg p-4">
                     <div className="text-sm text-gray-500">{s.label}</div>
@@ -501,7 +515,7 @@ export default function PartnersPage() {
                 <Field label="Phone">
                   <input
                     value={editing.phone || ''}
-                    onChange={(e) => setEditing({ ...editing, phone: e.target.value })}
+                    onChange={(e) => setEditing({ ...editing, phone: maskUS(e.target.value) })}
                     className={inputCls}
                     placeholder="(555) 123-4567"
                   />
@@ -575,19 +589,42 @@ export default function PartnersPage() {
                 <Field label="Category">
                   <select
                     value={editing.category || 'title_company'}
-                    onChange={(e) => setEditing({ ...editing, category: e.target.value })}
+                    onChange={(e) => {
+                      // A role that does not belong to the new category
+                      // is reset rather than silently kept: "Notary /
+                      // Loan Officer" is a row the officer cannot find
+                      // later, and it reads as data we mangled.
+                      const category = e.target.value;
+                      setEditing({
+                        ...editing,
+                        category,
+                        role: roleBelongsTo(category, editing.role)
+                          ? editing.role
+                          : defaultRoleFor(category),
+                      });
+                    }}
                     className={inputCls}
                   >
-                    {CATEGORIES.map((c) => <option key={c} value={c}>{titleCase(c)}</option>)}
+                    {PARTNER_CATEGORIES.map((c) => (
+                      <option key={c.key} value={c.key}>{c.label}</option>
+                    ))}
                   </select>
                 </Field>
                 <Field label="Role">
                   <select
-                    value={editing.role || 'title_officer'}
+                    value={editing.role || defaultRoleFor(editing.category)}
                     onChange={(e) => setEditing({ ...editing, role: e.target.value })}
                     className={inputCls}
                   >
-                    {ROLES.map((r) => <option key={r} value={r}>{titleCase(r)}</option>)}
+                    {rolesFor(editing.category).map((r) => (
+                      <option key={r.key} value={r.key}>{r.label}</option>
+                    ))}
+                    {/* A stored role the current category does not offer
+                        is still shown, so re-categorising a partner never
+                        silently rewrites what she recorded. */}
+                    {editing.role && !roleBelongsTo(editing.category, editing.role) && (
+                      <option value={editing.role}>{roleLabel(editing.role)}</option>
+                    )}
                   </select>
                 </Field>
               </div>

--- a/frontend/src/components/modals/AddPartnerModal.tsx
+++ b/frontend/src/components/modals/AddPartnerModal.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import { useState } from 'react'
+import { PARTNER_CATEGORIES } from '@/lib/partnerRegistry';
+import { maskUS, normalizePhone } from '@/lib/phone';
 import { X, Sparkles } from 'lucide-react'
 
 interface AddPartnerModalProps {
@@ -42,7 +44,8 @@ export function AddPartnerModal({ isOpen, onClose, onSave }: AddPartnerModalProp
     setSaving(true)
     
     try {
-      await onSave(formData)
+      // Masked as typed, E.164 on the wire — one column, one shape.
+      await onSave({ ...formData, phone: normalizePhone(formData.phone) })
       // Reset form
       setFormData({
         company_name: '',
@@ -113,14 +116,13 @@ export function AddPartnerModal({ isOpen, onClose, onSave }: AddPartnerModalProp
                 onChange={(e) => handleChange('category', e.target.value)}
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
               >
-                <option value="title_company">Title Company</option>
-                <option value="escrow_company">Escrow Company</option>
-                {/* NOTARY1: the signing request picks from here too. */}
-                <option value="notary">Notary</option>
-                <option value="attorney">Attorney</option>
-                <option value="real_estate">Real Estate Office</option>
-                <option value="lender">Lender</option>
-                <option value="other">Other</option>
+                {/* PARTNER2: derived. This list and the partners
+                    screen's had already diverged once — a partner added
+                    here arrived there as a category the edit dropdown
+                    could not represent. */}
+                {PARTNER_CATEGORIES.map((c) => (
+                  <option key={c.key} value={c.key}>{c.label}</option>
+                ))}
               </select>
             </div>
 
@@ -199,7 +201,7 @@ export function AddPartnerModal({ isOpen, onClose, onSave }: AddPartnerModalProp
             <input
               type="tel"
               value={formData.phone}
-              onChange={(e) => handleChange('phone', e.target.value)}
+              onChange={(e) => handleChange('phone', maskUS(e.target.value))}
               placeholder="(310) 555-1234"
               className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
             />

--- a/frontend/src/features/partners/QuickAddPartnerModal.tsx
+++ b/frontend/src/features/partners/QuickAddPartnerModal.tsx
@@ -3,6 +3,8 @@
 import { useState } from 'react';
 import { X, Building2, Loader2 } from 'lucide-react';
 import { usePartners, CreatePartnerData } from './PartnersContext';
+import { PARTNER_CATEGORIES, defaultRoleFor, roleBelongsTo, rolesFor } from '@/lib/partnerRegistry';
+import { maskUS, normalizePhone } from '@/lib/phone';
 import { toast } from 'sonner';
 
 interface QuickAddPartnerModalProps {
@@ -24,6 +26,7 @@ export function QuickAddPartnerModal({
   const [loading, setLoading] = useState(false);
   const [formData, setFormData] = useState<CreatePartnerData>({
     category,
+    role: defaultRoleFor(category),
     company_name: initialName,
     contact_name: '',
     email: '',
@@ -46,7 +49,7 @@ export function QuickAddPartnerModal({
 
     setLoading(true);
     try {
-      const newPartner = await create(formData);
+      const newPartner = await create({ ...formData, phone: normalizePhone(formData.phone) });
       if (newPartner) {
         toast.success('Partner added successfully');
         onCreated({
@@ -62,14 +65,11 @@ export function QuickAddPartnerModal({
     }
   };
 
-  const categories = [
-    { value: 'title_company', label: 'Title Company' },
-    { value: 'escrow_company', label: 'Escrow Company' },
-    { value: 'lender', label: 'Lender' },
-    { value: 'realtor', label: 'Realtor' },
-    { value: 'attorney', label: 'Attorney' },
-    { value: 'other', label: 'Other' },
-  ];
+  // PARTNER2: derived. This list was the THIRD copy and the most wrong
+  // of the three — it had `realtor` as a CATEGORY, while everywhere else
+  // `realtor` is a role belonging to `real_estate`. Same word, two
+  // positions in the model, in one product.
+  const categories = PARTNER_CATEGORIES;
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
@@ -110,13 +110,41 @@ export function QuickAddPartnerModal({
               </label>
               <select
                 value={formData.category}
-                onChange={(e) => setFormData({ ...formData, category: e.target.value })}
+                onChange={(e) => {
+                  const category = e.target.value;
+                  setFormData({
+                    ...formData,
+                    category,
+                    role: roleBelongsTo(category, formData.role)
+                      ? formData.role
+                      : defaultRoleFor(category),
+                  });
+                }}
                 className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
               >
                 {categories.map((cat) => (
-                  <option key={cat.value} value={cat.value}>
+                  <option key={cat.key} value={cat.key}>
                     {cat.label}
                   </option>
+                ))}
+              </select>
+            </div>
+
+            {/* Role — derived from the category above (PARTNER2). The two
+                lists were independent, which let a notary be filed as a
+                loan officer: not wrong in any way the system could see,
+                just useless when she later wants her notaries. */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Role
+              </label>
+              <select
+                value={formData.role || defaultRoleFor(formData.category)}
+                onChange={(e) => setFormData({ ...formData, role: e.target.value })}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
+              >
+                {rolesFor(formData.category).map((r) => (
+                  <option key={r.key} value={r.key}>{r.label}</option>
                 ))}
               </select>
             </div>
@@ -171,7 +199,7 @@ export function QuickAddPartnerModal({
                 <input
                   type="tel"
                   value={formData.phone}
-                  onChange={(e) => setFormData({ ...formData, phone: e.target.value })}
+                  onChange={(e) => setFormData({ ...formData, phone: maskUS(e.target.value) })}
                   placeholder="(555) 123-4567"
                   className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 focus:border-brand-500"
                 />

--- a/frontend/src/lib/partnerRegistry.ts
+++ b/frontend/src/lib/partnerRegistry.ts
@@ -1,0 +1,198 @@
+/**
+ * PARTNER2 — ONE registry for partner categories and their roles.
+ *
+ * ═══ WHY THIS FILE EXISTS ═══
+ *
+ * The category list had been copied into five places and had already
+ * diverged twice by the time anybody looked:
+ *
+ *  - `app/partners/page.tsx` offered four categories; the builder's
+ *    `AddPartnerModal` offered six, including `escrow_company` and
+ *    `attorney`. A partner added from the builder therefore arrived on
+ *    the partners screen as a category the edit dropdown could not
+ *    represent, and its chip rendered as "Other". PARTNER1 aligned those
+ *    two by hand and said in its note that hand-alignment is a fix with
+ *    a shelf life.
+ *  - `QuickAddPartnerModal` had a THIRD list, in which `realtor` is a
+ *    *category* — while everywhere else `realtor` is a *role* and
+ *    `real_estate` is the category. Same word, two positions in the
+ *    model, in the same product.
+ *  - `features/partners/types.ts` had a fourth, as a union type.
+ *
+ * The copies are the defect. So there is now one registry, every surface
+ * derives from it, and a pin fails if any surface hard-codes its own
+ * list. Adding a category is one entry here.
+ *
+ * ═══ ROLES DERIVE FROM CATEGORY ═══
+ *
+ * The two lists were independent, which let an officer file a notary as
+ * a "loan officer" — not wrong in any way the system could detect, just
+ * useless when she later wants her notaries. A role now belongs to a
+ * category, so the role dropdown answers the question the category
+ * already asked.
+ *
+ * ═══ UI METADATA ONLY (the doctrine constraint) ═══
+ *
+ * The same rule the FORMS registry lives under: a registry entry may
+ * carry LABELS and OPTIONS and nothing that decides anything. There is
+ * deliberately no field here for a default, an auto-apply, a fee, a
+ * jurisdiction, or any characterization of what a partner may do — those
+ * would be the registry quietly making a choice on somebody's behalf,
+ * which is §1's whole subject. Pinned in `partnerRegistry.test.ts`.
+ *
+ * A partner's category says how the officer FILES them. It says nothing
+ * about their authority, their licensure, or what they are permitted to
+ * do, and no code may read it as though it did.
+ */
+
+export type PartnerCategoryKey =
+  | 'title_company'
+  | 'escrow_company'
+  | 'notary'
+  | 'attorney'
+  | 'real_estate'
+  | 'lender'
+  | 'other';
+
+export interface PartnerRoleEntry {
+  /** Stored value. snake_case, stable — this is what lands in the column. */
+  key: string;
+  /** Display only. */
+  label: string;
+}
+
+export interface PartnerCategoryEntry {
+  key: PartnerCategoryKey;
+  label: string;
+  /** Plural, for counts and section headings. */
+  pluralLabel: string;
+  /** The roles that belong to this category. First is the default. */
+  roles: readonly PartnerRoleEntry[];
+}
+
+const OTHER_ROLE: PartnerRoleEntry = { key: 'other', label: 'Other' };
+
+export const PARTNER_CATEGORIES: readonly PartnerCategoryEntry[] = [
+  {
+    key: 'title_company',
+    label: 'Title Company',
+    pluralLabel: 'Title Companies',
+    roles: [
+      { key: 'title_officer', label: 'Title Officer' },
+      { key: 'escrow_officer', label: 'Escrow Officer' },
+      OTHER_ROLE,
+    ],
+  },
+  {
+    key: 'escrow_company',
+    label: 'Escrow Company',
+    pluralLabel: 'Escrow Companies',
+    roles: [
+      { key: 'escrow_officer', label: 'Escrow Officer' },
+      { key: 'escrow_assistant', label: 'Escrow Assistant' },
+      OTHER_ROLE,
+    ],
+  },
+  {
+    key: 'notary',
+    label: 'Notary',
+    pluralLabel: 'Notaries',
+    roles: [
+      { key: 'notary_public', label: 'Notary Public' },
+      { key: 'mobile_notary', label: 'Mobile Notary' },
+      OTHER_ROLE,
+    ],
+  },
+  {
+    key: 'attorney',
+    label: 'Attorney',
+    pluralLabel: 'Attorneys',
+    roles: [
+      { key: 'attorney', label: 'Attorney' },
+      { key: 'paralegal', label: 'Paralegal' },
+      OTHER_ROLE,
+    ],
+  },
+  {
+    key: 'real_estate',
+    label: 'Real Estate Office',
+    pluralLabel: 'Real Estate',
+    roles: [
+      { key: 'realtor', label: 'Realtor' },
+      { key: 'broker', label: 'Broker' },
+      { key: 'transaction_coordinator', label: 'Transaction Coordinator' },
+      OTHER_ROLE,
+    ],
+  },
+  {
+    key: 'lender',
+    label: 'Lender',
+    pluralLabel: 'Lenders',
+    roles: [
+      { key: 'loan_officer', label: 'Loan Officer' },
+      { key: 'loan_processor', label: 'Loan Processor' },
+      OTHER_ROLE,
+    ],
+  },
+  {
+    key: 'other',
+    label: 'Other',
+    pluralLabel: 'Other',
+    roles: [OTHER_ROLE],
+  },
+] as const;
+
+export const CATEGORY_KEYS: readonly string[] = PARTNER_CATEGORIES.map((c) => c.key);
+
+/** Every role key any category offers, deduplicated. The stored `role`
+ * column is validated against THIS rather than against one category's
+ * list, because a partner may be re-categorised and the old role should
+ * not become unreadable. */
+export const ALL_ROLE_KEYS: readonly string[] = Array.from(
+  new Set(PARTNER_CATEGORIES.flatMap((c) => c.roles.map((r) => r.key))),
+);
+
+export function categoryEntry(key?: string): PartnerCategoryEntry {
+  return (
+    PARTNER_CATEGORIES.find((c) => c.key === key) ??
+    PARTNER_CATEGORIES[PARTNER_CATEGORIES.length - 1]
+  );
+}
+
+export function categoryLabel(key?: string): string {
+  // An unknown key is DISPLAYED, not silently relabelled "Other": a
+  // partner filed under a category we later removed should read as what
+  // the officer chose, not as though she chose nothing.
+  const found = PARTNER_CATEGORIES.find((c) => c.key === key);
+  if (found) return found.label;
+  return key ? titleCaseKey(key) : 'Other';
+}
+
+export function rolesFor(categoryKey?: string): readonly PartnerRoleEntry[] {
+  return categoryEntry(categoryKey).roles;
+}
+
+export function defaultRoleFor(categoryKey?: string): string {
+  return rolesFor(categoryKey)[0].key;
+}
+
+export function roleLabel(key?: string): string {
+  for (const category of PARTNER_CATEGORIES) {
+    const found = category.roles.find((r) => r.key === key);
+    if (found) return found.label;
+  }
+  return key ? titleCaseKey(key) : 'Other';
+}
+
+/** Is this role offered by this category? Used to decide whether a
+ * category change should reset the role — never to reject a stored one. */
+export function roleBelongsTo(categoryKey: string | undefined, roleKey: string | undefined): boolean {
+  return !!roleKey && rolesFor(categoryKey).some((r) => r.key === roleKey);
+}
+
+function titleCaseKey(key: string): string {
+  return key
+    .split('_')
+    .map((w) => (w ? w[0].toUpperCase() + w.slice(1) : w))
+    .join(' ');
+}

--- a/frontend/src/lib/phone.ts
+++ b/frontend/src/lib/phone.ts
@@ -1,0 +1,127 @@
+/**
+ * PARTNER2 — US phone masking on input, normalized on the wire.
+ *
+ * ═══ THE SPLIT THAT MATTERS ═══
+ *
+ * What she TYPES gets formatted as she types: (626) 555-0134. What gets
+ * STORED is +16265550134. Those are different jobs and conflating them
+ * is how a phone column ends up holding eleven punctuation styles that
+ * no search can match — which is today's state: `partners.phone` is a
+ * free-text VARCHAR(50) and the partners screen searches it as a
+ * substring, so a partner saved as "626-555-0134" is invisible to
+ * somebody typing "(626) 555".
+ *
+ * Storage is E.164 because it is the format that is a FACT rather than a
+ * presentation: one number, one representation, comparable and
+ * dial-able. Display is regional because that is how a person reads it.
+ *
+ * ═══ WHAT THIS DOES NOT DO ═══
+ *
+ * It does not validate that a number is reachable, assigned, or a
+ * landline, and it does not reject numbers it cannot parse — an
+ * unparseable value is kept VERBATIM rather than discarded. An officer
+ * typing an extension, a UK number, or "ask for Dana" has given us
+ * information, and silently dropping it to keep a column tidy would be
+ * the product deciding it knows better. Formatting applies to things
+ * that look like US numbers; everything else passes through untouched.
+ */
+
+/** Digits only, no country code assumptions. */
+function digits(value: string): string {
+  return (value || '').replace(/\D/g, '');
+}
+
+/**
+ * Does this look like a US number we can safely reformat?
+ * 10 digits, or 11 beginning with 1. Anything else is left alone.
+ */
+export function looksUS(value: string): boolean {
+  const d = digits(value);
+  return d.length === 10 || (d.length === 11 && d.startsWith('1'));
+}
+
+/** The ten significant digits, or '' if this is not a US-shaped number. */
+function tenDigits(value: string): string {
+  const d = digits(value);
+  if (d.length === 10) return d;
+  if (d.length === 11 && d.startsWith('1')) return d.slice(1);
+  return '';
+}
+
+/**
+ * AS-TYPED masking. Called on every keystroke, so it must be stable
+ * under its own output — `maskUS(maskUS(x)) === maskUS(x)` — or the
+ * cursor fights the user.
+ *
+ * Partial input formats progressively: "626" → "(626) ", "6265" →
+ * "(626) 5". Past ten digits it stops adding punctuation rather than
+ * mangling an international number somebody is halfway through typing.
+ */
+export function maskUS(value: string): string {
+  const raw = value || '';
+  const d = digits(raw);
+
+  // A leading + means the officer is typing an international number.
+  // Hands off entirely — this function has nothing useful to say about it.
+  if (raw.trim().startsWith('+')) return raw;
+
+  // More than a US number's worth of digits: stop formatting rather than
+  // guess. Better a plain string than a wrong shape.
+  if (d.length > 11) return raw;
+
+  const body = d.length === 11 && d.startsWith('1') ? d.slice(1) : d;
+  const prefix = d.length === 11 && d.startsWith('1') ? '1 ' : '';
+
+  if (body.length === 0) return raw.replace(/[^\d+() .-]/g, '');
+  if (body.length <= 3) {
+    // Only wrap the area code once it is complete — wrapping a single
+    // digit as "(6" jumps the cursor past a paren the user did not type.
+    return body.length === 3 ? `${prefix}(${body}) ` : `${prefix}${body}`;
+  }
+  if (body.length <= 6) return `${prefix}(${body.slice(0, 3)}) ${body.slice(3)}`;
+  return `${prefix}(${body.slice(0, 3)}) ${body.slice(3, 6)}-${body.slice(6, 10)}`;
+}
+
+/**
+ * NORMALIZED for storage. `+1XXXXXXXXXX` for US-shaped input.
+ *
+ * Anything else is returned trimmed and verbatim: an international
+ * number, an extension, a note. We store what she meant; we do not
+ * store a truncation of it.
+ */
+export function normalizePhone(value: string | null | undefined): string {
+  const raw = (value || '').trim();
+  if (!raw) return '';
+  const ten = tenDigits(raw);
+  if (!ten) return raw;
+  return `+1${ten}`;
+}
+
+/**
+ * FOR DISPLAY, from whatever is stored. Handles the historical mess:
+ * rows written before this ticket hold "626-555-0134", "(626)555-0134",
+ * "6265550134" and worse, and all of them should read the same way now.
+ */
+export function formatPhone(value: string | null | undefined): string {
+  const raw = (value || '').trim();
+  if (!raw) return '';
+  const ten = tenDigits(raw);
+  if (!ten) return raw;
+  return `(${ten.slice(0, 3)}) ${ten.slice(3, 6)}-${ten.slice(6)}`;
+}
+
+/**
+ * A search-comparable form. The partners screen matches on this so that
+ * "6265550134", "(626) 555-0134" and "626-555" all find the same row —
+ * the substring search over raw text could not, which is the bug this
+ * pair of functions exists to close.
+ */
+export function phoneSearchKey(value: string | null | undefined): string {
+  // The TEN significant digits for a US-shaped number, all digits
+  // otherwise. Returning every digit — the first draft — keyed a stored
+  // `+16265550134` to `16265550134` and a typed `6265550134` to itself.
+  // Substring matching still worked, so the screen looked correct while
+  // equality quietly said no.
+  const raw = value || '';
+  return tenDigits(raw) || digits(raw);
+}


### PR DESCRIPTION
Part A of NOTARY2 + PARTNER2. Ships on its own; Part B (share entry points) and Part C (the coordination loop) follow. **No Part C code here** — `docs/NOTARY2_PLAN.md` carries the plan for your review.

## The registry

The category list had been copied into **five** files and had already diverged **twice**:

- the partners screen offered four categories, the builder's `AddPartnerModal` six — so a partner added in the builder arrived on the partners screen as a category the edit dropdown could not represent, and rendered as "Other" (fixed by hand in PARTNER1, with a note that hand-alignment has a shelf life);
- `QuickAddPartnerModal` held a third list in which **`realtor` was a CATEGORY**, while everywhere else `realtor` is a role belonging to `real_estate`. One word, two positions in the model, in the same product.

`lib/partnerRegistry.ts` is now the single source. Every surface derives from it, and the pin is **against copying** rather than against any particular wrong list: a category key appearing as a string literal in a partner surface fails the sweep.

**Roles derive from category** — notary → notary_public / mobile_notary, title company → title_officer / escrow_officer, and so on. The lists were independent before, which let an officer file a notary as a "loan officer": not wrong in any way the system could detect, just useless when she later wants her notaries. Changing category resets a role that does not belong; a stored role the new category does not offer is still rendered, so re-categorising never silently rewrites what she recorded.

**UI metadata only**, under the same constraint as the FORMS registry: no default, no auto-apply, no fee, no licensure, no characterization of what a partner may *do*. A category says how she FILES someone and nothing about their authority. Pinned by allowed-field-name equality — an allowlist, not a denylist of the fields somebody thought of.

`QuickAddPartnerModal` had no importers when I checked. I aligned it anyway rather than leaving it dead, because **Part B revives it** — the last ticket's "leave dead files alone" call is superseded by this ticket's own scope.

## The phone rule

Masked as typed — `(626) 555-0134` — stored as `+16265550134`. Different jobs, and conflating them is how `partners.phone` came to hold eleven punctuation styles the screen's substring search could not match: a row saved as `626-555-0134` was invisible to somebody typing `(626) 555`.

The rule exists in **both languages** — column shape is a storage concern, and "every current caller happens to be well-behaved" is a property of this afternoon, not of the system. That is exactly the divergence risk this ticket is deleting elsewhere, so it gets Doctrine A's treatment: **a shared corpus (`services/phone_cases.json`) that both suites read**, with the corpus as referee rather than either implementation.

**What it refuses to do:** discard what it cannot parse. An extension, a UK number, `ask for Dana` — that is information the officer chose to record, and dropping it to keep a column tidy would be the product deciding it knows better. Unparseable input survives verbatim.

**My own helper was wrong and the test caught it.** `phoneSearchKey` returned every digit, so a stored `+16265550134` keyed to `16265550134` while a typed `6265550134` keyed to itself. Substring matching still worked — the screen would have looked fine — while any equality comparison quietly said no. Fixed in both languages, with the reasoning in the docstring.

## §13.1 — the reversal, recorded

Signers now participate directly. Your reasoning is recorded rather than paraphrased:

> The signers are the scheduling constraint, so routing around them recreated the phone tag the feature exists to kill.

I added the part I think is worth keeping next to it: Option A optimised for the cost it could *see* — data held about a non-user — and priced the officer's relaying at zero, when that relaying is the entire problem.

**The superseded paragraph is kept verbatim.** A doctrine section that quietly rewrites its own history is worth less than one that shows its work.

**§13 otherwise stands unchanged**: an arrangement is not an act, booked ≠ happened, no auto-completion, `completed` stays officer-asserted. NOTARY1's fail-closed sweep is being **answered, not deleted** — Part C retargets it from "no signer contact anywhere" to "one purgeable row, no other table, deleted by a mechanism with a test."

## Three things from the plan you should see now

**There is no scheduler in this deployment.** No cron, no worker, no APScheduler, no Celery — `render.yaml` defines web services only. I checked before designing the purge around it. Part C will ship the purge as one function with two invocations: a script ready for a Render Cron Job, and a throttled in-request sweep needing no topology change. The sweep is a real mechanism and it is tested, but it runs only when somebody uses the product — it **lags gracefully rather than failing**, which is fine for a retention practice and **not** fine as the backing for a stated deletion window. Creating the cron service is Tier 3.

**NOTARY2 as specified is ~11.5 working days** — past two weeks once anything goes wrong. Recommended cut: Part D's month grid becomes a sorted agenda list in v1 (~1 day; no workflow depends on the grid). Recommended **against**: cutting the signer counter-proposal loop, which is the second-largest saving and is precisely the hole the reversal was made to close — cutting it spends two weeks rebuilding Option A with extra steps.

**One open question** in the plan: the notary's display name on the signer token view. A consumer asked to meet a stranger arguably should know who; equally it is another party's information on a surface whose whole point is minimum. Currently in the allowlist — say the word and it comes out.

## Gates

| gate | result |
|---|---|
| pytest, no database | 791 passed, 105 skipped |
| jest | 618 passed, 40 suites |
| tsc | 94 (baseline unchanged) |
| banned-claims | clean |

Both new pins were mutation-probed: planting a hard-coded category list back into a surface fails the copy sweep; breaking the phone rule in one language only fails against the shared corpus.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_