### PR TITLE
PARTNER2/B: two share actions, and the rolodex she already built (re-targeted to main)

### DIFF
--- a/backend/routers/partners.py
+++ b/backend/routers/partners.py
@@ -163,6 +163,15 @@ async def get_partners_selectlist(
                 'name': p['company_name'],
                 'category': p.get('category', 'other'),
                 'address': partner_address_line(p),
+                # PARTNER2/B: the rolodex is now a RECIPIENT picker, not
+                # only an address source. Sharing a deed or requesting a
+                # signing needs the person and their address — without
+                # these three the officer picks a partner and then
+                # retypes the email she already stored, which is the
+                # whole complaint this part answers.
+                'role': p.get('role', 'other'),
+                'contact_name': p.get('contact_name'),
+                'email': p.get('email'),
             }
             for p in partners
         ]

--- a/backend/tests/test_partners_routes.py
+++ b/backend/tests/test_partners_routes.py
@@ -48,8 +48,18 @@ def test_selectlist_resolves_to_selectlist_handler(client, path):
     assert res.status_code == 200
     # D2: the selectlist carries the partner's one-line address so
     # selecting a partner fills the deed's requesting-party block.
+    #
+    # PARTNER2/B added role, contact_name and email: the rolodex became a
+    # RECIPIENT picker, and without them the officer picks a partner and
+    # then retypes the address she already stored — the whole complaint.
+    #
+    # Asserted as an EXACT shape rather than a subset, deliberately. This
+    # endpoint's payload reaches a public-ish surface eventually, and a
+    # test that only checks the keys it remembers would not notice a
+    # fourth one arriving.
     assert res.json() == [
         {"id": "11111111-1111-1111-1111-111111111111",
          "name": "Pacific Coast Title", "category": "title",
-         "address": ""},
+         "address": "", "role": "other",
+         "contact_name": None, "email": None},
     ]

--- a/frontend/src/__tests__/honestShare.test.ts
+++ b/frontend/src/__tests__/honestShare.test.ts
@@ -15,8 +15,18 @@ import { describe, expect, it } from '@jest/globals';
 import * as fs from 'fs';
 import * as path from 'path';
 
+/**
+ * PARTNER2/B: the share flow moved out of `past-deeds/page.tsx` into its
+ * own component, and the inline modal was DELETED rather than kept
+ * alongside — two code paths creating the same kind of share with
+ * different wording is the divergence this ticket is deleting elsewhere.
+ *
+ * S1's property is unchanged and travels with the flow: the UI reports
+ * the transport's actual outcome and surfaces the link either way, so a
+ * share is usable with no email configured at all.
+ */
 const PAGE = fs.readFileSync(
-  path.join(__dirname, '..', 'app', 'past-deeds', 'page.tsx'),
+  path.join(__dirname, '..', 'features', 'signing', 'ShareForReviewModal.tsx'),
   'utf8'
 );
 
@@ -28,23 +38,38 @@ describe('S1 — share feedback tells the truth', () => {
   it('the result reads the backend truth: email_sent and approval_url', () => {
     expect(PAGE).toContain('data?.email_sent');
     expect(PAGE).toContain('data?.shared_deed?.approval_url');
+    expect(PAGE).toContain('data?.email_error');
   });
 
   it('email failure is stated, not hidden — with the manual path', () => {
-    expect(PAGE).toContain('could <strong>not</strong> be sent');
-    expect(PAGE).toContain('send it to the recipient yourself');
+    // The PROPERTY, not the old sentence: a failed send says so, and the
+    // link is offered for her to send herself.
+    expect(PAGE).toContain('The email did not go out');
+    expect(PAGE).toContain('Send the link below yourself');
+    // And the failure panel is visually distinct from success — an amber
+    // that means "this did not happen", per the palette's own rule.
+    expect(PAGE).toContain('bg-amber-50');
   });
 
   it('the review link is surfaced with a copy affordance', () => {
-    expect(PAGE).toContain('Review link');
-    expect(PAGE).toContain('navigator.clipboard.writeText(shareResult.approvalUrl)');
+    expect(PAGE).toContain('navigator.clipboard.writeText(result.url)');
+    expect(PAGE).toContain("{copied ? 'Copied' : 'Copy'}");
   });
 
-  it('opening the modal resets any previous result', () => {
-    const handler = PAGE.substring(
-      PAGE.indexOf('const handleShareClick'),
-      PAGE.indexOf('const handleShareSubmit')
+  it('a previous result cannot leak into the next share', () => {
+    // Was: an explicit `setShareResult(null)` in the open handler, because
+    // the modal lived inside the page and its state outlived it. The
+    // component now MOUNTS on open and unmounts on close, so the result
+    // state cannot survive — structurally rather than by remembering to
+    // clear it. Pinned at the mount site, which is where the guarantee is.
+    const page = fs.readFileSync(
+      path.join(__dirname, '..', 'app', 'past-deeds', 'page.tsx'),
+      'utf8'
     );
-    expect(handler).toContain('setShareResult(null)');
+    expect(page).toContain('{reviewDeedId !== null && (');
+    expect(page).toContain('onClose={() => setReviewDeedId(null)}');
+    // And the result state is local to the component, not the page.
+    expect(PAGE).toContain('const [result, setResult] = useState<');
+    expect(page).not.toContain('shareResult');
   });
 });

--- a/frontend/src/__tests__/legitimacyBatch.test.ts
+++ b/frontend/src/__tests__/legitimacyBatch.test.ts
@@ -108,15 +108,22 @@ describe('X2.3 — DTT breakdown, no fabricated city tax', () => {
 
 describe('X2.4/5 — share modal honesty', () => {
   it('recipient name is optional; email is the identity', () => {
-    const src = readSource('app', 'past-deeds', 'page.tsx');
-    expect(src).toContain('Recipient Name <span className="text-slate-400 font-normal">(optional)</span>');
-    // The name input carries no `required`; the email input still does.
-    const nameBlock = src.substring(src.indexOf('Recipient Name'), src.indexOf('Recipient Email'));
-    expect(nameBlock).not.toContain('required');
+    // PARTNER2/B: the typed-name-and-email pair moved into the recipient
+    // picker, where the name is optional BY CONSTRUCTION — she picks a
+    // partner and the name comes with them, or types an address and the
+    // name field is marked optional. The property is unchanged: an email
+    // identifies a recipient and a name never gates the send.
+    const src = readSource('features', 'partners', 'PartnerRecipientPicker.tsx');
+    expect(src).toContain('Their name (optional)');
+    const nameInput = src.substring(src.indexOf('Their name (optional)') - 400,
+                                    src.indexOf('Their name (optional)'));
+    expect(nameInput).not.toContain('required');
+    // The email input is the one that identifies.
+    expect(src).toMatch(/type="email"[\s\S]{0,200}placeholder="name@example\.com"/);
   });
 
   it('expiry copy states what actually happens at expiry', () => {
-    const src = readSource('app', 'past-deeds', 'page.tsx');
+    const src = readSource('features', 'signing', 'ShareForReviewModal.tsx');
     expect(src).toContain('When the link expires it stops working');
     expect(src).toContain('the deed itself is unaffected');
   });

--- a/frontend/src/__tests__/loudFailures.test.ts
+++ b/frontend/src/__tests__/loudFailures.test.ts
@@ -56,10 +56,18 @@ describe('X1 — session expiry is named at the login page', () => {
 });
 
 describe('X1 — renderer freeze: no full-viewport backdrop blur behind modals', () => {
+  // PARTNER2/B: past-deeds no longer OWNS a modal — its share flows moved
+  // into their own components — so the list follows the modals rather than
+  // the page that used to hold one. QuickAddPartnerModal is new to this
+  // list and was a live violation when it arrived: it kept `backdrop-blur`
+  // from before the X1 ruling because it had no importers at the time, and
+  // Part B revives it.
   const BLUR_SURFACES: Array<string[]> = [
-    ['app', 'past-deeds', 'page.tsx'],
     ['app', 'shared-deeds', 'page.tsx'],
     ['components', 'ui', 'ConfirmDialog.tsx'],
+    ['features', 'signing', 'ShareForReviewModal.tsx'],
+    ['features', 'signing', 'SigningRequestModal.tsx'],
+    ['features', 'partners', 'QuickAddPartnerModal.tsx'],
   ];
   for (const segments of BLUR_SURFACES) {
     it(`${segments.join('/')} dims without blurring`, () => {
@@ -70,10 +78,22 @@ describe('X1 — renderer freeze: no full-viewport backdrop blur behind modals',
   }
 });
 
-describe('X1 — share modal is viewport-safe', () => {
-  it('the modal is a flex column whose form body scrolls, keeping the footer reachable', () => {
-    const src = readSource('app', 'past-deeds', 'page.tsx');
-    expect(src).toMatch(/max-h-\[85vh\] flex flex-col/);
-    expect(src).toMatch(/onSubmit=\{handleShareSubmit\} className="[^"]*overflow-y-auto flex-1/);
-  });
+describe('X1 — the share modals are viewport-safe', () => {
+  // The PROPERTY: the panel is a flex column, its body scrolls, and the
+  // footer therefore stays reachable on a short viewport. Was pinned
+  // against one modal by its handler's NAME; both share modals now carry
+  // it, and naming the handler was pinning the spelling.
+  const MODALS: Array<string[]> = [
+    ['features', 'signing', 'ShareForReviewModal.tsx'],
+    ['features', 'signing', 'SigningRequestModal.tsx'],
+  ];
+  for (const segments of MODALS) {
+    it(`${segments.join('/')} scrolls its body, not its footer`, () => {
+      const src = readSource(...segments);
+      expect(src).toMatch(/max-h-\[85vh\] flex flex-col/);
+      expect(src).toMatch(/<form[^>]*className="flex flex-col min-h-0 flex-1"/);
+      expect(src).toMatch(/className="space-y-5 overflow-y-auto flex-1/);
+      expect(src).toMatch(/className="flex gap-3 pt-5 shrink-0"/);
+    });
+  }
 });

--- a/frontend/src/__tests__/shareEntryPoints.test.ts
+++ b/frontend/src/__tests__/shareEntryPoints.test.ts
@@ -1,0 +1,130 @@
+/**
+ * PARTNER2 / Part B — two actions, and the rolodex as the default.
+ *
+ * ═══ WHAT WAS WRONG ═══
+ *
+ * One generic "Share" button opened a modal that asked for a typed email
+ * address and a free-text role. It produced a REVIEW share, which meant
+ * the button quietly meant "review" without saying so, and requesting a
+ * signing was a different button that had arrived later.
+ *
+ * And both flows asked her to type an address she had already stored.
+ * She has a partners screen. Her notary is in it. The product ignored it
+ * every single time.
+ *
+ * ═══ THE TWO PROPERTIES PINNED HERE ═══
+ *
+ * 1. `share_kind` is decided by WHICH BUTTON SHE PRESSED — never
+ *    inferred from the payload, never asked as a radio button. Two
+ *    actions ask two different questions; making her classify her own
+ *    intent for the database's benefit before she can act is the thing
+ *    a kind-selector would have done.
+ * 2. The rolodex is the DEFAULT and typing is the FALLBACK. Not the
+ *    other way round, and not the only option either — a one-off
+ *    recipient is real, and forcing a partner row for somebody she will
+ *    email once would be the product being tidy at her expense.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
+
+const SRC = path.join(__dirname, '..');
+const read = (...p: string[]) => fs.readFileSync(path.join(SRC, ...p), 'utf8');
+
+const PAGE = read('app', 'past-deeds', 'page.tsx');
+const REVIEW = read('features', 'signing', 'ShareForReviewModal.tsx');
+const SIGNING = read('features', 'signing', 'SigningRequestModal.tsx');
+const PICKER = read('features', 'partners', 'PartnerRecipientPicker.tsx');
+
+describe('Part B — two distinct actions on the deed', () => {
+  it('the deed offers "Share for review" and "Request signing", separately', () => {
+    expect(PAGE).toContain('title="Share for review"');
+    expect(PAGE).toContain('title="Request signing"');
+    // The generic one is gone, not relabelled alongside them.
+    expect(PAGE).not.toContain('title="Share deed"');
+  });
+
+  it('each button opens its own modal', () => {
+    expect(PAGE).toContain('setReviewDeedId(deed.id)');
+    expect(PAGE).toContain('setSigningDeedId(deed.id)');
+    expect(PAGE).toContain('<ShareForReviewModal');
+    expect(PAGE).toContain('<SigningRequestModal');
+  });
+
+  it('the old inline share modal is deleted, not kept alongside', () => {
+    // Two code paths creating the same kind of share with different
+    // wording is precisely the divergence this ticket deletes elsewhere.
+    const code = codeOnly(PAGE);
+    expect(code).not.toContain('handleShareSubmit');
+    expect(code).not.toContain('shareModalOpen');
+    expect(code).not.toContain('ShareFormData');
+  });
+
+  it('share_kind comes from the endpoint each modal calls, never from a selector', () => {
+    // The review modal posts to the review endpoint; the signing modal
+    // posts to the signing endpoint. Neither sends a `share_kind` field
+    // and neither offers the officer a kind to choose.
+    expect(REVIEW).toContain("'/shared-deeds'");
+    expect(SIGNING).toContain('"/signing-requests"');
+    for (const src of [REVIEW, SIGNING]) {
+      expect(codeOnly(src)).not.toContain('share_kind');
+    }
+  });
+
+  it('the two modals speak their own status language', () => {
+    expect(REVIEW).toContain('Send the review request');
+    expect(SIGNING).toContain('Send the request');
+    // Neither borrows the other's words.
+    expect(REVIEW).not.toContain('availability');
+    expect(SIGNING).not.toContain('approve');
+  });
+});
+
+describe('Part B — the rolodex is the default, typing is the fallback', () => {
+  it('both modals pick a recipient from her partners', () => {
+    for (const src of [REVIEW, SIGNING]) {
+      expect(src).toContain('PartnerRecipientPicker');
+    }
+    // And neither keeps a raw email input of its own beside it.
+    expect(codeOnly(REVIEW)).not.toContain('recipient_email: recipientEmail');
+    expect(codeOnly(SIGNING)).not.toContain('notaryEmail');
+  });
+
+  it('the picker opens on the partner list, not on a text box', () => {
+    const code = codeOnly(PICKER);
+    // `typing` starts false: the list is what she sees first.
+    expect(code).toContain('const [typing, setTyping] = useState(false)');
+    expect(code).toContain('Choose from my partners');
+    expect(code).toContain('Someone else');
+  });
+
+  it('a signing request suggests notaries without hiding anyone else', () => {
+    expect(SIGNING).toContain('suggestCategory="notary"');
+    // Suggested-first, everyone-available: a mobile notary filed under
+    // "other" three months ago is still the person she wants, and a
+    // picker that knows better than her about her own contacts is one
+    // she works around.
+    expect(PICKER).toContain('Everyone else');
+    expect(PICKER).toContain("hits.filter((p) => p.category !== suggestCategory)");
+  });
+
+  it('a partner with no email is shown and says why, not filtered out', () => {
+    // "Why is Dana missing from this list" is a worse five minutes than
+    // a sentence explaining it.
+    expect(PICKER).toContain('No email on file');
+    expect(PICKER).toContain('disabled={!p.email}');
+  });
+
+  it('adding a partner inline reuses the existing path', () => {
+    // A fourth partner-creation form is how the category lists diverged.
+    expect(PICKER).toContain('QuickAddPartnerModal');
+    expect(PICKER).toContain('Add a new partner');
+    // And the newly-created partner is selected immediately.
+    expect(PICKER).toContain('onChange({ email: created.email');
+  });
+
+  it('a partner created without an email does not become a silent recipient', () => {
+    expect(PICKER).toContain('setTyping(true);');
+  });
+});

--- a/frontend/src/app/past-deeds/page.tsx
+++ b/frontend/src/app/past-deeds/page.tsx
@@ -6,6 +6,8 @@ import { useRouter } from "next/navigation"
 import Sidebar from "@/components/Sidebar"
 import { FileText, Download, Share2, Trash2, AlertCircle, CheckCircle, Clock, X, Plus, Loader2, Search, CalendarClock } from "lucide-react"
 import { SigningRequestModal } from "@/features/signing/SigningRequestModal"
+import { ShareForReviewModal } from "@/features/signing/ShareForReviewModal"
+import { PartnersProvider } from "@/features/partners/PartnersContext"
 import { toast } from "sonner"
 import { SessionExpiredError, apiFetch } from "@/lib/apiClient"
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog"
@@ -34,43 +36,23 @@ function partyNames(deed: Deed): string {
     .join("; ")
 }
 
-interface ShareFormData {
-  recipient_name: string
-  recipient_email: string
-  recipient_role: string
-  message: string
-  expires_in_hours: number
-}
-
 // ✅ PHASE 24-E: V0-generated Past Deeds page with all business logic preserved
 export default function PastDeedsPageV0() {
   const router = useRouter()
   const [deeds, setDeeds] = useState<Deed[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [shareModalOpen, setShareModalOpen] = useState(false)
   // NOTARY1: which deed, if any, has an open signing-request modal.
   const [signingDeedId, setSigningDeedId] = useState<number | null>(null)
-  const [selectedDeedId, setSelectedDeedId] = useState<number | null>(null)
-  const [shareError, setShareError] = useState<string | null>(null)
-  const [shareLoading, setShareLoading] = useState(false)
-  const [shareForm, setShareForm] = useState<ShareFormData>({
-    recipient_name: "",
-    recipient_email: "",
-    recipient_role: "Title Officer",
-    message: "",
-    expires_in_hours: 168, // 7 days default
-  })
+  // PARTNER2/B: and which has the review modal. Two states because two
+  // actions; a single "which modal" enum would have been the toggle this
+  // part exists to remove.
+  const [reviewDeedId, setReviewDeedId] = useState<number | null>(null)
   const [deleteConfirm, setDeleteConfirm] = useState<{ isOpen: boolean; deedId: number | null }>({
     isOpen: false,
     deedId: null,
   })
   const [downloadingId, setDownloadingId] = useState<number | null>(null)
-  // S1: the share result panel — email status reported truthfully, and the
-  // review link surfaced for manual sending (shares must be usable even
-  // with no email transport configured).
-  const [shareResult, setShareResult] = useState<{ approvalUrl: string; emailSent: boolean; emailError?: string } | null>(null)
-  const [linkCopied, setLinkCopied] = useState(false)
   // X2.7: find a deed without scrolling — text search + status filter.
   const [searchQuery, setSearchQuery] = useState("")
   const [statusFilter, setStatusFilter] = useState<"all" | "completed" | "draft">("all")
@@ -140,58 +122,6 @@ export default function PastDeedsPageV0() {
       toast.error(err instanceof Error ? err.message : "PDF not available for this deed")
     } finally {
       setDownloadingId(null)
-    }
-  }
-
-  const handleShareClick = (deedId: number) => {
-    setSelectedDeedId(deedId)
-    setShareModalOpen(true)
-    setShareError(null)
-    setShareResult(null)
-    setLinkCopied(false)
-  }
-
-  const handleShareSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    setShareLoading(true)
-    setShareError(null)
-
-    try {
-      const response = await apiFetch(
-        `/shared-deeds`,
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ deed_id: selectedDeedId, ...shareForm }),
-        },
-        { label: "Sharing deed" }
-      )
-
-      if (!response.ok) {
-        const data = await response.json().catch(() => ({}))
-        throw new Error(data.detail || `Failed to share deed (${response.status})`)
-      }
-
-      // S1: the backend says whether the email actually went out
-      // (email_sent) and hands back the review link — report THAT, never
-      // a fabricated "the recipient will receive an email."
-      const data = await response.json().catch(() => ({}))
-      setShareForm({
-        recipient_name: "",
-        recipient_email: "",
-        recipient_role: "Title Officer",
-        message: "",
-        expires_in_hours: 168,
-      })
-      setShareResult({
-        approvalUrl: data?.shared_deed?.approval_url || "",
-        emailSent: !!data?.email_sent,
-        emailError: typeof data?.email_error === "string" ? data.email_error : undefined,
-      })
-    } catch (err) {
-      setShareError(err instanceof Error ? err.message : "Failed to share deed")
-    } finally {
-      setShareLoading(false)
     }
   }
 
@@ -440,20 +370,25 @@ export default function PastDeedsPageV0() {
                                     <Download className="w-4 h-4" />
                                   )}
                                 </button>
+                                {/* PARTNER2/B: two actions, because they ask
+                                    two different questions. "Will you check
+                                    this?" and "are you free on Tuesday?" have
+                                    different recipients, different emails and
+                                    different outcomes — and the generic Share
+                                    button quietly meant "review" without ever
+                                    saying so. `share_kind` is set by which
+                                    button she pressed, never inferred. */}
                                 <button
-                                  onClick={() => handleShareClick(deed.id)}
+                                  onClick={() => setReviewDeedId(deed.id)}
                                   className="p-2 bg-slate-600 hover:bg-slate-700 text-white rounded-lg transition-colors"
-                                  title="Share deed"
+                                  title="Share for review"
                                 >
                                   <Share2 className="w-4 h-4" />
                                 </button>
-                                {/* NOTARY1: a different question from the one
-                                    the Share button asks — availability, not
-                                    approval — so it is a different button. */}
                                 <button
                                   onClick={() => setSigningDeedId(deed.id)}
                                   className="p-2 bg-slate-600 hover:bg-slate-700 text-white rounded-lg transition-colors"
-                                  title="Request a signing"
+                                  title="Request signing"
                                 >
                                   <CalendarClock className="w-4 h-4" />
                                 </button>
@@ -478,209 +413,29 @@ export default function PastDeedsPageV0() {
         </div>
       </main>
 
-      {/* Share Modal */}
-      {shareModalOpen && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
-          <div className="bg-white rounded-2xl shadow-2xl max-w-[550px] w-full p-6 max-h-[85vh] flex flex-col">
-            {/* Header */}
-            <div className="flex items-center justify-between mb-6">
-              <h2 className="text-2xl font-bold text-slate-800">Share Deed</h2>
-              <button
-                onClick={() => setShareModalOpen(false)}
-                className="p-2 hover:bg-slate-100 rounded-lg transition-colors"
-              >
-                <X className="w-5 h-5 text-slate-400 hover:text-slate-600" />
-              </button>
-            </div>
+      {/* PARTNER2/B: the inline share modal that used to live here is
+          GONE, not kept alongside the new one. It asked for a typed
+          email and a free-text role and produced a review share
+          without saying so; leaving it would have meant two code
+          paths creating the same kind of share with different
+          wording, which is the divergence this ticket is deleting
+          everywhere else. S1's honesty pins moved with it — see
+          ShareForReviewModal and __tests__/honestShare.test.ts. */}
 
-            {/* Error Banner */}
-            {shareError && (
-              <div className="mb-6 p-4 bg-red-50 border border-red-200 rounded-lg flex items-start gap-3">
-                <AlertCircle className="w-5 h-5 text-red-600 flex-shrink-0 mt-0.5" />
-                <p className="text-sm text-red-600">{shareError}</p>
-              </div>
-            )}
-
-            {/* S1: result panel — the truth about what happened, plus the
-                review link so the share works even with no email transport. */}
-            {shareResult ? (
-              <div className="space-y-4 overflow-y-auto flex-1 min-h-0 pr-1">
-                <div className="flex items-start gap-3 p-4 bg-green-50 border border-green-200 rounded-lg">
-                  <CheckCircle className="w-5 h-5 text-green-600 flex-shrink-0 mt-0.5" />
-                  <p className="text-sm text-green-800 font-medium">
-                    Share saved — the review link is active until it expires.
-                  </p>
-                </div>
-
-                {shareResult.emailSent ? (
-                  <p className="text-sm text-slate-600">
-                    A notification email with the review link was sent to the recipient.
-                  </p>
-                ) : (
-                  <div className="flex items-start gap-3 p-4 bg-amber-50 border border-amber-200 rounded-lg">
-                    <AlertCircle className="w-5 h-5 text-amber-600 flex-shrink-0 mt-0.5" />
-                    <div className="text-sm text-amber-800">
-                      <p>
-                        The notification email could <strong>not</strong> be sent.
-                        Copy the review link below and send it to the recipient yourself.
-                      </p>
-                      {shareResult.emailError && (
-                        <p className="mt-1 text-xs font-mono text-amber-700 break-words">
-                          {shareResult.emailError}
-                        </p>
-                      )}
-                    </div>
-                  </div>
-                )}
-
-                {shareResult.approvalUrl && (
-                  <div>
-                    <label className="block text-sm font-medium text-slate-700 mb-2">Review link</label>
-                    <div className="flex items-center gap-2">
-                      <input
-                        type="text"
-                        readOnly
-                        value={shareResult.approvalUrl}
-                        onFocus={(e) => e.target.select()}
-                        className="flex-1 px-3 py-2.5 text-sm font-mono border border-slate-300 rounded-lg bg-slate-50 text-slate-700"
-                      />
-                      <button
-                        type="button"
-                        onClick={() => {
-                          navigator.clipboard.writeText(shareResult.approvalUrl)
-                          setLinkCopied(true)
-                          setTimeout(() => setLinkCopied(false), 2000)
-                        }}
-                        className="px-4 py-2.5 bg-[#7C4DFF] hover:bg-[#6a3de8] text-white text-sm font-medium rounded-lg transition-colors flex-shrink-0"
-                      >
-                        {linkCopied ? "Copied!" : "Copy link"}
-                      </button>
-                    </div>
-                  </div>
-                )}
-
-                <div className="flex justify-end pt-2">
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setShareModalOpen(false)
-                      setShareResult(null)
-                    }}
-                    className="px-6 py-3 bg-slate-200 hover:bg-slate-300 text-slate-700 font-medium rounded-lg transition-colors"
-                  >
-                    Done
-                  </button>
-                </div>
-              </div>
-            ) : (
-            <form onSubmit={handleShareSubmit} className="space-y-4 overflow-y-auto flex-1 min-h-0 pr-1">
-              <div>
-                <label className="block text-sm font-medium text-slate-700 mb-2">
-                  Recipient Name <span className="text-slate-400 font-normal">(optional)</span>
-                </label>
-                <input
-                  type="text"
-                  value={shareForm.recipient_name}
-                  onChange={(e) => setShareForm({ ...shareForm, recipient_name: e.target.value })}
-                  className="w-full px-4 py-3 border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF] transition-colors"
-                  placeholder="John Doe"
-                />
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-slate-700 mb-2">
-                  Recipient Email <span className="text-red-500">*</span>
-                </label>
-                <input
-                  type="email"
-                  required
-                  value={shareForm.recipient_email}
-                  onChange={(e) => setShareForm({ ...shareForm, recipient_email: e.target.value })}
-                  className="w-full px-4 py-3 border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF] transition-colors"
-                  placeholder="john@example.com"
-                />
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-slate-700 mb-2">Recipient Role</label>
-                <select
-                  value={shareForm.recipient_role}
-                  onChange={(e) => setShareForm({ ...shareForm, recipient_role: e.target.value })}
-                  className="w-full px-4 py-3 border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF] transition-colors"
-                >
-                  <option>Title Officer</option>
-                  <option>Lender</option>
-                  <option>Escrow Officer</option>
-                  <option>Attorney</option>
-                  <option>Other</option>
-                </select>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-slate-700 mb-2">Message (Optional)</label>
-                <textarea
-                  rows={3}
-                  value={shareForm.message}
-                  onChange={(e) => setShareForm({ ...shareForm, message: e.target.value })}
-                  className="w-full px-4 py-3 border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF] transition-colors resize-none"
-                  placeholder="Add a message for the recipient..."
-                />
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-slate-700 mb-2">Link Expires In</label>
-                <select
-                  value={shareForm.expires_in_hours}
-                  onChange={(e) => setShareForm({ ...shareForm, expires_in_hours: parseInt(e.target.value) })}
-                  className="w-full px-4 py-3 border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF] transition-colors"
-                >
-                  <option value="24">24 hours</option>
-                  <option value="72">3 days</option>
-                  <option value="168">7 days (recommended)</option>
-                  <option value="336">14 days</option>
-                  <option value="720">30 days</option>
-                </select>
-                {/* X2.5: say what expiry actually does. */}
-                <p className="text-xs text-slate-500 mt-1">
-                  When the link expires it stops working and the share is marked
-                  expired — the deed itself is unaffected, and you can share it
-                  again anytime.
-                </p>
-              </div>
-
-              {/* Footer Buttons */}
-              <div className="flex items-center justify-end gap-3 pt-4">
-                <button
-                  type="button"
-                  onClick={() => setShareModalOpen(false)}
-                  className="px-6 py-3 bg-slate-200 hover:bg-slate-300 text-slate-700 font-medium rounded-lg transition-colors"
-                >
-                  Cancel
-                </button>
-                <button
-                  type="submit"
-                  disabled={shareLoading}
-                  className="px-6 py-3 bg-[#7C4DFF] hover:bg-[#6a3de8] text-white font-medium rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex items-center gap-2"
-                >
-                  {shareLoading ? (
-                    <>
-                      <Loader2 className="w-4 h-4 animate-spin" />
-                      Sending...
-                    </>
-                  ) : (
-                    "Share Deed"
-                  )}
-                </button>
-              </div>
-            </form>
-            )}
-          </div>
-        </div>
-      )}
-
-      {/* NOTARY1 — request a signing (officer → notary) */}
-      {signingDeedId !== null && (
-        <SigningRequestModal deedId={signingDeedId} onClose={() => setSigningDeedId(null)} />
+      {/* PARTNER2/B — the two share actions, each with its own modal.
+          Both are wrapped in PartnersProvider so the recipient picker and
+          its inline "add a new partner" reuse the EXISTING partner path
+          rather than growing a fourth creation form — a fourth form is
+          how the category lists diverged in the first place. */}
+      {(signingDeedId !== null || reviewDeedId !== null) && (
+        <PartnersProvider>
+          {signingDeedId !== null && (
+            <SigningRequestModal deedId={signingDeedId} onClose={() => setSigningDeedId(null)} />
+          )}
+          {reviewDeedId !== null && (
+            <ShareForReviewModal deedId={reviewDeedId} onClose={() => setReviewDeedId(null)} />
+          )}
+        </PartnersProvider>
       )}
 
       {/* Delete Confirmation Dialog */}

--- a/frontend/src/features/partners/PartnerRecipientPicker.tsx
+++ b/frontend/src/features/partners/PartnerRecipientPicker.tsx
@@ -1,0 +1,260 @@
+'use client';
+
+/**
+ * PARTNER2 / Part B — pick a recipient from the rolodex she already built.
+ *
+ * ═══ THE COMPLAINT THIS ANSWERS ═══
+ *
+ * Both share flows asked for a typed email address. The officer has a
+ * partners screen, she has filled it in, her notary and her title
+ * officers are in it with their addresses — and every time she shared a
+ * deed the product asked her to type an email from memory. She built a
+ * rolodex; the product ignored it.
+ *
+ * So the list is the DEFAULT and typing is the FALLBACK, which is the
+ * inversion this component exists to perform. "Someone else" is still
+ * there, because a one-off recipient is real and forcing her to create a
+ * partner row for a person she will email once would be the product
+ * being tidy at her expense.
+ *
+ * ═══ WHY IT FILTERS BUT DOES NOT RESTRICT ═══
+ *
+ * A signing request suggests notaries first, because that is who a
+ * signing request goes to. It does not HIDE the rest: a mobile notary
+ * filed under "other" three months ago is still the person she wants,
+ * and a picker that knows better than her about her own contacts is a
+ * picker she works around. Suggested-first, everyone-available.
+ *
+ * ═══ A PARTNER WITH NO EMAIL IS SHOWN, AND SAYS SO ═══
+ *
+ * Rather than filtered out. She stored them for a reason, and "why is
+ * Dana missing from this list" is a worse five minutes than an inline
+ * note saying no address is on file.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { ChevronDown, Mail, Plus, Search, UserPlus } from 'lucide-react';
+import { PartnerOption, usePartners } from './PartnersContext';
+import { QuickAddPartnerModal } from './QuickAddPartnerModal';
+import { categoryLabel, roleLabel } from '@/lib/partnerRegistry';
+
+export interface Recipient {
+  email: string;
+  name: string;
+  /** Set when she picked from the rolodex; absent for a typed address. */
+  partnerId?: string;
+}
+
+export function PartnerRecipientPicker({
+  value,
+  onChange,
+  suggestCategory,
+  label = 'Send to',
+}: {
+  value: Recipient | null;
+  onChange: (r: Recipient | null) => void;
+  /** Category floated to the top. Never used to hide anyone. */
+  suggestCategory?: string;
+  label?: string;
+}) {
+  const { partners, loading, refresh } = usePartners();
+  const [typing, setTyping] = useState(false);
+  const [query, setQuery] = useState('');
+  const [open, setOpen] = useState(false);
+  const [quickAdd, setQuickAdd] = useState(false);
+
+  useEffect(() => {
+    if (!partners.length) refresh?.();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const ordered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const matches = (p: PartnerOption) =>
+      !q ||
+      [p.label, p.contact_name, p.email, categoryLabel(p.category)]
+        .some((f) => (f || '').toLowerCase().includes(q));
+    const hits = partners.filter(matches);
+    if (!suggestCategory) return hits;
+    // Suggested first, everyone still present.
+    return [
+      ...hits.filter((p) => p.category === suggestCategory),
+      ...hits.filter((p) => p.category !== suggestCategory),
+    ];
+  }, [partners, query, suggestCategory]);
+
+  const suggestedCount = suggestCategory
+    ? partners.filter((p) => p.category === suggestCategory).length
+    : 0;
+
+  const choose = (p: PartnerOption) => {
+    if (!p.email) return;
+    onChange({
+      email: p.email,
+      name: p.contact_name || p.company_name || p.label,
+      partnerId: p.id,
+    });
+    setOpen(false);
+    setQuery('');
+  };
+
+  return (
+    <div>
+      <label className="block text-sm font-medium text-slate-700 mb-1">
+        {label} <span className="text-red-500">*</span>
+      </label>
+
+      {typing ? (
+        <div className="space-y-2">
+          <input
+            type="email"
+            autoFocus
+            value={value?.email || ''}
+            onChange={(e) => onChange({ email: e.target.value, name: value?.name || '' })}
+            placeholder="name@example.com"
+            className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF]"
+          />
+          <input
+            type="text"
+            value={value?.name || ''}
+            onChange={(e) => onChange({ email: value?.email || '', name: e.target.value })}
+            placeholder="Their name (optional)"
+            className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF]"
+          />
+          <button
+            type="button"
+            onClick={() => { setTyping(false); onChange(null); }}
+            className="text-sm text-[#7C4DFF] hover:underline"
+          >
+            ← Choose from my partners instead
+          </button>
+        </div>
+      ) : (
+        <div className="relative">
+          <button
+            type="button"
+            onClick={() => setOpen((o) => !o)}
+            className="w-full flex items-center justify-between gap-2 px-3 py-2 border border-slate-300 rounded-lg text-left hover:bg-slate-50"
+          >
+            {value ? (
+              <span className="min-w-0">
+                <span className="block font-medium text-slate-800 truncate">{value.name || value.email}</span>
+                <span className="block text-xs text-slate-500 truncate">{value.email}</span>
+              </span>
+            ) : (
+              <span className="text-slate-500">
+                {loading ? 'Loading your partners…' : 'Choose from my partners'}
+              </span>
+            )}
+            <ChevronDown className="w-4 h-4 text-slate-400 shrink-0" />
+          </button>
+
+          {open && (
+            <div className="absolute z-20 mt-1 w-full bg-white border border-slate-200 rounded-lg shadow-lg max-h-72 overflow-y-auto">
+              <div className="sticky top-0 bg-white border-b border-slate-100 p-2">
+                <div className="relative">
+                  <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+                  <input
+                    autoFocus
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    placeholder="Search your partners"
+                    className="w-full pl-8 pr-2 py-1.5 text-sm border border-slate-200 rounded-md focus:ring-1 focus:ring-[#7C4DFF]"
+                  />
+                </div>
+              </div>
+
+              {ordered.length === 0 && (
+                <p className="px-3 py-4 text-sm text-slate-500">
+                  {partners.length === 0
+                    ? 'No partners yet — add one below, or type an address.'
+                    : 'Nobody matches that.'}
+                </p>
+              )}
+
+              {ordered.map((p, i) => {
+                const isSuggested = !!suggestCategory && p.category === suggestCategory;
+                const firstOther = !!suggestCategory && i === suggestedCount && suggestedCount > 0 && !query;
+                return (
+                  <div key={p.id}>
+                    {firstOther && (
+                      <div className="px-3 py-1 text-[11px] uppercase tracking-wide text-slate-400 bg-slate-50">
+                        Everyone else
+                      </div>
+                    )}
+                    {isSuggested && i === 0 && !query && (
+                      <div className="px-3 py-1 text-[11px] uppercase tracking-wide text-slate-400 bg-slate-50">
+                        {categoryLabel(suggestCategory)}
+                      </div>
+                    )}
+                    <button
+                      type="button"
+                      disabled={!p.email}
+                      onClick={() => choose(p)}
+                      className="w-full text-left px-3 py-2 hover:bg-slate-50 disabled:hover:bg-white disabled:cursor-not-allowed"
+                    >
+                      <span className="block text-sm font-medium text-slate-800 truncate">
+                        {p.contact_name ? `${p.contact_name} — ${p.label}` : p.label}
+                      </span>
+                      <span className="block text-xs text-slate-500 truncate">
+                        {p.email ? (
+                          <>
+                            <Mail className="inline w-3 h-3 mr-1 -mt-0.5" />
+                            {p.email}
+                          </>
+                        ) : (
+                          // Shown, not hidden — "why is Dana missing" is a
+                          // worse five minutes than this sentence.
+                          <span className="text-amber-700">No email on file — add one on the Partners page</span>
+                        )}
+                        {p.role ? ` · ${roleLabel(p.role)}` : ''}
+                      </span>
+                    </button>
+                  </div>
+                );
+              })}
+
+              <div className="sticky bottom-0 bg-white border-t border-slate-100 flex">
+                <button
+                  type="button"
+                  onClick={() => { setQuickAdd(true); setOpen(false); }}
+                  className="flex-1 flex items-center gap-2 px-3 py-2 text-sm text-[#7C4DFF] hover:bg-slate-50"
+                >
+                  <Plus className="w-4 h-4" /> Add a new partner
+                </button>
+                <button
+                  type="button"
+                  onClick={() => { setTyping(true); setOpen(false); onChange(null); }}
+                  className="flex-1 flex items-center gap-2 px-3 py-2 text-sm text-slate-600 hover:bg-slate-50 border-l border-slate-100"
+                >
+                  <UserPlus className="w-4 h-4" /> Someone else
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Inline creation, reusing the existing path rather than a second
+          create form — a fourth partner-creation surface is how the
+          category lists diverged in the first place. */}
+      <QuickAddPartnerModal
+        isOpen={quickAdd}
+        onClose={() => setQuickAdd(false)}
+        initialCategory={suggestCategory}
+        onCreated={(created) => {
+          setQuickAdd(false);
+          if (created.email) {
+            onChange({ email: created.email, name: created.label, partnerId: created.id });
+          } else {
+            // Created without an address: say so instead of selecting a
+            // recipient we cannot reach.
+            setTyping(true);
+            onChange({ email: '', name: created.label });
+          }
+          refresh?.();
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/features/partners/PartnersContext.tsx
+++ b/frontend/src/features/partners/PartnersContext.tsx
@@ -33,6 +33,9 @@ export interface PartnerOption {
   contact_name?: string;
   /** D2: one-line mailing address, assembled server-side. */
   address?: string;
+  /** PARTNER2/B: the rolodex became a recipient picker. */
+  role?: string;
+  email?: string;
 }
 
 export interface CreatePartnerData {
@@ -132,6 +135,8 @@ export function PartnersProvider({ children }: { children: React.ReactNode }) {
         company_name: item.company_name,
         contact_name: item.contact_name,
         address: item.address || '',
+        role: item.role,
+        email: item.email,
       }));
 
       setPartners(normalized);

--- a/frontend/src/features/partners/QuickAddPartnerModal.tsx
+++ b/frontend/src/features/partners/QuickAddPartnerModal.tsx
@@ -10,9 +10,14 @@ import { toast } from 'sonner';
 interface QuickAddPartnerModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onCreated: (partner: { id: string; label: string }) => void;
+  /** PARTNER2/B: the email rides along, because the caller is now a
+   * RECIPIENT picker — a partner created mid-flow should be selectable
+   * immediately rather than requiring her to go and find it. */
+  onCreated: (partner: { id: string; label: string; email?: string }) => void;
   initialName?: string;
-  category?: string;
+  /** Named `initialCategory` because it SEEDS the form; the old name
+   * `category` read like it constrained what could be created. */
+  initialCategory?: string;
 }
 
 export function QuickAddPartnerModal({
@@ -20,8 +25,9 @@ export function QuickAddPartnerModal({
   onClose,
   onCreated,
   initialName = '',
-  category = 'title_company',
+  initialCategory = 'title_company',
 }: QuickAddPartnerModalProps) {
+  const category = initialCategory || 'title_company';
   const { create } = usePartners();
   const [loading, setLoading] = useState(false);
   const [formData, setFormData] = useState<CreatePartnerData>({
@@ -54,7 +60,8 @@ export function QuickAddPartnerModal({
         toast.success('Partner added successfully');
         onCreated({
           id: newPartner.id,
-          label: formData.company_name || formData.contact_name || '',
+          label: formData.contact_name || formData.company_name || '',
+          email: formData.email || undefined,
         });
         onClose();
       }
@@ -75,7 +82,7 @@ export function QuickAddPartnerModal({
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       {/* Backdrop */}
       <div 
-        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+        className="absolute inset-0 bg-black/50"
         onClick={onClose}
       />
       

--- a/frontend/src/features/signing/ShareForReviewModal.tsx
+++ b/frontend/src/features/signing/ShareForReviewModal.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+/**
+ * PARTNER2 / Part B — "Share for review", its own action and its own words.
+ *
+ * ═══ WHY TWO MODALS AND NOT ONE WITH A TOGGLE ═══
+ *
+ * There used to be one Share button. It asked for a typed email and a
+ * free-text "role", and it produced a review share — which meant
+ * requesting a signing was a different button somewhere else, and the
+ * generic one quietly meant "review" without saying so.
+ *
+ * Two actions ask two different QUESTIONS. "Will you check this?" and
+ * "are you free on Tuesday?" have different recipients, different
+ * emails, different status language and different outcomes. A single
+ * modal with a kind-selector would have made the officer classify her
+ * own intent for the database's benefit before she could act on it.
+ *
+ * `share_kind` is therefore set by WHICH BUTTON SHE PRESSED, never
+ * inferred and never asked.
+ */
+
+import { useState } from 'react';
+import { FileText, Loader2, X } from 'lucide-react';
+import { apiFetch } from '@/lib/apiClient';
+import { PartnerRecipientPicker, Recipient } from '@/features/partners/PartnerRecipientPicker';
+
+const EXPIRY_CHOICES = [
+  { hours: 72, label: '3 days' },
+  { hours: 168, label: '7 days' },
+  { hours: 336, label: '14 days' },
+];
+
+export function ShareForReviewModal({
+  deedId,
+  onClose,
+}: {
+  deedId: number;
+  onClose: () => void;
+}) {
+  const [recipient, setRecipient] = useState<Recipient | null>(null);
+  const [message, setMessage] = useState('');
+  const [expiresInHours, setExpiresInHours] = useState(168);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<{
+    url: string;
+    emailSent: boolean;
+    emailError?: string;
+  } | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!recipient?.email) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const response = await apiFetch(
+        '/shared-deeds',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            deed_id: deedId,
+            recipient_email: recipient.email,
+            recipient_name: recipient.name || undefined,
+            recipient_role: 'Reviewer',
+            message: message || undefined,
+            expires_in_hours: expiresInHours,
+          }),
+        },
+        { label: 'Sharing deed for review' },
+      );
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(data.detail || `Failed to share (${response.status})`);
+      }
+      // S1's rule: report the transport's actual outcome and surface the
+      // link either way, so a share works with no email configured.
+      setResult({
+        url: data?.shared_deed?.approval_url || '',
+        emailSent: !!data?.email_sent,
+        emailError: typeof data?.email_error === 'string' ? data.email_error : undefined,
+      });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to share');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
+      <div className="bg-white rounded-2xl shadow-2xl max-w-[560px] w-full max-h-[85vh] flex flex-col p-8">
+        <div className="flex items-center justify-between mb-6 shrink-0">
+          <h2 className="text-2xl font-bold text-slate-800 flex items-center gap-2">
+            <FileText className="w-6 h-6 text-[#7C4DFF]" />
+            Share for review
+          </h2>
+          <button onClick={onClose} className="p-2 hover:bg-slate-100 rounded-lg" aria-label="Close">
+            <X className="w-5 h-5 text-slate-400" />
+          </button>
+        </div>
+
+        {result ? (
+          <div className="space-y-4">
+            <p className="text-slate-700">
+              The review request is on the record. They can approve it or ask for
+              changes, and you will be told which.
+            </p>
+            <div
+              className={`rounded-lg border p-4 text-sm ${
+                result.emailSent
+                  ? 'border-slate-200 bg-slate-50 text-slate-700'
+                  : 'border-amber-200 bg-amber-50 text-amber-800'
+              }`}
+            >
+              {result.emailSent
+                ? `Email sent to ${recipient?.email}.`
+                : `The email did not go out${result.emailError ? `: ${result.emailError}` : ''}. Send the link below yourself.`}
+            </div>
+            {result.url && (
+              <div className="flex items-center gap-2">
+                <div className="flex-1 rounded-lg border border-slate-200 p-3 break-all text-xs text-slate-600">
+                  {result.url}
+                </div>
+                <button
+                  type="button"
+                  onClick={() => {
+                    navigator.clipboard.writeText(result.url);
+                    setCopied(true);
+                  }}
+                  className="px-3 py-2 text-sm border border-slate-300 rounded-lg hover:bg-slate-50"
+                >
+                  {copied ? 'Copied' : 'Copy'}
+                </button>
+              </div>
+            )}
+            <button
+              onClick={onClose}
+              className="w-full px-6 py-3 bg-[#7C4DFF] hover:bg-[#6a3de8] text-white font-medium rounded-lg"
+            >
+              Done
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={submit} className="flex flex-col min-h-0 flex-1">
+            {/* X1: the BODY scrolls, not the whole panel — a footer that
+                scrolls out of reach on a short viewport is a form she
+                cannot submit. */}
+            <div className="space-y-5 overflow-y-auto flex-1 pr-1">
+            <PartnerRecipientPicker
+              value={recipient}
+              onChange={setRecipient}
+              label="Ask for a review from"
+            />
+
+            <div>
+              <label className="block text-sm font-medium text-slate-700 mb-1">
+                Link expires after
+              </label>
+              <select
+                value={expiresInHours}
+                onChange={(e) => setExpiresInHours(Number(e.target.value))}
+                className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF]"
+              >
+                {EXPIRY_CHOICES.map((c) => (
+                  <option key={c.hours} value={c.hours}>{c.label}</option>
+                ))}
+              </select>
+              <p className="text-xs text-slate-500 mt-1">
+                When the link expires it stops working and the reviewer sees a
+                notice — the deed itself is unaffected.
+              </p>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-slate-700 mb-1">
+                Note (optional)
+              </label>
+              <textarea
+                value={message}
+                onChange={(e) => setMessage(e.target.value)}
+                rows={3}
+                className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF]"
+                placeholder="Anything they should look at in particular"
+              />
+            </div>
+
+            {error && (
+              <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+                {error}
+              </div>
+            )}
+            </div>
+
+            <div className="flex gap-3 pt-5 shrink-0">
+              <button
+                type="button"
+                onClick={onClose}
+                className="flex-1 px-4 py-3 border border-slate-300 text-slate-700 rounded-lg hover:bg-slate-50 font-medium"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={submitting || !recipient?.email}
+                className="flex-1 px-4 py-3 bg-[#7C4DFF] hover:bg-[#6a3de8] text-white font-medium rounded-lg disabled:opacity-50 flex items-center justify-center gap-2"
+              >
+                {submitting && <Loader2 className="w-4 h-4 animate-spin" />}
+                Send the review request
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/signing/SigningRequestModal.tsx
+++ b/frontend/src/features/signing/SigningRequestModal.tsx
@@ -18,6 +18,7 @@
 import { useState } from "react"
 import { CalendarClock, Loader2, Plus, Trash2, X } from "lucide-react"
 import { apiFetch } from "@/lib/apiClient"
+import { PartnerRecipientPicker, Recipient } from "@/features/partners/PartnerRecipientPicker"
 
 const MAX_WINDOWS = 3
 
@@ -52,8 +53,9 @@ export function SigningRequestModal({
   deedId: number
   onClose: () => void
 }) {
-  const [notaryEmail, setNotaryEmail] = useState("")
-  const [notaryName, setNotaryName] = useState("")
+  // PARTNER2/B: the rolodex, not a text box. She filed her notary
+  // months ago; asking her to retype the address is the complaint.
+  const [notary, setNotary] = useState<Recipient | null>(null)
   const [location, setLocation] = useState("")
   const [windows, setWindows] = useState<Window[]>([{ start: "", end: "" }])
   const [submitting, setSubmitting] = useState(false)
@@ -77,8 +79,8 @@ export function SigningRequestModal({
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({
             deed_id: deedId,
-            notary_email: notaryEmail,
-            notary_name: notaryName || undefined,
+            notary_email: notary?.email,
+            notary_name: notary?.name || undefined,
             location: location || undefined,
             proposed_windows: complete.map((w) => ({
               start: withOffset(w.start),
@@ -110,8 +112,8 @@ export function SigningRequestModal({
 
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
-      <div className="bg-white rounded-2xl shadow-2xl max-w-[600px] w-full max-h-[90vh] overflow-y-auto p-8">
-        <div className="flex items-center justify-between mb-6">
+      <div className="bg-white rounded-2xl shadow-2xl max-w-[600px] w-full max-h-[85vh] flex flex-col p-8">
+        <div className="flex items-center justify-between mb-6 shrink-0">
           <h2 className="text-2xl font-bold text-slate-800 flex items-center gap-2">
             <CalendarClock className="w-6 h-6 text-[#7C4DFF]" />
             Request a signing
@@ -146,7 +148,7 @@ export function SigningRequestModal({
               }`}
             >
               {result.emailSent
-                ? `Email sent to ${notaryEmail}.`
+                ? `Email sent to ${notary?.email}.`
                 : `The email did not go out${result.emailError ? `: ${result.emailError}` : ""}. Send the link below yourself.`}
             </div>
             {result.link && (
@@ -166,41 +168,25 @@ export function SigningRequestModal({
             </button>
           </div>
         ) : (
-          <form onSubmit={submit} className="space-y-5">
-            <div>
-              <label className="block text-sm font-medium text-slate-700 mb-1">
-                Notary email <span className="text-red-500">*</span>
-              </label>
-              <input
-                type="email"
-                required
-                value={notaryEmail}
-                onChange={(e) => setNotaryEmail(e.target.value)}
-                className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF]"
-                placeholder="notary@example.com"
-              />
-            </div>
+          <form onSubmit={submit} className="flex flex-col min-h-0 flex-1">
+            {/* X1: the body scrolls, the footer stays reachable. */}
+            <div className="space-y-5 overflow-y-auto flex-1 pr-1">
+            <PartnerRecipientPicker
+              value={notary}
+              onChange={setNotary}
+              suggestCategory="notary"
+              label="Ask a notary"
+            />
 
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              <div>
-                <label className="block text-sm font-medium text-slate-700 mb-1">Notary name</label>
-                <input
-                  type="text"
-                  value={notaryName}
-                  onChange={(e) => setNotaryName(e.target.value)}
-                  className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF]"
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-slate-700 mb-1">Where</label>
-                <input
-                  type="text"
-                  value={location}
-                  onChange={(e) => setLocation(e.target.value)}
-                  className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF]"
-                  placeholder="Defaults to the property address"
-                />
-              </div>
+            <div>
+              <label className="block text-sm font-medium text-slate-700 mb-1">Where</label>
+              <input
+                type="text"
+                value={location}
+                onChange={(e) => setLocation(e.target.value)}
+                className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF]"
+                placeholder="Defaults to the property address"
+              />
             </div>
 
             <div>
@@ -269,7 +255,9 @@ export function SigningRequestModal({
               signers are not contacted — that stays with you.
             </p>
 
-            <div className="flex gap-3">
+            </div>
+
+            <div className="flex gap-3 pt-5 shrink-0">
               <button
                 type="button"
                 onClick={onClose}
@@ -279,7 +267,7 @@ export function SigningRequestModal({
               </button>
               <button
                 type="submit"
-                disabled={submitting || !notaryEmail || complete.length === 0}
+                disabled={submitting || !notary?.email || complete.length === 0}
                 className="flex-1 px-4 py-3 bg-[#7C4DFF] hover:bg-[#6a3de8] text-white font-medium rounded-lg disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center justify-center gap-2"
               >
                 {submitting && <Loader2 className="w-4 h-4 animate-spin" />}


### PR DESCRIPTION
**Mechanical re-open of #147.** Same commit, correct base.

#147 was stacked on #146's branch. Squash-merging #146 did not retarget it, so merging #147 landed Part B on `claude/partner2-registry-phone` instead of `main` — Part A reached main, Part B did not. This is the identical commit cherry-picked onto current `main`, verified green there (jest 632/41 suites, tsc 94, pytest 792 no-DB).

My mistake, and the lesson is narrow: **a stacked PR whose base is squash-merged does not follow its base to main.** Merge-commit bases retarget; squash bases don't, because the squash is a new commit and the old base branch simply still exists. Next stacked pair gets a plain re-base-to-main before merging, or no stack at all.

Content is unchanged from #147 — full description there. In brief:

- one generic "Share" button becomes **"Share for review"** and **"Request signing"**; `share_kind` is set by which button she pressed, never inferred, never a selector;
- the old inline modal is **deleted**, not kept alongside;
- the **rolodex is the default**, typing the fallback; notaries suggested first without hiding anyone; a partner with no email shown with the reason rather than filtered out; "Add a new partner" reuses `QuickAddPartnerModal`;
- `/partners/selectlist` gains `role`, `contact_name`, `email`;
- four earlier tickets' pins (S1, X1 ×2, X2.4/5) **retargeted at the property**, which caught a live `backdrop-blur` violation in `QuickAddPartnerModal` — reviving a dead file makes its violations live.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_