### PR TITLE
NOTARY2 (2/n): the loop's routes — three parties, three postures

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -222,6 +222,12 @@ app.include_router(deeds_crud_router)
 from routers.sharing import router as sharing_router
 app.include_router(sharing_router)
 
+# NOTARY2 — the coordination loop. Its own router rather than more of
+# sharing.py: `deed_shares` is review-only from here, and the two files
+# now hold two different models of the same word.
+from routers.signing import router as signing_router
+app.include_router(signing_router, tags=["Signing"])
+
 from routers.pricing import router as pricing_router
 app.include_router(pricing_router)
 

--- a/backend/routers/signing.py
+++ b/backend/routers/signing.py
@@ -1,0 +1,639 @@
+"""NOTARY2 — the coordination loop's routes.
+
+Three parties, three postures, and the differences are the design:
+
+  OFFICER — session-authenticated. Creates the request, adds signers,
+    watches, and may override the booked time. She does NOT gate the
+    final time: notary + signers converging books it and she is told
+    (owner ruling). Her override is recorded as HER assertion, distinct
+    from the parties' agreement.
+
+  NOTARY — token. Posts the times she is free, accepts or declines a
+    signer's proposal, and sees the package she needs at the table.
+
+  SIGNER — token, and THE FIRST CONSUMER SURFACE THIS PRODUCT HAS EVER
+    HAD. Picks from the offered times or proposes one, up to the cap.
+    Sees the street line, who is coordinating, who is coming, and the
+    times. Nothing else — `services/signing_surfaces.py` builds that
+    package from an allowlist and both the builder and the suite assert
+    the key set by equality.
+
+Every token route is unauthenticated and therefore throttled, per-token
+and per-IP, the RED-H1.2 treatment. A token that can be enumerated is a
+property address disclosed, and these are consumers' addresses now.
+"""
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel, Field
+
+import db
+from auth import get_current_user_id
+from services import signing_loop as loop
+from services import signing_purge, signing_surfaces
+from utils.throttle import client_key, throttle
+
+router = APIRouter()
+
+APP_URL = lambda: os.getenv("FRONTEND_URL", "https://deedpro-frontend-new.vercel.app")  # noqa: E731
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Payloads
+# ══════════════════════════════════════════════════════════════════════
+
+class SignerIn(BaseModel):
+    """One signer on the request.
+
+    Contact details are PER-REQUEST and land on `signing_participants`
+    only (§13.1). Nothing here reaches `deeds`, the `parties` JSONB, or
+    any profile table, and the suite sweeps the schema to prove it.
+    """
+    name: str = Field(..., min_length=1, max_length=255)
+    email: str = Field(..., min_length=3, max_length=320)
+    phone: Optional[str] = None
+
+
+class CreateSigningRequest(BaseModel):
+    deed_id: int
+    notary_email: str
+    notary_name: Optional[str] = None
+    notary_company: Optional[str] = None
+    notary_partner_id: Optional[str] = None
+    signers: List[SignerIn]
+    location: Optional[str] = None
+    # IANA, not an offset. A signing happens at one place and everybody
+    # involved reads the clock on the wall where they are going.
+    tz_name: str = "America/Los_Angeles"
+    expires_in_days: int = 21
+
+
+class WindowIn(BaseModel):
+    start: str
+    end: str
+
+
+class PostWindows(BaseModel):
+    windows: List[WindowIn]
+
+
+class AnswerIn(BaseModel):
+    window_id: int
+    answer: str
+
+
+class ProposeIn(BaseModel):
+    start: str
+    end: str
+
+
+class OfficerOverride(BaseModel):
+    """Owner ruling: she retains an override. Recorded as her assertion."""
+    window_id: Optional[int] = None
+    booked_at: Optional[str] = None
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Loading
+# ══════════════════════════════════════════════════════════════════════
+
+def _rows(cur) -> List[Dict[str, Any]]:
+    return [dict(r) for r in (cur.fetchall() or [])]
+
+
+def _load(request_id: int) -> Dict[str, Any]:
+    """The whole aggregate in one place. Four small queries beat four
+    call sites each remembering which pieces convergence needs."""
+    with db.conn.cursor() as cur:
+        cur.execute("SELECT * FROM signing_requests WHERE id = %s", (request_id,))
+        req = cur.fetchone()
+        if not req:
+            raise HTTPException(status_code=404, detail="Signing request not found")
+        req = dict(req)
+        cur.execute("SELECT * FROM signing_participants WHERE signing_request_id = %s "
+                    "ORDER BY id", (request_id,))
+        participants = _rows(cur)
+        cur.execute("SELECT * FROM signing_windows WHERE signing_request_id = %s "
+                    "ORDER BY starts_at", (request_id,))
+        windows = _rows(cur)
+        cur.execute("SELECT r.* FROM signing_responses r JOIN signing_windows w "
+                    "ON w.id = r.window_id WHERE w.signing_request_id = %s",
+                    (request_id,))
+        responses = _rows(cur)
+        cur.execute("SELECT * FROM deeds WHERE id = %s", (req["deed_id"],))
+        deed = dict(cur.fetchone() or {})
+        cur.execute("SELECT id, full_name, email FROM users WHERE id = %s",
+                    (req["officer_user_id"],))
+        officer = dict(cur.fetchone() or {})
+    return {"request": req, "participants": participants, "windows": windows,
+            "responses": responses, "deed": deed, "officer": officer}
+
+
+def _participant_by_token(token: str, http_request: Request) -> Dict[str, Any]:
+    """Resolve a token to a participant, with the link's own scoping.
+
+    Throttled BEFORE the database is touched: an unauthenticated route
+    that queries first is a route somebody can use to measure us. The
+    UUID guard is the same reason NOTARY1 has one — a malformed token is
+    a Postgres TYPE ERROR, not a miss, and on a shared connection that
+    aborts the whole request's transaction.
+    """
+    throttle(f"signing-token:{client_key(http_request)}", limit=60, window_seconds=60)
+    try:
+        uuid.UUID(token)
+    except (ValueError, AttributeError, TypeError):
+        raise HTTPException(status_code=404, detail="This link is not valid")
+    throttle(f"signing-token:{token}", limit=120, window_seconds=60)
+
+    with db.conn.cursor() as cur:
+        cur.execute("SELECT * FROM signing_participants WHERE token = %s", (token,))
+        me = cur.fetchone()
+    if not me:
+        raise HTTPException(status_code=404, detail="This link is not valid")
+    me = dict(me)
+    if me.get("revoked_at"):
+        raise HTTPException(status_code=403, detail="This link has been withdrawn")
+    if me.get("expires_at") and me["expires_at"] < datetime.now(timezone.utc):
+        raise HTTPException(status_code=410, detail="This link has expired")
+    return me
+
+
+def _owned_request(request_id: int, user_id: int) -> Dict[str, Any]:
+    world = _load(request_id)
+    if world["request"]["officer_user_id"] != user_id:
+        # 404 not 403 — see _owned_deed_or_404's reasoning: "it exists but
+        # is not yours" turns id enumeration into an inventory.
+        raise HTTPException(status_code=404, detail="Signing request not found")
+    return world
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Officer
+# ══════════════════════════════════════════════════════════════════════
+
+@router.post("/signing-requests/v2")
+def create_signing_request(payload: CreateSigningRequest,
+                           user_id: int = Depends(get_current_user_id)):
+    """Create the request and mint one token per participant."""
+    from routers.sharing import _owned_deed_or_404
+
+    deed = _owned_deed_or_404(payload.deed_id, user_id)
+    if not payload.signers:
+        raise HTTPException(status_code=400,
+                            detail="A signing needs at least one signer")
+    if len(payload.signers) > 6:
+        raise HTTPException(status_code=400,
+                            detail="At most six signers on one request")
+
+    expires = datetime.now(timezone.utc) + timedelta(days=max(1, min(90, payload.expires_in_days)))
+    try:
+        with db.conn.cursor() as cur:
+            cur.execute(
+                """INSERT INTO signing_requests
+                       (deed_id, officer_user_id, location, tz_name, expires_at)
+                   VALUES (%s, %s, %s, %s, %s) RETURNING id""",
+                (payload.deed_id, user_id,
+                 payload.location or deed.get("property_address"),
+                 payload.tz_name, expires))
+            request_id = cur.fetchone()["id"]
+
+            people = [(loop.ROLE_NOTARY, payload.notary_name, payload.notary_company,
+                       payload.notary_email, None, payload.notary_partner_id)]
+            people += [(loop.ROLE_SIGNER, s.name, None, s.email, s.phone, None)
+                       for s in payload.signers]
+            tokens = {}
+            for role, name, company, email, phone, partner_id in people:
+                token = str(uuid.uuid4())
+                cur.execute(
+                    """INSERT INTO signing_participants
+                           (signing_request_id, party_role, display_name,
+                            company_name, email, phone, partner_id, token, expires_at)
+                       VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING id""",
+                    (request_id, role, name, company, email, phone,
+                     partner_id, token, expires))
+                tokens[cur.fetchone()["id"]] = (role, token, name, email)
+        db.conn.commit()
+    except HTTPException:
+        raise
+    except Exception as e:
+        try:
+            db.conn.rollback()
+        except Exception:
+            pass
+        print(f"[NOTARY2] ❌ could not create signing request: {e}")
+        # §4: a request we did not store is not a request. Nobody gets a
+        # link to a row that does not exist.
+        raise HTTPException(status_code=500, detail="Could not create the signing request")
+
+    return {
+        "success": True,
+        "signing_request_id": request_id,
+        "expires_at": expires.isoformat(),
+        "participants": [
+            {"id": pid, "party_role": role, "name": name,
+             "link": f"{APP_URL()}/signing/{token}"}
+            for pid, (role, token, name, _email) in tokens.items()
+        ],
+        # The notary is asked first: she posts availability, and the
+        # signers are invited once there is something to answer. Emailing
+        # a consumer "pick a time" before any time exists would be asking
+        # them to do nothing.
+        "next": "the notary posts her availability",
+    }
+
+
+@router.get("/signing-requests/v2/{request_id}")
+def officer_view(request_id: int, user_id: int = Depends(get_current_user_id)):
+    world = _owned_request(request_id, user_id)
+    return _officer_payload(world)
+
+
+@router.get("/signing-requests/v2")
+def officer_agenda(user_id: int = Depends(get_current_user_id)):
+    """Part D — every signing across every file, soonest first.
+
+    An AGENDA rather than a month grid (owner-accepted cut). A list
+    sorted by date answers "what is coming up and what is stuck"
+    completely; the grid is the attractive version of the same facts.
+
+    Read-only aggregation. No new state, no availability engine.
+    """
+    if not db.conn:
+        raise HTTPException(status_code=500, detail="Database connection not available")
+    with db.conn.cursor() as cur:
+        cur.execute("""
+            SELECT sr.*, d.property_address, d.deed_type,
+                   (SELECT display_name FROM signing_participants
+                     WHERE signing_request_id = sr.id AND party_role = 'notary'
+                     ORDER BY id LIMIT 1) AS notary_name
+              FROM signing_requests sr
+              JOIN deeds d ON d.id = sr.deed_id
+             WHERE sr.officer_user_id = %s
+             ORDER BY COALESCE(sr.booked_at, sr.expires_at) ASC
+        """, (user_id,))
+        rows = _rows(cur)
+
+        out = []
+        for row in rows:
+            cur.execute("SELECT * FROM signing_windows WHERE signing_request_id = %s",
+                        (row["id"],))
+            windows = _rows(cur)
+            cur.execute("SELECT r.* FROM signing_responses r JOIN signing_windows w "
+                        "ON w.id = r.window_id WHERE w.signing_request_id = %s",
+                        (row["id"],))
+            responses = _rows(cur)
+            cur.execute("SELECT * FROM signing_participants WHERE signing_request_id = %s",
+                        (row["id"],))
+            participants = _rows(cur)
+            out.append({
+                "id": row["id"],
+                "deed_id": row["deed_id"],
+                "property_address": row.get("property_address"),
+                "deed_type": row.get("deed_type"),
+                "notary_name": row.get("notary_name"),
+                "state": loop.request_state(row, windows, responses),
+                # The server's sentence, rendered verbatim by every
+                # surface — §13 rule 3.
+                "summary": loop.state_label(row, windows, responses, participants),
+                "booked_at": _iso(row.get("booked_at")),
+                "booked_by": row.get("booked_by"),
+                "expires_at": _iso(row.get("expires_at")),
+                "signers": len([p for p in participants
+                                if p["party_role"] == loop.ROLE_SIGNER]),
+            })
+
+    # Housekeeping rides an authenticated read rather than a public one:
+    # the officer's own page is a fine place to spend 20ms, and a
+    # consumer's token view is not.
+    signing_purge.sweep_if_due(db.conn)
+    return out
+
+
+@router.post("/signing-requests/v2/{request_id}/override")
+def officer_override(request_id: int, payload: OfficerOverride,
+                     user_id: int = Depends(get_current_user_id)):
+    """She sets or changes the time herself.
+
+    Recorded as `booked_by = 'officer'`, which is the whole point: the
+    record must never claim the parties agreed to a time she chose. Both
+    assertions are real; they are different assertions.
+    """
+    world = _owned_request(request_id, user_id)
+    if payload.window_id is not None:
+        window = next((w for w in world["windows"]
+                       if int(w["id"]) == int(payload.window_id)), None)
+        if window is None:
+            raise HTTPException(status_code=400, detail="That is not one of the times offered")
+        when = window["starts_at"]
+    elif payload.booked_at:
+        try:
+            when = datetime.fromisoformat(payload.booked_at.replace("Z", "+00:00"))
+        except ValueError:
+            raise HTTPException(status_code=400,
+                                detail="booked_at must be an ISO-8601 date and time")
+        if when.tzinfo is None:
+            raise HTTPException(
+                status_code=400,
+                detail="That time needs its UTC offset — a wall-clock time "
+                       "without a zone is not a time")
+    else:
+        raise HTTPException(status_code=400, detail="Give a time or one of the offered windows")
+
+    with db.conn.cursor() as cur:
+        # No `WHERE booked_at IS NULL` guard here, deliberately, and the
+        # difference from convergence is the point: convergence writes
+        # once and never argues with itself, while an override is the
+        # officer CORRECTING the record — including a booking that
+        # already exists.
+        cur.execute("""UPDATE signing_requests
+                          SET booked_at = %s, booked_by = %s,
+                              booked_asserted_at = now(), updated_at = now()
+                        WHERE id = %s""",
+                    (when, loop.BOOKED_BY_OFFICER, request_id))
+    db.conn.commit()
+    return _officer_payload(_load(request_id))
+
+
+@router.post("/signing-requests/v2/{request_id}/cancel")
+def officer_cancel(request_id: int, user_id: int = Depends(get_current_user_id)):
+    _owned_request(request_id, user_id)
+    with db.conn.cursor() as cur:
+        cur.execute("UPDATE signing_requests SET cancelled_at = now(), "
+                    "updated_at = now() WHERE id = %s AND cancelled_at IS NULL",
+                    (request_id,))
+        cur.execute("UPDATE signing_participants SET revoked_at = now(), "
+                    "updated_at = now() WHERE signing_request_id = %s "
+                    "AND revoked_at IS NULL", (request_id,))
+    db.conn.commit()
+    return _officer_payload(_load(request_id))
+
+
+def _officer_payload(world: Dict[str, Any]) -> Dict[str, Any]:
+    """Her view. Wider than the token surfaces because she typed these
+    people in — but it still shows what each party can see, so that "what
+    does the signer get" is answerable without reading this file."""
+    req, parts = world["request"], world["participants"]
+    windows, responses = world["windows"], world["responses"]
+    tz = req.get("tz_name")
+    return {
+        "id": req["id"],
+        "deed_id": req["deed_id"],
+        "property_address": world["deed"].get("property_address"),
+        "tz_name": tz,
+        "state": loop.request_state(req, windows, responses),
+        "summary": loop.state_label(req, windows, responses, parts),
+        "booked_at": _iso(req.get("booked_at")),
+        "booked_by": req.get("booked_by"),
+        "booked_asserted_at": _iso(req.get("booked_asserted_at")),
+        "expires_at": _iso(req.get("expires_at")),
+        "cancelled_at": _iso(req.get("cancelled_at")),
+        "proposals_remaining": max(0, loop.MAX_SIGNER_PROPOSALS
+                                   - int(req.get("signer_proposals") or 0)),
+        "participants": [
+            {"id": p["id"], "party_role": p["party_role"],
+             "name": p.get("display_name"), "email": p.get("email"),
+             "company": p.get("company_name"),
+             "link": f"{APP_URL()}/signing/{p['token']}",
+             "viewed_at": _iso(p.get("last_viewed_at")),
+             "revoked": bool(p.get("revoked_at")),
+             "contact_purged": bool(p.get("contact_purged_at"))}
+            for p in parts
+        ],
+        "windows": [
+            {"id": w["id"], "label": loop.window_label(w, tz),
+             "origin": w.get("origin"), "declined": bool(w.get("declined_at")),
+             "waiting_on": loop.outstanding_parties(parts, int(w["id"]), responses)}
+            for w in windows
+        ],
+    }
+
+
+def _iso(value: Any) -> Any:
+    return value.isoformat() if hasattr(value, "isoformat") else value
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Token surfaces
+# ══════════════════════════════════════════════════════════════════════
+
+@router.get("/signing/{token}")
+def token_view(token: str, http_request: Request):
+    """One route, two packages. Which one you get is decided by the row
+    your token resolves to, never by a query parameter."""
+    me = _participant_by_token(token, http_request)
+    world = _load(me["signing_request_id"])
+
+    with db.conn.cursor() as cur:
+        cur.execute("UPDATE signing_participants SET last_viewed_at = now() "
+                    "WHERE id = %s", (me["id"],))
+    db.conn.commit()
+
+    if me["party_role"] == loop.ROLE_NOTARY:
+        return signing_surfaces.notary_package(
+            request=world["request"], me=me, participants=world["participants"],
+            windows=world["windows"], responses=world["responses"],
+            deed=world["deed"], officer=world["officer"], token=token)
+    return signing_surfaces.signer_package(
+        request=world["request"], me=me, participants=world["participants"],
+        windows=world["windows"], responses=world["responses"],
+        deed=world["deed"], officer=world["officer"])
+
+
+@router.post("/signing/{token}/windows")
+def notary_post_windows(token: str, payload: PostWindows, http_request: Request):
+    """The notary posts the times she is free. Notary-only."""
+    me = _participant_by_token(token, http_request)
+    if me["party_role"] != loop.ROLE_NOTARY:
+        raise HTTPException(status_code=403,
+                            detail="Only the notary posts availability")
+    try:
+        parsed = loop.parse_windows([w.model_dump() for w in payload.windows])
+    except loop.SigningLoopError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    with db.conn.cursor() as cur:
+        for w in parsed:
+            cur.execute(
+                """INSERT INTO signing_windows
+                       (signing_request_id, starts_at, ends_at, origin, proposed_by)
+                   VALUES (%s, %s, %s, %s, %s) RETURNING id""",
+                (me["signing_request_id"], w["starts_at"], w["ends_at"],
+                 loop.ORIGIN_NOTARY, me["id"]))
+            window_id = cur.fetchone()["id"]
+            # Posting a time IS saying she is free then. Making her then
+            # tick her own windows would be the product asking a question
+            # it already has the answer to.
+            cur.execute(
+                """INSERT INTO signing_responses (window_id, participant_id, answer)
+                   VALUES (%s, %s, %s)
+                   ON CONFLICT (window_id, participant_id) DO UPDATE
+                       SET answer = EXCLUDED.answer, asserted_at = now()""",
+                (window_id, me["id"], loop.ANSWER_AVAILABLE))
+    db.conn.commit()
+    _book_if_converged(me["signing_request_id"])
+    return token_view(token, http_request)
+
+
+@router.post("/signing/{token}/answer")
+def answer_window(token: str, payload: AnswerIn, http_request: Request):
+    """Anybody with a live token answers one window.
+
+    A signer saying yes may be the answer that books it. The notary
+    saying yes to a signer's proposal is how she accepts one.
+    """
+    me = _participant_by_token(token, http_request)
+    throttle(f"signing-answer:{token}", limit=30, window_seconds=60)
+    if payload.answer not in loop.ANSWERS:
+        raise HTTPException(status_code=400, detail="Answer must be available or unavailable")
+
+    with db.conn.cursor() as cur:
+        cur.execute("SELECT * FROM signing_windows WHERE id = %s AND "
+                    "signing_request_id = %s",
+                    (payload.window_id, me["signing_request_id"]))
+        window = cur.fetchone()
+        if not window:
+            raise HTTPException(status_code=404, detail="That time is not on this request")
+        if window["declined_at"]:
+            raise HTTPException(status_code=409, detail="That time is no longer offered")
+        cur.execute(
+            """INSERT INTO signing_responses (window_id, participant_id, answer)
+               VALUES (%s, %s, %s)
+               ON CONFLICT (window_id, participant_id) DO UPDATE
+                   SET answer = EXCLUDED.answer, asserted_at = now()""",
+            (payload.window_id, me["id"], payload.answer))
+    db.conn.commit()
+    _book_if_converged(me["signing_request_id"])
+    return token_view(token, http_request)
+
+
+@router.post("/signing/{token}/propose")
+def signer_propose(token: str, payload: ProposeIn, http_request: Request):
+    """A signer offers a time the notary did not.
+
+    THIS CREATES A PROPOSAL, NOT A BOOKING (owner ruling). It lands as a
+    window the notary must accept — she answers `available` on it, which
+    may immediately converge — or decline.
+    """
+    me = _participant_by_token(token, http_request)
+    if me["party_role"] != loop.ROLE_SIGNER:
+        raise HTTPException(status_code=403,
+                            detail="The notary posts availability rather than proposing")
+    throttle(f"signing-propose:{token}", limit=10, window_seconds=3600)
+
+    world = _load(me["signing_request_id"])
+    req = world["request"]
+    if req.get("booked_at"):
+        raise HTTPException(status_code=409, detail="A time is already agreed")
+
+    used = int(req.get("signer_proposals") or 0)
+    if used >= loop.MAX_SIGNER_PROPOSALS:
+        # The honest refusal, naming the officer (owner ruling). An
+        # unbounded thread is how a scheduling tool becomes a chat app,
+        # and the graceful degradation is the phone call that works.
+        raise HTTPException(
+            status_code=409,
+            detail=loop.proposal_refusal(world["officer"].get("full_name")))
+
+    try:
+        parsed = loop.parse_window(payload.model_dump())
+    except loop.SigningLoopError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    with db.conn.cursor() as cur:
+        cur.execute(
+            """INSERT INTO signing_windows
+                   (signing_request_id, starts_at, ends_at, origin, proposed_by)
+               VALUES (%s, %s, %s, %s, %s) RETURNING id""",
+            (me["signing_request_id"], parsed["starts_at"], parsed["ends_at"],
+             loop.ORIGIN_SIGNER_PROPOSAL, me["id"]))
+        window_id = cur.fetchone()["id"]
+        cur.execute(
+            """INSERT INTO signing_responses (window_id, participant_id, answer)
+               VALUES (%s, %s, %s)""",
+            (window_id, me["id"], loop.ANSWER_AVAILABLE))
+        cur.execute("UPDATE signing_requests SET signer_proposals = signer_proposals + 1, "
+                    "updated_at = now() WHERE id = %s", (me["signing_request_id"],))
+    db.conn.commit()
+    return token_view(token, http_request)
+
+
+@router.post("/signing/{token}/decline/{window_id}")
+def notary_decline(token: str, window_id: int, http_request: Request):
+    """The notary declines a signer's proposal. Notary-only."""
+    me = _participant_by_token(token, http_request)
+    if me["party_role"] != loop.ROLE_NOTARY:
+        raise HTTPException(status_code=403, detail="Only the notary declines a proposal")
+    with db.conn.cursor() as cur:
+        cur.execute("""UPDATE signing_windows SET declined_at = now()
+                        WHERE id = %s AND signing_request_id = %s
+                          AND origin = %s AND declined_at IS NULL""",
+                    (window_id, me["signing_request_id"], loop.ORIGIN_SIGNER_PROPOSAL))
+    db.conn.commit()
+    return token_view(token, http_request)
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Convergence
+# ══════════════════════════════════════════════════════════════════════
+
+def _book_if_converged(request_id: int) -> Optional[int]:
+    """Check after every answer, and write the booking ONCE.
+
+    `WHERE booked_at IS NULL` is the guard, exactly like T-5's
+    supersession pointer: two final answers arriving together must not
+    produce two bookings, and the loser of that race is a no-op rather
+    than an error — both parties did say yes.
+
+    Nothing here marks anything completed. §13: the parties agreed a
+    time; whether they kept it is not something this system knows.
+    """
+    world = _load(request_id)
+    if world["request"].get("booked_at") or world["request"].get("cancelled_at"):
+        return None
+    window_id = loop.converged_window_id(
+        world["participants"], world["windows"], world["responses"])
+    if window_id is None:
+        return None
+    window = next(w for w in world["windows"] if int(w["id"]) == window_id)
+    with db.conn.cursor() as cur:
+        cur.execute("""UPDATE signing_requests
+                          SET booked_at = %s, booked_by = %s,
+                              booked_asserted_at = now(), updated_at = now()
+                        WHERE id = %s AND booked_at IS NULL
+                    RETURNING id""",
+                    (window["starts_at"], loop.BOOKED_BY_CONVERGENCE, request_id))
+        won = cur.fetchone()
+    db.conn.commit()
+    if not won:
+        return None
+    _tell_everyone(request_id)
+    return window_id
+
+
+def _tell_everyone(request_id: int) -> None:
+    """The in-app record first, then the emails. E1's ordering.
+
+    Best-effort and never fatal: a booking that happened must not be
+    undone because a mail server was slow.
+    """
+    try:
+        world = _load(request_id)
+        from utils.notifications import create_notification
+        create_notification(
+            db.conn,
+            user_id=world["request"]["officer_user_id"],
+            ntype="signing_booked",
+            title="Signing time agreed",
+            message=loop.state_label(world["request"], world["windows"],
+                                     world["responses"], world["participants"]),
+            link=f"/signings?focus={request_id}",
+        )
+    except Exception as e:
+        try:
+            db.conn.rollback()
+        except Exception:
+            pass
+        print(f"[NOTARY2] ⚠️ booking notification failed (non-blocking): {e}")

--- a/backend/tests/snapshots/openapi_routes.json
+++ b/backend/tests/snapshots/openapi_routes.json
@@ -285,6 +285,18 @@
  ],
  [
   "GET",
+  "/signing-requests/v2"
+ ],
+ [
+  "GET",
+  "/signing-requests/v2/{request_id}"
+ ],
+ [
+  "GET",
+  "/signing/{token}"
+ ],
+ [
+  "GET",
   "/usage/limit-check/user/{user_id}"
  ],
  [
@@ -462,6 +474,34 @@
  [
   "POST",
   "/signing-requests"
+ ],
+ [
+  "POST",
+  "/signing-requests/v2"
+ ],
+ [
+  "POST",
+  "/signing-requests/v2/{request_id}/cancel"
+ ],
+ [
+  "POST",
+  "/signing-requests/v2/{request_id}/override"
+ ],
+ [
+  "POST",
+  "/signing/{token}/answer"
+ ],
+ [
+  "POST",
+  "/signing/{token}/decline/{window_id}"
+ ],
+ [
+  "POST",
+  "/signing/{token}/propose"
+ ],
+ [
+  "POST",
+  "/signing/{token}/windows"
  ],
  [
   "POST",

--- a/backend/tests/test_db_row_contract.py
+++ b/backend/tests/test_db_row_contract.py
@@ -18,6 +18,7 @@ These tests are CI-safe (no database) except where marked.
 """
 import inspect
 import os
+import ast
 import re
 from pathlib import Path
 
@@ -159,13 +160,38 @@ def test_row_type_serialises_as_a_json_object():
 def test_rows_are_never_returned_raw_from_an_endpoint():
     """Belt to the braces above: even with a dict-subclass row type,
     handing raw rows to the client leaks column layout into the API
-    contract. Kept, and widened to catch the assign-then-return form
-    that the original pattern list missed."""
+    contract.
+
+    NARROWED TO WHAT THE NAME ALREADY SAID — an ENDPOINT. The previous
+    version scanned each router file as one blob, so any occurrence of
+    the shape anywhere in the file was an offence, including in a private
+    loader whose output is fed to an explicit payload builder and never
+    reaches a client. NOTARY2's `_rows()` is exactly that, and the pin
+    flagged it.
+
+    Two ways to answer a false positive: change the code so the string
+    stops matching, or make the pin match the property. The first is
+    gaming a test; a helper renamed to dodge a regex is the same helper.
+    So the pin now walks the AST and checks only functions carrying a
+    route decorator — which is what "from an endpoint" meant all along,
+    and still catches the real case: a handler returning rows straight to
+    the client. Probed both ways before this was committed.
+    """
     offenders = []
     for path in (BACKEND / "routers").rglob("*.py"):
-        src = code_only(path.read_text(encoding="utf-8", errors="ignore"))
-        for pattern in [r"return\s+cur(?:sor)?\.fetch(?:one|all)\(\)",
-                        r"return\s+\[?\s*dict\(r\)\s+for", ]:
-            if re.search(pattern, src):
-                offenders.append(str(path.relative_to(BACKEND)))
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8", errors="ignore"))
+        except SyntaxError:
+            continue
+        for fn in ast.walk(tree):
+            if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            decorators = " ".join(ast.unparse(d) for d in fn.decorator_list)
+            if not re.search(r"\b(router|app)\.(get|post|put|patch|delete)\b", decorators):
+                continue
+            body = ast.unparse(fn)
+            for pattern in [r"return\s+cur(?:sor)?\.fetch(?:one|all)\(\)",
+                            r"return\s+\[?\s*dict\(\w+\)\s+for", ]:
+                if re.search(pattern, body):
+                    offenders.append(f"{path.relative_to(BACKEND)}::{fn.name}")
     assert offenders == [], f"raw row returned to the client in: {offenders}"

--- a/backend/tests/test_notary2_routes.py
+++ b/backend/tests/test_notary2_routes.py
@@ -1,0 +1,408 @@
+"""NOTARY2 — the loop, driven end to end over HTTP.
+
+The service suite proves the RULES. This proves the WIRING, and the
+distinction has cost this codebase real defects: A1 shipped three
+never-run bugs because the only tests bypassed HTTP and the database, and
+NOTARY1's `_ConnectionProxy` defect was invisible until CI ran the
+no-database job. So this drives the real app against a real Postgres.
+
+The scenario every test builds on: an officer creates a request for one
+notary and two signers, the notary posts times, the signers answer, and
+somewhere in there it either books or does not.
+"""
+import os
+import sys
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+BACKEND = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(BACKEND))
+
+from services import signing_loop as loop  # noqa: E402
+
+pytestmark = pytest.mark.skipif(not os.getenv("DATABASE_URL"),
+                                reason="needs a database")
+
+
+@pytest.fixture(autouse=True)
+def clear_throttle():
+    """The token routes are throttled, and the buckets are process-global.
+
+    Without this, a suite that drives forty token calls trips its own
+    rate limit and the failure looks like a routing bug. The persistent-
+    state lesson, one layer up: in-memory state survives between TESTS
+    the way a table survives between RUNS.
+    """
+    from utils import throttle
+    throttle.reset()
+    yield
+    throttle.reset()
+
+
+@pytest.fixture
+def world():
+    import psycopg2
+    from database import create_tables
+    from db_rows import ROW_FACTORY
+    create_tables()
+    conn = psycopg2.connect(os.environ["DATABASE_URL"], cursor_factory=ROW_FACTORY)
+    conn.autocommit = True
+    tag = uuid.uuid4().hex[:8]
+    with conn.cursor() as cur:
+        cur.execute("INSERT INTO users (email, password_hash, full_name, role) "
+                    "VALUES (%s, 'x', 'Dana Reyes', 'user') RETURNING id",
+                    (f"dana-{tag}@n2.test",))
+        officer = cur.fetchone()["id"]
+        cur.execute("INSERT INTO users (email, password_hash, full_name, role) "
+                    "VALUES (%s, 'x', 'Stranger', 'user') RETURNING id",
+                    (f"stranger-{tag}@n2.test",))
+        stranger = cur.fetchone()["id"]
+        cur.execute("""INSERT INTO deeds (user_id, deed_type, property_address, apn,
+                                          grantor_name, grantee_name, county, status)
+                       VALUES (%s, 'grant_deed', '9 Private Way, Los Angeles, CA 90017',
+                               '1234-567-890', 'PRIVATE GRANTOR', 'PRIVATE GRANTEE',
+                               'Los Angeles', 'completed') RETURNING id""", (officer,))
+        deed = cur.fetchone()["id"]
+    yield {"officer": officer, "stranger": stranger, "deed": deed,
+           "conn": conn, "tag": tag}
+    conn.close()
+
+
+def client_for(user_id: int):
+    from fastapi.testclient import TestClient
+    from auth import create_access_token
+    from main import app
+    c = TestClient(app)
+    c.headers.update({
+        "Authorization": f"Bearer {create_access_token({'sub': str(user_id), 'email': 'x@n2.test'})}"})
+    return c
+
+
+def public():
+    from fastapi.testclient import TestClient
+    from main import app
+    return TestClient(app)
+
+
+def _windows(n=2, days_out=7):
+    base = datetime.now(timezone.utc) + timedelta(days=days_out)
+    return [{"start": (base + timedelta(days=i)).isoformat(),
+             "end": (base + timedelta(days=i, hours=1)).isoformat()}
+            for i in range(n)]
+
+
+def _create(world, signers=2):
+    r = client_for(world["officer"]).post("/signing-requests/v2", json={
+        "deed_id": world["deed"],
+        "notary_email": "nora@notary.test",
+        "notary_name": "Nora Vance",
+        "notary_company": "Vance Mobile Notary",
+        "signers": [{"name": f"Signer {i}", "email": f"s{i}@example.test"}
+                    for i in range(signers)],
+    })
+    assert r.status_code == 200, r.text
+    body = r.json()
+    tokens = {}
+    for p in body["participants"]:
+        tokens.setdefault(p["party_role"], []).append(p["link"].rsplit("/", 1)[-1])
+    return body["signing_request_id"], tokens
+
+
+# ══════════════════════════════════════════════════════════════════════
+# The whole loop
+# ══════════════════════════════════════════════════════════════════════
+
+def test_notary_posts_signers_agree_and_it_books(world):
+    request_id, tokens = _create(world)
+    notary = tokens[loop.ROLE_NOTARY][0]
+    signers = tokens[loop.ROLE_SIGNER]
+    pub = public()
+
+    posted = pub.post(f"/signing/{notary}/windows", json={"windows": _windows()})
+    assert posted.status_code == 200, posted.text
+    assert posted.json()["state"] == loop.STATE_PARTIALLY_AGREED, (
+        "posting availability IS an answer — she should not have to tick her own windows")
+
+    view = pub.get(f"/signing/{signers[0]}").json()
+    assert view["party_role"] == loop.ROLE_SIGNER
+    window_id = view["windows"][0]["id"]
+
+    first = pub.post(f"/signing/{signers[0]}/answer",
+                     json={"window_id": window_id, "answer": "available"})
+    assert first.status_code == 200
+    assert first.json()["state"] != loop.STATE_BOOKED, "one signer is not everyone"
+
+    second = pub.post(f"/signing/{signers[1]}/answer",
+                      json={"window_id": window_id, "answer": "available"})
+    assert second.status_code == 200
+    assert second.json()["state"] == loop.STATE_BOOKED
+
+    with world["conn"].cursor() as cur:
+        cur.execute("SELECT booked_at, booked_by, booked_asserted_at "
+                    "FROM signing_requests WHERE id = %s", (request_id,))
+        row = cur.fetchone()
+    assert row["booked_by"] == loop.BOOKED_BY_CONVERGENCE, (
+        "the parties agreed — the record must not credit the officer")
+    assert row["booked_at"] is not None
+    assert row["booked_asserted_at"] is not None
+
+
+def test_the_officer_is_not_asked_to_approve_the_time(world):
+    """Owner ruling: she initiates and is notified; she does not gate."""
+    request_id, tokens = _create(world)
+    pub = public()
+    pub.post(f"/signing/{tokens[loop.ROLE_NOTARY][0]}/windows",
+             json={"windows": _windows()})
+    view = pub.get(f"/signing/{tokens[loop.ROLE_SIGNER][0]}").json()
+    wid = view["windows"][0]["id"]
+    for token in tokens[loop.ROLE_SIGNER]:
+        pub.post(f"/signing/{token}/answer", json={"window_id": wid, "answer": "available"})
+
+    officer = client_for(world["officer"]).get(f"/signing-requests/v2/{request_id}").json()
+    assert officer["state"] == loop.STATE_BOOKED
+    assert officer["booked_by"] == loop.BOOKED_BY_CONVERGENCE
+
+
+def test_a_signer_saying_no_does_not_book(world):
+    _, tokens = _create(world)
+    pub = public()
+    pub.post(f"/signing/{tokens[loop.ROLE_NOTARY][0]}/windows", json={"windows": _windows()})
+    wid = pub.get(f"/signing/{tokens[loop.ROLE_SIGNER][0]}").json()["windows"][0]["id"]
+    pub.post(f"/signing/{tokens[loop.ROLE_SIGNER][0]}/answer",
+             json={"window_id": wid, "answer": "available"})
+    last = pub.post(f"/signing/{tokens[loop.ROLE_SIGNER][1]}/answer",
+                    json={"window_id": wid, "answer": "unavailable"})
+    assert last.json()["state"] != loop.STATE_BOOKED
+
+
+# ══════════════════════════════════════════════════════════════════════
+# The signer surface — the first consumer surface
+# ══════════════════════════════════════════════════════════════════════
+
+def test_the_signer_view_carries_nothing_from_the_instrument(world):
+    _, tokens = _create(world)
+    pub = public()
+    pub.post(f"/signing/{tokens[loop.ROLE_NOTARY][0]}/windows", json={"windows": _windows()})
+    body = pub.get(f"/signing/{tokens[loop.ROLE_SIGNER][0]}").text
+    for secret in ("1234-567-890", "PRIVATE GRANTOR", "PRIVATE GRANTEE",
+                   "grant_deed", "Los Angeles", "90017"):
+        assert secret not in body, f"the signer surface leaked {secret!r}"
+    assert "9 Private Way" in body
+
+
+def test_the_signer_sees_the_notary_by_name_and_company_only(world):
+    _, tokens = _create(world)
+    pub = public()
+    view = pub.get(f"/signing/{tokens[loop.ROLE_SIGNER][0]}").json()
+    assert view["notary"] == {"name": "Nora Vance", "company": "Vance Mobile Notary"}
+    assert "nora@notary.test" not in pub.get(f"/signing/{tokens[loop.ROLE_SIGNER][0]}").text
+
+
+def test_one_signer_never_sees_another(world):
+    _, tokens = _create(world)
+    body = public().get(f"/signing/{tokens[loop.ROLE_SIGNER][0]}").text
+    assert "s1@example.test" not in body
+    assert "Signer 1" not in body
+
+
+def test_a_signer_cannot_post_availability(world):
+    """Posting windows is the notary's act. A route that merely hid the
+    button on her page would not be a rule."""
+    _, tokens = _create(world)
+    r = public().post(f"/signing/{tokens[loop.ROLE_SIGNER][0]}/windows",
+                      json={"windows": _windows()})
+    assert r.status_code == 403
+
+
+def test_a_notary_cannot_propose_as_though_she_were_a_signer(world):
+    _, tokens = _create(world)
+    r = public().post(f"/signing/{tokens[loop.ROLE_NOTARY][0]}/propose",
+                      json=_windows(1)[0])
+    assert r.status_code == 403
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Proposals and the cap
+# ══════════════════════════════════════════════════════════════════════
+
+def test_a_signer_proposal_is_a_proposal_not_a_booking(world):
+    """Owner ruling. A signer offering a time the notary did not must not
+    put an appointment in anybody's calendar on their own say-so."""
+    _, tokens = _create(world, signers=1)
+    pub = public()
+    pub.post(f"/signing/{tokens[loop.ROLE_NOTARY][0]}/windows", json={"windows": _windows(1)})
+    proposed = pub.post(f"/signing/{tokens[loop.ROLE_SIGNER][0]}/propose",
+                        json=_windows(1, days_out=30)[0])
+    assert proposed.status_code == 200, proposed.text
+    assert proposed.json()["state"] != loop.STATE_BOOKED
+
+    notary_view = pub.get(f"/signing/{tokens[loop.ROLE_NOTARY][0]}").json()
+    origins = [w["origin"] for w in notary_view["windows"]]
+    assert loop.ORIGIN_SIGNER_PROPOSAL in origins
+
+
+def test_the_notary_accepting_a_proposal_can_book_it(world):
+    _, tokens = _create(world, signers=1)
+    pub = public()
+    pub.post(f"/signing/{tokens[loop.ROLE_NOTARY][0]}/windows", json={"windows": _windows(1)})
+    pub.post(f"/signing/{tokens[loop.ROLE_SIGNER][0]}/propose",
+             json=_windows(1, days_out=30)[0])
+    notary_view = pub.get(f"/signing/{tokens[loop.ROLE_NOTARY][0]}").json()
+    proposal = next(w for w in notary_view["windows"]
+                    if w["origin"] == loop.ORIGIN_SIGNER_PROPOSAL)
+    accepted = pub.post(f"/signing/{tokens[loop.ROLE_NOTARY][0]}/answer",
+                        json={"window_id": proposal["id"], "answer": "available"})
+    assert accepted.json()["state"] == loop.STATE_BOOKED
+
+
+def test_a_declined_proposal_stops_being_answerable(world):
+    _, tokens = _create(world, signers=1)
+    pub = public()
+    pub.post(f"/signing/{tokens[loop.ROLE_NOTARY][0]}/windows", json={"windows": _windows(1)})
+    pub.post(f"/signing/{tokens[loop.ROLE_SIGNER][0]}/propose",
+             json=_windows(1, days_out=30)[0])
+    view = pub.get(f"/signing/{tokens[loop.ROLE_NOTARY][0]}").json()
+    proposal = next(w for w in view["windows"] if w["origin"] == loop.ORIGIN_SIGNER_PROPOSAL)
+    pub.post(f"/signing/{tokens[loop.ROLE_NOTARY][0]}/decline/{proposal['id']}")
+    again = pub.post(f"/signing/{tokens[loop.ROLE_SIGNER][0]}/answer",
+                     json={"window_id": proposal["id"], "answer": "available"})
+    assert again.status_code == 409
+
+
+def test_the_cap_is_three_and_the_refusal_names_the_officer(world):
+    """Owner ruling: three, AGGREGATE. Two signers alternating twice each
+    is six emails and the same deadlock a cap exists to prevent."""
+    _, tokens = _create(world, signers=2)
+    pub = public()
+    pub.post(f"/signing/{tokens[loop.ROLE_NOTARY][0]}/windows", json={"windows": _windows(1)})
+    # Alternating signers, to prove the cap is not per-person.
+    order = [tokens[loop.ROLE_SIGNER][0], tokens[loop.ROLE_SIGNER][1],
+             tokens[loop.ROLE_SIGNER][0]]
+    for i, token in enumerate(order):
+        r = pub.post(f"/signing/{token}/propose", json=_windows(1, days_out=30 + i)[0])
+        assert r.status_code == 200, r.text
+    refused = pub.post(f"/signing/{tokens[loop.ROLE_SIGNER][1]}/propose",
+                       json=_windows(1, days_out=60)[0])
+    assert refused.status_code == 409
+    assert "Dana Reyes" in refused.json()["detail"]
+    assert "call" in refused.json()["detail"].lower()
+
+    # And picking an existing time still works — the cap closes the
+    # negotiation, not the feature.
+    view = pub.get(f"/signing/{tokens[loop.ROLE_SIGNER][1]}").json()
+    assert view["proposals_remaining"] == 0
+    assert pub.post(f"/signing/{tokens[loop.ROLE_SIGNER][1]}/answer",
+                    json={"window_id": view["windows"][0]["id"],
+                          "answer": "available"}).status_code == 200
+
+
+# ══════════════════════════════════════════════════════════════════════
+# The officer's override
+# ══════════════════════════════════════════════════════════════════════
+
+def test_the_override_is_recorded_as_her_assertion(world):
+    request_id, tokens = _create(world)
+    officer = client_for(world["officer"])
+    when = (datetime.now(timezone.utc) + timedelta(days=14)).isoformat()
+    r = officer.post(f"/signing-requests/v2/{request_id}/override",
+                     json={"booked_at": when})
+    assert r.status_code == 200, r.text
+    assert r.json()["booked_by"] == loop.BOOKED_BY_OFFICER
+    assert "you recorded" in r.json()["summary"].lower()
+
+
+def test_the_override_refuses_a_time_without_a_zone(world):
+    """The NOTARY1 bug, closed on every path that accepts a time."""
+    request_id, _ = _create(world)
+    r = client_for(world["officer"]).post(
+        f"/signing-requests/v2/{request_id}/override",
+        json={"booked_at": "2026-09-01T10:00:00"})
+    assert r.status_code == 400
+    assert "offset" in r.json()["detail"].lower()
+
+
+def test_the_officer_can_correct_a_booking_the_parties_made(world):
+    """Convergence writes once and never argues with itself; an override
+    is the officer CORRECTING the record, including a booking that
+    already exists. The record keeps which is which."""
+    request_id, tokens = _create(world)
+    pub = public()
+    pub.post(f"/signing/{tokens[loop.ROLE_NOTARY][0]}/windows", json={"windows": _windows()})
+    wid = pub.get(f"/signing/{tokens[loop.ROLE_SIGNER][0]}").json()["windows"][0]["id"]
+    for token in tokens[loop.ROLE_SIGNER]:
+        pub.post(f"/signing/{token}/answer", json={"window_id": wid, "answer": "available"})
+
+    officer = client_for(world["officer"])
+    assert officer.get(f"/signing-requests/v2/{request_id}").json()["booked_by"] == \
+        loop.BOOKED_BY_CONVERGENCE
+    when = (datetime.now(timezone.utc) + timedelta(days=20)).isoformat()
+    r = officer.post(f"/signing-requests/v2/{request_id}/override", json={"booked_at": when})
+    assert r.json()["booked_by"] == loop.BOOKED_BY_OFFICER
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Authorization and link lifecycle
+# ══════════════════════════════════════════════════════════════════════
+
+def test_a_stranger_cannot_create_a_request_on_someone_elses_deed(world):
+    r = client_for(world["stranger"]).post("/signing-requests/v2", json={
+        "deed_id": world["deed"], "notary_email": "n@x.test",
+        "signers": [{"name": "S", "email": "s@x.test"}]})
+    assert r.status_code == 404
+
+
+def test_a_stranger_cannot_read_or_override_someone_elses_request(world):
+    request_id, _ = _create(world)
+    stranger = client_for(world["stranger"])
+    assert stranger.get(f"/signing-requests/v2/{request_id}").status_code == 404
+    assert stranger.post(f"/signing-requests/v2/{request_id}/override",
+                         json={"booked_at": datetime.now(timezone.utc).isoformat()}
+                         ).status_code == 404
+
+
+def test_a_malformed_token_is_refused_before_postgres_sees_it(world):
+    """`token` is a UUID column: a malformed value is a TYPE ERROR, not a
+    miss, and on the shared connection it aborts the request."""
+    for bad in ("not-a-token", "1 OR 1=1", "../../etc/passwd"):
+        assert public().get(f"/signing/{bad}").status_code == 404
+
+
+def test_cancelling_withdraws_every_link(world):
+    request_id, tokens = _create(world)
+    client_for(world["officer"]).post(f"/signing-requests/v2/{request_id}/cancel")
+    pub = public()
+    for role_tokens in tokens.values():
+        for token in role_tokens:
+            assert pub.get(f"/signing/{token}").status_code == 403
+
+
+def test_an_expired_link_stops_answering(world):
+    request_id, tokens = _create(world)
+    with world["conn"].cursor() as cur:
+        cur.execute("UPDATE signing_participants SET expires_at = now() - interval '1 day' "
+                    "WHERE signing_request_id = %s", (request_id,))
+    pub = public()
+    token = tokens[loop.ROLE_SIGNER][0]
+    assert pub.get(f"/signing/{token}").status_code == 410
+    assert pub.post(f"/signing/{token}/answer",
+                    json={"window_id": 1, "answer": "available"}).status_code == 410
+
+
+def test_the_agenda_lists_signings_across_files(world):
+    """Part D, as an agenda rather than a month grid (owner-accepted cut)."""
+    request_id, _ = _create(world)
+    rows = client_for(world["officer"]).get("/signing-requests/v2").json()
+    mine = [r for r in rows if r["id"] == request_id]
+    assert mine, "the officer's own signing is missing from her agenda"
+    assert mine[0]["property_address"]
+    assert mine[0]["summary"], "no status line"
+    assert mine[0]["signers"] == 2
+
+
+def test_the_agenda_shows_only_her_own(world):
+    request_id, _ = _create(world)
+    rows = client_for(world["stranger"]).get("/signing-requests/v2").json()
+    assert all(r["id"] != request_id for r in rows)


### PR DESCRIPTION
The wiring for #149's rules. Ten routes, 22 HTTP tests driving the real app against a real Postgres — the service suite proves the *rules*, only this proves the *wiring*, and that distinction has cost this codebase real defects (A1 shipped three never-run bugs whose only tests bypassed HTTP and the database).

Branched off `main` after #149 merged, per the no-stacking rule.

## Who may do what — as rules, not hidden buttons

The officer creates, watches, and may override. She **does not gate the final time**: notary + signers converging books it and she's told. Her override writes `booked_by = 'officer'` so the record never claims the parties agreed to a time she chose alone.

One deliberate asymmetry worth flagging: **the override has no `WHERE booked_at IS NULL` guard** while convergence does. Convergence writes once and never argues with itself; an override is the officer *correcting* the record, including a booking that already exists. Different verbs, different guards.

The notary posts availability; a signer can't. A signer proposes; the notary can't. Both refusals are 403s from the server. And **posting a window is answering it** — making her tick her own times would be the product asking a question it already has the answer to.

## The cap, and the honest refusal

Three proposals, **aggregate**. The test alternates two signers to prove it isn't per-person — two people alternating twice each is six emails and the same deadlock. At the cap the refusal names the officer and says she'll call, and **picking an existing time still works**: the cap closes the negotiation, not the feature.

## Every token route is throttled

Per-token and per-IP, *before* the database is touched. These are consumers' addresses now, and an enumerable token is a property address disclosed. UUID guard per NOTARY1's reasoning: a malformed token is a Postgres type error, not a miss, and on the shared connection it poisons the request.

## Part D ships as an agenda

`GET /signing-requests/v2` — every signing across every file, soonest first, carrying the server's own status sentence. No month grid, no new state, no availability engine, per your accepted cut.

The purge sweep rides **this** route rather than a token route: the officer's own authenticated page is a fine place to spend 20ms of housekeeping, a consumer's token view is not.

## A pin narrowed to what its name already said

`test_rows_are_never_returned_raw_from_an_endpoint` scanned each router file as one blob, so the shape *anywhere* in the file was an offence — including in a private loader feeding an explicit payload builder, which is what NOTARY2's `_rows()` is.

Two ways to answer a false positive: change the code so the string stops matching, or make the pin match the property. **The first is gaming a test** — a helper renamed to dodge a regex is the same helper. So the pin now walks the AST and checks only functions carrying a route decorator, which is what "from an endpoint" meant all along. Probed both ways: it still catches a handler returning rows raw, and it now names the function instead of the file.

## Gates

| gate | result |
|---|---|
| pytest, no database | 824 passed, 134 skipped |
| pytest, with database | 958 passed |
| jest | 632 passed |
| tsc | 94 (unchanged) |
| six-flow / API baselines | ✔ ✔ |
| banned-claims | clean |
| OpenAPI | re-recorded — 10 added, 0 removed |

Three mutation probes, all biting: letting one signer book it, making the cap per-signer, leaking the APN to a signer.

## Remaining for Part C

The officer's multi-signer create UI, the three token pages, five email templates + `.ics` to everyone, reminders, and the NOTARY1 → NOTARY2 migration. Backend loop is now complete and provable end to end; what's left is surfaces and delivery.

## One thing for you

**`build-and-test` flaked on #149 with `NextFontError: Failed to fetch 'Inter' from Google Fonts`.** Not a diff problem — the same job passed twenty minutes earlier on identical frontend code, and a re-run went green. But the build fetches the font from Google at build time with no local fallback, so this will keep happening. Fixing it means vendoring the font via `next/font/local`. Out of scope here and I haven't touched it — flagging so it doesn't read as random CI noise the third time.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_