### PR TITLE
NOTARY2 (5/5): reminders and the NOTARY1 migration — Part C complete

### DIFF
--- a/backend/routers/signing.py
+++ b/backend/routers/signing.py
@@ -362,6 +362,84 @@ def officer_override(request_id: int, payload: OfficerOverride,
     return _officer_payload(_load(request_id))
 
 
+MAX_REMINDERS = 3
+
+
+@router.post("/signing-requests/v2/{request_id}/remind")
+def officer_remind(request_id: int, user_id: int = Depends(get_current_user_id)):
+    """Nudge whoever has not answered. OFFICER-TRIGGERED ONLY, and capped.
+
+    Not automatic, per the ruling — and the reason is worth stating,
+    because "send a reminder after 48h" is the obvious feature. Half the
+    parties here are CONSUMERS who never signed up. An uncapped automatic
+    sender pointed at somebody's client is a spam vector aimed through
+    our own customer, and she is the one who would be blamed for it. She
+    decides when a nudge is appropriate; she knows whether she has
+    already phoned them.
+
+    Capped at three per participant regardless, because "she decides" is
+    not a defence if the button can be held down.
+
+    Only people who have ANSWERED NOTHING are reminded. Somebody who said
+    "not that time" has answered; re-asking them the same question is how
+    a product teaches people to ignore it.
+    """
+    world = _owned_request(request_id, user_id)
+    req = world["request"]
+    if req.get("booked_at") or req.get("cancelled_at"):
+        raise HTTPException(status_code=409,
+                            detail="This signing is settled — there is nobody to chase")
+
+    live_windows = [w for w in world["windows"] if not w.get("declined_at")]
+    answered = {int(r["participant_id"]) for r in world["responses"]}
+    tz = req.get("tz_name")
+    labels = [loop.window_label(w, tz) for w in live_windows]
+    officer_name, company = _officer_bits(world)
+    notary = next(iter(_party(world, loop.ROLE_NOTARY)), {})
+    street = (world["deed"].get("property_address") or "").split(",")[0].strip()
+
+    sent, skipped = [], []
+    from utils.notifications import send_signing_reminder
+    for p in world["participants"]:
+        if p.get("revoked_at") or not p.get("email"):
+            continue
+        if int(p["id"]) in answered:
+            skipped.append({"name": p.get("display_name"), "why": "already answered"})
+            continue
+        if int(p.get("reminders_sent") or 0) >= MAX_REMINDERS:
+            skipped.append({"name": p.get("display_name"), "why": "reminded three times"})
+            continue
+        consumer = p["party_role"] == loop.ROLE_SIGNER
+        # A signer with no times to look at cannot act on a reminder, so
+        # chasing them would be noise aimed at the wrong person — the
+        # notary is who the request is waiting on.
+        if consumer and not labels:
+            skipped.append({"name": p.get("display_name"), "why": "no times posted yet"})
+            continue
+        ok, reason = send_signing_reminder(
+            recipient_email=p["email"],
+            recipient_name=p.get("display_name") or "",
+            officer_name=officer_name, officer_company=company,
+            notary_name=notary.get("display_name"),
+            property_text=street if consumer else (world["deed"].get("property_address") or ""),
+            window_texts=labels, link=_link(p), is_consumer=consumer)
+        # The ATTEMPT counts, not the delivery — fail-closed, because
+        # this is a spam cap pointed at consumers. "The transport
+        # reported an error" is not proof nothing arrived (a timeout
+        # after acceptance looks identical to a rejection), and the cost
+        # of the two mistakes is asymmetric: undercounting means somebody
+        # gets a fourth email they did not consent to, overcounting means
+        # the officer picks up the phone one nudge early.
+        with db.conn.cursor() as cur:
+            cur.execute("UPDATE signing_participants SET reminders_sent = "
+                        "reminders_sent + 1, updated_at = now() WHERE id = %s",
+                        (p["id"],))
+        sent.append({"name": p.get("display_name"), "delivered": ok, "reason": reason})
+    db.conn.commit()
+    return {"success": True, "sent": sent, "skipped": skipped,
+            "remaining_per_person": MAX_REMINDERS}
+
+
 @router.post("/signing-requests/v2/{request_id}/cancel")
 def officer_cancel(request_id: int, user_id: int = Depends(get_current_user_id)):
     _owned_request(request_id, user_id)

--- a/backend/scripts/migrate_notary1_signings.py
+++ b/backend/scripts/migrate_notary1_signings.py
@@ -1,0 +1,56 @@
+"""NOTARY2 — run the NOTARY1 signing-request migration.
+
+    DATABASE_URL=postgresql://... python backend/scripts/migrate_notary1_signings.py --dry-run
+    DATABASE_URL=postgresql://... python backend/scripts/migrate_notary1_signings.py
+
+Idempotent: a second run finds nothing. Dry-run first — it reports what
+WOULD move without writing, which is the only way to see the count before
+committing to it.
+"""
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+def main() -> int:
+    url = os.getenv("DATABASE_URL")
+    if not url:
+        print("DATABASE_URL is not set — refusing to guess at a database",
+              file=sys.stderr)
+        return 1
+
+    import psycopg2
+    from db_rows import ROW_FACTORY
+    from services.signing_migration import migrate
+
+    dry = "--dry-run" in sys.argv
+    conn = psycopg2.connect(url, cursor_factory=ROW_FACTORY)
+    try:
+        # Standing rule: verify the database before trusting it. A
+        # migration pointed at the wrong Postgres reports "nothing to
+        # migrate" and looks like success.
+        with conn.cursor() as cur:
+            cur.execute("SELECT current_database() AS db, inet_server_addr() AS host")
+            ident = cur.fetchone()
+        print(f"database: {ident['db']} on {ident['host']}")
+
+        report = migrate(conn, dry_run=dry)
+        if dry:
+            conn.rollback()
+        else:
+            conn.commit()
+        print(json.dumps(report, indent=2, default=str))
+        return 0
+    except Exception as e:
+        conn.rollback()
+        print(f"migration failed: {type(e).__name__}: {e}", file=sys.stderr)
+        return 1
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/services/signing_migration.py
+++ b/backend/services/signing_migration.py
@@ -1,0 +1,178 @@
+"""NOTARY2 — carrying NOTARY1's signing requests into the new model.
+
+═══ WHY THIS EXISTS FOR AN EXPECTED ZERO ROWS ═══
+
+NOTARY1 shipped hours before NOTARY2 started and there is no design
+partner yet, so production almost certainly holds no `deed_shares` row
+with `share_kind = 'signing_request'`. "There is probably no data" is how
+data gets lost, so the transform is written and tested rather than
+assumed — and if the count really is zero, this run is a no-op that says
+so out loud.
+
+═══ WHAT CARRIES, AND WHAT CANNOT ═══
+
+NOTARY1's model was officer→notary: the OFFICER proposed windows and the
+notary tapped one. NOTARY2 inverted it. So the transform is not a
+field-for-field copy, and two things deserve naming:
+
+  THE NOTARY'S TOKEN IS REUSED, not reissued. A live link in somebody's
+  inbox must keep working; a migration that silently invalidates a link
+  the officer already sent is a migration that creates a support ticket
+  per row.
+
+  THE OFFICER'S PROPOSED WINDOWS BECOME `origin = 'officer'`, which is a
+  value the new model already has. They are not relabelled 'notary' —
+  that would be the record claiming she offered times she never saw.
+
+An old `scheduled_at` set by the notary becomes her `available` response
+on the matching window, which is what it meant. Set by the OFFICER, it
+becomes `booked_by = 'officer'` — the same dual-assertion distinction
+NOTARY1 recorded, carried rather than flattened.
+
+═══ IDEMPOTENT ═══
+
+Guarded on `signing_requests.migrated_from_share_id`, so a second run
+finds nothing. The column exists for exactly this and is otherwise
+unread.
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any, Dict, List
+
+from services import signing_loop as loop
+
+SOURCE_SQL = """
+    SELECT ds.*, d.property_address, u.full_name AS owner_name
+      FROM deed_shares ds
+      JOIN deeds d ON d.id = ds.deed_id
+      LEFT JOIN users u ON u.id = ds.owner_user_id
+     WHERE ds.share_kind = 'signing_request'
+       AND NOT EXISTS (
+           SELECT 1 FROM signing_requests sr
+            WHERE sr.migrated_from_share_id = ds.id)
+"""
+
+
+def _windows_of(row: Dict[str, Any]) -> List[Dict[str, str]]:
+    raw = row.get("proposed_windows")
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except ValueError:
+            return []
+    return [w for w in (raw or []) if isinstance(w, dict)]
+
+
+def migrate(conn, *, dry_run: bool = False) -> Dict[str, Any]:
+    """Carry every un-migrated NOTARY1 signing share across.
+
+    Returns a report rather than a count: "migrated 0" and "migrated 0
+    because the query found nothing" read the same in a log, and only one
+    of them is reassuring.
+    """
+    from datetime import datetime
+
+    moved, skipped = [], []
+    with conn.cursor() as cur:
+        cur.execute(SOURCE_SQL)
+        sources = [dict(r) for r in (cur.fetchall() or [])]
+
+        for share in sources:
+            windows = _windows_of(share)
+            parsed = []
+            for w in windows:
+                try:
+                    start = datetime.fromisoformat(str(w.get("start")))
+                    end = datetime.fromisoformat(str(w.get("end")))
+                except (TypeError, ValueError):
+                    continue
+                # NOTARY1 stored offsets as text and ASSUMED UTC when one
+                # was missing — the bug #149 closed. Carrying a naive
+                # time forward would import the defect into the new
+                # model, so it is skipped and REPORTED rather than
+                # guessed at a second time.
+                if start.tzinfo is None or end.tzinfo is None:
+                    continue
+                parsed.append((start, end))
+
+            if not parsed:
+                skipped.append({"share_id": share["id"],
+                                "why": "no window carried a UTC offset"})
+                continue
+
+            if dry_run:
+                moved.append({"share_id": share["id"], "windows": len(parsed),
+                              "dry_run": True})
+                continue
+
+            cur.execute(
+                """INSERT INTO signing_requests
+                       (deed_id, officer_user_id, location, tz_name, expires_at,
+                        migrated_from_share_id)
+                   VALUES (%s, %s, %s, %s, %s, %s) RETURNING id""",
+                (share["deed_id"], share["owner_user_id"],
+                 share.get("property_address"), "America/Los_Angeles",
+                 share["expires_at"], share["id"]))
+            request_id = cur.fetchone()["id"]
+
+            # The notary keeps her token. A live link in an inbox must
+            # keep working.
+            cur.execute(
+                """INSERT INTO signing_participants
+                       (signing_request_id, party_role, display_name, email,
+                        token, expires_at)
+                   VALUES (%s, %s, %s, %s, %s, %s) RETURNING id""",
+                (request_id, loop.ROLE_NOTARY, share.get("recipient_email"),
+                 share.get("recipient_email"), share["token"], share["expires_at"]))
+            notary_id = cur.fetchone()["id"]
+
+            window_ids = []
+            for start, end in parsed:
+                cur.execute(
+                    """INSERT INTO signing_windows
+                           (signing_request_id, starts_at, ends_at, origin, proposed_by)
+                       VALUES (%s, %s, %s, %s, %s) RETURNING id""",
+                    (request_id, start, end, loop.ORIGIN_OFFICER, notary_id))
+                window_ids.append((cur.fetchone()["id"], start))
+
+            # What the old `scheduled_at` MEANT, carried rather than
+            # flattened: the notary's tap was her availability; the
+            # officer's entry was her own assertion.
+            when = share.get("scheduled_at")
+            if when is not None:
+                if share.get("scheduled_by") == "notary":
+                    match = next((wid for wid, s in window_ids if s == when), None)
+                    if match:
+                        cur.execute(
+                            """INSERT INTO signing_responses
+                                   (window_id, participant_id, answer)
+                               VALUES (%s, %s, %s)
+                               ON CONFLICT (window_id, participant_id) DO NOTHING""",
+                            (match, notary_id, loop.ANSWER_AVAILABLE))
+                cur.execute(
+                    """UPDATE signing_requests
+                          SET booked_at = %s, booked_by = %s,
+                              booked_asserted_at = %s
+                        WHERE id = %s""",
+                    (when,
+                     loop.BOOKED_BY_OFFICER if share.get("scheduled_by") == "officer"
+                     else loop.BOOKED_BY_CONVERGENCE,
+                     share.get("scheduled_asserted_at") or when, request_id))
+
+            moved.append({"share_id": share["id"], "signing_request_id": request_id,
+                          "windows": len(parsed), "booked": when is not None})
+
+    return {
+        "found": len(sources),
+        "migrated": len(moved),
+        "skipped": skipped,
+        "detail": moved,
+        # The sentence that distinguishes "nothing to do" from "the query
+        # is broken", which a bare count cannot.
+        "note": ("no NOTARY1 signing requests remain to migrate"
+                 if not sources else f"{len(moved)} of {len(sources)} carried across"),
+    }

--- a/backend/tests/snapshots/openapi_routes.json
+++ b/backend/tests/snapshots/openapi_routes.json
@@ -489,6 +489,10 @@
  ],
  [
   "POST",
+  "/signing-requests/v2/{request_id}/remind"
+ ],
+ [
+  "POST",
   "/signing/{token}/answer"
  ],
  [

--- a/backend/tests/test_admin3_email_outcomes.py
+++ b/backend/tests/test_admin3_email_outcomes.py
@@ -63,7 +63,7 @@ def test_no_module_outside_notifications_sends_mail():
 
 
 def test_every_template_routes_through_send():
-    """All eighteen, named. A template that renders and sends without a
+    """All nineteen, named. A template that renders and sends without a
     `_send` name is a template whose rows land under the wrong label —
     which is worse than no label, because the log then lies quietly.
 
@@ -84,7 +84,7 @@ def test_every_template_routes_through_send():
         f"declared TEMPLATES and actual _send labels disagree: "
         f"only-declared={set(TEMPLATES) - named}, only-used={named - set(TEMPLATES)}"
     )
-    assert len(TEMPLATES) == 18
+    assert len(TEMPLATES) == 19
 
 
 # ── The recorder's two constraints ───────────────────────────────────

--- a/backend/tests/test_notary2_coordination.py
+++ b/backend/tests/test_notary2_coordination.py
@@ -621,3 +621,136 @@ def test_purge_status_reports_what_is_overdue(conn):
     status = purge_status(conn)
     assert status["retention_days"] == loop.CONTACT_RETENTION_DAYS
     assert status["overdue"] >= 1
+
+
+# ══════════════════════════════════════════════════════════════════════
+# The NOTARY1 → NOTARY2 migration
+#
+# Written and tested for an expected ZERO rows. "There is probably no
+# data" is how data gets lost.
+# ══════════════════════════════════════════════════════════════════════
+
+def _notary1_share(conn, *, tag: str, windows, scheduled_at=None, scheduled_by=None):
+    """A NOTARY1-shaped signing share, in the old model."""
+    with conn.cursor() as cur:
+        cur.execute("INSERT INTO users (email, password_hash, full_name, role) "
+                    "VALUES (%s,'x','Dana','user') RETURNING id", (f"o-{tag}@n1.test",))
+        officer = cur.fetchone()["id"]
+        cur.execute("INSERT INTO deeds (user_id, deed_type, property_address, status) "
+                    "VALUES (%s,'grant_deed','1 Old Way, LA, CA','completed') "
+                    "RETURNING id", (officer,))
+        deed = cur.fetchone()["id"]
+        token = str(uuid.uuid4())
+        cur.execute(
+            """INSERT INTO deed_shares (deed_id, owner_user_id, recipient_email, token,
+                                        status, share_kind, proposed_windows, expires_at,
+                                        scheduled_at, scheduled_by, scheduled_asserted_at)
+               VALUES (%s,%s,%s,%s,'sent','signing_request',%s::jsonb,%s,%s,%s,%s)
+               RETURNING id""",
+            (deed, officer, "nora@notary.test", token, json.dumps(windows),
+             datetime.now(timezone.utc) + timedelta(days=10),
+             scheduled_at, scheduled_by,
+             datetime.now(timezone.utc) if scheduled_at else None))
+        return cur.fetchone()["id"], token
+
+
+@dbonly
+def test_the_migration_carries_a_notary1_request_across(conn):
+    from services.signing_migration import migrate
+    start = datetime.now(timezone.utc) + timedelta(days=3)
+    share_id, token = _notary1_share(
+        conn, tag=uuid.uuid4().hex[:6],
+        windows=[{"start": start.isoformat(),
+                  "end": (start + timedelta(hours=1)).isoformat()}])
+    report = migrate(conn)
+    assert report["migrated"] >= 1
+    with conn.cursor() as cur:
+        cur.execute("SELECT id FROM signing_requests WHERE migrated_from_share_id = %s",
+                    (share_id,))
+        request_id = cur.fetchone()["id"]
+        cur.execute("SELECT token, party_role FROM signing_participants "
+                    "WHERE signing_request_id = %s", (request_id,))
+        parts = cur.fetchall()
+    # THE LIVE LINK KEEPS WORKING. A migration that silently invalidates
+    # a link the officer already sent is one support ticket per row.
+    assert [str(p["token"]) for p in parts] == [token]
+    assert [p["party_role"] for p in parts] == ["notary"]
+
+
+@dbonly
+def test_the_officers_windows_are_not_relabelled_as_the_notarys(conn):
+    """NOTARY1's windows were the OFFICER's proposals. Marking them
+    `notary` would be the record claiming she offered times she never
+    saw."""
+    from services.signing_migration import migrate
+    start = datetime.now(timezone.utc) + timedelta(days=4)
+    share_id, _ = _notary1_share(
+        conn, tag=uuid.uuid4().hex[:6],
+        windows=[{"start": start.isoformat(),
+                  "end": (start + timedelta(hours=1)).isoformat()}])
+    migrate(conn)
+    with conn.cursor() as cur:
+        cur.execute("""SELECT w.origin FROM signing_windows w
+                         JOIN signing_requests r ON r.id = w.signing_request_id
+                        WHERE r.migrated_from_share_id = %s""", (share_id,))
+        assert [r["origin"] for r in cur.fetchall()] == ["officer"]
+
+
+@dbonly
+def test_who_asserted_the_old_time_survives_the_move(conn):
+    """NOTARY1 kept the notary's tap and the officer's phone call apart.
+    Flattening them here would lose the distinction the whole shape
+    exists to preserve."""
+    from services.signing_migration import migrate
+    start = datetime.now(timezone.utc) + timedelta(days=5)
+    share_id, _ = _notary1_share(
+        conn, tag=uuid.uuid4().hex[:6],
+        windows=[{"start": start.isoformat(),
+                  "end": (start + timedelta(hours=1)).isoformat()}],
+        scheduled_at=start, scheduled_by="officer")
+    migrate(conn)
+    with conn.cursor() as cur:
+        cur.execute("SELECT booked_by, booked_at FROM signing_requests "
+                    "WHERE migrated_from_share_id = %s", (share_id,))
+        row = cur.fetchone()
+    assert row["booked_by"] == "officer"
+    assert row["booked_at"] is not None
+
+
+@dbonly
+def test_a_naive_time_is_skipped_and_reported_not_guessed_at(conn):
+    """NOTARY1 assumed UTC for a time with no offset — the bug #149
+    closed. Carrying one forward would import the defect into the new
+    model, so it is refused and REPORTED."""
+    from services.signing_migration import migrate
+    share_id, _ = _notary1_share(
+        conn, tag=uuid.uuid4().hex[:6],
+        windows=[{"start": "2026-09-01T10:00:00", "end": "2026-09-01T11:00:00"}])
+    report = migrate(conn)
+    assert share_id in [s["share_id"] for s in report["skipped"]]
+    assert "offset" in report["skipped"][0]["why"]
+
+
+@dbonly
+def test_the_migration_is_idempotent(conn):
+    from services.signing_migration import migrate
+    start = datetime.now(timezone.utc) + timedelta(days=6)
+    _notary1_share(conn, tag=uuid.uuid4().hex[:6],
+                   windows=[{"start": start.isoformat(),
+                             "end": (start + timedelta(hours=1)).isoformat()}])
+    first = migrate(conn)
+    second = migrate(conn)
+    assert first["migrated"] >= 1
+    assert second["migrated"] == 0
+    assert "no NOTARY1 signing requests remain" in second["note"]
+
+
+@dbonly
+def test_the_report_distinguishes_nothing_to_do_from_a_broken_query(conn):
+    """"migrated 0" and "migrated 0 because the query found nothing" read
+    identically in a log, and only one of them is reassuring."""
+    from services.signing_migration import migrate
+    migrate(conn)  # drain anything left by other tests
+    report = migrate(conn)
+    assert report["found"] == 0
+    assert "no NOTARY1 signing requests remain" in report["note"]

--- a/backend/tests/test_notary2_routes.py
+++ b/backend/tests/test_notary2_routes.py
@@ -502,3 +502,109 @@ def test_windows_that_book_immediately_do_not_also_say_pick_a_time(world):
     pub.post(f"/signing/{tokens[loop.ROLE_NOTARY][0]}/windows",
              json={"windows": _windows(1, days_out=40)})
     assert 'signing_windows_posted' not in [t for t, _ in _sent_since(world["conn"], mark)]
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Reminders — officer-triggered, capped, and aimed only at silence
+# ══════════════════════════════════════════════════════════════════════
+
+def test_a_reminder_goes_only_to_people_who_have_answered_nothing(world):
+    """Somebody who said "not that time" HAS answered. Re-asking them the
+    same question is how a product teaches people to ignore it."""
+    _, tokens = _create(world)
+    pub = public()
+    officer = client_for(world["officer"])
+    pub.post(f"/signing/{tokens[loop.ROLE_NOTARY][0]}/windows", json={"windows": _windows()})
+    wid = pub.get(f"/signing/{tokens[loop.ROLE_SIGNER][0]}").json()["windows"][0]["id"]
+    pub.post(f"/signing/{tokens[loop.ROLE_SIGNER][0]}/answer",
+             json={"window_id": wid, "answer": "unavailable"})
+
+    mark = _mark(world["conn"])
+    r = officer.post(f"/signing-requests/v2/{world_request_id(world)}/remind")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    # The notary answered by posting; signer 0 answered "no"; only signer
+    # 1 is silent.
+    assert [s["name"] for s in body["sent"]] == ["Signer 1"]
+    assert {s["why"] for s in body["skipped"]} == {"already answered"}
+    assert [t for t, _ in _sent_since(world["conn"], mark)] == ["signing_reminder"]
+
+
+def test_a_signer_is_not_chased_before_there_are_times_to_look_at(world):
+    """A reminder they cannot act on is noise aimed at the wrong person —
+    the request is waiting on the notary, not on them."""
+    _, _tokens = _create(world)
+    r = client_for(world["officer"]).post(
+        f"/signing-requests/v2/{world_request_id(world)}/remind")
+    body = r.json()
+    assert [s["name"] for s in body["sent"]] == ["Nora Vance"]
+    assert {s["why"] for s in body["skipped"]} == {"no times posted yet"}
+
+
+def test_the_reminder_cap_is_three_per_person(world):
+    _, _tokens = _create(world)
+    officer = client_for(world["officer"])
+    rid = world_request_id(world)
+    for _ in range(3):
+        officer.post(f"/signing-requests/v2/{rid}/remind")
+    body = officer.post(f"/signing-requests/v2/{rid}/remind").json()
+    assert body["sent"] == []
+    assert "reminded three times" in {s["why"] for s in body["skipped"]}
+
+
+def test_a_failed_send_still_counts_against_the_cap(world):
+    """Fail-closed. "The transport reported an error" is not proof
+    nothing arrived, and the two mistakes cost differently: undercounting
+    means a consumer gets an email they did not consent to."""
+    _, _tokens = _create(world)
+    officer = client_for(world["officer"])
+    rid = world_request_id(world)
+    officer.post(f"/signing-requests/v2/{rid}/remind")
+    with world["conn"].cursor() as cur:
+        cur.execute("SELECT reminders_sent FROM signing_participants "
+                    "WHERE signing_request_id = %s AND party_role = 'notary'", (rid,))
+        # No transport is configured in tests, so every send "fails".
+        assert cur.fetchone()["reminders_sent"] == 1
+
+
+def test_a_settled_signing_has_nobody_to_chase(world):
+    _, tokens = _create(world)
+    pub = public()
+    pub.post(f"/signing/{tokens[loop.ROLE_NOTARY][0]}/windows", json={"windows": _windows()})
+    wid = pub.get(f"/signing/{tokens[loop.ROLE_SIGNER][0]}").json()["windows"][0]["id"]
+    for t in tokens[loop.ROLE_SIGNER]:
+        pub.post(f"/signing/{t}/answer", json={"window_id": wid, "answer": "available"})
+    r = client_for(world["officer"]).post(
+        f"/signing-requests/v2/{world_request_id(world)}/remind")
+    assert r.status_code == 409
+
+
+def test_a_stranger_cannot_send_reminders_on_someone_elses_request(world):
+    _create(world)
+    r = client_for(world["stranger"]).post(
+        f"/signing-requests/v2/{world_request_id(world)}/remind")
+    assert r.status_code == 404
+
+
+def test_the_reminder_asks_the_same_question_the_original_ask_did(world):
+    """NOTARY1 refused to reuse the review reminder because it asked the
+    wrong question. A reminder that REPHRASES is one the recipient has to
+    re-read from scratch — and no urgency theatre on a consumer who is
+    doing us a favour."""
+    from utils import email_templates as t
+    subject, html, text = t.signing_reminder(
+        "Sam", "Dana Reyes", "Pacific Coast Title", "Nora", "9 Private Way",
+        ["Tuesday at 10:00 AM"], "http://x", True)
+    assert "still" in (subject + html).lower()
+    for pressure in ("urgent", "immediately", "final notice", "asap",
+                     "act now", "last chance"):
+        assert pressure not in html.lower(), f"urgency theatre: {pressure}"
+    # And it offers the way out that always works.
+    assert "call" in html.lower()
+
+
+def world_request_id(world) -> int:
+    with world["conn"].cursor() as cur:
+        cur.execute("SELECT id FROM signing_requests WHERE officer_user_id = %s "
+                    "ORDER BY id DESC LIMIT 1", (world["officer"],))
+        return cur.fetchone()["id"]

--- a/backend/utils/email_templates.py
+++ b/backend/utils/email_templates.py
@@ -527,6 +527,60 @@ def signing_windows_posted(signer_name, officer_name, officer_company, notary_na
                           content, False), text
 
 
+def signing_reminder(recipient_name, officer_name, officer_company,
+                     notary_name, property_text, window_texts, link,
+                     is_consumer: bool) -> Rendered:
+    """NOTARY2 — the officer nudges somebody who has not answered.
+
+    ONE TEMPLATE FOR BOTH PARTIES, register chosen by `is_consumer` — the
+    same pattern as the booking notice, and for the same reason: two
+    near-identical templates drift, and the drift is invisible because
+    each one looks fine on its own.
+
+    NOTARY1 refused to reuse the review reminder for a signing because it
+    asked the wrong question ("waiting on your review"). This one asks
+    the SAME question the original ask did, with "still" in front of it —
+    a reminder that rephrases is a reminder the recipient has to re-read
+    from scratch.
+
+    No urgency theatre. Nothing here says "urgent", "immediately" or
+    "final notice": the officer chose to send this, the recipient has not
+    done anything wrong, and manufactured pressure on a consumer who is
+    doing us a favour is how a product gets ignored.
+    """
+    subject = f"Still need a time — {property_text}"
+    listed = "".join(
+        f'<tr><td style="padding:4px 0;font-size:14px;color:{INK};font-weight:600;">'
+        f"&bull;&nbsp;{_esc(w)}</td></tr>" for w in (window_texts or []))
+    if is_consumer:
+        body = (
+            _p(f"Hi {_esc(recipient_name) or 'there'},")
+            + _p(f"<strong>{_esc(officer_name)}</strong>"
+                 + (f" at {_esc(officer_company)}" if officer_company else "")
+                 + " is still waiting to hear which time works for you.")
+            + ('<table role="presentation" cellpadding="0" cellspacing="0" '
+               f'style="margin:10px 0;">{listed}</table>' if listed else "")
+            + _button(link, "Pick a time")
+            + _p(f'<span style="font-size:13px;color:#8a94a0;">If none of them work you '
+                 f"can suggest another, or just call {_esc(officer_name)}.</span>")
+        )
+        text = (f"{officer_name} is still waiting to hear which time works for you.\n\n"
+                + "".join(f"  - {w}\n" for w in (window_texts or []))
+                + f"\nPick a time: {link}\n\n"
+                f"If none of them work you can suggest another, or call {officer_name}.")
+    else:
+        body = (
+            _p(f"Hi {_esc(recipient_name) or 'there'},")
+            + _p(f"<strong>{_esc(officer_name)}</strong> is still waiting on times for "
+                 f"the signing at {_esc(property_text)}.")
+            + _button(link, "Post the times you are free")
+        )
+        text = (f"{officer_name} is still waiting on times for the signing at "
+                f"{property_text}.\n\nPost your availability: {link}")
+    return subject, _base(f"Still waiting on a time — {property_text}", body,
+                          not is_consumer), text
+
+
 def signing_proposal_received(notary_name, signer_name, officer_name,
                               property_address, window_text, link) -> Rendered:
     """NOTARY2 — a signer suggested a time the notary did not offer."""

--- a/backend/utils/notifications.py
+++ b/backend/utils/notifications.py
@@ -35,7 +35,7 @@ TEMPLATES = (
     # tell everybody when it lands. There is deliberately no sixth for
     # "the signing happened," because nothing in this product knows that.
     "notary_invited", "signing_windows_posted",
-    "signing_proposal_received", "signing_booked",
+    "signing_proposal_received", "signing_booked", "signing_reminder",
 )
 
 
@@ -265,6 +265,16 @@ def send_signing_windows_posted(recipient_email: str, signer_name: str,
                      signer_name, officer_name, officer_company, notary_name,
                      property_street, window_texts, link),
                  context={"party": "signer", "windows": len(window_texts or [])})
+
+
+def send_signing_reminder(recipient_email: str, recipient_name: str,
+                          officer_name: str, officer_company: Optional[str],
+                          notary_name: Optional[str], property_text: str,
+                          window_texts, link: str, is_consumer: bool) -> SendResult:
+    return _send("signing_reminder", recipient_email, email_templates.signing_reminder(
+        recipient_name, officer_name, officer_company, notary_name,
+        property_text, window_texts, link, is_consumer),
+        context={"party": "signer" if is_consumer else "professional"})
 
 
 def send_signing_proposal_received(recipient_email: str, notary_name: str,

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -658,7 +658,15 @@ That is worse than the version-pin problem it was found by. A config file
 that lies by OMISSION is harder to catch than one that lies by contents:
 nothing about `render.yaml` says "this is some of what runs."
 
-**Two ways to make it honest, and this is an owner call:**
+**OWNER RULING (2026-08-11): do the expensive half — but AFTER Part C.**
+Bring the purge cron, and any other service added outside the file, into
+`render.yaml`, and make the repo authoritative for deploy topology. Its
+own ticket, sequenced after NOTARY2 Part C completes rather than folded
+into this wave — a deploy-topology change landing in the middle of a
+feature wave is how a bad afternoon becomes a bad week. The interim
+header stands until then.
+
+**Two ways to make it honest, and the owner has now chosen (1):**
 
 1. **Bring the cron into `render.yaml`** so the file is the inventory,
    and keep it that way. More work, and it makes the repo the source of


### PR DESCRIPTION
The last two pieces. **Part C is complete** — the coordination loop works end to end, reaches everyone, and carries NOTARY1's data forward.

## Reminders are officer-triggered, and that's the design

"Send a reminder after 48 hours" is the obvious feature and it's wrong here. **Half the parties are consumers who never signed up.** An automatic sender pointed at somebody's client is a spam vector aimed *through* our own customer — and she's the one who'd be blamed for it. She decides when a nudge is appropriate, because she knows whether she already phoned them.

Capped at three per participant anyway, because "she decides" isn't a defence if the button can be held down.

**The cap counts attempts, not deliveries.** Fail-closed: "the transport reported an error" isn't proof nothing arrived (a timeout after acceptance looks identical to a rejection), and the two mistakes cost differently — undercounting means a consumer gets a fourth email they didn't consent to, overcounting means she picks up the phone one nudge early.

Two rules about *who* gets chased:

- **Only people who have answered nothing.** Somebody who said "not that time" has answered; re-asking them is how a product teaches people to ignore it.
- **A signer is never chased before any times exist.** A reminder they can't act on is noise aimed at the wrong person — the request is waiting on the notary.

The copy asks **the same question the original ask did**, with "still" in front. A reminder that rephrases is one the recipient re-reads from scratch. And no urgency theatre — pinned against *urgent, immediately, final notice, act now*. Manufactured pressure on a consumer doing us a favour is how a product gets ignored.

## The migration, written for an expected zero rows

Production almost certainly holds no NOTARY1 signing share. **"There is probably no data" is how data gets lost**, so it's written and tested rather than assumed.

Four decisions worth naming:

**The notary's token is reused, not reissued.** A live link in an inbox must keep working; a migration that silently invalidates one the officer already sent is a support ticket per row.

**The officer's windows become `origin='officer'`, not `'notary'`.** Relabelling them would be the record claiming she offered times she never saw.

**Who asserted the old time survives.** The notary's tap becomes her availability response; the officer's entry becomes `booked_by='officer'`. NOTARY1 kept those apart, and flattening them here would lose the distinction the whole shape exists for.

**A naive time is skipped and reported, not guessed at.** NOTARY1 assumed UTC for a time with no offset — the bug #149 closed. Carrying one forward would import the defect into the new model.

The report distinguishes *nothing to do* from *the query is broken* — "migrated 0" and "migrated 0 because the query found nothing" read identically in a log and only one is reassuring. And the script prints `current_database()` and host before doing anything, per the standing rule a wrong-database migration just taught us.

## Your render.yaml ruling, recorded with its sequencing

Bring the cron and any other undeclared service in, make the repo authoritative — **as its own ticket after Part C, not folded into this wave.** A deploy-topology change landing mid-feature-wave is how a bad afternoon becomes a bad week. The interim header stands; `PYTHON_VERSION` still held pending your number.

## Gates

| gate | result |
|---|---|
| pytest, no database | 825 passed |
| pytest, with database | 977 passed |
| jest | 655 passed |
| tsc | 94 (unchanged) |
| six-flow / API baselines | ✔ ✔ |
| banned-claims | clean |
| OpenAPI | re-recorded — one route added |

The migration script runs clean against a real database: `found 0, migrated 0, "no NOTARY1 signing requests remain to migrate"`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_