### PR TITLE
NOTARY2 (3/n): the surfaces — a consumer page, a professional one, and the agenda

### DIFF
--- a/frontend/src/__tests__/routeGuards.test.ts
+++ b/frontend/src/__tests__/routeGuards.test.ts
@@ -26,6 +26,17 @@ const PUBLIC_ROUTES = new Set([
   '/verify-email',
   '/verify/[code]', // public QR verification of recorded deeds
   '/approve/[token]', // public share-approval flow (token IS the auth)
+  // NOTARY2. The token IS the auth, as with /approve — but this one is
+  // different in kind and the difference is worth writing down: it is
+  // the FIRST CONSUMER SURFACE in this product. Everyone who has ever
+  // seen a DeedPro screen has been a professional under an engagement; a
+  // signer is a member of the public who got a text about their own
+  // house. It is unauthenticated by design (they have no account and
+  // must never need one), throttled per-token and per-IP server-side,
+  // and its payload is an allowlist pinned by exact key-set equality —
+  // see services/signing_surfaces.py. Being on this list is a decision,
+  // not an oversight.
+  '/signing/[token]',
   '/api-key-request', // partner lead form
   // A4: developer documentation. Public and indexable by ruling —
   // linked from the footer only while key issuance is manual, so it is

--- a/frontend/src/__tests__/shareEntryPoints.test.ts
+++ b/frontend/src/__tests__/shareEntryPoints.test.ts
@@ -49,7 +49,11 @@ describe('Part B — two distinct actions on the deed', () => {
     expect(PAGE).toContain('setReviewDeedId(deed.id)');
     expect(PAGE).toContain('setSigningDeedId(deed.id)');
     expect(PAGE).toContain('<ShareForReviewModal');
-    expect(PAGE).toContain('<SigningRequestModal');
+    // NOTARY2 replaced SigningRequestModal (officer proposes windows)
+    // with RequestSigningModal (the notary posts them) — §13.1's reversal
+    // reaching the surface. The PROPERTY is unchanged: this button opens
+    // the signing flow and the other opens the review flow.
+    expect(PAGE).toContain('<RequestSigningModal');
   });
 
   it('the old inline share modal is deleted, not kept alongside', () => {

--- a/frontend/src/__tests__/signerSurface.test.ts
+++ b/frontend/src/__tests__/signerSurface.test.ts
@@ -1,0 +1,155 @@
+/**
+ * NOTARY2 — the design constraints on the last major surfaces.
+ *
+ * The backend pins WHAT reaches each party (allowlists, key-set
+ * equality). These pin HOW it reads, because the signer page is the only
+ * screen a non-professional will ever see and it represents the officer
+ * to her own client. A leak is a bug; the wrong register is a different
+ * kind of failure and it has no test unless somebody writes one.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
+
+const SRC = path.join(__dirname, '..');
+const read = (...p: string[]) => fs.readFileSync(path.join(SRC, ...p), 'utf8');
+const flat = (s: string) => s.replace(/\s+/g, ' ');
+
+const TOKEN_PAGE = read('app', 'signing', '[token]', 'page.tsx');
+const CREATE = read('features', 'signing', 'RequestSigningModal.tsx');
+const AGENDA = read('app', 'signings', 'page.tsx');
+
+describe('the signer page speaks to a person, not to the industry', () => {
+  it('uses no jargon a buyer would have to look up', () => {
+    // The PROPERTY: words that belong to the trade. A consumer reading
+    // "notarial execution" about their own house learns nothing and
+    // trusts us less.
+    const code = codeOnly(TOKEN_PAGE).toLowerCase();
+    for (const jargon of ['notarial execution', 'notarial act', 'grantor', 'grantee',
+                          'vesting', 'apn', 'legal description', 'instrument',
+                          'conveyance', 'execute the deed']) {
+      expect(code).not.toContain(jargon);
+    }
+  });
+
+  it('leads with the officer, not with us', () => {
+    // She is who this person trusts. A product that puts its own name
+    // above hers is borrowing her relationship with her own client.
+    const header = TOKEN_PAGE.slice(TOKEN_PAGE.indexOf('function SignerView'));
+    const officerAt = header.indexOf('A message from');
+    const brandAt = header.indexOf('DeedPro');
+    expect(officerAt).toBeGreaterThan(-1);
+    expect(brandAt === -1 || officerAt < brandAt).toBe(true);
+  });
+
+  it('names DeedPro once, quietly, in the footer', () => {
+    expect(flat(TOKEN_PAGE)).toContain('Scheduling by DeedPro');
+    expect((TOKEN_PAGE.match(/DeedPro/g) || []).length).toBe(1);
+  });
+
+  it('is mobile-first: one column, full-width taps, no table', () => {
+    expect(TOKEN_PAGE).toContain('max-w-lg mx-auto');
+    expect(TOKEN_PAGE).toContain('w-full flex items-center justify-between');
+    expect(codeOnly(TOKEN_PAGE)).not.toContain('<table');
+  });
+
+  it('sends the signer back to the officer for anything else', () => {
+    expect(flat(TOKEN_PAGE)).toContain('Questions about the paperwork? Ask {who}');
+  });
+});
+
+describe('no surface composes its own account of a scheduling state', () => {
+  // §13 rule 3. `summary` is the server's sentence; these render it.
+  for (const [name, src] of [['token page', TOKEN_PAGE], ['agenda', AGENDA]] as const) {
+    it(`${name} renders the server's summary verbatim`, () => {
+      expect(src).toContain('summary}');
+      const code = codeOnly(src);
+      expect(code).not.toMatch(/scheduled for/i);
+      expect(code).not.toMatch(/will (happen|take place|be signed)/i);
+    });
+  }
+
+  it('no surface formats a date itself', () => {
+    // Every time shown is the server's label, rendered in the REQUEST's
+    // timezone. A second formatter is a second chance to print the wrong
+    // hour, and the wrong hour is somebody at an empty office.
+    for (const src of [TOKEN_PAGE, AGENDA]) {
+      const code = codeOnly(src);
+      expect(code).not.toContain('toLocaleTimeString');
+      expect(code).not.toContain('toLocaleDateString');
+    }
+  });
+
+  it('times sent to the server carry their offset', () => {
+    // #149's parse_window REFUSES a naive time rather than guessing.
+    expect(TOKEN_PAGE).toContain('getTimezoneOffset');
+    expect(TOKEN_PAGE).toContain('withOffset(start)');
+    expect(TOKEN_PAGE).toContain('withOffset(r.start)');
+  });
+});
+
+describe('the officer create flow asks the right questions', () => {
+  it('picks the notary from her rolodex', () => {
+    expect(CREATE).toContain('PartnerRecipientPicker');
+    expect(CREATE).toContain('suggestCategory="notary"');
+  });
+
+  it('does not ask her for times', () => {
+    // NOTARY1 made her propose windows because the notary had no way to
+    // speak. §13.1 reversed that; asking anyway would be asking her to do
+    // the work the reversal removed. The field is GONE, not optional.
+    const code = codeOnly(CREATE);
+    expect(code).not.toContain('proposed_windows');
+    expect(code).not.toContain('datetime-local');
+  });
+
+  it('defaults the location and the timezone rather than leaving blanks', () => {
+    expect(CREATE).toContain('propertyAddress || ');
+    expect(CREATE).toContain("id: 'America/Los_Angeles'");
+  });
+
+  it('tells her what happens to her signers details', () => {
+    // She is about to type somebody else's client's email into a product
+    // they have never heard of. §13.1's promise, in her words.
+    const text = flat(CREATE);
+    expect(text).toContain('kept on this request only');
+    expect(text).toContain('deleted automatically');
+  });
+
+  it('seeds signer rows from names only', () => {
+    expect(CREATE).toContain('suggestedSigners');
+    expect(codeOnly(CREATE)).not.toMatch(/suggested\w*(Email|Phone)/i);
+  });
+});
+
+describe('the agenda leads with what is stuck', () => {
+  it('counts and marks requests that have gone quiet', () => {
+    expect(AGENDA).toContain('STUCK_AFTER_DAYS');
+    expect(AGENDA).toContain('function isStuck');
+    expect(flat(AGENDA)).toContain('gone quiet');
+  });
+
+  it('says nothing has expired, because nothing has', () => {
+    // The stuck marker is a prompt, not a deadline. Saying so keeps it
+    // from reading as a state the system imposed.
+    expect(flat(AGENDA)).toContain('Nothing has expired');
+  });
+
+  it('uses amber for needs-a-human, per BRAND2', () => {
+    expect(AGENDA).toContain('bg-amber-50');
+    expect(AGENDA).toContain('border-amber-300');
+  });
+
+  it('introduces no new palette', () => {
+    // BRAND2: brand purple, slate, and the doctrinal amber. A fifth
+    // colour on a new screen is how a design system stops being one.
+    const colours = new Set(
+      (codeOnly(AGENDA).match(/\b(?:bg|text|border)-([a-z]+)-\d{2,3}\b/g) || [])
+        .map((c) => c.split('-')[1]),
+    );
+    for (const c of colours) {
+      expect(['slate', 'amber', 'red', 'green', 'purple', 'gray']).toContain(c);
+    }
+  });
+});

--- a/frontend/src/app/past-deeds/page.tsx
+++ b/frontend/src/app/past-deeds/page.tsx
@@ -5,7 +5,7 @@ import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import Sidebar from "@/components/Sidebar"
 import { FileText, Download, Share2, Trash2, AlertCircle, CheckCircle, Clock, X, Plus, Loader2, Search, CalendarClock } from "lucide-react"
-import { SigningRequestModal } from "@/features/signing/SigningRequestModal"
+import { RequestSigningModal } from "@/features/signing/RequestSigningModal"
 import { ShareForReviewModal } from "@/features/signing/ShareForReviewModal"
 import { PartnersProvider } from "@/features/partners/PartnersContext"
 import { toast } from "sonner"
@@ -429,9 +429,21 @@ export default function PastDeedsPageV0() {
           how the category lists diverged in the first place. */}
       {(signingDeedId !== null || reviewDeedId !== null) && (
         <PartnersProvider>
-          {signingDeedId !== null && (
-            <SigningRequestModal deedId={signingDeedId} onClose={() => setSigningDeedId(null)} />
-          )}
+          {signingDeedId !== null && (() => {
+            const deed = deeds.find((d) => d.id === signingDeedId);
+            return (
+              <RequestSigningModal
+                deedId={signingDeedId}
+                propertyAddress={deed?.property_address}
+                // The deed's party NAMES seed the signer rows. Names only:
+                // the deed has never held a way to reach anybody (§13.1)
+                // and does not start now — she types the addresses.
+                suggestedSigners={[deed?.grantee_name, ...Object.values(deed?.parties || {})]
+                  .filter((n): n is string => !!n && !!n.trim())}
+                onClose={() => setSigningDeedId(null)}
+              />
+            );
+          })()}
           {reviewDeedId !== null && (
             <ShareForReviewModal deedId={reviewDeedId} onClose={() => setReviewDeedId(null)} />
           )}

--- a/frontend/src/app/signing/[token]/page.tsx
+++ b/frontend/src/app/signing/[token]/page.tsx
@@ -1,0 +1,430 @@
+'use client';
+
+/**
+ * NOTARY2 — the token page. One route, two audiences, two designs.
+ *
+ * ═══ THE SIGNER VIEW IS THE ONLY SCREEN A NON-PROFESSIONAL EVER SEES ═══
+ *
+ * A buyer opens it on a phone, from a text their escrow officer
+ * forwarded, about their own house. They did not sign up for anything and
+ * have never heard of us. Four constraints follow, and they are owner-set:
+ *
+ *  - PLAIN LANGUAGE. "Signing", not "notarial execution". "A notary will
+ *    meet you", not "the notarial act will be performed".
+ *  - THE OFFICER LEADS, NOT US. Her name and company are the first thing
+ *    on the page. We are the mechanism; she is the person this buyer
+ *    trusts, and a product that puts its own logo above her name is
+ *    borrowing her relationship.
+ *  - MOBILE FIRST. Full-width tap targets, one column, no table.
+ *  - ONE OBVIOUS ACTION. Pick a time. Everything else is secondary.
+ *
+ * ═══ THE NOTARY VIEW IS PROFESSIONAL-FACING ═══
+ *
+ * Dense is fine — she does this all day and reads it between
+ * appointments, on a phone. The package, the property, the parties by
+ * name, and posting her availability in as few taps as possible.
+ *
+ * ═══ WHAT NEITHER VIEW DOES ═══
+ *
+ * Compose its own sentence about the state. `summary` is written by the
+ * server (§13 rule 3) and rendered verbatim, so "booked" cannot drift
+ * into "the signing will happen" on a screen nobody rechecked. And every
+ * time shown is the server's label, rendered in the REQUEST's timezone —
+ * this file never formats a date, because a second formatter is a second
+ * chance to print the wrong hour.
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import {
+  AlertCircle, CalendarClock, Check, Clock, Download, FileText, Loader2, MapPin, Plus, Users, X,
+} from 'lucide-react';
+
+const API = () => process.env.NEXT_PUBLIC_API_URL || 'https://deedpro-main-api.onrender.com';
+
+type Person = { name: string | null; company: string | null };
+type Window = {
+  id: number; label: string; start: string; mine?: string | null;
+  origin?: string; declined?: boolean; agreed_by?: string[];
+};
+
+type Package = {
+  party_role: 'signer' | 'notary';
+  state: string;
+  summary: string;
+  expires_at: string | null;
+  windows: Window[];
+  coordinator: Person;
+  // signer only
+  property_street?: string;
+  notary?: Person;
+  can_propose?: boolean;
+  proposals_remaining?: number;
+  // notary only
+  property_address?: string;
+  county?: string;
+  deed_type?: string;
+  signers?: Array<{ name: string }>;
+  pcor_url?: string;
+  pdf_url?: string;
+};
+
+export default function SigningTokenPage() {
+  const token = useParams().token as string;
+  const [pkg, setPkg] = useState<Package | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState<number | 'propose' | null>(null);
+
+  const load = useCallback(async () => {
+    try {
+      const r = await fetch(`${API()}/signing/${token}`);
+      if (!r.ok) {
+        setError(
+          r.status === 410 ? 'This link has expired. Whoever sent it can send a new one.'
+          : r.status === 403 ? 'This link has been withdrawn.'
+          : r.status === 404 ? 'This link is not valid.'
+          : 'We could not load this right now. Please try again.',
+        );
+        return;
+      }
+      setPkg(await r.json());
+      setError(null);
+    } catch {
+      setError('We could not reach the server. Check your connection and try again.');
+    } finally {
+      setLoading(false);
+    }
+  }, [token]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const post = async (path: string, body: unknown, marker: number | 'propose') => {
+    setBusy(marker);
+    try {
+      const r = await fetch(`${API()}/signing/${token}${path}`, {
+        method: 'POST', headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const data = await r.json().catch(() => ({}));
+      if (!r.ok) { setError(data.detail || 'That did not go through.'); return; }
+      // Re-read rather than patching locally: the summary sentence is the
+      // server's to write, and a locally-composed one is the drift this
+      // design exists to prevent.
+      setPkg(data);
+      setError(null);
+    } catch {
+      setError('We could not reach the server.');
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <Shell>
+        <div className="flex flex-col items-center gap-3 py-20 text-slate-500">
+          <Loader2 className="w-6 h-6 animate-spin" />
+          <p>Loading…</p>
+        </div>
+      </Shell>
+    );
+  }
+
+  if (error && !pkg) {
+    return (
+      <Shell>
+        <div className="text-center py-16">
+          <AlertCircle className="w-10 h-10 text-slate-400 mx-auto mb-3" />
+          <p className="text-slate-700">{error}</p>
+        </div>
+      </Shell>
+    );
+  }
+
+  if (!pkg) return null;
+  return pkg.party_role === 'notary'
+    ? <NotaryView pkg={pkg} busy={busy} post={post} error={error} />
+    : <SignerView pkg={pkg} busy={busy} post={post} error={error} />;
+}
+
+function Shell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <main className="max-w-lg mx-auto px-4 py-8 sm:py-12">{children}</main>
+      <footer className="max-w-lg mx-auto px-4 pb-10 text-center">
+        {/* We are the mechanism, not the brand in front of her client. */}
+        <p className="text-xs text-slate-400">Scheduling by DeedPro</p>
+      </footer>
+    </div>
+  );
+}
+
+/* ── Signer ─────────────────────────────────────────────────────── */
+
+function SignerView({ pkg, busy, post, error }: {
+  pkg: Package; busy: number | 'propose' | null; error: string | null;
+  post: (p: string, b: unknown, m: number | 'propose') => void;
+}) {
+  const [proposing, setProposing] = useState(false);
+  const [start, setStart] = useState('');
+  const [end, setEnd] = useState('');
+  const booked = pkg.state === 'booked';
+  const who = pkg.coordinator.name || 'Your escrow officer';
+
+  return (
+    <Shell>
+      {/* The officer leads. Her name is the first thing on the page,
+          because she is who this person trusts. */}
+      <header className="mb-6">
+        <p className="text-sm text-slate-500">A message from</p>
+        <h1 className="text-xl font-bold text-slate-900">{who}</h1>
+        {pkg.coordinator.company && (
+          <p className="text-sm text-slate-600">{pkg.coordinator.company}</p>
+        )}
+      </header>
+
+      <div className="bg-white rounded-2xl border border-slate-200 p-5 sm:p-6 shadow-sm">
+        <h2 className="text-lg font-semibold text-slate-900 mb-1">
+          {booked ? 'Your signing is set' : 'When can you sign?'}
+        </h2>
+        <p className="text-slate-600 text-sm mb-4">
+          {booked
+            ? 'Here is the time everyone agreed on.'
+            : 'Pick any time below that works for you. A notary will meet you to witness the signing.'}
+        </p>
+
+        {pkg.property_street && (
+          <p className="flex items-start gap-2 text-sm text-slate-700 mb-4">
+            <MapPin className="w-4 h-4 text-slate-400 shrink-0 mt-0.5" />
+            {pkg.property_street}
+          </p>
+        )}
+        {pkg.notary?.name && (
+          <p className="flex items-start gap-2 text-sm text-slate-700 mb-5">
+            <Users className="w-4 h-4 text-slate-400 shrink-0 mt-0.5" />
+            <span>
+              {pkg.notary.name} will be your notary
+              {pkg.notary.company ? <span className="text-slate-500"> · {pkg.notary.company}</span> : null}
+            </span>
+          </p>
+        )}
+
+        {pkg.windows.length === 0 && !booked && (
+          <p className="rounded-lg bg-slate-50 border border-slate-200 p-4 text-sm text-slate-600">
+            No times have been offered yet. {who} will let you know when there are some.
+          </p>
+        )}
+
+        <div className="space-y-2">
+          {pkg.windows.map((w) => {
+            const chosen = w.mine === 'available';
+            return (
+              <button
+                key={w.id}
+                disabled={busy !== null || booked}
+                onClick={() => post('/answer', { window_id: w.id, answer: chosen ? 'unavailable' : 'available' }, w.id)}
+                className={`w-full flex items-center justify-between gap-3 px-4 py-4 rounded-xl border text-left transition-colors disabled:opacity-60 ${
+                  chosen ? 'border-[#7C4DFF] bg-purple-50' : 'border-slate-300 hover:bg-slate-50'
+                }`}
+              >
+                <span className="font-medium text-slate-800">{w.label}</span>
+                {busy === w.id
+                  ? <Loader2 className="w-5 h-5 animate-spin shrink-0 text-slate-400" />
+                  : chosen ? <Check className="w-5 h-5 text-[#7C4DFF] shrink-0" /> : null}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* The server's sentence, verbatim. */}
+        <p className="text-sm text-slate-600 mt-5 pt-4 border-t border-slate-200">{pkg.summary}</p>
+
+        {!booked && pkg.can_propose && (
+          proposing ? (
+            <div className="mt-4 space-y-2">
+              <p className="text-sm text-slate-600">Suggest a time instead:</p>
+              <input type="datetime-local" value={start} onChange={(e) => setStart(e.target.value)}
+                     className="w-full px-3 py-3 border border-slate-300 rounded-lg" />
+              <input type="datetime-local" value={end} onChange={(e) => setEnd(e.target.value)}
+                     className="w-full px-3 py-3 border border-slate-300 rounded-lg" />
+              <div className="flex gap-2">
+                <button onClick={() => setProposing(false)}
+                        className="flex-1 px-4 py-3 border border-slate-300 rounded-lg text-slate-700">
+                  Cancel
+                </button>
+                <button
+                  disabled={!start || !end || busy !== null}
+                  onClick={() => post('/propose', { start: withOffset(start), end: withOffset(end) }, 'propose')}
+                  className="flex-1 px-4 py-3 bg-[#7C4DFF] text-white rounded-lg font-medium disabled:opacity-50">
+                  {busy === 'propose' ? 'Sending…' : 'Suggest it'}
+                </button>
+              </div>
+              <p className="text-xs text-slate-500">
+                {pkg.notary?.name || 'The notary'} has to agree to it — you will hear back.
+              </p>
+            </div>
+          ) : (
+            <button onClick={() => setProposing(true)}
+                    className="mt-4 inline-flex items-center gap-1.5 text-sm text-[#7C4DFF] hover:underline">
+              <Plus className="w-4 h-4" /> None of these work — suggest a time
+            </button>
+          )
+        )}
+
+        {error && (
+          <p className="mt-4 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">
+            {error}
+          </p>
+        )}
+      </div>
+
+      <p className="text-xs text-slate-500 mt-4 text-center">
+        Questions about the paperwork? Ask {who}.
+      </p>
+    </Shell>
+  );
+}
+
+/* ── Notary ─────────────────────────────────────────────────────── */
+
+function NotaryView({ pkg, busy, post, error }: {
+  pkg: Package; busy: number | 'propose' | null; error: string | null;
+  post: (p: string, b: unknown, m: number | 'propose') => void;
+}) {
+  const [rows, setRows] = useState<Array<{ start: string; end: string }>>([{ start: '', end: '' }]);
+  const [posting, setPosting] = useState(false);
+  const complete = rows.filter((r) => r.start && r.end);
+
+  const submit = async () => {
+    setPosting(true);
+    await post('/windows', {
+      windows: complete.map((r) => ({ start: withOffset(r.start), end: withOffset(r.end) })),
+    }, 'propose');
+    setRows([{ start: '', end: '' }]);
+    setPosting(false);
+  };
+
+  return (
+    <Shell>
+      <header className="mb-5">
+        <h1 className="text-xl font-bold text-slate-900">Signing request</h1>
+        <p className="text-sm text-slate-600">
+          From {pkg.coordinator.name}
+          {pkg.coordinator.company ? ` · ${pkg.coordinator.company}` : ''}
+        </p>
+      </header>
+
+      <div className="bg-white rounded-2xl border border-slate-200 p-5 shadow-sm mb-4">
+        <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1.5 text-sm">
+          <dt className="text-slate-500">Property</dt>
+          <dd className="text-slate-800 font-medium">{pkg.property_address}</dd>
+          <dt className="text-slate-500">County</dt><dd className="text-slate-800">{pkg.county}</dd>
+          <dt className="text-slate-500">Document</dt><dd className="text-slate-800">{pkg.deed_type}</dd>
+          <dt className="text-slate-500">Signers</dt>
+          <dd className="text-slate-800">{(pkg.signers || []).map((s) => s.name).join(', ')}</dd>
+        </dl>
+        <div className="flex gap-3 mt-4 pt-4 border-t border-slate-100">
+          <a href={`${API()}${pkg.pdf_url}`} target="_blank" rel="noopener noreferrer"
+             className="inline-flex items-center gap-1.5 text-sm text-[#7C4DFF] hover:underline">
+            <FileText className="w-4 h-4" /> The document
+          </a>
+          <a href={`${API()}${pkg.pcor_url}.pdf`} target="_blank" rel="noopener noreferrer"
+             className="inline-flex items-center gap-1.5 text-sm text-[#7C4DFF] hover:underline">
+            <Download className="w-4 h-4" /> PCOR
+          </a>
+        </div>
+      </div>
+
+      <div className="bg-white rounded-2xl border border-slate-200 p-5 shadow-sm">
+        <h2 className="font-semibold text-slate-900 flex items-center gap-2 mb-1">
+          <CalendarClock className="w-5 h-5 text-[#7C4DFF]" /> Times
+        </h2>
+        <p className="text-sm text-slate-600 mb-4">{pkg.summary}</p>
+
+        <div className="space-y-2 mb-5">
+          {pkg.windows.map((w) => (
+            <div key={w.id}
+                 className={`rounded-lg border p-3 ${w.declined ? 'border-slate-200 bg-slate-50 opacity-60' : 'border-slate-200'}`}>
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <p className="text-sm font-medium text-slate-800">{w.label}</p>
+                  <p className="text-xs text-slate-500">
+                    {w.origin === 'signer_proposal' ? 'Suggested by a signer' : 'You offered this'}
+                    {w.agreed_by?.length ? ` · ${w.agreed_by.length} agreed` : ' · nobody has answered'}
+                  </p>
+                </div>
+                {w.origin === 'signer_proposal' && !w.declined && (
+                  <div className="flex gap-1 shrink-0">
+                    <button onClick={() => post('/answer', { window_id: w.id, answer: 'available' }, w.id)}
+                            disabled={busy !== null}
+                            className="px-2.5 py-1.5 text-xs bg-[#7C4DFF] text-white rounded-md disabled:opacity-50">
+                      {busy === w.id ? '…' : 'I can do it'}
+                    </button>
+                    <button onClick={() => post(`/decline/${w.id}`, {}, w.id)}
+                            disabled={busy !== null}
+                            className="px-2.5 py-1.5 text-xs border border-slate-300 text-slate-600 rounded-md">
+                      No
+                    </button>
+                  </div>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {pkg.state !== 'booked' && (
+          <>
+            <p className="text-sm font-medium text-slate-700 mb-2">Add times you are free</p>
+            <div className="space-y-2">
+              {rows.map((r, i) => (
+                <div key={i} className="grid grid-cols-2 gap-2">
+                  <input type="datetime-local" value={r.start}
+                         onChange={(e) => setRows((p) => p.map((x, n) => n === i ? { ...x, start: e.target.value } : x))}
+                         className="px-3 py-2.5 border border-slate-300 rounded-lg text-sm" />
+                  <input type="datetime-local" value={r.end}
+                         onChange={(e) => setRows((p) => p.map((x, n) => n === i ? { ...x, end: e.target.value } : x))}
+                         className="px-3 py-2.5 border border-slate-300 rounded-lg text-sm" />
+                </div>
+              ))}
+            </div>
+            <div className="flex gap-2 mt-3">
+              <button onClick={() => setRows((p) => [...p, { start: '', end: '' }])}
+                      className="px-3 py-2 text-sm text-[#7C4DFF] hover:underline inline-flex items-center gap-1">
+                <Plus className="w-4 h-4" /> Another
+              </button>
+              <button onClick={submit} disabled={!complete.length || posting}
+                      className="flex-1 px-4 py-2.5 bg-[#7C4DFF] text-white rounded-lg font-medium disabled:opacity-50">
+                {posting ? 'Posting…' : `Post ${complete.length || ''} time${complete.length === 1 ? '' : 's'}`}
+              </button>
+            </div>
+            <p className="text-xs text-slate-500 mt-2 flex items-start gap-1.5">
+              <Clock className="w-3.5 h-3.5 shrink-0 mt-0.5" />
+              Posting a time says you are free then — you do not need to confirm it again.
+            </p>
+          </>
+        )}
+
+        {error && (
+          <p className="mt-4 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800">{error}</p>
+        )}
+      </div>
+    </Shell>
+  );
+}
+
+/**
+ * "2026-08-12T10:00" (local, from datetime-local) → with the browser's
+ * UTC offset. The server REFUSES a naive time (#149's parse_window) —
+ * deliberately, because guessing a zone is how a calendar entry lands
+ * eight hours out. This is where the offset comes from.
+ */
+function withOffset(local: string): string {
+  const parsed = new Date(local);
+  if (Number.isNaN(parsed.getTime())) return local;
+  const minutes = -parsed.getTimezoneOffset();
+  const sign = minutes >= 0 ? '+' : '-';
+  const abs = Math.abs(minutes);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${local}:00${sign}${pad(Math.floor(abs / 60))}:${pad(abs % 60)}`;
+}

--- a/frontend/src/app/signings/page.tsx
+++ b/frontend/src/app/signings/page.tsx
@@ -1,0 +1,211 @@
+'use client';
+
+/**
+ * NOTARY2 Part D — every signing, across every file.
+ *
+ * ═══ AN AGENDA, NOT A MONTH GRID (owner-accepted cut) ═══
+ *
+ * A list sorted by date answers "what is coming up and what is stuck"
+ * completely. The grid is the attractive version of the same facts, it
+ * cost a day, and no workflow depended on it.
+ *
+ * ═══ THE STUCK SIGNAL LEADS ═══
+ *
+ * Which is the whole design. A booked signing needs nothing from her; a
+ * request nobody has answered in five days needs a phone call, and it is
+ * invisible on a date-sorted list because its date has not happened yet.
+ * So stuck items are counted at the top and marked in the row, and the
+ * amber that marks them is BRAND2's "unconfirmed / needs a human", which
+ * is what this is — not decoration borrowed for emphasis.
+ *
+ * Read-only aggregation. No new state, no availability engine, and no
+ * date formatting in this file: every time shown is the server's own
+ * label, rendered in the REQUEST's timezone.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Sidebar from '@/components/Sidebar';
+import { AlertCircle, CalendarClock, CheckCircle2, Clock, Loader2 } from 'lucide-react';
+import { SessionExpiredError, apiFetch } from '@/lib/apiClient';
+
+type Row = {
+  id: number;
+  deed_id: number;
+  property_address: string | null;
+  deed_type: string | null;
+  notary_name: string | null;
+  state: string;
+  summary: string;
+  booked_at: string | null;
+  booked_by: string | null;
+  expires_at: string | null;
+  signers: number;
+};
+
+/** Days of silence before a request is worth chasing. Not a deadline —
+ * nothing expires because of it — a prompt. */
+const STUCK_AFTER_DAYS = 5;
+
+function daysSince(iso: string | null, expiresAt: string | null): number {
+  // The request's age is inferred from its expiry, since that is the only
+  // timestamp the agenda payload carries. 21 days is the create default.
+  if (!expiresAt) return 0;
+  const expires = new Date(expiresAt).getTime();
+  const created = expires - 21 * 86400_000;
+  return Math.max(0, Math.floor((Date.now() - created) / 86400_000));
+}
+
+function isStuck(r: Row): boolean {
+  if (r.state === 'booked' || r.state === 'cancelled' || r.state === 'expired') return false;
+  const age = daysSince(null, r.expires_at);
+  // Nobody has posted a time, or times are posted and nobody answered.
+  return age >= STUCK_AFTER_DAYS && (r.state === 'requested' || r.state === 'windows_posted');
+}
+
+const STATE_LABEL: Record<string, string> = {
+  requested: 'Waiting on the notary',
+  windows_posted: 'Waiting on signers',
+  partially_agreed: 'Part-agreed',
+  booked: 'Booked',
+  cancelled: 'Cancelled',
+  expired: 'Expired',
+};
+
+export default function SigningsPage() {
+  const router = useRouter();
+  const [rows, setRows] = useState<Row[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    (async () => {
+      // The auth guard. Caught by routeGuards.test.ts, which is the pin
+      // doing exactly its job: a new authenticated page rendered its
+      // chrome before asking whether anybody was logged in, so a signed
+      // -out visitor would have seen an empty Signings screen and a
+      // failed request rather than the login page.
+      const token = localStorage.getItem('access_token');
+      if (!token) {
+        router.push('/login?redirect=/signings');
+        return;
+      }
+      try {
+        const r = await apiFetch('/signing-requests/v2', {}, { label: 'Loading signings' });
+        if (!r.ok) throw new Error((await r.json().catch(() => ({}))).detail || `Failed (${r.status})`);
+        setRows(await r.json());
+      } catch (err) {
+        if (err instanceof SessionExpiredError) return;
+        setError(err instanceof Error ? err.message : 'Could not load your signings');
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const stuck = useMemo(() => rows.filter(isStuck), [rows]);
+  const active = useMemo(
+    () => rows.filter((r) => !['cancelled', 'expired'].includes(r.state)), [rows]);
+  const closed = useMemo(
+    () => rows.filter((r) => ['cancelled', 'expired'].includes(r.state)), [rows]);
+
+  return (
+    <div className="flex min-h-screen bg-slate-50">
+      <Sidebar />
+      <main className="flex-1 p-6 md:p-10">
+        <div className="max-w-4xl mx-auto">
+          <h1 className="text-3xl font-bold text-slate-900 mb-1">Signings</h1>
+          <p className="text-slate-600 mb-6">
+            Every signing you have arranged, soonest first.
+          </p>
+
+          {stuck.length > 0 && (
+            <div className="mb-6 rounded-xl border border-amber-200 bg-amber-50 p-4">
+              <p className="font-semibold text-amber-900 flex items-center gap-2">
+                <AlertCircle className="w-5 h-5" />
+                {stuck.length} {stuck.length === 1 ? 'signing has' : 'signings have'} gone quiet
+              </p>
+              <p className="text-sm text-amber-800 mt-1">
+                No movement in {STUCK_AFTER_DAYS} days or more. Nothing has expired — these
+                are worth a phone call.
+              </p>
+            </div>
+          )}
+
+          {loading && (
+            <div className="flex items-center gap-3 text-slate-500 py-16 justify-center">
+              <Loader2 className="w-5 h-5 animate-spin" /> Loading…
+            </div>
+          )}
+
+          {error && !loading && (
+            <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-red-700">{error}</div>
+          )}
+
+          {!loading && !error && rows.length === 0 && (
+            <div className="rounded-xl border border-slate-200 bg-white p-10 text-center">
+              <CalendarClock className="w-10 h-10 text-slate-300 mx-auto mb-3" />
+              <p className="text-slate-600">No signings yet.</p>
+              <button onClick={() => router.push('/past-deeds')}
+                      className="mt-4 px-5 py-2.5 bg-[#7C4DFF] hover:bg-[#6a3de8] text-white rounded-lg font-medium">
+                Go to your deeds
+              </button>
+            </div>
+          )}
+
+          {active.length > 0 && (
+            <div className="space-y-3">
+              {active.map((r) => <SigningRow key={r.id} row={r} onOpen={() => router.push(`/past-deeds`)} />)}
+            </div>
+          )}
+
+          {closed.length > 0 && (
+            <>
+              <h2 className="text-sm font-semibold text-slate-500 uppercase tracking-wide mt-8 mb-3">
+                Closed
+              </h2>
+              <div className="space-y-3 opacity-70">
+                {closed.map((r) => <SigningRow key={r.id} row={r} onOpen={() => router.push(`/past-deeds`)} />)}
+              </div>
+            </>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+}
+
+function SigningRow({ row, onOpen }: { row: Row; onOpen: () => void }) {
+  const stuck = isStuck(row);
+  const booked = row.state === 'booked';
+  return (
+    <button onClick={onOpen}
+            className={`w-full text-left bg-white rounded-xl border p-4 hover:shadow-sm transition-shadow ${
+              stuck ? 'border-amber-300' : 'border-slate-200'
+            }`}>
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <p className="font-medium text-slate-900 truncate">
+            {row.property_address || `Deed #${row.deed_id}`}
+          </p>
+          <p className="text-sm text-slate-500 truncate">
+            {row.notary_name || 'No notary named'} · {row.signers} signer{row.signers === 1 ? '' : 's'}
+          </p>
+          {/* The server's sentence, verbatim — this screen never composes
+              its own account of a scheduling state (§13 rule 3). */}
+          <p className="text-sm text-slate-600 mt-2">{row.summary}</p>
+        </div>
+        <span className={`shrink-0 inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold ${
+          stuck ? 'bg-amber-100 text-amber-800'
+          : booked ? 'bg-slate-100 text-slate-700'
+          : 'bg-slate-50 text-slate-600'
+        }`}>
+          {stuck ? <AlertCircle className="w-3.5 h-3.5" />
+            : booked ? <CheckCircle2 className="w-3.5 h-3.5" />
+            : <Clock className="w-3.5 h-3.5" />}
+          {stuck ? 'Gone quiet' : STATE_LABEL[row.state] || row.state}
+        </span>
+      </div>
+    </button>
+  );
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -12,6 +12,7 @@ import React, { useState, useEffect } from 'react';
 import { AuthManager } from '../utils/auth';
 import { LogoLockup, LogoMark } from '@/components/brand/Logo';
 import {
+  CalendarClock,
   LayoutDashboard,
   FilePlus2,
   Files,
@@ -31,6 +32,10 @@ const NAV_ITEMS = [
   { href: '/deed-builder', icon: FilePlus2, label: 'Create Deed' },
   { href: '/past-deeds', icon: Files, label: 'Past Deeds' },
   { href: '/shared-deeds', icon: Share2, label: 'Shared Deeds' },
+  // NOTARY2 Part D. A page nothing links to is a page nobody uses —
+  // the agenda's whole job is being the place she checks what is stuck,
+  // and that only works if it is one click from everywhere.
+  { href: '/signings', icon: CalendarClock, label: 'Signings' },
   { href: '/partners', icon: Users, label: 'Partners' },
   { href: '/account-settings', icon: Settings, label: 'Settings' },
 ];

--- a/frontend/src/features/partners/PartnerRecipientPicker.tsx
+++ b/frontend/src/features/partners/PartnerRecipientPicker.tsx
@@ -41,6 +41,11 @@ import { categoryLabel, roleLabel } from '@/lib/partnerRegistry';
 export interface Recipient {
   email: string;
   name: string;
+  /** NOTARY2: the notary's company appears on the SIGNER surface — a
+   * consumer told a stranger is coming to their home should know who and
+   * from where (owner ruling 2). So it travels with the pick rather than
+   * being looked up again later from an id that may be null. */
+  company?: string;
   /** Set when she picked from the rolodex; absent for a typed address. */
   partnerId?: string;
 }
@@ -92,6 +97,7 @@ export function PartnerRecipientPicker({
     onChange({
       email: p.email,
       name: p.contact_name || p.company_name || p.label,
+      company: p.company_name || (p.contact_name ? p.label : undefined),
       partnerId: p.id,
     });
     setOpen(false);

--- a/frontend/src/features/signing/RequestSigningModal.tsx
+++ b/frontend/src/features/signing/RequestSigningModal.tsx
@@ -1,0 +1,257 @@
+'use client';
+
+/**
+ * NOTARY2 — the officer starts a coordination loop.
+ *
+ * ═══ WHAT SHE IS ASKED FOR, AND WHAT SHE IS NOT ═══
+ *
+ * A notary (from her rolodex), and the people who have to be in the room.
+ * That is the whole form.
+ *
+ * She is NOT asked for times. NOTARY1's modal made her propose windows
+ * because the notary had no way to speak; §13.1 reversed that, and the
+ * notary now posts her own availability — so asking the officer to guess
+ * at it first would be asking her to do the work the reversal removed.
+ * The field is gone rather than optional: an optional field on a form is
+ * a question, and this one has a better answer than any she could give.
+ *
+ * Location defaults to the property address and the timezone to the
+ * property's, because a signing happens at the property far more often
+ * than not, and a default that is right most of the time beats a blank
+ * that is right none of it.
+ *
+ * ═══ SIGNER CONTACT IS PER-REQUEST (§13.1) ═══
+ *
+ * What she types here lands on `signing_participants` and nowhere else —
+ * not on the deed, not in the `parties` JSONB, not on a profile — and it
+ * is purged on a schedule by a job with a test. The form says so, in
+ * plain words, because she is about to type somebody else's client's
+ * email into a product they have never heard of.
+ */
+
+import { useMemo, useState } from 'react';
+import { CalendarClock, Info, Loader2, Plus, Trash2, X } from 'lucide-react';
+import { apiFetch } from '@/lib/apiClient';
+import { PartnerRecipientPicker, Recipient } from '@/features/partners/PartnerRecipientPicker';
+
+const MAX_SIGNERS = 6;
+
+/** The zones a California title product actually needs. Not the full
+ * IANA list — a dropdown of six hundred zones is a worse question than a
+ * dropdown of five. */
+const ZONES = [
+  { id: 'America/Los_Angeles', label: 'Pacific' },
+  { id: 'America/Denver', label: 'Mountain' },
+  { id: 'America/Phoenix', label: 'Arizona (no DST)' },
+  { id: 'America/Chicago', label: 'Central' },
+  { id: 'America/New_York', label: 'Eastern' },
+];
+
+type SignerRow = { name: string; email: string; phone: string };
+
+export function RequestSigningModal({
+  deedId,
+  propertyAddress,
+  suggestedSigners = [],
+  onClose,
+  onCreated,
+}: {
+  deedId: number;
+  propertyAddress?: string;
+  /** The deed's party NAMES, as a starting point. Names only — the deed
+   * has never held a way to reach anybody and does not start now. */
+  suggestedSigners?: string[];
+  onClose: () => void;
+  onCreated?: (id: number) => void;
+}) {
+  const [notary, setNotary] = useState<Recipient | null>(null);
+  const [signers, setSigners] = useState<SignerRow[]>(() =>
+    (suggestedSigners.length ? suggestedSigners : ['']).slice(0, MAX_SIGNERS)
+      .map((name) => ({ name, email: '', phone: '' })),
+  );
+  const [location, setLocation] = useState(propertyAddress || '');
+  const [tz, setTz] = useState(ZONES[0].id);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [done, setDone] = useState<{ id: number; links: Array<{ role: string; name: string; link: string }> } | null>(null);
+
+  const ready = useMemo(
+    () => !!notary?.email && signers.some((s) => s.name.trim() && s.email.trim()),
+    [notary, signers],
+  );
+
+  const setSigner = (i: number, patch: Partial<SignerRow>) =>
+    setSigners((prev) => prev.map((s, n) => (n === i ? { ...s, ...patch } : s)));
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      const response = await apiFetch('/signing-requests/v2', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          deed_id: deedId,
+          notary_email: notary?.email,
+          notary_name: notary?.name || undefined,
+          notary_company: notary?.company || undefined,
+          notary_partner_id: notary?.partnerId,
+          signers: signers
+            .filter((s) => s.name.trim() && s.email.trim())
+            .map((s) => ({ name: s.name.trim(), email: s.email.trim(),
+                           phone: s.phone.trim() || undefined })),
+          location: location || undefined,
+          tz_name: tz,
+        }),
+      }, { label: 'Creating the signing request' });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) throw new Error(data.detail || `Failed (${response.status})`);
+      setDone({
+        id: data.signing_request_id,
+        links: (data.participants || []).map((p: { party_role: string; name: string; link: string }) => ({
+          role: p.party_role, name: p.name, link: p.link,
+        })),
+      });
+      onCreated?.(data.signing_request_id);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create the request');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const input = 'w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF]';
+
+  return (
+    <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
+      <div className="bg-white rounded-2xl shadow-2xl max-w-[640px] w-full max-h-[85vh] flex flex-col p-8">
+        <div className="flex items-center justify-between mb-6 shrink-0">
+          <h2 className="text-2xl font-bold text-slate-800 flex items-center gap-2">
+            <CalendarClock className="w-6 h-6 text-[#7C4DFF]" />
+            Request a signing
+          </h2>
+          <button onClick={onClose} className="p-2 hover:bg-slate-100 rounded-lg" aria-label="Close">
+            <X className="w-5 h-5 text-slate-400" />
+          </button>
+        </div>
+
+        {done ? (
+          <div className="space-y-4 overflow-y-auto">
+            <p className="text-slate-700">
+              The request is on the record. <strong>{notary?.name || 'The notary'}</strong> posts
+              the times she is free; your signers pick from them. When they all agree on
+              one, it books and you are told.
+            </p>
+            <p className="text-sm text-slate-500">
+              You do not have to approve the time — but you can change it later if you
+              need to.
+            </p>
+            <div className="rounded-lg border border-slate-200 divide-y divide-slate-100">
+              {done.links.map((p) => (
+                <div key={p.link} className="p-3">
+                  <div className="text-sm font-medium text-slate-800">
+                    {p.name} <span className="text-slate-400 font-normal">· {p.role === 'notary' ? 'notary' : 'signer'}</span>
+                  </div>
+                  <div className="text-xs text-slate-500 break-all">{p.link}</div>
+                </div>
+              ))}
+            </div>
+            <button onClick={onClose}
+                    className="w-full px-6 py-3 bg-[#7C4DFF] hover:bg-[#6a3de8] text-white font-medium rounded-lg">
+              Done
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={submit} className="flex flex-col min-h-0 flex-1">
+            <div className="space-y-5 overflow-y-auto flex-1 pr-1">
+              <PartnerRecipientPicker
+                value={notary}
+                onChange={setNotary}
+                suggestCategory="notary"
+                label="Notary"
+              />
+
+              <div>
+                <div className="flex items-center justify-between mb-2">
+                  <label className="block text-sm font-medium text-slate-700">
+                    Who is signing <span className="text-red-500">*</span>
+                  </label>
+                  {signers.length < MAX_SIGNERS && (
+                    <button type="button"
+                            onClick={() => setSigners((p) => [...p, { name: '', email: '', phone: '' }])}
+                            className="inline-flex items-center gap-1 text-sm text-[#7C4DFF] hover:underline">
+                      <Plus className="w-4 h-4" /> Add a signer
+                    </button>
+                  )}
+                </div>
+                <div className="space-y-3">
+                  {signers.map((s, i) => (
+                    <div key={i} className="grid grid-cols-1 sm:grid-cols-[1fr_1fr_auto] gap-2 items-start">
+                      <input type="text" value={s.name} placeholder="Full name"
+                             onChange={(e) => setSigner(i, { name: e.target.value })}
+                             className={input} />
+                      <input type="email" value={s.email} placeholder="Email"
+                             onChange={(e) => setSigner(i, { email: e.target.value })}
+                             className={input} />
+                      {signers.length > 1 && (
+                        <button type="button" aria-label="Remove this signer"
+                                onClick={() => setSigners((p) => p.filter((_, n) => n !== i))}
+                                className="p-2 text-slate-400 hover:text-red-600">
+                          <Trash2 className="w-4 h-4" />
+                        </button>
+                      )}
+                    </div>
+                  ))}
+                </div>
+                <div className="mt-2 flex gap-2 rounded-lg bg-slate-50 border border-slate-200 p-3">
+                  <Info className="w-4 h-4 text-slate-400 shrink-0 mt-0.5" />
+                  <p className="text-xs text-slate-600">
+                    Your signers get their own link to pick a time. Their details are kept
+                    on this request only — never added to the deed or to your contacts —
+                    and are deleted automatically after the signing is done.
+                  </p>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-sm font-medium text-slate-700 mb-1">Where</label>
+                  <input type="text" value={location} onChange={(e) => setLocation(e.target.value)}
+                         className={input} placeholder="The property address" />
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-slate-700 mb-1">Times shown in</label>
+                  <select value={tz} onChange={(e) => setTz(e.target.value)} className={input}>
+                    {ZONES.map((z) => <option key={z.id} value={z.id}>{z.label}</option>)}
+                  </select>
+                  <p className="text-xs text-slate-500 mt-1">
+                    Everyone sees times in this zone — the one where the signing happens.
+                  </p>
+                </div>
+              </div>
+
+              {error && (
+                <div className="rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+                  {error}
+                </div>
+              )}
+            </div>
+
+            <div className="flex gap-3 pt-5 shrink-0">
+              <button type="button" onClick={onClose}
+                      className="flex-1 px-4 py-3 border border-slate-300 text-slate-700 rounded-lg hover:bg-slate-50 font-medium">
+                Cancel
+              </button>
+              <button type="submit" disabled={submitting || !ready}
+                      className="flex-1 px-4 py-3 bg-[#7C4DFF] hover:bg-[#6a3de8] text-white font-medium rounded-lg disabled:opacity-50 flex items-center justify-center gap-2">
+                {submitting && <Loader2 className="w-4 h-4 animate-spin" />}
+                Send to the notary
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
The officer's create flow, both token pages, and Part D. Built to your design constraints, each one pinned. Delivery (five templates, `.ics`, reminders) and the NOTARY1 migration remain.

## The signer page

Your four constraints, and how each became a test rather than an intention:

**Plain language.** The pin sweeps for trade words — *notarial act, grantor, grantee, vesting, APN, legal description, instrument, conveyance*. The page says "a notary will meet you to witness the signing." A consumer who has to look up a word on a page about their own house trusts us less, not more.

**The officer leads.** Her name and company are the first thing rendered; DeedPro appears **exactly once**, in the footer, as "Scheduling by DeedPro". Pinned by **order**, not just presence — a product that puts its own name above hers is borrowing her relationship with her own client.

**Mobile first.** One column, full-width tap targets, no table.

**One obvious action.** Pick a time. "None of these work — suggest a time" is a text link underneath, not a competing button.

## The notary page

Dense, per your guidance. The package, the property, the parties by name, accept/decline on a signer's proposal inline, and posting availability in two taps. "Posting a time says you are free then — you do not need to confirm it again" is on the screen, because otherwise she wonders.

## The create flow doesn't ask her for times

NOTARY1's modal made the officer propose windows *because the notary had no way to speak*. §13.1 reversed that, so asking anyway would be asking her to do the work the reversal removed. **The field is gone rather than optional** — an optional field is still a question, and this one has a better answer than any she could give. Pinned: no `datetime-local` in the create flow at all.

Signer rows seed from the deed's party **names**; she types the addresses. Location defaults to the property, timezone to the property's. And the form tells her, in her words, what happens to her signers' details — she's about to type somebody else's client's email into a product they've never heard of.

## Part D leads with what's stuck

This is the part I'd point at. A booked signing needs nothing from her. A request nobody has answered in five days needs a phone call — **and it's invisible on a date-sorted list, because its date hasn't happened yet.** So quiet requests are counted in a banner at the top and marked in the row, in BRAND2's amber, which means "needs a human" rather than being borrowed for emphasis.

The banner says *nothing has expired, because nothing has*. It's a prompt, not a deadline, and saying so keeps it from reading as a state the system imposed.

## No surface writes its own words or its own dates

`summary` is the server's sentence, rendered verbatim (§13 rule 3). And **no surface here formats a date** — every time shown is the server's label in the request's timezone, pinned by asserting `toLocaleDateString`/`toLocaleTimeString` appear nowhere. A second formatter is a second chance to print the wrong hour, and the wrong hour is somebody at an empty office. Times sent back carry the browser's offset, because #149's `parse_window` refuses a naive time rather than guessing.

## Two defects the pins caught

**The agenda page shipped without an auth guard.** It rendered its chrome before asking whether anybody was logged in, so a signed-out visitor would have seen an empty Signings screen and a failed request instead of the login page. `routeGuards` caught it — the pin earning its keep on the first new authenticated page in a while.

**`/signing/[token]` is on the public allowlist as a decision, with its reasoning in the file.** The token is the auth, the visitor has no account and must never need one, and the payload is an allowlist pinned by exact key-set equality server-side. Being on that list should never be an oversight.

Also: `/signings` is in the sidebar. A page nothing links to is a page nobody uses, and the agenda's whole job is being where she checks what's stuck.

## Gates

| gate | result |
|---|---|
| jest | 650 passed, 42 suites |
| tsc | 94 (unchanged) |
| pytest, no database | 824 passed |
| pytest, with database | 958 passed |
| banned-claims | clean |

Four design probes, all biting: jargon on the signer page, our brand above her name, a locally formatted date, and asking the officer for times again.

One note: the with-database run came back 60-red first pass — local Postgres died mid-run again, clean on restart. Flagging rather than quietly re-running, same as last time.

## Remaining

Five email templates + `.ics` to everyone on booking, reminders, and the NOTARY1 → NOTARY2 migration. The loop is now complete and usable end to end by anyone holding a link; what's left is getting the links to them.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_