### PR TITLE
NOTARY2 (1/n): the coordination loop's foundation — schema, convergence, surfaces, purge

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -270,6 +270,134 @@ def create_tables():
             "ALTER TABLE deed_shares ADD COLUMN IF NOT EXISTS scheduled_by VARCHAR(16)",
             "ALTER TABLE deed_shares ADD COLUMN IF NOT EXISTS scheduled_asserted_at TIMESTAMPTZ",
             "CREATE INDEX IF NOT EXISTS idx_deed_shares_kind ON deed_shares(share_kind, created_at DESC)",
+            # ══ NOTARY2: the coordination loop ═══════════════════
+            #
+            # WHY NOT MORE COLUMNS ON deed_shares. NOTARY1 put the signing
+            # request there because one share = one recipient = one row,
+            # and there was one recipient. NOTARY2 is ONE REQUEST WITH N
+            # PARTICIPANTS, each holding their own token, seeing their own
+            # surface and recording their own answers. That is an
+            # aggregate with children; flattening it means either rows
+            # re-associated by convention or JSONB carrying identity and
+            # access — and identity and access are the two things that
+            # must be constrainable by the schema rather than by care.
+            #
+            # `deed_shares` therefore stays REVIEW-ONLY from here.
+            #
+            # THERE IS NO STATUS COLUMN, and that is T-5's ruling in its
+            # third application. The four states the owner named are all
+            # derivable and none is a fact of its own:
+            #     requested        no rows in signing_windows
+            #     windows posted   windows exist, nobody has converged
+            #     partially agreed some available answers, not a full set
+            #     booked           booked_at IS NOT NULL
+            # `cancelled_at` gets its own column for the same reason a
+            # status value would be wrong: a cancelled request that HAD
+            # been partially agreed must stay expressible.
+            """CREATE TABLE IF NOT EXISTS signing_requests (
+                id BIGSERIAL PRIMARY KEY,
+                deed_id INT NOT NULL REFERENCES deeds(id) ON DELETE CASCADE,
+                officer_user_id INT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                location TEXT,
+                -- ONE IANA ZONE PER REQUEST, not per-window offsets. A
+                -- signing happens at ONE PLACE, so the place's zone is a
+                -- property of the request. This also closes a NOTARY1
+                -- latent bug: that code stored ISO strings with offsets
+                -- in JSONB and assumed UTC when an offset was missing,
+                -- so a naive time produced a calendar file up to eight
+                -- hours out — silently, on the one artifact whose entire
+                -- job is to be at the right moment.
+                tz_name VARCHAR(64) NOT NULL DEFAULT 'America/Los_Angeles',
+                expires_at TIMESTAMPTZ NOT NULL,
+                cancelled_at TIMESTAMPTZ,
+                -- The RED-S4 trio. `booked_at` is WRITTEN rather than
+                -- derived, which looks like it contradicts the no-status
+                -- rule above and does not: an agreement is an EVENT WITH
+                -- A MOMENT (the last party's answer, not the moment
+                -- somebody ran the query), and the officer's override
+                -- must have something to disagree WITH. Written once,
+                -- SQL-guarded, exactly like T-5's supersession pointer.
+                booked_at TIMESTAMPTZ,
+                booked_by VARCHAR(16),          -- 'convergence' | 'officer'
+                booked_asserted_at TIMESTAMPTZ,
+                -- The round-trip cap's counter (owner ruling: 3,
+                -- AGGREGATE — two signers alternating twice each is six
+                -- emails and the same deadlock).
+                signer_proposals INT NOT NULL DEFAULT 0,
+                contact_purged_at TIMESTAMPTZ,
+                migrated_from_share_id INT,
+                created_at TIMESTAMPTZ DEFAULT now(),
+                updated_at TIMESTAMPTZ DEFAULT now()
+            )""",
+            # SIGNER CONTACT LIVES HERE AND NOWHERE ELSE (§13.1). One
+            # table, one row per participant, a purge stamp beside it, and
+            # a fail-closed sweep in the suite asserting no other table
+            # grows a contact-shaped column. `display_name` is deliberately
+            # NOT purged: a name is not contact information, and the
+            # record of who agreed to what must outlive our ability to
+            # reach them.
+            """CREATE TABLE IF NOT EXISTS signing_participants (
+                id BIGSERIAL PRIMARY KEY,
+                signing_request_id BIGINT NOT NULL
+                    REFERENCES signing_requests(id) ON DELETE CASCADE,
+                party_role VARCHAR(16) NOT NULL,        -- 'notary' | 'signer'
+                display_name VARCHAR(255),
+                company_name VARCHAR(255),             -- notary's, shown to signers
+                email VARCHAR(320),                    -- PURGEABLE for signers
+                phone VARCHAR(32),                     -- PURGEABLE for signers
+                partner_id UUID,                       -- the notary, from her rolodex
+                token UUID NOT NULL UNIQUE,
+                expires_at TIMESTAMPTZ NOT NULL,
+                revoked_at TIMESTAMPTZ,
+                last_viewed_at TIMESTAMPTZ,
+                reminders_sent INT NOT NULL DEFAULT 0,
+                contact_purged_at TIMESTAMPTZ,
+                created_at TIMESTAMPTZ DEFAULT now(),
+                updated_at TIMESTAMPTZ DEFAULT now()
+            )""",
+            """CREATE TABLE IF NOT EXISTS signing_windows (
+                id BIGSERIAL PRIMARY KEY,
+                signing_request_id BIGINT NOT NULL
+                    REFERENCES signing_requests(id) ON DELETE CASCADE,
+                starts_at TIMESTAMPTZ NOT NULL,
+                ends_at TIMESTAMPTZ NOT NULL,
+                origin VARCHAR(16) NOT NULL,   -- 'notary'|'signer_proposal'|'officer'
+                proposed_by BIGINT NOT NULL
+                    REFERENCES signing_participants(id) ON DELETE CASCADE,
+                declined_at TIMESTAMPTZ,
+                created_at TIMESTAMPTZ DEFAULT now()
+            )""",
+            # One answer per party per window; changing your mind is an
+            # UPDATE, not a second row. A history of a person's
+            # indecision is not something this product needs to keep.
+            """CREATE TABLE IF NOT EXISTS signing_responses (
+                id BIGSERIAL PRIMARY KEY,
+                window_id BIGINT NOT NULL
+                    REFERENCES signing_windows(id) ON DELETE CASCADE,
+                participant_id BIGINT NOT NULL
+                    REFERENCES signing_participants(id) ON DELETE CASCADE,
+                answer VARCHAR(16) NOT NULL,   -- 'available' | 'unavailable'
+                asserted_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                UNIQUE (window_id, participant_id)
+            )""",
+            "CREATE INDEX IF NOT EXISTS idx_signing_requests_deed ON signing_requests(deed_id)",
+            "CREATE INDEX IF NOT EXISTS idx_signing_requests_officer ON signing_requests(officer_user_id, created_at DESC)",
+            "CREATE INDEX IF NOT EXISTS idx_signing_participants_request ON signing_participants(signing_request_id)",
+            "CREATE INDEX IF NOT EXISTS idx_signing_windows_request ON signing_windows(signing_request_id, starts_at)",
+            "CREATE INDEX IF NOT EXISTS idx_signing_responses_window ON signing_responses(window_id)",
+            # The purge job's working set: signer rows still holding
+            # contact details. Partial index — the purged majority is not
+            # what the sweep scans for.
+            "CREATE INDEX IF NOT EXISTS idx_signing_participants_unpurged ON signing_participants(signing_request_id) WHERE contact_purged_at IS NULL",
+            # The job ledger the throttled in-request sweep coordinates
+            # on. Not a scheduler; a record of when the sweep last ran, so
+            # concurrent requests do not all run it.
+            """CREATE TABLE IF NOT EXISTS system_jobs (
+                job_name VARCHAR(64) PRIMARY KEY,
+                last_run_at TIMESTAMPTZ,
+                last_result TEXT,
+                updated_at TIMESTAMPTZ DEFAULT now()
+            )""",
             """CREATE TABLE IF NOT EXISTS plan_limits (
                 plan_name VARCHAR(50) PRIMARY KEY,
                 max_deeds_per_month INT,

--- a/backend/scripts/purge_signer_contact.py
+++ b/backend/scripts/purge_signer_contact.py
@@ -1,0 +1,76 @@
+"""NOTARY2 — the signer-contact purge, as a standalone job.
+
+READY FOR A RENDER CRON JOB, which does not exist yet. Creating that
+service is a deploy-topology change and therefore Tier 3 — the owner's
+call, not this repo's. Until it exists, the in-request sweep in
+`services/signing_purge.py` carries the work; it lags gracefully rather
+than failing, and it runs only when somebody uses the product.
+
+That distinction is the whole reason this script exists ahead of the
+service: a retention PRACTICE can lag, and a retention PROMISE cannot.
+The moment the privacy statement names a window, this needs a scheduler
+behind it.
+
+Usage:
+    DATABASE_URL=postgresql://... python backend/scripts/purge_signer_contact.py
+    DATABASE_URL=... python backend/scripts/purge_signer_contact.py --status
+    DATABASE_URL=... python backend/scripts/purge_signer_contact.py --dry-run
+
+Suggested Render Cron Job (owner-side, Tier 3):
+    schedule:      0 4 * * *          # daily, 4am UTC
+    command:       python backend/scripts/purge_signer_contact.py
+    env:           DATABASE_URL from the deedpro-db database
+
+Exit codes: 0 on success, 1 on failure — so a cron service's own
+alerting sees a failed purge rather than a silent one.
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+def main() -> int:
+    url = os.getenv("DATABASE_URL")
+    if not url:
+        print("DATABASE_URL is not set — refusing to guess at a database",
+              file=sys.stderr)
+        return 1
+
+    import psycopg2
+    from db_rows import ROW_FACTORY
+    from services.signing_purge import purge_signer_contact, purge_status
+
+    status_only = "--status" in sys.argv
+    dry_run = "--dry-run" in sys.argv
+
+    conn = psycopg2.connect(url, cursor_factory=ROW_FACTORY)
+    try:
+        if status_only:
+            print(json.dumps(purge_status(conn), indent=2, default=str))
+            return 0
+
+        purged = purge_signer_contact(conn)
+        if dry_run:
+            # The count is real; the write is not kept. Useful before the
+            # first production run, when "how many rows would this touch"
+            # is the only question worth asking.
+            conn.rollback()
+            print(f"[dry-run] would purge {purged} participant rows")
+            return 0
+
+        conn.commit()
+        print(f"purged contact details on {purged} participant rows")
+        return 0
+    except Exception as e:
+        conn.rollback()
+        print(f"purge failed: {type(e).__name__}: {e}", file=sys.stderr)
+        return 1
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/services/signing_loop.py
+++ b/backend/services/signing_loop.py
@@ -1,0 +1,322 @@
+"""NOTARY2 — the coordination loop, and the three rules it must not bend.
+
+═══ WHAT CHANGED FROM NOTARY1, AND WHY ═══
+
+NOTARY1 built Option A: the officer relayed, the product coordinated
+officer↔notary, and no signer was ever contacted. The owner reversed it,
+and the reasoning is worth carrying here rather than only in the doctrine
+file, because this module is where it becomes code:
+
+    The signers are the scheduling constraint. Routing around them
+    recreated the phone tag the feature exists to kill.
+
+Option A priced the officer's relaying at zero. It is not zero; it is the
+whole problem. A notary offers three windows, the officer phones two
+signers, one can do Tuesday and one cannot, and she is back on the phone
+to the notary. So the loop is now: notary posts availability → signers
+pick or propose → convergence books it → the officer is TOLD.
+
+═══ SIGNER CONTACT: ONE ROW, PURGED, NOWHERE ELSE (§13.1) ═══
+
+Signers are consumers. They have no account and no way to ask us for
+anything. So their contact details live on `signing_participants` and
+nowhere else — not on `deeds`, not in the `parties` JSONB, not on `users`
+or `partners` — they are purged on a schedule by a MECHANISM rather than
+a discipline, and `display_name` survives the purge because a name is not
+contact information and the record of who agreed to what must outlive our
+ability to reach them.
+
+NOTARY1's fail-closed sweep is ANSWERED here, not deleted: it moves from
+"no signer contact anywhere" to "one purgeable row, no other table."
+
+═══ §13 STANDS UNCHANGED ═══
+
+BOOKED IS NOT HAPPENED. There is no auto-completion, no timer, and
+nothing in this module infers a signing from a clock. `completed` remains
+the officer's word. A booking is an arrangement several people agreed to;
+whether anybody kept it is not something this system knows, and the
+sentence-writing functions below exist so that no surface can quietly
+start claiming otherwise.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Iterable, List, Optional, Sequence
+
+# ── Vocabulary ───────────────────────────────────────────────────────
+ROLE_NOTARY = "notary"
+ROLE_SIGNER = "signer"
+PARTY_ROLES = (ROLE_NOTARY, ROLE_SIGNER)
+
+ORIGIN_NOTARY = "notary"
+ORIGIN_SIGNER_PROPOSAL = "signer_proposal"
+ORIGIN_OFFICER = "officer"
+ORIGINS = (ORIGIN_NOTARY, ORIGIN_SIGNER_PROPOSAL, ORIGIN_OFFICER)
+
+ANSWER_AVAILABLE = "available"
+ANSWER_UNAVAILABLE = "unavailable"
+ANSWERS = (ANSWER_AVAILABLE, ANSWER_UNAVAILABLE)
+
+BOOKED_BY_CONVERGENCE = "convergence"
+BOOKED_BY_OFFICER = "officer"
+BOOKERS = (BOOKED_BY_CONVERGENCE, BOOKED_BY_OFFICER)
+
+# Owner ruling: three, AGGREGATE across the request. Not per signer —
+# two signers alternating twice each is six emails and the same deadlock
+# a cap exists to prevent.
+MAX_SIGNER_PROPOSALS = 3
+
+# How long signer contact survives a finished request. Proposed default;
+# the number is the owner's to set, and whatever it becomes must match
+# whatever the privacy statement says, because that sentence converts
+# this practice into a promise.
+CONTACT_RETENTION_DAYS = 90
+
+MAX_WINDOWS_PER_POST = 5
+
+
+class SigningLoopError(ValueError):
+    """A request we will not accept, carrying the reason a human needs."""
+
+
+# ── Derived state (T-5's ruling, third application) ──────────────────
+
+STATE_REQUESTED = "requested"
+STATE_WINDOWS_POSTED = "windows_posted"
+STATE_PARTIALLY_AGREED = "partially_agreed"
+STATE_BOOKED = "booked"
+STATE_CANCELLED = "cancelled"
+STATE_EXPIRED = "expired"
+
+
+def request_state(request: Dict[str, Any], windows: Sequence[Dict[str, Any]],
+                  responses: Sequence[Dict[str, Any]],
+                  now: Optional[datetime] = None) -> str:
+    """The state, COMPUTED. There is no status column and there must not be.
+
+    Deliberately absent from the vocabulary: anything meaning the signing
+    HAPPENED. A booked time that has passed is still `booked` — a clock
+    moving is not evidence that three people met in a room, and §13 is
+    the whole reason this function cannot say otherwise.
+    """
+    now = now or datetime.now(timezone.utc)
+    if request.get("cancelled_at"):
+        return STATE_CANCELLED
+    if request.get("booked_at"):
+        return STATE_BOOKED
+    expires = request.get("expires_at")
+    if expires and expires < now:
+        return STATE_EXPIRED
+    live = [w for w in windows if not w.get("declined_at")]
+    if not live:
+        return STATE_REQUESTED
+    if any(r.get("answer") == ANSWER_AVAILABLE for r in responses):
+        return STATE_PARTIALLY_AGREED
+    return STATE_WINDOWS_POSTED
+
+
+# ── Convergence ──────────────────────────────────────────────────────
+
+def converged_window_id(participants: Sequence[Dict[str, Any]],
+                        windows: Sequence[Dict[str, Any]],
+                        responses: Sequence[Dict[str, Any]]) -> Optional[int]:
+    """The window everybody said yes to, or None.
+
+    THE RULE: a window books when it is not declined, the notary answered
+    `available`, and EVERY live signer answered `available`. Revoked
+    participants are excluded — a signer removed from the request cannot
+    hold the others hostage — and a request with no signers cannot
+    converge on the notary alone, because a signing with nobody to sign
+    is not an arrangement anybody made.
+
+    Earliest wins when two windows qualify. Not "the most recently
+    answered": if three people are free at two times, the sooner one is
+    the one they meant, and picking by answer order would make the
+    outcome depend on who happened to click last.
+    """
+    live = [p for p in participants if not p.get("revoked_at")]
+    notaries = [p for p in live if p.get("party_role") == ROLE_NOTARY]
+    signers = [p for p in live if p.get("party_role") == ROLE_SIGNER]
+    if not notaries or not signers:
+        return None
+
+    yes: Dict[int, set] = {}
+    for r in responses:
+        if r.get("answer") == ANSWER_AVAILABLE:
+            yes.setdefault(int(r["window_id"]), set()).add(int(r["participant_id"]))
+
+    needed = {int(p["id"]) for p in notaries[:1]} | {int(p["id"]) for p in signers}
+
+    candidates = [
+        w for w in windows
+        if not w.get("declined_at") and needed <= yes.get(int(w["id"]), set())
+    ]
+    if not candidates:
+        return None
+    return int(min(candidates, key=lambda w: w["starts_at"])["id"])
+
+
+def outstanding_parties(participants: Sequence[Dict[str, Any]],
+                        window_id: int,
+                        responses: Sequence[Dict[str, Any]]) -> List[str]:
+    """Who has not answered on this window — names only, never addresses.
+
+    Used to tell the officer what a request is waiting on. It returns
+    display names because that is what she needs to chase somebody; it
+    does not return contact details, because a status line is not a
+    reason to widen what a surface carries.
+    """
+    answered = {
+        int(r["participant_id"]) for r in responses
+        if int(r["window_id"]) == int(window_id)
+    }
+    return [
+        (p.get("display_name") or "Unnamed")
+        for p in participants
+        if not p.get("revoked_at") and int(p["id"]) not in answered
+    ]
+
+
+# ── The words, written once (§13, rule 3) ────────────────────────────
+
+def state_label(request: Dict[str, Any], windows: Sequence[Dict[str, Any]],
+                responses: Sequence[Dict[str, Any]],
+                participants: Sequence[Dict[str, Any]],
+                now: Optional[datetime] = None) -> str:
+    """The sentence every surface renders, composed in ONE place.
+
+    THE POINT, unchanged from NOTARY1: "booked" must never read as "will
+    happen". The product knows an arrangement was made and knows nothing
+    about whether it was kept. Every screen calls this rather than
+    writing its own version, so the distinction cannot erode one surface
+    at a time — and both suites pin that no screen composes its own.
+    """
+    state = request_state(request, windows, responses, now=now)
+    if state == STATE_CANCELLED:
+        return "Signing request cancelled"
+    if state == STATE_EXPIRED:
+        return "Signing request expired — nobody agreed a time before the links lapsed"
+    if state == STATE_BOOKED:
+        when = _fmt_instant(request.get("booked_at"), request.get("tz_name"))
+        if request.get("booked_by") == BOOKED_BY_OFFICER:
+            return f"You recorded a signing time of {when}"
+        return f"Everyone agreed on {when}"
+    if state == STATE_REQUESTED:
+        notary = next((p for p in participants
+                       if p.get("party_role") == ROLE_NOTARY), None)
+        who = (notary or {}).get("display_name") or "The notary"
+        return f"Waiting on {who} to post the times she is free"
+    live = [w for w in windows if not w.get("declined_at")]
+    if state == STATE_PARTIALLY_AGREED:
+        pending = _pending_count(participants, live, responses)
+        if pending == 1:
+            return f"{len(live)} times offered — waiting on 1 more person"
+        return f"{len(live)} times offered — waiting on {pending} more people"
+    return f"{len(live)} times offered — nobody has answered yet"
+
+
+def _pending_count(participants: Sequence[Dict[str, Any]],
+                   windows: Sequence[Dict[str, Any]],
+                   responses: Sequence[Dict[str, Any]]) -> int:
+    """People who have not answered on ANY live window."""
+    answered = {int(r["participant_id"]) for r in responses
+                if any(int(w["id"]) == int(r["window_id"]) for w in windows)}
+    return len([p for p in participants
+                if not p.get("revoked_at") and int(p["id"]) not in answered])
+
+
+def proposal_refusal(officer_name: Optional[str]) -> str:
+    """The honest sentence when the round-trip cap is reached.
+
+    Owner ruling: it names the officer. "This has not converged" tells a
+    signer nothing they can act on; "Dana will call you" tells them the
+    thing that is about to happen, which is also true — the officer is
+    notified in the same breath.
+    """
+    who = (officer_name or "").strip() or "The person coordinating this signing"
+    return (f"These times still have not worked for everyone. {who} will call "
+            f"you to sort it out — no need to do anything else here.")
+
+
+# ── Windows ──────────────────────────────────────────────────────────
+
+def parse_window(raw: Dict[str, Any]) -> Dict[str, datetime]:
+    """One `{start, end}` with offsets, into instants.
+
+    An offset is REQUIRED. NOTARY1 accepted naive times and assumed UTC,
+    which produced a calendar file up to eight hours out — silently, on
+    the one artifact whose entire job is being at the right moment. A
+    time without a zone is not a time, and guessing one is how somebody
+    drives to an empty office.
+    """
+    start, end = raw.get("start"), raw.get("end")
+    if not start or not end:
+        raise SigningLoopError("A time needs a start and an end")
+    try:
+        s = datetime.fromisoformat(str(start))
+        e = datetime.fromisoformat(str(end))
+    except ValueError:
+        raise SigningLoopError("That is not a valid date and time") from None
+    if s.tzinfo is None or e.tzinfo is None:
+        raise SigningLoopError(
+            "A time must carry its UTC offset — a wall-clock time without a "
+            "zone is not a time, and guessing one lands somebody at an empty "
+            "office an hour early")
+    if e <= s:
+        raise SigningLoopError("That time ends before it starts")
+    return {"starts_at": s, "ends_at": e}
+
+
+def parse_windows(raw: Any) -> List[Dict[str, datetime]]:
+    if not isinstance(raw, list) or not raw:
+        raise SigningLoopError("Offer at least one time")
+    if len(raw) > MAX_WINDOWS_PER_POST:
+        raise SigningLoopError(
+            f"At most {MAX_WINDOWS_PER_POST} times at once")
+    return [parse_window(w) for w in raw]
+
+
+def _fmt_instant(value: Any, tz_name: Optional[str]) -> str:
+    """An instant in the REQUEST's zone, in words.
+
+    The zone comes from the request rather than from the server or the
+    reader's browser: a signing happens at a place, and everybody
+    involved should read the same clock — the one on the wall where they
+    are going.
+    """
+    if not hasattr(value, "strftime"):
+        return str(value)
+    dt = value
+    try:
+        from zoneinfo import ZoneInfo
+        if tz_name:
+            dt = value.astimezone(ZoneInfo(tz_name))
+    except Exception:
+        # An unknown zone is not a reason to fail a status line. Render
+        # the instant we have and let it be plainly UTC rather than
+        # pretending to a locality we could not resolve.
+        pass
+    hour = dt.strftime("%I:%M %p").lstrip("0")
+    return f"{dt.strftime('%A, %B')} {dt.day}, {dt.year} at {hour}"
+
+
+def window_label(window: Dict[str, Any], tz_name: Optional[str]) -> str:
+    """One window, in words, in the request's zone. The only place a
+    window becomes English — see state_label for why that matters."""
+    start, end = window.get("starts_at"), window.get("ends_at")
+    if not hasattr(start, "strftime"):
+        return f"{start} – {end}"
+    text = _fmt_instant(start, tz_name)
+    if hasattr(end, "strftime"):
+        try:
+            from zoneinfo import ZoneInfo
+            e = end.astimezone(ZoneInfo(tz_name)) if tz_name else end
+        except Exception:
+            e = end
+        text += f" – {e.strftime('%I:%M %p').lstrip('0')}"
+    return text
+
+
+def default_expiry(days: int = 21) -> datetime:
+    return datetime.now(timezone.utc) + timedelta(days=days)

--- a/backend/services/signing_purge.py
+++ b/backend/services/signing_purge.py
@@ -1,0 +1,190 @@
+"""NOTARY2 — the signer-contact purge. A MECHANISM, not a discipline.
+
+═══ THE PROBLEM THIS SOLVES, AND THE ONE IT DOES NOT ═══
+
+§13.1 reversed "no signer contact anywhere" to "one purgeable row." The
+word doing the work is PURGEABLE, and the owner's ruling was explicit:
+the purge is a mechanism with a real test, not a note in a runbook.
+
+**There is no scheduler in this deployment.** No cron service, no worker,
+no APScheduler, no Celery — `render.yaml` defines web services only. That
+was verified before this file was designed rather than assumed after.
+
+So the purge is one function with two invocations:
+
+1. `backend/scripts/purge_signer_contact.py` — ready for a Render Cron
+   Job. Creating that service is a deploy-topology change, which is Tier
+   3 and the owner's alone.
+2. `sweep_if_due()` — a throttled in-request sweep, coordinating on a
+   `system_jobs` row taken with `FOR UPDATE SKIP LOCKED`, so concurrent
+   requests do not all run it and none of them waits.
+
+**The honest limitation, stated here so it cannot be discovered later:**
+the in-request sweep runs only when somebody uses the product. It LAGS
+gracefully; it does not fail. That is fine for a retention practice and
+it is NOT fine as the backing for a sentence in a privacy statement that
+names a window. The moment ruling 1's privacy language says "90 days,"
+the cron service stops being optional — which is exactly the owner's
+ruling 3, recorded in the ledger as a hard requirement before the first
+real signer email.
+
+═══ WHAT SURVIVES THE PURGE ═══
+
+`display_name` survives. A name is not contact information, and the
+record of who agreed to what must outlive our ability to reach them —
+otherwise a purge quietly rewrites history into "somebody agreed."
+Responses, windows and the booking survive for the same reason.
+
+`email` and `phone` are NULLed and `contact_purged_at` is stamped, so the
+row can prove it was purged rather than merely being empty. An empty
+column and a purged column look identical without that stamp, and "we
+never had it" and "we deleted it on the 14th" are different answers to a
+question somebody may one day ask.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+
+JOB_NAME = "signer_contact_purge"
+
+# How often the in-request sweep may run. An hour is chosen against the
+# cost of the query rather than the retention window — the deadline is 90
+# days, so lag measured in hours is invisible, and a sweep that ran on
+# every request would be a self-inflicted load problem.
+SWEEP_INTERVAL_SECONDS = 3600
+
+# The retention window. Imported from the loop module so the number lives
+# in one place and matches whatever the privacy statement ends up saying.
+from services.signing_loop import CONTACT_RETENTION_DAYS  # noqa: E402
+
+# A request is "finished" when it can no longer change: booked and past,
+# cancelled, or expired. The clock starts THERE rather than at creation —
+# a signing booked for three months out must keep its contact details
+# until it happens, and counting from creation would purge the addresses
+# of an appointment that has not occurred yet.
+_FINISHED_AT = """
+    GREATEST(
+        COALESCE(sr.cancelled_at, 'epoch'::timestamptz),
+        COALESCE(sr.booked_at,    'epoch'::timestamptz),
+        COALESCE(sr.expires_at,   'epoch'::timestamptz)
+    )
+"""
+
+PURGE_SQL = f"""
+    UPDATE signing_participants sp
+       SET email = NULL,
+           phone = NULL,
+           contact_purged_at = now(),
+           updated_at = now()
+      FROM signing_requests sr
+     WHERE sr.id = sp.signing_request_id
+       AND sp.party_role = 'signer'
+       AND sp.contact_purged_at IS NULL
+       AND (sp.email IS NOT NULL OR sp.phone IS NOT NULL)
+       AND {_FINISHED_AT} < %s
+    RETURNING sp.id
+"""
+
+
+def purge_signer_contact(conn, *, older_than_days: int = CONTACT_RETENTION_DAYS,
+                         now: Optional[datetime] = None) -> int:
+    """NULL the contact details of signers on finished requests.
+
+    Idempotent by construction: `contact_purged_at IS NULL` means a second
+    run finds nothing, and the stamp is what makes that true rather than
+    a convention about who calls this.
+
+    Returns the number of rows purged. The caller commits — this function
+    does not, so it can run inside a script's transaction or a sweep's
+    without deciding for either.
+    """
+    now = now or datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=older_than_days)
+    with conn.cursor() as cur:
+        cur.execute(PURGE_SQL, (cutoff,))
+        rows = cur.fetchall() or []
+    return len(rows)
+
+
+def sweep_if_due(conn, *, interval_seconds: int = SWEEP_INTERVAL_SECONDS,
+                 now: Optional[datetime] = None) -> Optional[int]:
+    """Run the purge at most once per interval, across all workers.
+
+    Returns the purged count when this call did the work, or None when
+    another call had it recently or is holding it right now.
+
+    `FOR UPDATE SKIP LOCKED` rather than a plain lock, deliberately: a
+    request that arrives while the sweep is running must not WAIT for it.
+    The purge is housekeeping and the request is a person; housekeeping
+    never blocks a person.
+
+    Never raises. A failed sweep must not fail the request that happened
+    to trigger it — but it prints loudly, because a purge that silently
+    stops running is exactly the failure the ledger's cron requirement
+    exists to make unnecessary.
+    """
+    now = now or datetime.now(timezone.utc)
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO system_jobs (job_name, last_run_at) VALUES (%s, NULL) "
+                "ON CONFLICT (job_name) DO NOTHING", (JOB_NAME,))
+            cur.execute(
+                "SELECT last_run_at FROM system_jobs WHERE job_name = %s "
+                "FOR UPDATE SKIP LOCKED", (JOB_NAME,))
+            row = cur.fetchone()
+            if row is None:
+                return None  # somebody else is sweeping; not our turn
+            last = row["last_run_at"] if isinstance(row, dict) else row[0]
+            if last is not None and (now - last).total_seconds() < interval_seconds:
+                return None
+
+            purged = purge_signer_contact(conn, now=now)
+            cur.execute(
+                "UPDATE system_jobs SET last_run_at = %s, last_result = %s, "
+                "updated_at = now() WHERE job_name = %s",
+                (now, f"purged {purged}", JOB_NAME))
+        conn.commit()
+        if purged:
+            print(f"[signer-purge] purged contact details on {purged} participant rows")
+        return purged
+    except Exception as e:
+        try:
+            conn.rollback()
+        except Exception:
+            pass
+        print(f"[signer-purge] ⚠️ sweep failed (non-blocking): "
+              f"{type(e).__name__}: {str(e)[:200]}")
+        return None
+
+
+def purge_status(conn) -> Dict[str, Any]:
+    """What an operator needs to answer "is this actually running?"
+
+    Exists because the in-request sweep's weakness is invisibility: it
+    either ran or it did not, and without this there is nothing to look
+    at. If the cron service lands, this is also how it is verified.
+    """
+    with conn.cursor() as cur:
+        cur.execute("SELECT last_run_at, last_result FROM system_jobs "
+                    "WHERE job_name = %s", (JOB_NAME,))
+        job = cur.fetchone()
+        cur.execute(
+            f"""SELECT count(*) AS n FROM signing_participants sp
+                  JOIN signing_requests sr ON sr.id = sp.signing_request_id
+                 WHERE sp.party_role = 'signer'
+                   AND sp.contact_purged_at IS NULL
+                   AND (sp.email IS NOT NULL OR sp.phone IS NOT NULL)
+                   AND {_FINISHED_AT} < %s""",
+            (datetime.now(timezone.utc) - timedelta(days=CONTACT_RETENTION_DAYS),))
+        overdue = cur.fetchone()
+    return {
+        "job": JOB_NAME,
+        "retention_days": CONTACT_RETENTION_DAYS,
+        "last_run_at": (job or {}).get("last_run_at") if job else None,
+        "last_result": (job or {}).get("last_result") if job else None,
+        # The number that matters: rows that SHOULD be purged and are not.
+        # Non-zero and rising means the sweep is not running.
+        "overdue": (overdue or {}).get("n", 0) if overdue else 0,
+    }

--- a/backend/services/signing_surfaces.py
+++ b/backend/services/signing_surfaces.py
@@ -1,0 +1,219 @@
+"""NOTARY2 — what each party may see, as ALLOWLISTS.
+
+═══ WHY ALLOWLISTS AND NOT EXCLUSIONS ═══
+
+Owner ruling, and it is the right instinct: *a denylist enumerates the
+examples somebody thought of.* "Do not send the APN" is a rule about the
+APN. It says nothing about the legal description somebody adds next
+quarter, and the failure mode is silent — the field simply appears on a
+consumer's screen and nobody is notified.
+
+So each surface below builds its payload from a NAMED SET OF KEYS, and
+the suite pins the response's key set by EXACT EQUALITY. A new field
+cannot reach a party without failing a test, whether or not anybody
+remembered this file existed.
+
+═══ THE SIGNER SURFACE IS THE FIRST CONSUMER SURFACE THIS PRODUCT HAS ═══
+
+Everyone who has ever seen a DeedPro screen has been an escrow officer, a
+title officer, or a notary the officer chose — professionals, under an
+engagement. A signer is a member of the public who received an email
+about their own house. They did not sign up, cannot log in, and cannot
+ask us for anything.
+
+What they get is: which property, who is coordinating, who is coming, the
+times, and a way to answer. Not the instrument, not the parcel number,
+not the legal description, not the tax figures, not the other signer.
+
+═══ THE NOTARY'S NAME AND COMPANY ARE ON IT (owner-ruled) ═══
+
+She is a professional acting professionally, her name will be on the
+certificate, and a consumer told a stranger is coming to their home
+deserves to know who. Her EMAIL, PHONE and ADDRESS stay out: the signer
+needs to know who is coming, not how to reach her independently — that
+is the officer's coordination to hold, and routing around it is how a
+scheduling product becomes an unmoderated introduction service.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Sequence
+
+from services import signing_loop as loop
+
+# ── The allowlists, named so the pins can read them ──────────────────
+
+SIGNER_KEYS = frozenset({
+    "party_role",
+    "property_street",     # first comma segment ONLY — never the full address
+    "coordinator",         # {name, company} — the officer
+    "notary",              # {name, company} — no email, no phone, no address
+    "windows",
+    "my_answers",
+    "can_propose",
+    "proposals_remaining",
+    "state",
+    "summary",
+    "expires_at",
+})
+
+NOTARY_KEYS = frozenset({
+    "party_role",
+    "property_address",
+    "county",
+    "deed_type",
+    "coordinator",
+    "signers",             # display names only
+    "windows",
+    "my_answers",
+    "state",
+    "summary",
+    "expires_at",
+    "pcor_url",
+    "pdf_url",
+})
+
+# Every key that would carry a way to reach somebody. The signer package
+# is checked against this too — belt and braces, because the allowlist
+# protects the SHAPE and this protects the CONTENT of a nested object.
+CONTACT_KEYS = frozenset({"email", "phone", "mobile", "cell", "address",
+                          "address_line1", "postal_code", "contact"})
+
+
+def _street_only(address: Optional[str]) -> str:
+    """The first comma segment. A signer knows which house is theirs from
+    the street line; the city, county and parcel are the instrument's
+    business, not the appointment's."""
+    if not address:
+        return ""
+    return str(address).split(",")[0].strip()
+
+
+def _person(name: Optional[str], company: Optional[str] = None) -> Dict[str, Any]:
+    """A person, as a name and at most a company. There is deliberately
+    no branch of this function that adds an address of any kind."""
+    return {"name": (name or "").strip() or None,
+            "company": (company or "").strip() or None}
+
+
+def signer_package(*, request: Dict[str, Any], me: Dict[str, Any],
+                   participants: Sequence[Dict[str, Any]],
+                   windows: Sequence[Dict[str, Any]],
+                   responses: Sequence[Dict[str, Any]],
+                   deed: Dict[str, Any],
+                   officer: Dict[str, Any]) -> Dict[str, Any]:
+    """MINIMUM SURFACE. Consumer-facing.
+
+    Read the key set, not the code: whatever is not in `SIGNER_KEYS` is
+    not here, and the suite proves it by equality rather than by reading
+    this function charitably.
+    """
+    tz = request.get("tz_name")
+    notary = next((p for p in participants
+                   if p.get("party_role") == loop.ROLE_NOTARY), {})
+    mine = {int(r["window_id"]): r["answer"] for r in responses
+            if int(r["participant_id"]) == int(me["id"])}
+    live = [w for w in windows if not w.get("declined_at")]
+    used = int(request.get("signer_proposals") or 0)
+
+    package = {
+        "party_role": loop.ROLE_SIGNER,
+        "property_street": _street_only(deed.get("property_address")),
+        "coordinator": _person(officer.get("full_name"), officer.get("company_name")),
+        "notary": _person(notary.get("display_name"), notary.get("company_name")),
+        "windows": [
+            {"id": int(w["id"]), "label": loop.window_label(w, tz),
+             "start": w["starts_at"].isoformat() if hasattr(w["starts_at"], "isoformat") else w["starts_at"],
+             "mine": mine.get(int(w["id"]))}
+            for w in live
+        ],
+        "my_answers": mine,
+        "can_propose": used < loop.MAX_SIGNER_PROPOSALS and not request.get("booked_at"),
+        "proposals_remaining": max(0, loop.MAX_SIGNER_PROPOSALS - used),
+        "state": loop.request_state(request, windows, responses),
+        "summary": loop.state_label(request, windows, responses, participants),
+        "expires_at": _iso(me.get("expires_at")),
+    }
+    assert set(package) == SIGNER_KEYS, "signer package drifted from its allowlist"
+    return package
+
+
+def notary_package(*, request: Dict[str, Any], me: Dict[str, Any],
+                   participants: Sequence[Dict[str, Any]],
+                   windows: Sequence[Dict[str, Any]],
+                   responses: Sequence[Dict[str, Any]],
+                   deed: Dict[str, Any],
+                   officer: Dict[str, Any],
+                   token: str) -> Dict[str, Any]:
+    """The notary's surface. Wider than the signer's and narrower than the
+    officer's: she is going to the address, checking IDs against names,
+    and notarising this instrument, so she gets the address, the party
+    names and the package. She does not get signer contact details —
+    she has no reason to reach them directly and the officer does."""
+    tz = request.get("tz_name")
+    mine = {int(r["window_id"]): r["answer"] for r in responses
+            if int(r["participant_id"]) == int(me["id"])}
+    package = {
+        "party_role": loop.ROLE_NOTARY,
+        "property_address": deed.get("property_address"),
+        "county": deed.get("county"),
+        "deed_type": deed.get("deed_type"),
+        "coordinator": _person(officer.get("full_name"), officer.get("company_name")),
+        "signers": [
+            {"name": p.get("display_name") or "Signer"}
+            for p in participants
+            if p.get("party_role") == loop.ROLE_SIGNER and not p.get("revoked_at")
+        ],
+        "windows": [
+            {"id": int(w["id"]), "label": loop.window_label(w, tz),
+             "origin": w.get("origin"),
+             "declined": bool(w.get("declined_at")),
+             "start": _iso(w.get("starts_at")),
+             "mine": mine.get(int(w["id"])),
+             "agreed_by": _agreed_names(participants, responses, int(w["id"]))}
+            for w in windows
+        ],
+        "my_answers": mine,
+        "state": loop.request_state(request, windows, responses),
+        "summary": loop.state_label(request, windows, responses, participants),
+        "expires_at": _iso(me.get("expires_at")),
+        "pcor_url": f"/signing/{token}/pcor",
+        "pdf_url": f"/signing/{token}/pdf",
+    }
+    assert set(package) == NOTARY_KEYS, "notary package drifted from its allowlist"
+    return package
+
+
+def _agreed_names(participants: Sequence[Dict[str, Any]],
+                  responses: Sequence[Dict[str, Any]], window_id: int) -> List[str]:
+    by_id = {int(p["id"]): p for p in participants}
+    return [
+        (by_id[int(r["participant_id"])].get("display_name") or "Signer")
+        for r in responses
+        if int(r["window_id"]) == window_id and r.get("answer") == loop.ANSWER_AVAILABLE
+        and int(r["participant_id"]) in by_id
+    ]
+
+
+def _iso(value: Any) -> Any:
+    return value.isoformat() if hasattr(value, "isoformat") else value
+
+
+def contains_contact(payload: Any) -> List[str]:
+    """Walk a package and report any key that would carry a way to reach
+    somebody. Used by the suite against the SIGNER package specifically —
+    the allowlist protects the top-level shape, and this protects the
+    nested objects inside it."""
+    found: List[str] = []
+
+    def walk(node: Any, path: str) -> None:
+        if isinstance(node, dict):
+            for key, value in node.items():
+                if key.lower() in CONTACT_KEYS:
+                    found.append(f"{path}.{key}" if path else key)
+                walk(value, f"{path}.{key}" if path else str(key))
+        elif isinstance(node, (list, tuple)):
+            for i, item in enumerate(node):
+                walk(item, f"{path}[{i}]")
+
+    walk(payload, "")
+    return found

--- a/backend/tests/source_text.py
+++ b/backend/tests/source_text.py
@@ -15,6 +15,32 @@ own local strip, and by T-2 there were four of them in this directory
 with slightly different behaviour — one stripped comments but not
 docstrings, which is exactly how the sixth trip happened.
 
+═══ A SECOND FAMILY, RECORDED HERE BECAUSE THIS IS WHERE PEOPLE LOOK ═══
+
+`code_only` solves pins that read SOURCE. There is a sibling problem for
+pins that read the DATABASE, and it has now bitten twice:
+
+**Any pin reading a table that survives between runs must establish its
+own baseline.** A test asserting "a row with this template exists" or
+"this job has not run recently" is measuring the history of the test
+database rather than the behaviour of the code — and it passes with the
+code deliberately broken, which is the worst thing a test can do.
+
+- `email_log` (NOTARY1): "the officer's email was attempted" was
+  satisfied by a row from an earlier run. Fixed with a high-water mark —
+  `MAX(id)` taken BEFORE the action, and the assertion scoped to rows
+  above it.
+- `system_jobs` (NOTARY2): "the sweep ran" failed on the suite's second
+  execution because the first had legitimately throttled it. Fixed by
+  resetting the singleton row in setup.
+
+Two shapes, matching the two shapes of table: **high-water mark** for
+append-only ledgers, **reset in setup** for singletons. Either way the
+test states what it depends on instead of inheriting it.
+
+Both were found by mutation-probing a green result, not by the suite
+going red — which is the argument for probing every green first run.
+
 T-3 consolidated the Python side. The eighth trip (RED-H1.4, on a
 comment recording an `OPENAI_AVAILABLE` removal) cost one import instead
 of a debugging session, which is the argument for this file.

--- a/backend/tests/test_notary2_coordination.py
+++ b/backend/tests/test_notary2_coordination.py
@@ -1,0 +1,623 @@
+"""NOTARY2 — the coordination loop, and the pin that was ANSWERED.
+
+═══ THE RETARGETED SWEEP ═══
+
+NOTARY1 pinned "no signer contact anywhere," fail-closed across the whole
+backend, precisely so that adding it would be a deliberate act that trips
+a test rather than a diff nobody read. §13.1 reversed the ruling, so the
+pin is being ANSWERED rather than deleted — narrowed to the promise we
+can actually keep:
+
+    was:  no signer contact exists anywhere in the product
+    is:   signer contact exists on ONE table, reaches no other, and is
+          deleted on a schedule by a mechanism with a test
+
+The new sweep is stricter in the way that matters. "Anywhere" was easy to
+satisfy and easy to abandon; "exactly one table, and here is the purge"
+is a claim with three separate ways to fail, and all three are pinned
+below.
+"""
+import ast
+import json
+import os
+import re
+import sys
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+BACKEND = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(BACKEND))
+
+from tests.source_text import code_only  # noqa: E402
+
+from services import signing_loop as loop  # noqa: E402
+from services import signing_surfaces as surfaces  # noqa: E402
+
+DATABASE = BACKEND / "database.py"
+
+
+# ══════════════════════════════════════════════════════════════════════
+# §13.1 — one table holds signer contact, and no other
+# ══════════════════════════════════════════════════════════════════════
+
+# The PROPERTY: a way to reach a grantor, grantee or signer.
+_PARTY = r"(signer|grantor|grantee|buyer|seller|borrower)"
+_CONTACT = r"(email|phone|mobile|cell|sms|contact)"
+SIGNER_CONTACT = re.compile(
+    rf"\b({_PARTY}_{_CONTACT}|{_CONTACT}_{_PARTY})\b", re.IGNORECASE)
+
+# Tables that must NEVER carry it. `parties` is a JSONB column on deeds
+# rather than a table, so it is covered by the JSONB pin below.
+FORBIDDEN_TABLES = ("deeds", "users", "partners", "user_profiles", "deed_shares")
+
+
+def _ddl_for(table: str) -> str:
+    """The CREATE body plus every ALTER naming this table.
+
+    The first draft closed the CREATE block on the first `)\"\"\"` it could
+    find, which is not the table's closing paren when the body contains
+    one — so scanning `users` swallowed everything down to the next
+    triple-quote and reported a column belonging to `deeds` as if it were
+    on `users`. It over-matched, so it could only produce FALSE ALARMS
+    rather than misses, but a pin that names the wrong table sends
+    somebody to the wrong file. Found by mutation-probing this suite,
+    which is the whole reason for probing a green result.
+
+    Paren counting, so the block ends where the table ends.
+    """
+    src = DATABASE.read_text(encoding="utf-8")
+    chunks = []
+    marker = f"CREATE TABLE IF NOT EXISTS {table} ("
+    at = src.find(marker)
+    while at != -1:
+        i = at + len(marker)
+        depth = 1
+        while i < len(src) and depth:
+            if src[i] == "(":
+                depth += 1
+            elif src[i] == ")":
+                depth -= 1
+            i += 1
+        chunks.append(src[at:i])
+        at = src.find(marker, i)
+    for match in re.finditer(rf"\"ALTER TABLE {table} [^\"]*\"", src):
+        chunks.append(match.group(0))
+    return "\n".join(chunks)
+
+
+def test_signer_contact_reaches_no_other_table():
+    """THE RETARGETED PIN. Not "nowhere" any more — "nowhere else".
+
+    A signer's email on `deeds` would put third-party contact data on
+    every deed row, which changes what a database dump IS. That was the
+    original objection and the reversal does not touch it: what changed
+    is that the officer may now coordinate WITH signers, not that their
+    details may spread.
+    """
+    offenders = []
+    for table in FORBIDDEN_TABLES:
+        ddl = _ddl_for(table)
+        for match in SIGNER_CONTACT.finditer(ddl):
+            offenders.append(f"{table} → {match.group(0)}")
+    assert offenders == [], (
+        f"signer contact reached a table it must not: {offenders} — §13.1 "
+        "allows it on signing_participants and nowhere else")
+
+
+def test_exactly_one_table_holds_it():
+    """And that table is the one with the purge machinery on it."""
+    src = code_only(DATABASE)
+    creates = re.findall(r"CREATE TABLE IF NOT EXISTS (\w+) \((.*?)\n\s*\)",
+                         src, re.DOTALL)
+    holders = [
+        name for name, body in creates
+        if re.search(r"\bemail\b", body) and re.search(r"\bcontact_purged_at\b", body)
+    ]
+    assert holders == ["signing_participants"], (
+        f"tables holding purgeable contact: {holders} — there must be exactly "
+        "one, or the purge is a claim about a place rather than a mechanism")
+
+
+def test_the_parties_jsonb_never_carries_a_way_to_reach_anybody():
+    """`deeds.parties` holds NAMES because names print on the instrument.
+
+    It is a JSONB column, so the schema cannot constrain it — which makes
+    the writer the only place a pin can stand.
+    """
+    offenders = []
+    for path in BACKEND.rglob("*.py"):
+        if {"tests", "__pycache__"} & set(path.parts):
+            continue
+        src = code_only(path)
+        for match in re.finditer(r"parties\[[\"']([a-z_]+)[\"']\]|"
+                                 r"parties\.get\([\"']([a-z_]+)[\"']", src):
+            key = match.group(1) or match.group(2)
+            if re.search(_CONTACT, key, re.IGNORECASE):
+                offenders.append(f"{path.relative_to(BACKEND)} → parties[{key}]")
+    assert offenders == [], f"a contact detail was written into deeds.parties: {offenders}"
+
+
+def test_the_purge_exists_and_is_reachable_two_ways():
+    """Owner ruling 3: build both halves. The script ships ready for a
+    cron service that does not exist yet; the in-request sweep ships
+    working. A purge that is only a script is a discipline."""
+    from services import signing_purge
+    assert callable(signing_purge.purge_signer_contact)
+    assert callable(signing_purge.sweep_if_due)
+    assert (BACKEND / "scripts" / "purge_signer_contact.py").exists()
+    # And the script names the Tier-3 dependency rather than implying the
+    # scheduler exists.
+    script = (BACKEND / "scripts" / "purge_signer_contact.py").read_text()
+    assert "Tier 3" in script
+    assert "does not exist yet" in script
+
+
+def test_the_purge_keeps_the_name_and_drops_the_address():
+    """A name is not contact information, and the record of who agreed to
+    what must outlive our ability to reach them — otherwise the purge
+    quietly rewrites history into "somebody agreed"."""
+    src = code_only(BACKEND / "services" / "signing_purge.py")
+    assert "email = NULL" in src
+    assert "phone = NULL" in src
+    assert "contact_purged_at = now()" in src
+    assert "display_name" not in src, (
+        "the purge touches display_name — a name is not contact information")
+
+
+# ══════════════════════════════════════════════════════════════════════
+# §13 stands: booked is not happened
+# ══════════════════════════════════════════════════════════════════════
+
+def test_no_state_means_it_happened():
+    """The vocabulary, checked by walking the AST rather than reading the
+    source, so what is pinned is what the function can SAY."""
+    tree = ast.parse((BACKEND / "services" / "signing_loop.py").read_text())
+    consts = {
+        node.targets[0].id: node.value.value
+        for node in tree.body
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant)
+        and isinstance(node.targets[0], ast.Name)
+        and node.targets[0].id.startswith("STATE_")
+    }
+    assert set(consts.values()) == {
+        "requested", "windows_posted", "partially_agreed",
+        "booked", "cancelled", "expired",
+    }
+    for value in consts.values():
+        assert "complete" not in value and "happen" not in value and "signed" not in value
+
+
+def test_a_booked_time_that_has_passed_is_still_only_booked():
+    """The §13 pin, executable. A clock moving is not evidence that three
+    people met in a room."""
+    past = datetime.now(timezone.utc) - timedelta(days=30)
+    request = {"booked_at": past, "expires_at": past,
+               "booked_by": loop.BOOKED_BY_CONVERGENCE, "tz_name": "America/Los_Angeles"}
+    assert loop.request_state(request, [], []) == loop.STATE_BOOKED
+
+
+def test_nothing_in_the_loop_compares_a_booking_to_the_clock():
+    src = code_only(BACKEND / "services" / "signing_loop.py")
+    assert not re.search(r"booked_at\s*[<>]", src), (
+        "something compares the booked time to now — a passed appointment "
+        "is not a completed one")
+    assert "completed" not in src
+
+
+def test_the_label_never_promises_the_signing_will_happen():
+    request = {"booked_at": datetime(2026, 9, 1, 17, tzinfo=timezone.utc),
+               "booked_by": loop.BOOKED_BY_CONVERGENCE,
+               "tz_name": "America/Los_Angeles"}
+    label = loop.state_label(request, [], [], [])
+    for promise in ("will happen", "will be signed", "will take place",
+                    "is confirmed", "guaranteed", "completed"):
+        assert promise not in label.lower(), f"the label promises: {label}"
+    assert "agreed" in label.lower()
+
+
+def test_the_officers_booking_is_distinguishable_from_the_parties_agreement():
+    """Owner ruling: she retains an override, recorded as HER assertion."""
+    when = datetime(2026, 9, 1, 17, tzinfo=timezone.utc)
+    theirs = loop.state_label(
+        {"booked_at": when, "booked_by": loop.BOOKED_BY_CONVERGENCE,
+         "tz_name": "America/Los_Angeles"}, [], [], [])
+    hers = loop.state_label(
+        {"booked_at": when, "booked_by": loop.BOOKED_BY_OFFICER,
+         "tz_name": "America/Los_Angeles"}, [], [], [])
+    assert theirs != hers
+    assert "you recorded" in hers.lower()
+    assert "everyone agreed" in theirs.lower()
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Convergence
+# ══════════════════════════════════════════════════════════════════════
+
+def _world(n_signers=2):
+    parts = [{"id": 1, "party_role": loop.ROLE_NOTARY, "display_name": "Nora"}]
+    parts += [{"id": 10 + i, "party_role": loop.ROLE_SIGNER,
+               "display_name": f"Signer {i}"} for i in range(n_signers)]
+    base = datetime(2026, 9, 1, 17, tzinfo=timezone.utc)
+    windows = [{"id": 100 + i, "starts_at": base + timedelta(days=i),
+                "ends_at": base + timedelta(days=i, hours=1)} for i in range(3)]
+    return parts, windows
+
+
+def _yes(window_id, participant_id):
+    return {"window_id": window_id, "participant_id": participant_id,
+            "answer": loop.ANSWER_AVAILABLE}
+
+
+def test_a_window_books_only_when_everyone_said_yes():
+    parts, windows = _world()
+    # Notary + one signer: not enough.
+    responses = [_yes(100, 1), _yes(100, 10)]
+    assert loop.converged_window_id(parts, windows, responses) is None
+    responses.append(_yes(100, 11))
+    assert loop.converged_window_id(parts, windows, responses) == 100
+
+
+def test_the_notary_alone_never_converges():
+    """A signing with nobody to sign is not an arrangement anybody made."""
+    parts, windows = _world(n_signers=0)
+    assert loop.converged_window_id(parts, windows, [_yes(100, 1)]) is None
+
+
+def test_the_earliest_qualifying_window_wins():
+    """Not the most recently answered: if everyone is free at two times,
+    the sooner one is the one they meant, and picking by answer order
+    would make the outcome depend on who clicked last."""
+    parts, windows = _world()
+    responses = []
+    for wid in (102, 100):
+        responses += [_yes(wid, 1), _yes(wid, 10), _yes(wid, 11)]
+    assert loop.converged_window_id(parts, windows, responses) == 100
+
+
+def test_a_declined_window_cannot_book():
+    parts, windows = _world()
+    windows[0]["declined_at"] = datetime.now(timezone.utc)
+    responses = [_yes(100, 1), _yes(100, 10), _yes(100, 11)]
+    assert loop.converged_window_id(parts, windows, responses) is None
+
+
+def test_a_revoked_signer_cannot_hold_the_others_hostage():
+    parts, windows = _world()
+    parts[2]["revoked_at"] = datetime.now(timezone.utc)
+    responses = [_yes(100, 1), _yes(100, 10)]
+    assert loop.converged_window_id(parts, windows, responses) == 100
+
+
+def test_an_unavailable_answer_is_not_a_yes():
+    parts, windows = _world()
+    responses = [_yes(100, 1), _yes(100, 10),
+                 {"window_id": 100, "participant_id": 11,
+                  "answer": loop.ANSWER_UNAVAILABLE}]
+    assert loop.converged_window_id(parts, windows, responses) is None
+
+
+# ══════════════════════════════════════════════════════════════════════
+# The round-trip cap
+# ══════════════════════════════════════════════════════════════════════
+
+def test_the_cap_is_three_aggregate():
+    assert loop.MAX_SIGNER_PROPOSALS == 3
+
+
+def test_the_refusal_names_the_officer():
+    """Owner ruling. "This has not converged" tells a signer nothing they
+    can act on; "Dana will call you" tells them what happens next."""
+    text = loop.proposal_refusal("Dana Reyes")
+    assert "Dana Reyes" in text
+    assert "call" in text.lower()
+    # And it does not blame them or ask them to keep trying.
+    assert "sorry" not in text.lower()
+    assert "try again" not in text.lower()
+
+
+def test_the_refusal_still_works_with_no_officer_name():
+    text = loop.proposal_refusal(None)
+    assert text and "None" not in text
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Times carry their zone
+# ══════════════════════════════════════════════════════════════════════
+
+def test_a_time_without_an_offset_is_refused():
+    """The NOTARY1 bug, closed. That code accepted naive times and assumed
+    UTC, producing a calendar file up to eight hours out — silently, on
+    the one artifact whose whole job is being at the right moment."""
+    with pytest.raises(loop.SigningLoopError) as e:
+        loop.parse_window({"start": "2026-09-01T10:00:00",
+                           "end": "2026-09-01T11:00:00"})
+    assert "offset" in str(e.value).lower()
+
+
+def test_a_time_with_an_offset_is_kept_as_an_instant():
+    parsed = loop.parse_window({"start": "2026-09-01T10:00:00-07:00",
+                                "end": "2026-09-01T11:00:00-07:00"})
+    assert parsed["starts_at"].utcoffset() == timedelta(hours=-7)
+
+
+def test_a_window_that_ends_before_it_starts_is_refused():
+    with pytest.raises(loop.SigningLoopError):
+        loop.parse_window({"start": "2026-09-01T11:00:00-07:00",
+                           "end": "2026-09-01T10:00:00-07:00"})
+
+
+def test_the_label_renders_in_the_requests_zone_not_the_servers():
+    """A signing happens at a place, and everybody involved should read
+    the clock on the wall where they are going."""
+    window = {"starts_at": datetime(2026, 9, 1, 17, tzinfo=timezone.utc),
+              "ends_at": datetime(2026, 9, 1, 18, tzinfo=timezone.utc)}
+    la = loop.window_label(window, "America/Los_Angeles")
+    ny = loop.window_label(window, "America/New_York")
+    assert "10:00 AM" in la
+    assert "1:00 PM" in ny
+
+
+def test_an_unknown_zone_does_not_break_a_status_line():
+    window = {"starts_at": datetime(2026, 9, 1, 17, tzinfo=timezone.utc),
+              "ends_at": datetime(2026, 9, 1, 18, tzinfo=timezone.utc)}
+    assert loop.window_label(window, "Mars/Olympus_Mons")
+
+
+# ══════════════════════════════════════════════════════════════════════
+# The token surfaces, as allowlists
+# ══════════════════════════════════════════════════════════════════════
+
+def _packages():
+    parts, windows = _world()
+    parts[0].update({"company_name": "Reyes Mobile Notary",
+                     "email": "nora@notary.test", "phone": "+16265550134",
+                     "expires_at": datetime(2026, 12, 1, tzinfo=timezone.utc)})
+    for p in parts[1:]:
+        p.update({"email": "consumer@example.test", "phone": "+16265550199",
+                  "expires_at": datetime(2026, 12, 1, tzinfo=timezone.utc)})
+    request = {"tz_name": "America/Los_Angeles", "signer_proposals": 0,
+               "expires_at": datetime(2026, 12, 1, tzinfo=timezone.utc)}
+    deed = {"property_address": "9 Private Way, Los Angeles, CA 90017",
+            "apn": "1234-567-890", "county": "Los Angeles",
+            "deed_type": "grant_deed", "grantor_name": "PRIVATE GRANTOR",
+            "grantee_name": "PRIVATE GRANTEE",
+            "legal_description": "LOT 4 OF TRACT 1234"}
+    officer = {"full_name": "Dana Reyes", "company_name": "Pacific Coast Title",
+               "email": "dana@pct.test"}
+    signer = surfaces.signer_package(
+        request=request, me=parts[1], participants=parts, windows=windows,
+        responses=[], deed=deed, officer=officer)
+    notary = surfaces.notary_package(
+        request=request, me=parts[0], participants=parts, windows=windows,
+        responses=[], deed=deed, officer=officer, token="tok")
+    return signer, notary, deed
+
+
+def test_the_signer_package_is_exactly_its_allowlist():
+    signer, _, _ = _packages()
+    assert set(signer) == surfaces.SIGNER_KEYS
+
+
+def test_the_signer_package_carries_no_way_to_reach_anybody():
+    """The allowlist protects the SHAPE; this protects the nested objects
+    inside it — a `notary` object that grew an `email` would still pass a
+    top-level key check."""
+    signer, _, _ = _packages()
+    assert surfaces.contains_contact(signer) == []
+
+
+def test_the_signer_never_sees_the_instrument():
+    """Owner ruling: property street address, who is coordinating, who is
+    coming, the times, pick-or-propose. Nothing else."""
+    signer, _, deed = _packages()
+    blob = json.dumps(signer)
+    for secret in (deed["apn"], deed["legal_description"],
+                   deed["grantor_name"], deed["grantee_name"],
+                   deed["county"], deed["deed_type"]):
+        assert secret not in blob, f"the signer surface leaked {secret!r}"
+    # The street line only — never the full address with city and ZIP.
+    assert signer["property_street"] == "9 Private Way"
+    assert "90017" not in blob
+
+
+def test_the_signer_sees_who_is_coming_but_not_how_to_reach_her():
+    """Owner ruling 2. A professional whose name will be on the
+    certificate, and a consumer told a stranger is coming to their home
+    deserves to know who — but the signer needs to know who is coming,
+    not how to reach her independently."""
+    signer, _, _ = _packages()
+    assert signer["notary"]["name"] == "Nora"
+    assert signer["notary"]["company"] == "Reyes Mobile Notary"
+    assert set(signer["notary"]) == {"name", "company"}
+    assert "nora@notary.test" not in json.dumps(signer)
+
+
+def test_one_signer_never_sees_another():
+    signer, _, _ = _packages()
+    blob = json.dumps(signer)
+    assert "Signer 1" not in blob
+    assert "consumer@example.test" not in blob
+
+
+def test_the_notary_package_is_exactly_its_allowlist():
+    _, notary, _ = _packages()
+    assert set(notary) == surfaces.NOTARY_KEYS
+
+
+def test_the_notary_sees_names_to_check_ids_against_but_no_signer_contact():
+    _, notary, _ = _packages()
+    assert [s["name"] for s in notary["signers"]] == ["Signer 0", "Signer 1"]
+    assert "consumer@example.test" not in json.dumps(notary)
+    assert surfaces.contains_contact(notary["signers"]) == []
+
+
+def test_the_allowlists_are_declared_not_derived():
+    """A key set computed from the payload would agree with itself no
+    matter what the payload became. These are written down, and the
+    builders assert against them at runtime as well."""
+    src = code_only(BACKEND / "services" / "signing_surfaces.py")
+    assert "SIGNER_KEYS = frozenset(" in src
+    assert "NOTARY_KEYS = frozenset(" in src
+    assert src.count("assert set(package)") == 2
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Executable — the purge, against a real database
+# ══════════════════════════════════════════════════════════════════════
+
+dbonly = pytest.mark.skipif(not os.getenv("DATABASE_URL"), reason="needs a database")
+
+
+@pytest.fixture
+def conn():
+    import psycopg2
+    from database import create_tables
+    from db_rows import ROW_FACTORY
+    create_tables()
+    c = psycopg2.connect(os.environ["DATABASE_URL"], cursor_factory=ROW_FACTORY)
+    c.autocommit = False
+    yield c
+    c.rollback()
+    c.close()
+
+
+def _seed_request(conn, *, finished_days_ago: int, tag: str):
+    """A finished request with a notary and one signer, both with contact
+    details. `finished_days_ago` sets how long ago it expired."""
+    finished = datetime.now(timezone.utc) - timedelta(days=finished_days_ago)
+    with conn.cursor() as cur:
+        cur.execute("INSERT INTO users (email, password_hash, full_name, role) "
+                    "VALUES (%s, 'x', 'Officer', 'user') RETURNING id",
+                    (f"officer-{tag}@n2.test",))
+        officer = cur.fetchone()["id"]
+        cur.execute("INSERT INTO deeds (user_id, deed_type, property_address, status) "
+                    "VALUES (%s, 'grant_deed', '1 Test St, LA, CA', 'completed') "
+                    "RETURNING id", (officer,))
+        deed = cur.fetchone()["id"]
+        cur.execute("INSERT INTO signing_requests (deed_id, officer_user_id, "
+                    "tz_name, expires_at) VALUES (%s, %s, 'America/Los_Angeles', %s) "
+                    "RETURNING id", (deed, officer, finished))
+        req = cur.fetchone()["id"]
+        ids = {}
+        for role, name in ((loop.ROLE_NOTARY, "Nora"), (loop.ROLE_SIGNER, "Sam")):
+            cur.execute(
+                "INSERT INTO signing_participants (signing_request_id, party_role, "
+                "display_name, email, phone, token, expires_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, %s) RETURNING id",
+                (req, role, name, f"{name.lower()}-{tag}@n2.test", "+16265550134",
+                 str(uuid.uuid4()), finished))
+            ids[role] = cur.fetchone()["id"]
+    return req, ids
+
+
+@dbonly
+def test_the_purge_removes_contact_and_keeps_the_name(conn):
+    from services.signing_purge import purge_signer_contact
+    _, ids = _seed_request(conn, finished_days_ago=200, tag=uuid.uuid4().hex[:6])
+    assert purge_signer_contact(conn) >= 1
+    with conn.cursor() as cur:
+        cur.execute("SELECT display_name, email, phone, contact_purged_at "
+                    "FROM signing_participants WHERE id = %s", (ids[loop.ROLE_SIGNER],))
+        row = cur.fetchone()
+    assert row["email"] is None
+    assert row["phone"] is None
+    assert row["display_name"] == "Sam", "a name is not contact information"
+    assert row["contact_purged_at"] is not None, (
+        "without the stamp, 'we never had it' and 'we deleted it' look identical")
+
+
+@dbonly
+def test_the_purge_leaves_the_notary_alone(conn):
+    """She is a partner the officer chose, under an engagement — not a
+    consumer we found on a deed. Her row is the rolodex's business."""
+    from services.signing_purge import purge_signer_contact
+    _, ids = _seed_request(conn, finished_days_ago=200, tag=uuid.uuid4().hex[:6])
+    purge_signer_contact(conn)
+    with conn.cursor() as cur:
+        cur.execute("SELECT email FROM signing_participants WHERE id = %s",
+                    (ids[loop.ROLE_NOTARY],))
+        assert cur.fetchone()["email"] is not None
+
+
+@dbonly
+def test_a_request_still_inside_the_window_is_untouched(conn):
+    from services.signing_purge import purge_signer_contact
+    _, ids = _seed_request(conn, finished_days_ago=5, tag=uuid.uuid4().hex[:6])
+    purge_signer_contact(conn)
+    with conn.cursor() as cur:
+        cur.execute("SELECT email FROM signing_participants WHERE id = %s",
+                    (ids[loop.ROLE_SIGNER],))
+        assert cur.fetchone()["email"] is not None
+
+
+@dbonly
+def test_a_booking_in_the_future_keeps_its_contact_details(conn):
+    """The clock starts when the request FINISHES, not when it was made.
+    Counting from creation would purge the addresses of an appointment
+    that has not happened yet."""
+    from services.signing_purge import purge_signer_contact
+    tag = uuid.uuid4().hex[:6]
+    req, ids = _seed_request(conn, finished_days_ago=200, tag=tag)
+    with conn.cursor() as cur:
+        cur.execute("UPDATE signing_requests SET booked_at = %s WHERE id = %s",
+                    (datetime.now(timezone.utc) + timedelta(days=10), req))
+    purge_signer_contact(conn)
+    with conn.cursor() as cur:
+        cur.execute("SELECT email FROM signing_participants WHERE id = %s",
+                    (ids[loop.ROLE_SIGNER],))
+        assert cur.fetchone()["email"] is not None
+
+
+@dbonly
+def test_the_purge_is_idempotent(conn):
+    from services.signing_purge import purge_signer_contact
+    _seed_request(conn, finished_days_ago=200, tag=uuid.uuid4().hex[:6])
+    first = purge_signer_contact(conn)
+    second = purge_signer_contact(conn)
+    assert first >= 1
+    assert second == 0, "a second run must find nothing — the stamp is what makes that true"
+
+
+@dbonly
+def test_the_sweep_throttles_itself(conn):
+    """`system_jobs` is a LEDGER and survives between runs.
+
+    The first draft called `sweep_if_due` twice and asserted the first
+    ran — which failed on the second execution of this suite, because an
+    earlier run had already stamped `last_run_at` inside the hour and the
+    throttle was doing exactly its job. Same trap as the email_log
+    high-water mark: a test that reads persistent state without
+    establishing it is measuring history rather than behaviour.
+
+    So the throttle window is established explicitly here.
+    """
+    from services.signing_purge import JOB_NAME, sweep_if_due
+    _seed_request(conn, finished_days_ago=200, tag=uuid.uuid4().hex[:6])
+    with conn.cursor() as cur:
+        cur.execute("DELETE FROM system_jobs WHERE job_name = %s", (JOB_NAME,))
+    conn.commit()
+
+    first = sweep_if_due(conn)
+    second = sweep_if_due(conn)
+    assert first is not None, "the first sweep should have run"
+    assert second is None, "the second must be throttled, not run again"
+
+    # And the throttle is a WINDOW, not a one-shot: a call after the
+    # interval runs again.
+    later = sweep_if_due(conn, now=datetime.now(timezone.utc) + timedelta(hours=2))
+    assert later is not None, "the sweep never runs again — that is a stuck job, not a throttle"
+
+
+@dbonly
+def test_purge_status_reports_what_is_overdue(conn):
+    """The in-request sweep's weakness is invisibility. This is the number
+    an operator watches: rows that SHOULD be purged and are not."""
+    from services.signing_purge import purge_status
+    _seed_request(conn, finished_days_ago=200, tag=uuid.uuid4().hex[:6])
+    conn.commit()
+    status = purge_status(conn)
+    assert status["retention_days"] == loop.CONTACT_RETENTION_DAYS
+    assert status["overdue"] >= 1

--- a/docs/EXECUTION_POLICY.md
+++ b/docs/EXECUTION_POLICY.md
@@ -60,6 +60,41 @@ substantively incomplete deed; the legal-choice doctrine was unchanged.
   in the PR that re-records it.
 - The frontend `tsc` error baseline (currently **114**) may only go down.
 
+## Dead code and revived code
+
+**Reviving a dead file makes its violations live.** A file with no
+importers is outside the blast radius of every ruling made while it was
+dead — not because anybody exempted it, but because nothing pointed at it
+when the sweep ran. The moment a ticket imports it, everything the
+product decided in the interval applies to it retroactively and
+un-negotiably.
+
+The concrete instance, kept because the shape recurs:
+`QuickAddPartnerModal` still carried a full-viewport `backdrop-blur` from
+before the X1 renderer-freeze ruling, and a category list in which
+`realtor` was a CATEGORY where every live surface treated it as a role of
+`real_estate`. Both were harmless while nothing imported it. PARTNER2's
+Part B imported it, and both became live defects in the same commit.
+
+**What this means for a ticket that touches dead code:**
+
+1. *Leaving a dead file alone is correct* when nothing in the ticket
+   revives it. Cleaning up an unreferenced file is scope the owner did
+   not ask for.
+2. *Reviving one obliges you to bring it up to current doctrine* in the
+   same diff — every pin the product has added since it went dark. Not
+   as a follow-up ticket; the revival and the conformance are one change,
+   because a half-revived file is a live surface running an old rulebook.
+3. *Both of those can be true in consecutive tickets about the same file*,
+   and saying so plainly is better than pretending the first call was
+   wrong. PARTNER1's "leave the dead files alone" was right when it was
+   made and wrong the moment Part B revived them.
+
+The general form: **a pin's coverage is the set of files something
+imports, not the set of files that exist.** When the import graph grows,
+re-run the sweeps against the new graph rather than assuming the last
+green run still describes the product.
+
 ## Product doctrine (the why)
 
 **The two-tier rule.**

--- a/docs/EXECUTION_POLICY.md
+++ b/docs/EXECUTION_POLICY.md
@@ -95,6 +95,51 @@ imports, not the set of files that exist.** When the import graph grows,
 re-run the sweeps against the new graph rather than assuming the last
 green run still describes the product.
 
+## Pull requests and stacking
+
+**A squash-merged base does not carry its stack.** Stacking PR B on PR
+A's branch works until A is squash-merged — at which point the squash is
+a NEW commit on main, A's branch still exists unchanged, and B is still
+pointed at it. Merging B then lands B on A's branch instead of on main,
+reports "merged" truthfully, and leaves main without B's work.
+
+This happened with #146 → #147: Part A reached main, Part B did not, and
+the merge API said success both times. It was caught by checking that
+main actually contained the files rather than trusting the word "merged."
+
+**The operational rule: no stacking unless the child is re-based onto
+main before it is merged.** In practice that means either
+- open the second PR against `main` and wait for the first to land, or
+- cherry-pick onto a fresh branch off current main and re-open.
+
+**And the general form, which is the part worth keeping:** a merge
+reporting success is a statement about the merge, not about main. When a
+PR's whole point is that some code reaches production, verify the code
+reached the branch production deploys from. `git log origin/main` and
+`ls` cost five seconds.
+
+## Test helpers and persistent state
+
+**Any pin that reads a table surviving between runs must establish its
+own baseline.** A test asserting "a row with this template exists" or
+"this job has not run recently" is measuring the HISTORY of the test
+database, not the behaviour of the code under test — and it passes with
+the code deliberately broken, which is the worst failure a test has.
+
+Two instances, both found by mutation-probing a green result:
+- `email_log` (NOTARY1) — "the officer's email was attempted" was
+  satisfied by a row from an earlier run. Fixed with a high-water mark
+  (`MAX(id)`) taken before the action.
+- `system_jobs` (NOTARY2) — "the sweep ran" failed on the second
+  execution of the suite because the first had legitimately throttled it.
+  Fixed by deleting the job row in setup, and extended to assert the
+  throttle is a WINDOW rather than a one-shot.
+
+The two shapes of fix: **take a high-water mark before acting** when the
+table is append-only, or **reset the row in setup** when it is a
+singleton. Either way the test states what it depends on instead of
+inheriting it.
+
 ## Product doctrine (the why)
 
 **The two-tier rule.**


### PR DESCRIPTION
**This is not all of Part C.** It is the load-bearing half — where a design error is expensive and hard to unwind — with the routes and UI still to come. Honest status at the bottom.

## Schema: four tables, no status column

`deed_shares` was right for NOTARY1 (one share = one recipient = one row) and is wrong for NOTARY2, which is **one request with N participants**, each holding their own token, seeing their own surface, recording their own answers. Flattening that means either rows re-associated by convention or JSONB carrying identity and access — the two things that must be constrainable by the schema rather than by care. `deed_shares` stays review-only.

**No status column.** All four states derive: `requested` (no windows) / `windows_posted` / `partially_agreed` / `booked` (`booked_at IS NOT NULL`). `cancelled_at` is its own column so a cancelled request that *had* been partially agreed stays expressible. T-5's ruling, third application.

**`booked_at` is written, not derived** — and that isn't a contradiction. An agreement is an event with a moment (the last party's answer, not whenever somebody ran the query), and your override must have something to disagree *with*. SQL-guarded single write, RED-S4 trio, `booked_by ∈ {convergence, officer}` so the record never claims the parties agreed to a time you set alone.

**One IANA zone per request** — and this closes a live NOTARY1 bug you should know about. That code stored ISO offsets in JSONB and **assumed UTC when an offset was missing**, so a naive time produced a calendar file up to eight hours out. Silently, on the one artifact whose entire job is being at the right moment. `parse_window` now refuses a time without an offset rather than guessing.

## The surfaces are allowlists

Each package is built from a **named key set** and pinned by exact equality — plus a recursive contact-key walk, because the allowlist protects the *shape* and a nested `notary` object could grow an `email` while the top-level keys still looked right. Both probes bite.

The **notary's name and company are on the signer surface** per your ruling. Email, phone and address are not: the signer needs to know who's coming, not how to reach her independently — that's the officer's coordination to hold, and routing around it is how a scheduling product becomes an unmoderated introduction service.

## The purge

Both halves. `purge_signer_contact()` NULLs email and phone and **stamps `contact_purged_at`** — the stamp matters, because "we never had it" and "we deleted it on the 14th" are different answers and an empty column can't tell them apart. **`display_name` survives**: a name is not contact information, and the record of who agreed to what must outlive our ability to reach them.

The retention clock starts when a request **finishes**, not when it was created — counting from creation would purge the details of an appointment three months out that hasn't happened yet. Pinned.

`sweep_if_due()` throttles on `system_jobs` with `FOR UPDATE SKIP LOCKED`, so housekeeping never blocks a person. `scripts/purge_signer_contact.py` ships ready for the cron job that doesn't exist, and says so in its own docstring — a retention *practice* can lag, a retention *promise* cannot. `--status` reports `overdue`, which is the number an operator watches: rows that should be purged and aren't.

## NOTARY1's fail-closed pin, answered

| | |
|---|---|
| was | no signer contact exists anywhere in the product |
| is | it exists on **one** table, reaches no other, and is deleted on a schedule by a mechanism with a test |

Stricter where it counts. "Anywhere" was easy to satisfy and easy to abandon; "exactly one table, and here is the purge" has three separate ways to fail and all three are pinned — including a sweep over `deeds.parties` JSONB writes, since a JSONB column can't be constrained by the schema and the writer is the only place a pin can stand.

## The dead-code lesson, generalized

Into `EXECUTION_POLICY.md`, per your instruction: **a pin's coverage is the set of files something imports, not the set of files that exist.** Reviving a dead file makes its violations live, and both "leave it alone" and "bring it up to doctrine" can be correct in consecutive tickets about the same file.

## Two defects this suite found in itself

Green on the first run, so it got probed.

- **The DDL scanner closed a CREATE block on the first `)"""`** rather than the matching paren, so scanning `users` swallowed `deeds`' columns and attributed them to the wrong table. False alarms only — but a pin that names the wrong file sends somebody to the wrong place.
- **The throttle test read `system_jobs` without establishing it**, so it passed or failed on whether the suite had run in the last hour. Same measuring-history-instead-of-behaviour trap as NOTARY1's `email_log` assertion. Now it establishes the window, and asserts the throttle is a *window* rather than a one-shot — a sweep that never runs again is a stuck job, not a throttle.

## Status — what's done and what isn't

**Done:** schema (converged against a real Postgres), convergence rule, derived state, the single sentence-writer, window parsing, both token-surface builders, the purge with its script and status command, 39 tests.

**Remaining:** routes for all three parties, the officer's multi-signer create flow, three token pages, five email templates + `.ics` to everyone, reminders, the NOTARY1 → NOTARY2 migration, and Part D's agenda list. On my ~11.5-day estimate this is roughly the first 2 days.

## Gates

| gate | result |
|---|---|
| pytest, no database | 824 passed, 112 skipped |
| pytest, with database | 936 passed |
| six-flow / API baselines | ✔ ✔ |
| banned-claims | clean |

Four mutation probes, all biting: planting signer contact on `deeds`, adding a key to the signer package, leaking an email into a nested object, and letting the notary converge alone.

**Merge or hold as you prefer** — it's additive (new tables, new modules, no route changes), so it's safe on main ahead of the rest, and it keeps the next PR to routes-and-UI only.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_