### PR TITLE
docs + render.yaml header: the pin ruling, and what the file actually describes

### DIFF
--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -607,3 +607,105 @@ them rather than what they are.
 from before this engagement is Tier 3 twice over: irreversible, and
 possibly somebody's data. The useful next step is read-only — list its
 tables and row counts — and that is the owner's to run.
+
+## `render.yaml` — owner ruling, and which reality we are in (2026-08-11)
+
+**Ruling:** pin `PYTHON_VERSION` explicitly for every service defined in
+`render.yaml`, matching what production actually runs. Whichever of the
+two possibilities is true, the fix is the same — the repo should express
+the rule, and an unpinned runtime on the customer-facing API is the same
+latent failure the cron just demonstrated, one Render default bump away.
+
+**HELD, PENDING A VALUE.** The owner is reading the current version off
+`deedpro-main-api`. Not guessed: writing a plausible version into a
+deploy file is how a "fix" becomes an outage on the next deploy, and a
+wrong pin is worse than no pin because it looks deliberate.
+
+**The one-line change, ready to apply** — under `deedpro-main-api`'s
+`envVars`, alongside the existing entries:
+
+```yaml
+  - key: PYTHON_VERSION
+    value: "3.X.Y"        # ← the value from deedpro-main-api's dashboard
+```
+
+Landing it together with a pin — a test asserting every service block in
+`render.yaml` carries `PYTHON_VERSION` — so the rule survives the next
+service somebody adds. The pin is written and held with the value rather
+than committed failing.
+
+### Which reality we are in: the dashboard is authoritative
+
+The question was whether `render.yaml` describes production or the
+dashboard does. **It does not describe production, and this is checkable
+without any dashboard access:**
+
+`render.yaml` defines **exactly one service** — `deedpro-main-api` — plus
+a database reference. Production runs at minimum:
+
+| running | in `render.yaml`? |
+|---|---|
+| `deedpro-main-api` (web) | yes |
+| the purge cron job | **no** |
+| Postgres `deedpro` | by reference only |
+
+The cron the owner created and debugged over four failures **appears
+nowhere in this file.** So the file is already a partial description, and
+anything reading it as the deployment inventory is reading a subset that
+does not announce itself as one.
+
+That is worse than the version-pin problem it was found by. A config file
+that lies by OMISSION is harder to catch than one that lies by contents:
+nothing about `render.yaml` says "this is some of what runs."
+
+**Two ways to make it honest, and this is an owner call:**
+
+1. **Bring the cron into `render.yaml`** so the file is the inventory,
+   and keep it that way. More work, and it makes the repo the source of
+   truth for deploy topology — which is a real commitment, not a
+   formatting preference.
+2. **Say so at the top of the file** — a header stating that services are
+   managed in the Render dashboard and this file is a reference for the
+   main API only. Cheap, honest, and it stops the next person trusting
+   it.
+
+Doing neither leaves a file that will be believed. Recommended: (2) now,
+(1) if deploy topology ever gets complicated enough to need review.
+
+## TICKET — services assert their tables and name the database (queued)
+
+**Why it is a ticket rather than a note.** It cost an afternoon of the
+owner's time and two redeploys on an untested hypothesis. Invariant #4
+applied to diagnostics: an error that names its context is a different
+quality of error.
+
+`relation "signing_participants" does not exist` sent us hunting for a
+schema that had never run. The same failure, phrased with its context —
+
+```
+signing_participants not found in deedpro_database on dpg-d1vbos95… —
+expected deedpro on dpg-d208q5um…
+```
+
+— ends the investigation in one run and names the actual defect.
+
+**Scope.** A small startup assertion, used by any service that depends on
+specific tables:
+
+- `services/db_identity.py` — `assert_tables(conn, *names)` which, on a
+  miss, raises with `current_database()`, `inet_server_addr()`,
+  `inet_server_port()` and the missing table names in the message;
+- called from `scripts/purge_signer_contact.py` before it does anything;
+- an optional `--verify` flag printing the same identity block, so
+  "which database is this service on" is answerable without a psql
+  session;
+- the same call available to any future worker or cron.
+
+**Acceptance.** Pointing the purge script at the wrong database produces
+a message naming both databases; pointing it at the right one is silent.
+Tested by running it against a database that lacks the table.
+
+**Effort.** Half a day. **Not urgent** — the specific defect is fixed and
+the standing rule is recorded — but it is the difference between a rule
+people must remember and a mechanism that remembers for them, which is
+the same distinction the purge itself was held to.

--- a/render.yaml
+++ b/render.yaml
@@ -1,3 +1,26 @@
+# ⚠️ THIS FILE IS NOT THE DEPLOYMENT INVENTORY.
+#
+# Services are managed in the Render dashboard. This file describes
+# `deedpro-main-api` and nothing else — the purge cron job
+# (`signer_contact_purge`, added 2026-08-11) runs in production and does
+# not appear here, and neither will anything else created in the
+# dashboard.
+#
+# Recorded because a config file that lies by OMISSION is harder to catch
+# than one that lies by contents: nothing about a YAML file announces
+# that it is a subset. Anyone reading this as "what runs" is reading a
+# partial list that does not say so.
+#
+# Owner-ruled 2026-08-11: every service defined here pins PYTHON_VERSION
+# explicitly, matching what `deedpro-main-api` actually runs. An unpinned
+# service inherits whatever Render's default is on the day it builds —
+# which is exactly how the cron's first build died compiling Rust for a
+# pydantic_core with no 3.14 wheel. The value is HELD pending the owner
+# reading it off the dashboard; it is not guessed, because a wrong pin in
+# a deploy file looks deliberate and fails on the next deploy.
+#
+# See docs/OWNER_LEDGER.md, "render.yaml — owner ruling".
+
 # Fixed monorepo deployment configuration
 services:
 # ============================================================================


### PR DESCRIPTION
Your ruling recorded, the value held, and an answer to the question underneath it.

## The pin: ruling recorded, value held

`PYTHON_VERSION` gets pinned for every service in `render.yaml`, matching what `deedpro-main-api` runs. **I have not guessed the value.** A plausible-looking version in a deploy file is how a fix becomes the next outage, and a wrong pin is worse than no pin because it looks deliberate. The one-line change is written out in the ledger ready to paste, and lands together with a test asserting every service block carries it — held rather than committed failing.

## Which reality we're in — answered, and I didn't need the dashboard

**`render.yaml` defines exactly one service.** The purge cron you created and debugged over four failures appears nowhere in it.

| running in production | in `render.yaml`? |
|---|---|
| `deedpro-main-api` | yes |
| the purge cron | **no** |
| Postgres `deedpro` | by reference only |

So it's your first possibility: the dashboard is authoritative and the file describes a subset.

**And that's worse than the version-pin problem that found it.** A config file that lies by *omission* is harder to catch than one that lies by contents — nothing about a YAML file announces that it's partial. The version pin at least fails loudly one day. An incomplete inventory just gets believed.

This PR adds the header saying so, which is the cheap half:

> ⚠️ THIS FILE IS NOT THE DEPLOYMENT INVENTORY. Services are managed in the Render dashboard. This file describes `deedpro-main-api` and nothing else…

**The expensive half is your call, not mine:** bringing the cron into `render.yaml` and keeping it there makes the repo the source of truth for deploy topology. That's a real commitment — every future service has to go through the file — not a formatting preference. I'd do the header now and the migration only if topology gets complicated enough to need review. Left as a question rather than assumed.

## The diagnostic corollary, as a ticket

Not a note. It cost an afternoon and two redeploys on an untested hypothesis, which is the definition of something that earns a ticket.

`relation "signing_participants" does not exist` sent us hunting for a schema that had never run. The same failure with its context:

```
signing_participants not found in deedpro_database on dpg-d1vbos95… —
expected deedpro on dpg-d208q5um…
```

Scope, acceptance and effort are in the ledger: a `services/db_identity.py` with `assert_tables(conn, *names)` that raises naming `current_database()`, host and port; called from the purge script before it does anything; a `--verify` flag printing the same block. Half a day, not urgent — the defect is fixed and the rule recorded — but it's the difference between a rule people must remember and a mechanism that remembers for them. Which is the same standard the purge itself was held to.

## On the sentence

You're right that it happened to you, and I'd add the part that makes it general rather than a story about one afternoon: **the wrong reading was the more competent one.** "Missing table" → "the DDL hasn't run" is what a careful engineer concludes, because it's true almost every time. That's exactly why it's expensive — the failure mode isn't carelessness, it's a good prior applied to a case that violates it. Which is why it has to be a *rule* and a *mechanism*, not a thing to remember.

Docs and one comment block. No code, no gates affected.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_