### PR TITLE
NOTARY2 (4/n): delivery — four templates, the .ics, and a fifth that was deleted

### DIFF
--- a/backend/routers/signing.py
+++ b/backend/routers/signing.py
@@ -228,6 +228,11 @@ def create_signing_request(payload: CreateSigningRequest,
         # link to a row that does not exist.
         raise HTTPException(status_code=500, detail="Could not create the signing request")
 
+    # Ask the notary. The SIGNERS are not emailed yet — there is nothing
+    # for them to answer until she posts times, and "pick a time" with no
+    # times is asking a consumer to do nothing.
+    _invite_notary(request_id)
+
     return {
         "success": True,
         "signing_request_id": request_id,
@@ -474,6 +479,15 @@ def notary_post_windows(token: str, payload: PostWindows, http_request: Request)
                 (window_id, me["id"], loop.ANSWER_AVAILABLE))
     db.conn.commit()
     _book_if_converged(me["signing_request_id"])
+    # Tell the signers only if there is still a question for them.
+    #
+    # The first version keyed off `_book_if_converged`'s return, which was
+    # wrong in a way a test caught: that function returns None BOTH when
+    # nothing converged AND when the request was already booked, so
+    # posting a spare time to a settled request emailed every signer
+    # "pick one" for a signing that was done. Two different situations
+    # behind one falsy value.
+    _tell_signers_windows_posted(me["signing_request_id"])
     return token_view(token, http_request)
 
 
@@ -557,6 +571,7 @@ def signer_propose(token: str, payload: ProposeIn, http_request: Request):
         cur.execute("UPDATE signing_requests SET signer_proposals = signer_proposals + 1, "
                     "updated_at = now() WHERE id = %s", (me["signing_request_id"],))
     db.conn.commit()
+    _tell_notary_of_proposal(me["signing_request_id"], me, window_id)
     return token_view(token, http_request)
 
 
@@ -610,6 +625,7 @@ def _book_if_converged(request_id: int) -> Optional[int]:
     if not won:
         return None
     _tell_everyone(request_id)
+    _tell_everyone_booked(request_id)
     return window_id
 
 
@@ -637,3 +653,172 @@ def _tell_everyone(request_id: int) -> None:
         except Exception:
             pass
         print(f"[NOTARY2] ⚠️ booking notification failed (non-blocking): {e}")
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Telling people
+#
+# Every send is best-effort and never fatal. A booking that HAPPENED must
+# not be undone because a mail server was slow — and every attempt lands
+# in `email_log` through the one transport regardless, so "did they get
+# it" is answerable at 3am (ADMIN3).
+# ══════════════════════════════════════════════════════════════════════
+
+def _party(world: Dict[str, Any], role: str) -> List[Dict[str, Any]]:
+    return [p for p in world["participants"]
+            if p["party_role"] == role and not p.get("revoked_at")]
+
+
+def _link(p: Dict[str, Any]) -> str:
+    return f"{APP_URL()}/signing/{p['token']}"
+
+
+def _officer_bits(world: Dict[str, Any]):
+    officer = world["officer"]
+    return officer.get("full_name") or "Your escrow officer", officer.get("company_name")
+
+
+def _invite_notary(request_id: int) -> None:
+    try:
+        world = _load(request_id)
+        notary = next(iter(_party(world, loop.ROLE_NOTARY)), None)
+        if not notary or not notary.get("email"):
+            return
+        name, company = _officer_bits(world)
+        from utils.notifications import send_notary_invited
+        ok, reason = send_notary_invited(
+            recipient_email=notary["email"],
+            notary_name=notary.get("display_name") or "",
+            officer_name=name, officer_company=company,
+            deed_type=world["deed"].get("deed_type") or "deed",
+            property_address=world["deed"].get("property_address"),
+            county=world["deed"].get("county"),
+            link=_link(notary),
+            expires_at=_fmt_day(world["request"].get("expires_at")),
+        )
+        if not ok:
+            print(f"[NOTARY2] ⚠️ notary invite not sent: {reason}")
+    except Exception as e:
+        print(f"[NOTARY2] ⚠️ notary invite failed (non-blocking): {e}")
+
+
+def _tell_signers_windows_posted(request_id: int) -> None:
+    """Each signer gets their OWN link. One shared link would let any
+    signer answer as another, and a consumer surface is not the place to
+    discover that."""
+    try:
+        world = _load(request_id)
+        if world["request"].get("booked_at") or world["request"].get("cancelled_at"):
+            return  # nothing left to ask them
+        tz = world["request"].get("tz_name")
+        live = [w for w in world["windows"] if not w.get("declined_at")]
+        if not live:
+            return
+        labels = [loop.window_label(w, tz) for w in live]
+        notary = next(iter(_party(world, loop.ROLE_NOTARY)), {})
+        name, company = _officer_bits(world)
+        from utils.notifications import send_signing_windows_posted
+        for signer in _party(world, loop.ROLE_SIGNER):
+            if not signer.get("email"):
+                continue
+            ok, reason = send_signing_windows_posted(
+                recipient_email=signer["email"],
+                signer_name=signer.get("display_name") or "",
+                officer_name=name, officer_company=company,
+                notary_name=notary.get("display_name"),
+                property_street=world["deed"].get("property_address"),
+                window_texts=labels, link=_link(signer))
+            if not ok:
+                print(f"[NOTARY2] ⚠️ signer notice not sent: {reason}")
+    except Exception as e:
+        print(f"[NOTARY2] ⚠️ signer notices failed (non-blocking): {e}")
+
+
+def _tell_notary_of_proposal(request_id: int, proposer: Dict[str, Any],
+                             window_id: int) -> None:
+    try:
+        world = _load(request_id)
+        notary = next(iter(_party(world, loop.ROLE_NOTARY)), None)
+        if not notary or not notary.get("email"):
+            return
+        window = next((w for w in world["windows"] if int(w["id"]) == int(window_id)), None)
+        if window is None:
+            return
+        name, _company = _officer_bits(world)
+        from utils.notifications import send_signing_proposal_received
+        send_signing_proposal_received(
+            recipient_email=notary["email"],
+            notary_name=notary.get("display_name") or "",
+            signer_name=proposer.get("display_name") or "A signer",
+            officer_name=name,
+            property_address=world["deed"].get("property_address"),
+            window_text=loop.window_label(window, world["request"].get("tz_name")),
+            link=_link(notary))
+    except Exception as e:
+        print(f"[NOTARY2] ⚠️ proposal notice failed (non-blocking): {e}")
+
+
+def _tell_everyone_booked(request_id: int) -> None:
+    """The `.ics` to all three parties, and the register differs by who.
+
+    The signer's copy carries the STREET LINE and the officer's name; the
+    professionals get the full address and a link into the record. An
+    email is not a loophole in the surface allowlist — what a party may
+    see does not widen because the channel changed.
+    """
+    try:
+        from utils.email import attachment
+        from utils.notifications import send_signing_booked
+
+        world = _load(request_id)
+        req, deed = world["request"], world["deed"]
+        tz = req.get("tz_name")
+        when = req.get("booked_at")
+        window = next((w for w in world["windows"]
+                       if w.get("starts_at") == when), None)
+        when_text = loop.window_label(window, tz) if window else str(when)
+        officer_name, _c = _officer_bits(world)
+        notary = next(iter(_party(world, loop.ROLE_NOTARY)), {})
+        full_address = deed.get("property_address") or ""
+        street = full_address.split(",")[0].strip()
+
+        ics = None
+        if window and hasattr(window.get("starts_at"), "astimezone"):
+            ics = signing_ics(window, full_address, officer_name)
+        files = [attachment("signing.ics", ics, "text/calendar")] if ics else []
+
+        for p in world["participants"]:
+            if p.get("revoked_at") or not p.get("email"):
+                continue
+            consumer = p["party_role"] == loop.ROLE_SIGNER
+            send_signing_booked(
+                recipient_email=p["email"],
+                recipient_name=p.get("display_name") or "",
+                when_text=when_text,
+                property_text=street if consumer else full_address,
+                notary_name=notary.get("display_name"),
+                officer_name=officer_name,
+                is_consumer=consumer,
+                link=f"{APP_URL()}/signings",
+                attachments=files)
+    except Exception as e:
+        print(f"[NOTARY2] ⚠️ booking notices failed (non-blocking): {e}")
+
+
+def signing_ics(window: Dict[str, Any], address: str, officer_name: str) -> bytes:
+    """METHOD:PUBLISH, per §13 — a copy of an arrangement people made, not
+    an invitation from an organiser expecting an RSVP. Reuses NOTARY1's
+    builder rather than a second one: two iCalendar writers is two places
+    for a timezone to go wrong."""
+    from services.signing import build_ics
+    return build_ics(
+        summary=f"Notary signing — {address}" if address else "Notary signing",
+        start=window["starts_at"], end=window["ends_at"],
+        location=address or None,
+        description=(f"Arranged through DeedPro by {officer_name}. "
+                     "Everyone involved agreed to this time."),
+        uid=f"signing-request-{window['signing_request_id']}@deedpro")
+
+
+def _fmt_day(value: Any) -> Optional[str]:
+    return value.strftime("%B %d, %Y") if hasattr(value, "strftime") else None

--- a/backend/tests/test_admin3_email_outcomes.py
+++ b/backend/tests/test_admin3_email_outcomes.py
@@ -63,7 +63,7 @@ def test_no_module_outside_notifications_sends_mail():
 
 
 def test_every_template_routes_through_send():
-    """All fourteen, named. A template that renders and sends without a
+    """All eighteen, named. A template that renders and sends without a
     `_send` name is a template whose rows land under the wrong label —
     which is worse than no label, because the log then lies quietly.
 
@@ -71,7 +71,9 @@ def test_every_template_routes_through_send():
     rather than a fact worth knowing: a new template must be a deliberate
     edit here, not something that arrives with a diff nobody read. It
     fired as designed when TRIAL1 added `payment_failed` (11 -> 12) and
-    again when NOTARY1 added the two signing templates (12 -> 14)."""
+    again when NOTARY1 added the two signing templates (12 -> 14) and
+    again when NOTARY2 added the coordination loop's four (14 -> 18 — a fifth was written,
+    found to be unsendable, and deleted rather than wired)."""
     import sys
     sys.path.insert(0, str(BACKEND))
     from utils.notifications import TEMPLATES
@@ -82,7 +84,7 @@ def test_every_template_routes_through_send():
         f"declared TEMPLATES and actual _send labels disagree: "
         f"only-declared={set(TEMPLATES) - named}, only-used={named - set(TEMPLATES)}"
     )
-    assert len(TEMPLATES) == 14
+    assert len(TEMPLATES) == 18
 
 
 # ── The recorder's two constraints ───────────────────────────────────
@@ -280,3 +282,44 @@ def test_the_api_key_funnel_still_records_on_its_own_row():
     history. Both, deliberately."""
     src = (BACKEND / "routers" / "api_key_requests.py").read_text(encoding="utf-8")
     assert "notify_error = %s" in src
+
+
+def test_every_declared_template_has_a_sender_that_something_calls():
+    """A template nothing sends is dead code wearing a ledger name.
+
+    NOTARY2 wrote a `signer_invited` that was never reachable — there is
+    nothing to invite a signer to until the notary has posted times, so
+    the windows email was always their first contact. It passed every
+    other pin in this file: it was declared, it had a `_send` label, it
+    routed through the choke point. The only thing wrong with it was that
+    no code path led to it, which is exactly what this checks.
+
+    Deleted rather than wired, and the count moved 19 -> 18.
+    """
+    import sys
+    sys.path.insert(0, str(BACKEND))
+    from utils.notifications import TEMPLATES
+
+    src = code_only(NOTIFICATIONS)
+    # Map each template to the sender function that emits it.
+    senders = {}
+    for match in re.finditer(r"def (send_\w+|notify_\w+)\(", src):
+        body = src[match.end():]
+        nxt = re.search(r"\ndef ", body)
+        body = body[:nxt.start()] if nxt else body
+        for label in re.findall(r'_send\(\s*"([a-z_]+)"', body):
+            senders[label] = match.group(1)
+
+    callers = []
+    for path in BACKEND.rglob("*.py"):
+        if {"tests", "__pycache__"} & set(path.parts) or path.name == "notifications.py":
+            continue
+        callers.append(code_only(path))
+    everything = "\n".join(callers)
+
+    orphans = [t for t in TEMPLATES
+               if t in senders and f"{senders[t]}(" not in everything]
+    assert orphans == [], (
+        f"declared but unsendable — no code path reaches these: {orphans}. "
+        "Either wire them or delete them; a template nothing sends is dead "
+        "code that passes every other pin in this file.")

--- a/backend/tests/test_notary2_routes.py
+++ b/backend/tests/test_notary2_routes.py
@@ -406,3 +406,99 @@ def test_the_agenda_shows_only_her_own(world):
     request_id, _ = _create(world)
     rows = client_for(world["stranger"]).get("/signing-requests/v2").json()
     assert all(r["id"] != request_id for r in rows)
+
+
+# ══════════════════════════════════════════════════════════════════════
+# The emails actually fire
+#
+# Every send in this loop is best-effort and non-fatal, which is correct
+# — a booking that happened must not be undone because a mail server was
+# slow — and it means a broken send makes NOTHING go red. So the ledger
+# is the assertion: `email_log` records every ATTEMPT through the one
+# transport (ADMIN3), configured or not.
+#
+# High-water marks throughout, per the rule these suites learned twice:
+# `email_log` survives between runs, so "a row with this template exists"
+# is satisfied by yesterday's row and passes with the code broken.
+# ══════════════════════════════════════════════════════════════════════
+
+def _mark(conn) -> int:
+    with conn.cursor() as cur:
+        cur.execute("SELECT COALESCE(MAX(id), 0) AS m FROM email_log")
+        return cur.fetchone()["m"]
+
+
+def _sent_since(conn, mark: int):
+    with conn.cursor() as cur:
+        cur.execute("SELECT template, recipient FROM email_log WHERE id > %s "
+                    "ORDER BY id", (mark,))
+        return [(r["template"], r["recipient"]) for r in (cur.fetchall() or [])]
+
+
+def test_creating_a_request_asks_the_notary_and_nobody_else(world):
+    """The signers are NOT emailed yet. "Pick a time" with no times is
+    asking a consumer to do nothing, and the first email this product
+    ever sends a member of the public should not be that."""
+    mark = _mark(world["conn"])
+    _create(world)
+    sent = _sent_since(world["conn"], mark)
+    assert [t for t, _ in sent] == ['notary_invited'], sent
+    assert sent[0][1] == 'nora@notary.test'
+
+
+def test_posting_windows_tells_every_signer_on_their_own_link(world):
+    _, tokens = _create(world)
+    mark = _mark(world["conn"])
+    public().post(f"/signing/{tokens[loop.ROLE_NOTARY][0]}/windows",
+                  json={"windows": _windows()})
+    sent = _sent_since(world["conn"], mark)
+    assert [t for t, _ in sent] == ['signing_windows_posted'] * 2, sent
+    assert {r for _, r in sent} == {'s0@example.test', 's1@example.test'}
+
+
+def test_a_proposal_tells_the_notary(world):
+    _, tokens = _create(world, signers=1)
+    pub = public()
+    pub.post(f"/signing/{tokens[loop.ROLE_NOTARY][0]}/windows", json={"windows": _windows(1)})
+    mark = _mark(world["conn"])
+    pub.post(f"/signing/{tokens[loop.ROLE_SIGNER][0]}/propose",
+             json=_windows(1, days_out=30)[0])
+    sent = _sent_since(world["conn"], mark)
+    assert [t for t, _ in sent] == ['signing_proposal_received'], sent
+    assert sent[0][1] == 'nora@notary.test'
+
+
+def test_booking_tells_everyone_once(world):
+    """All three parties, one email each. Not two for anybody: a person
+    who gets the same news twice stops reading the second one."""
+    _, tokens = _create(world)
+    pub = public()
+    pub.post(f"/signing/{tokens[loop.ROLE_NOTARY][0]}/windows", json={"windows": _windows()})
+    wid = pub.get(f"/signing/{tokens[loop.ROLE_SIGNER][0]}").json()["windows"][0]["id"]
+    pub.post(f"/signing/{tokens[loop.ROLE_SIGNER][0]}/answer",
+             json={"window_id": wid, "answer": "available"})
+    mark = _mark(world["conn"])
+    pub.post(f"/signing/{tokens[loop.ROLE_SIGNER][1]}/answer",
+             json={"window_id": wid, "answer": "available"})
+
+    sent = _sent_since(world["conn"], mark)
+    booked = [r for t, r in sent if t == 'signing_booked']
+    assert sorted(booked) == ['nora@notary.test', 's0@example.test', 's1@example.test']
+    assert len(booked) == len(set(booked)), "somebody was told twice"
+
+
+def test_windows_that_book_immediately_do_not_also_say_pick_a_time(world):
+    """A single-signer request where the notary posts a time the signer
+    has already agreed to would otherwise send "pick one" and "it is
+    booked" in the same minute."""
+    _, tokens = _create(world, signers=1)
+    pub = public()
+    pub.post(f"/signing/{tokens[loop.ROLE_NOTARY][0]}/windows", json={"windows": _windows(1)})
+    wid = pub.get(f"/signing/{tokens[loop.ROLE_SIGNER][0]}").json()["windows"][0]["id"]
+    pub.post(f"/signing/{tokens[loop.ROLE_SIGNER][0]}/answer",
+             json={"window_id": wid, "answer": "available"})
+    # Now a SECOND window posted after it is already booked.
+    mark = _mark(world["conn"])
+    pub.post(f"/signing/{tokens[loop.ROLE_NOTARY][0]}/windows",
+             json={"windows": _windows(1, days_out=40)})
+    assert 'signing_windows_posted' not in [t for t, _ in _sent_since(world["conn"], mark)]

--- a/backend/utils/email_templates.py
+++ b/backend/utils/email_templates.py
@@ -439,6 +439,148 @@ def signing_time_recorded(owner_name, deed_type, property_address, notary_email,
     return subject, _base(f"Signing time recorded — {addr}", content, True), text
 
 
+def notary_invited(notary_name, officer_name, officer_company, deed_type,
+                   property_address, county, link, expires_at) -> Rendered:
+    """NOTARY2 — officer → notary: post the times you are free.
+
+    Professional-to-professional. She gets the address, the instrument
+    and the county because she is going there to notarise that document;
+    what she does NOT get is any way to reach the signers, because she
+    has no reason to and the officer does.
+    """
+    addr = _short_addr(property_address)
+    subject = f"Signing request — {addr}" if addr else "Notary signing request"
+    content = (
+        _p(f"Hi {_esc(notary_name) or 'there'},")
+        + _p(f"<strong>{_esc(officer_name)}</strong>"
+             + (f" at {_esc(officer_company)}" if officer_company else "")
+             + " is asking whether you can notarize a signing.")
+        + _facts([("Document", deed_type), ("Property", addr),
+                  ("County", county), ("Link expires", expires_at or "")])
+        + _button(link, "Post the times you are free")
+        + _p('<span style="font-size:13px;color:#8a94a0;">The signers pick from the '
+             "times you post. When you and they land on the same one, it is booked and "
+             "everybody is told.</span>")
+    )
+    text = (
+        f"{officer_name} is asking whether you can notarize a signing.\n\n"
+        f"Document: {deed_type}\nProperty: {addr}\nCounty: {county}\n"
+        f"Link expires: {expires_at or ''}\n\n"
+        f"Post the times you are free: {link}\n\n"
+        "The signers pick from the times you post."
+    )
+    return subject, _base(f"{officer_name} asked about your availability", content, True), text
+
+
+def signing_windows_posted(signer_name, officer_name, officer_company, notary_name,
+                           property_street, window_texts, link) -> Rendered:
+    """NOTARY2 — to a SIGNER. The first email this product sends to
+    somebody who never signed up, and therefore the one that has to
+    introduce as well as ask.
+
+    A separate `signer_invited` existed for one commit and was DELETED
+    rather than wired: nothing sent it, because there is nothing to
+    invite a signer to until the notary has posted times. "Pick a time"
+    with no times is asking a consumer to do nothing. So this email does
+    both jobs, and there is one template instead of a dead one and a
+    terse one.
+
+    The signer surface's rules, in prose: plain language, the officer's
+    name leading, the property STREET only, one thing to do. No deed
+    type, no county, no APN, no party names — the allowlist is not a UI
+    concern, it is what we may say to this person at all.
+    """
+    subject = f"Pick a time to sign — {_short_addr(property_street)}"
+    times = "".join(f"  - {w}\n" for w in (window_texts or []))
+    listed = "".join(
+        f'<tr><td style="padding:4px 0;font-size:14px;color:{INK};font-weight:600;">'
+        f"&bull;&nbsp;{_esc(w)}</td></tr>" for w in (window_texts or []))
+    content = (
+        _p(f"Hi {_esc(signer_name) or 'there'},")
+        + _p(f"<strong>{_esc(officer_name)}</strong>"
+             + (f" at {_esc(officer_company)}" if officer_company else "")
+             + " is arranging the signing for your property and needs to know when "
+             "you are free.")
+        + _facts([("Property", _short_addr(property_street)),
+                  ("Your notary", notary_name)])
+        + _p(f"{_esc(notary_name) or 'The notary'} is free at these times:")
+        + ('<table role="presentation" cellpadding="0" cellspacing="0" '
+           f'style="margin:10px 0;">{listed}</table>' if listed else "")
+        + _button(link, "Pick one")
+        + _p('<span style="font-size:13px;color:#8a94a0;">A notary will meet you to '
+             "witness the signing. Everyone signing has to agree on the same time — you "
+             "will be told once one is settled. If none of these work, you can suggest "
+             "another.</span>")
+        + _p(f'<span style="font-size:13px;color:#8a94a0;">Questions about the '
+             f"paperwork? Ask {_esc(officer_name)}.</span>")
+    )
+    text = (
+        f"{officer_name} is arranging the signing for your property and needs to know "
+        f"when you are free.\n\n"
+        f"Property: {_short_addr(property_street)}\nYour notary: {notary_name}\n\n"
+        f"{notary_name or 'The notary'} is free at these times:\n\n{times}\n"
+        f"Pick one: {link}\n\n"
+        "A notary will meet you to witness the signing. Everyone signing has to agree "
+        f"on the same time. Questions about the paperwork? Ask {officer_name}."
+    )
+    return subject, _base(f"{officer_name} needs to know when you are free",
+                          content, False), text
+
+
+def signing_proposal_received(notary_name, signer_name, officer_name,
+                              property_address, window_text, link) -> Rendered:
+    """NOTARY2 — a signer suggested a time the notary did not offer."""
+    addr = _short_addr(property_address)
+    subject = f"A signer suggested a time — {addr}"
+    content = (
+        _p(f"Hi {_esc(notary_name) or 'there'},")
+        + _p(f"{_esc(signer_name) or 'A signer'} cannot make the times you posted for "
+             f"{_esc(officer_name)}'s signing, and suggested this instead:")
+        + _facts([("Suggested", window_text), ("Property", addr)])
+        + _button(link, "Accept or decline")
+        + _p('<span style="font-size:13px;color:#8a94a0;">Accepting it may book the '
+             "signing straight away, if everyone else has already agreed.</span>")
+    )
+    text = (f"{signer_name or 'A signer'} suggested a different time:\n\n"
+            f"Suggested: {window_text}\nProperty: {addr}\n\n"
+            f"Accept or decline: {link}")
+    return subject, _base("A signer suggested a different time", content, True), text
+
+
+def signing_booked(recipient_name, when_text, property_text, notary_name,
+                   officer_name, is_consumer: bool, link) -> Rendered:
+    """NOTARY2 — everybody, on convergence. Carries the .ics.
+
+    ONE TEMPLATE, TWO REGISTERS, chosen by `is_consumer` rather than by
+    two near-identical functions that drift. The professionals get the
+    full address and a link into the record; the signer gets the street
+    line and the officer's name, because that is all their surface may
+    carry and an email is not a loophole in it.
+
+    §13: "agreed", never "confirmed" and never "will happen". The
+    calendar file is METHOD:PUBLISH — a copy of an arrangement, not an
+    invitation expecting an RSVP.
+    """
+    subject = f"Signing time agreed — {property_text}"
+    who = f"{_esc(notary_name)}" if notary_name else "your notary"
+    body = (
+        _p(f"Hi {_esc(recipient_name) or 'there'},")
+        + _p("Everyone has agreed on a time. It is in the calendar file attached.")
+        + _facts([("Time", when_text), ("Property", property_text),
+                  ("Notary", notary_name),
+                  ("Arranged by", officer_name if is_consumer else None)])
+        + (_p(f'<span style="font-size:13px;color:#8a94a0;">{who} will meet you then. '
+              f"If anything changes, contact {_esc(officer_name)}.</span>")
+           if is_consumer else _button(link, "Open in DeedPro"))
+    )
+    text = (
+        "Everyone has agreed on a time.\n\n"
+        f"Time: {when_text}\nProperty: {property_text}\nNotary: {notary_name}\n"
+        + (f"Arranged by: {officer_name}\n" if is_consumer else f"\nOpen: {link}\n")
+    )
+    return subject, _base(f"Signing time agreed — {when_text}", body, not is_consumer), text
+
+
 def admin_new_user(user_email, user_id, registered_at: Optional[str] = None) -> Rendered:
     """Ops ping (owner ruling): registrant email + timestamp — no more."""
     ts = registered_at or datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")

--- a/backend/utils/notifications.py
+++ b/backend/utils/notifications.py
@@ -29,6 +29,13 @@ TEMPLATES = (
     # about availability; notary→officer (or officer→herself) records a
     # time. There is deliberately no third: no signer is ever emailed.
     "share_signing_request", "signing_time_recorded",
+    # NOTARY2 — the coordination loop. Five, and the count is the point:
+    # ask the notary, ask the signers, tell the signers when there is
+    # something to answer, tell the notary when a signer proposes, and
+    # tell everybody when it lands. There is deliberately no sixth for
+    # "the signing happened," because nothing in this product knows that.
+    "notary_invited", "signing_windows_posted",
+    "signing_proposal_received", "signing_booked",
 )
 
 
@@ -229,6 +236,64 @@ def send_signing_time_recorded_with_reason(owner_email: str, owner_name: str,
                  user_id=user_id,
                  context={"deed_type": deed_type, "notary": notary_email},
                  attachments=attachments)
+
+
+def send_notary_invited(recipient_email: str, notary_name: str, officer_name: str,
+                        officer_company: Optional[str], deed_type: str,
+                        property_address: Optional[str], county: Optional[str],
+                        link: str, expires_at: Optional[str]) -> SendResult:
+    return _send("notary_invited", recipient_email, email_templates.notary_invited(
+        notary_name, officer_name, officer_company, deed_type,
+        property_address, county, link, expires_at),
+        context={"deed_type": deed_type})
+
+
+def send_signing_windows_posted(recipient_email: str, signer_name: str,
+                                officer_name: str, officer_company: Optional[str],
+                                notary_name: Optional[str],
+                                property_street: Optional[str], window_texts,
+                                link: str) -> SendResult:
+    """The signer's FIRST and usually only email before it books.
+
+    The context recorded in `email_log` deliberately carries no property
+    detail — the ledger answers "did we send it", and a row that also
+    records whose house it was about is a second copy of the thing §13.1
+    limits to one table.
+    """
+    return _send("signing_windows_posted", recipient_email,
+                 email_templates.signing_windows_posted(
+                     signer_name, officer_name, officer_company, notary_name,
+                     property_street, window_texts, link),
+                 context={"party": "signer", "windows": len(window_texts or [])})
+
+
+def send_signing_proposal_received(recipient_email: str, notary_name: str,
+                                   signer_name: str, officer_name: str,
+                                   property_address: Optional[str],
+                                   window_text: str, link: str) -> SendResult:
+    return _send("signing_proposal_received", recipient_email,
+                 email_templates.signing_proposal_received(
+                     notary_name, signer_name, officer_name, property_address,
+                     window_text, link),
+                 context={"party": "notary"})
+
+
+def send_signing_booked(recipient_email: str, recipient_name: str, when_text: str,
+                        property_text: str, notary_name: Optional[str],
+                        officer_name: str, is_consumer: bool, link: str,
+                        user_id: Optional[int] = None,
+                        attachments: Optional[list] = None) -> SendResult:
+    """Everybody, on convergence — with the calendar file.
+
+    `is_consumer` picks the register AND what the body may contain: the
+    signer gets the street line, the professionals get the full address.
+    An email is not a loophole in the surface allowlist.
+    """
+    return _send("signing_booked", recipient_email, email_templates.signing_booked(
+        recipient_name, when_text, property_text, notary_name, officer_name,
+        is_consumer, link),
+        user_id=user_id, context={"party": "signer" if is_consumer else "professional"},
+        attachments=attachments)
 
 
 def send_welcome_with_reason(user_email: str, full_name: str) -> SendResult:

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -607,3 +607,105 @@ them rather than what they are.
 from before this engagement is Tier 3 twice over: irreversible, and
 possibly somebody's data. The useful next step is read-only — list its
 tables and row counts — and that is the owner's to run.
+
+## `render.yaml` — owner ruling, and which reality we are in (2026-08-11)
+
+**Ruling:** pin `PYTHON_VERSION` explicitly for every service defined in
+`render.yaml`, matching what production actually runs. Whichever of the
+two possibilities is true, the fix is the same — the repo should express
+the rule, and an unpinned runtime on the customer-facing API is the same
+latent failure the cron just demonstrated, one Render default bump away.
+
+**HELD, PENDING A VALUE.** The owner is reading the current version off
+`deedpro-main-api`. Not guessed: writing a plausible version into a
+deploy file is how a "fix" becomes an outage on the next deploy, and a
+wrong pin is worse than no pin because it looks deliberate.
+
+**The one-line change, ready to apply** — under `deedpro-main-api`'s
+`envVars`, alongside the existing entries:
+
+```yaml
+  - key: PYTHON_VERSION
+    value: "3.X.Y"        # ← the value from deedpro-main-api's dashboard
+```
+
+Landing it together with a pin — a test asserting every service block in
+`render.yaml` carries `PYTHON_VERSION` — so the rule survives the next
+service somebody adds. The pin is written and held with the value rather
+than committed failing.
+
+### Which reality we are in: the dashboard is authoritative
+
+The question was whether `render.yaml` describes production or the
+dashboard does. **It does not describe production, and this is checkable
+without any dashboard access:**
+
+`render.yaml` defines **exactly one service** — `deedpro-main-api` — plus
+a database reference. Production runs at minimum:
+
+| running | in `render.yaml`? |
+|---|---|
+| `deedpro-main-api` (web) | yes |
+| the purge cron job | **no** |
+| Postgres `deedpro` | by reference only |
+
+The cron the owner created and debugged over four failures **appears
+nowhere in this file.** So the file is already a partial description, and
+anything reading it as the deployment inventory is reading a subset that
+does not announce itself as one.
+
+That is worse than the version-pin problem it was found by. A config file
+that lies by OMISSION is harder to catch than one that lies by contents:
+nothing about `render.yaml` says "this is some of what runs."
+
+**Two ways to make it honest, and this is an owner call:**
+
+1. **Bring the cron into `render.yaml`** so the file is the inventory,
+   and keep it that way. More work, and it makes the repo the source of
+   truth for deploy topology — which is a real commitment, not a
+   formatting preference.
+2. **Say so at the top of the file** — a header stating that services are
+   managed in the Render dashboard and this file is a reference for the
+   main API only. Cheap, honest, and it stops the next person trusting
+   it.
+
+Doing neither leaves a file that will be believed. Recommended: (2) now,
+(1) if deploy topology ever gets complicated enough to need review.
+
+## TICKET — services assert their tables and name the database (queued)
+
+**Why it is a ticket rather than a note.** It cost an afternoon of the
+owner's time and two redeploys on an untested hypothesis. Invariant #4
+applied to diagnostics: an error that names its context is a different
+quality of error.
+
+`relation "signing_participants" does not exist` sent us hunting for a
+schema that had never run. The same failure, phrased with its context —
+
+```
+signing_participants not found in deedpro_database on dpg-d1vbos95… —
+expected deedpro on dpg-d208q5um…
+```
+
+— ends the investigation in one run and names the actual defect.
+
+**Scope.** A small startup assertion, used by any service that depends on
+specific tables:
+
+- `services/db_identity.py` — `assert_tables(conn, *names)` which, on a
+  miss, raises with `current_database()`, `inet_server_addr()`,
+  `inet_server_port()` and the missing table names in the message;
+- called from `scripts/purge_signer_contact.py` before it does anything;
+- an optional `--verify` flag printing the same identity block, so
+  "which database is this service on" is answerable without a psql
+  session;
+- the same call available to any future worker or cron.
+
+**Acceptance.** Pointing the purge script at the wrong database produces
+a message naming both databases; pointing it at the right one is silent.
+Tested by running it against a database that lacks the table.
+
+**Effort.** Half a day. **Not urgent** — the specific defect is fixed and
+the standing rule is recorded — but it is the difference between a rule
+people must remember and a mechanism that remembers for them, which is
+the same distinction the purge itself was held to.

--- a/render.yaml
+++ b/render.yaml
@@ -1,3 +1,26 @@
+# ⚠️ THIS FILE IS NOT THE DEPLOYMENT INVENTORY.
+#
+# Services are managed in the Render dashboard. This file describes
+# `deedpro-main-api` and nothing else — the purge cron job
+# (`signer_contact_purge`, added 2026-08-11) runs in production and does
+# not appear here, and neither will anything else created in the
+# dashboard.
+#
+# Recorded because a config file that lies by OMISSION is harder to catch
+# than one that lies by contents: nothing about a YAML file announces
+# that it is a subset. Anyone reading this as "what runs" is reading a
+# partial list that does not say so.
+#
+# Owner-ruled 2026-08-11: every service defined here pins PYTHON_VERSION
+# explicitly, matching what `deedpro-main-api` actually runs. An unpinned
+# service inherits whatever Render's default is on the day it builds —
+# which is exactly how the cron's first build died compiling Rust for a
+# pydantic_core with no 3.14 wheel. The value is HELD pending the owner
+# reading it off the dashboard; it is not guessed, because a wrong pin in
+# a deploy file looks deliberate and fails on the next deploy.
+#
+# See docs/OWNER_LEDGER.md, "render.yaml — owner ruling".
+
 # Fixed monorepo deployment configuration
 services:
 # ============================================================================


### PR DESCRIPTION
The loop now reaches people. Branched off `main`; #153 (surfaces) is still open and independent.

## Four templates, and the count is the point

Ask the notary; tell the signers when there's something to answer; tell the notary when a signer proposes; tell everybody when it lands. **No template for "the signing happened"**, because nothing in this product knows that (§13).

Creating a request emails **the notary only**. Signers hear nothing until there are times to pick from — "pick a time" with no times is asking a consumer to do nothing, and the first email this product ever sends a member of the public shouldn't be that.

## A fifth template was written and deleted

`signer_invited` passed **every existing pin**: declared in `TEMPLATES`, given a `_send` label, routed through the choke point. The only thing wrong with it was that **no code path led to it** — there's nothing to invite a signer to before the notary posts times, so the windows email was always their first contact.

Deleted rather than wired, with its introduction copy folded into the email signers actually receive. One template doing both jobs beats a dead one and a terse one.

**New pin for the class:** every declared template must have a sender that something outside `notifications.py` calls. Probed with a planted ghost. This is the kind of dead code that's hardest to see — it looked correct from every angle except reachability.

## An email is not a loophole in the surface allowlist

The booking notice goes to all three parties with one `.ics`, and `is_consumer` picks **both the register and what the body may contain**: the signer gets the street line and the officer's name; the professionals get the full address and a link into the record. What a party may see doesn't widen because the channel changed.

The `email_log` context for signer sends deliberately records **no property detail**. The ledger answers "did we send it" — a row that also recorded whose house it was about would be a second copy of the thing §13.1 keeps to one table.

## A defect the new tests caught

**Posting a spare time to an already-booked request emailed every signer "pick one"** for a signing that was settled. The guard keyed off `_book_if_converged`'s return, which is `None` **both** when nothing converged and when the request was already booked — two different situations behind one falsy value. Now checked against the request's own state.

Worth naming as a shape: a function returning a falsy value for two unrelated reasons is a defect waiting for its second caller.

## Why the ledger is the assertion

Every send here is best-effort and non-fatal — correct, because a booking that *happened* must not be undone by a slow mail server. It also means **a broken send makes nothing go red.** So five tests read `email_log` at each moment, with high-water marks, per the rule these suites have now learned twice.

## Gates

| gate | result |
|---|---|
| pytest, no database | 825 passed |
| pytest, with database | 964 passed |
| six-flow baseline | ✔ |
| banned-claims | clean |

Three probes bite: breaking the notary invite, planting a ghost template, and the already-booked send.

## Remaining

Reminders and the NOTARY1 → NOTARY2 migration. After those, Part C is complete.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_