### PR TITLE
docs: the purge cron's deployment, and two standing rules it produced

### DIFF
--- a/docs/EXECUTION_POLICY.md
+++ b/docs/EXECUTION_POLICY.md
@@ -95,6 +95,30 @@ imports, not the set of files that exist.** When the import graph grows,
 re-run the sweeps against the new graph rather than assuming the last
 green run still describes the product.
 
+## Deployed services
+
+Both rules below are owner-set, from the purge cron's four-failure
+deployment (2026-08-11; full account in `OWNER_LEDGER.md`).
+
+**Every Render service pins `PYTHON_VERSION` explicitly.** Not only the
+ones that have broken. A service without an explicit version inherits
+whatever Render's default is on the day it builds, so the runtime can
+change under a service nobody touched — which is how the cron's first
+build died compiling Rust for a `pydantic_core` with no 3.14 wheel.
+
+**Any service handed a `DATABASE_URL` is verified against the API's
+before it is trusted.** Compare `current_database()`, host and port from
+both sides. A connection that SUCCEEDS tells you nothing about whether it
+is the right database: the cron connected happily to a second, older
+Postgres in the same account and reported a missing table. "Table does
+not exist" and "you are looking at the wrong server" produce the same
+error message, and the first reading is the one that wastes an afternoon.
+
+Corollary for anything with a specific table to find: assert it at
+startup and NAME THE DATABASE in the failure. "signing_participants not
+found in deedpro_database on dpg-d1vb…" ends the investigation in one
+run; "relation does not exist" starts a schema hunt.
+
 ## Pull requests and stacking
 
 **A squash-merged base does not carry its stack.** Stacking PR B on PR

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -532,12 +532,18 @@ rows that SHOULD be purged and are not.
 
 **The four failures, in order, because each one is a different lesson:**
 
-1. **Python 3.14.** Render defaulted the new service to 3.14, where
-   `pydantic_core` has no wheel and the build died compiling Rust. Fixed
-   by pinning `PYTHON_VERSION` to match the main API.
-2. **Internal hostname did not resolve.** The internal Postgres hostname
-   works from a web service and not from a cron service. Fixed with the
-   External Database URL.
+1. **Python 3.14.** Render defaults a NEW service to the newest Python,
+   where `pydantic_core` has no wheel — so pip falls back to building
+   from source, and the Rust build then fails on a read-only filesystem.
+   Two independent reasons it cannot work, which is why the error is
+   confusing: the first line blames Rust and the last blames permissions.
+   Fixed by pinning `PYTHON_VERSION` **to match `deedpro-main-api`** —
+   matching the API specifically, not merely pinning something, because
+   a cron running a different interpreter than the API it shares a
+   codebase with is a second class of bug waiting.
+2. **Internal hostname did not resolve.** Render's internal Postgres
+   hostname resolves from a web service and NOT from a cron service. The
+   External Database URL is required for cron.
 3. **`signing_participants` missing.** Read as "the schema has not
    converged," which was wrong — the table was missing because of (4).
 4. **THE REAL ONE: the external URL pointed at a DIFFERENT DATABASE.**

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -517,3 +517,87 @@ we reach it.
   derives from it, and a pin fails if any surface grows its own list.
   `QuickAddPartnerModal` had no importers at the time; it was aligned
   anyway rather than left dead, because NOTARY2 Part B revives it.
+
+## Purge cron — deployed 2026-08-11, after four sequential failures
+
+The NOTARY2 signer-contact purge now runs on a Render Cron Job. Owner
+ruling 3's hard requirement is **met**: the cron exists before the first
+real signer email, which matters because the privacy statement will name
+a retention window and that converts the practice into a promise.
+
+Current state: **green — "purged contact details on 0 participant rows."**
+Zero is the correct answer today; there are no signing requests old
+enough to purge. The number to watch is `--status`'s `overdue`, which is
+rows that SHOULD be purged and are not.
+
+**The four failures, in order, because each one is a different lesson:**
+
+1. **Python 3.14.** Render defaulted the new service to 3.14, where
+   `pydantic_core` has no wheel and the build died compiling Rust. Fixed
+   by pinning `PYTHON_VERSION` to match the main API.
+2. **Internal hostname did not resolve.** The internal Postgres hostname
+   works from a web service and not from a cron service. Fixed with the
+   External Database URL.
+3. **`signing_participants` missing.** Read as "the schema has not
+   converged," which was wrong — the table was missing because of (4).
+4. **THE REAL ONE: the external URL pointed at a DIFFERENT DATABASE.**
+   `deedpro_database` on `dpg-d1vbos95pdvs73d2lvng`, not the API's
+   `deedpro` on `dpg-d208q5umcj7s73as68g0`. The cron had been connecting
+   successfully, to the wrong Postgres, and reporting a missing table.
+
+Failure 3 is the one worth sitting with. **A connection that succeeds
+tells you nothing about whether it is the right database.** "Table does
+not exist" and "you are looking at the wrong server" are the same error
+message, and the first reading is the one that wastes an afternoon.
+
+### Standing rule 1 — every Render service pins `PYTHON_VERSION`
+
+Not "the ones that have broken." A service without an explicit version
+inherits whatever Render's default happens to be on the day it builds,
+which means the runtime can change under a service that nobody touched.
+
+**Open item:** `render.yaml` in this repo pins `PYTHON_VERSION` for
+**nothing** — the main API included. Either the deployed services are
+configured in the Render dashboard and `render.yaml` is no longer
+authoritative (in which case the file is misleading and should say so),
+or it is authoritative and the main API has exactly the exposure the cron
+just demonstrated. Worth resolving; it is a deploy-topology question and
+therefore Tier 3.
+
+### Standing rule 2 — a `DATABASE_URL` is verified before it is trusted
+
+Any service handed a `DATABASE_URL` must be checked against the API's
+own, by identity rather than by the connection succeeding:
+
+```sql
+SELECT current_database(), inet_server_addr(), inet_server_port(),
+       current_setting('server_version');
+```
+
+Run it from the new service and from the API, and compare. A matching
+`current_database()` on a different host is still the wrong database —
+two instances can carry the same database name, and in this account they
+nearly did.
+
+The cheap version, for a service whose job involves a specific table:
+have the service assert the table exists at startup and say WHICH
+database it looked in when it does not. "signing_participants not found
+in deedpro_database on dpg-d1vb…" would have ended this in one run.
+
+### Owner item — a second Postgres instance exists in the account
+
+`deedpro_database` on `dpg-d1vbos95pdvs73d2lvng` is not the API's
+database and nothing in this repo references it. It may be a
+pre-engagement fossil. **Owner investigating.**
+
+Same class as the `deedpro-external-api` ghost service (deleted
+2026-08-03): infrastructure that exists, costs money, answers when
+something connects to it, and corresponds to no code. The pattern is
+worth naming — a ghost service returns 401s and a ghost database returns
+"table does not exist," and both look like bugs in the thing that found
+them rather than what they are.
+
+**Do not delete it on our say-so.** A database that might hold real rows
+from before this engagement is Tier 3 twice over: irreversible, and
+possibly somebody's data. The useful next step is read-only — list its
+tables and row counts — and that is the owner's to run.


### PR DESCRIPTION
Docs only — `OWNER_LEDGER.md` and `EXECUTION_POLICY.md`. No code.

**The purge cron is deployed and green.** Owner ruling 3's hard requirement is met: it exists before the first real signer email, which is the point at which the privacy statement's stated window converts the practice into a promise.

"Purged 0 participant rows" is the correct answer today — nothing is old enough. The number worth watching is `--status`'s `overdue`: rows that *should* be purged and aren't.

## The four failures, recorded because each is a different lesson

1. Render defaulted to **Python 3.14**, where `pydantic_core` has no wheel and the build died compiling Rust.
2. The **internal Postgres hostname doesn't resolve from a cron service** — it works from a web service.
3. **`signing_participants` missing** — read as "the schema hasn't converged," which was wrong.
4. **The real one:** the External Database URL pointed at a *different Postgres*. `deedpro_database` on `dpg-d1vbos95…`, not the API's `deedpro` on `dpg-d208q5um…`.

Number 3 is the one I'd want anyone reading this to sit with:

> **A connection that succeeds tells you nothing about whether it's the right database.** "Table does not exist" and "you are looking at the wrong server" are the same error message, and the first reading is the one that wastes an afternoon.

## The two standing rules

**Every Render service pins `PYTHON_VERSION` explicitly** — not only the ones that have broken. An unpinned service inherits whatever Render's default is the day it builds, so the runtime can change under a service nobody touched.

**Any service handed a `DATABASE_URL` is verified against the API's** by identity (`current_database()`, host, port) rather than by the connection succeeding. Both sides, compared. A matching database *name* on a different host is still the wrong database — two instances can carry the same name, and in this account they nearly did.

Corollary I'd add for the next service like this: have it assert its table at startup and **name the database in the failure**. `signing_participants not found in deedpro_database on dpg-d1vb…` ends the investigation in one run; `relation does not exist` starts a schema hunt.

## One open item I flagged rather than fixed

**`render.yaml` in this repo pins `PYTHON_VERSION` for nothing — the main API included.** So either:

- the deployed services are configured in the Render dashboard and `render.yaml` is no longer authoritative, in which case the file is actively misleading about what's deployed; or
- it *is* authoritative, and the main API has exactly the exposure the cron just demonstrated — one Render default bump from the same build failure.

Deploy topology is Tier 3, so it's recorded rather than changed. But it's worth resolving either way, because a config file that doesn't describe production is worse than no config file.

## Owner item — the second Postgres

`deedpro_database` on `dpg-d1vbos95…` is referenced by no code in this repo. Filed in the same class as the `deedpro-external-api` ghost service you deleted on 2026-08-03 — infrastructure that exists, costs money, answers when something connects to it, and corresponds to nothing.

The pattern is worth naming: **a ghost service returns 401s and a ghost database returns "table does not exist."** Both look like bugs in whatever found them rather than what they are.

Recorded explicitly as **not to be deleted on our say-so.** A database that might hold real rows from before this engagement is Tier 3 twice over — irreversible, and possibly somebody's data. The useful next step is a read-only inventory (tables and row counts), and that's yours to run.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_