### PR TITLE
Pin PYTHON_VERSION to 3.12.7 across render.yaml, with the pin that keeps it

### DIFF
--- a/backend/tests/test_render_service_pins.py
+++ b/backend/tests/test_render_service_pins.py
@@ -1,0 +1,93 @@
+"""Every service in `render.yaml` pins its Python.
+
+═══ WHY A TEST AND NOT A CONVENTION ═══
+
+The purge cron's first build died compiling Rust, because Render defaulted
+a NEW service to 3.14 and `pydantic_core` has no wheel for it. Nobody
+chose 3.14; nobody chose anything. The service inherited whatever the
+default was on the afternoon it was created.
+
+That is the failure this pin exists for, and it is not "somebody forgot".
+It is that an unpinned service has a runtime NOBODY DECIDED, which can
+change under it while the repo stays byte-identical. A convention cannot
+catch that; the next service is created by whoever is on shift.
+
+═══ WHAT THIS FILE CANNOT PROVE ═══
+
+Only that services DECLARED HERE carry a pin. `render.yaml` describes one
+service and production runs at least three — the cron is not in it — so a
+green run here is not "every deployed service is pinned". It is "every
+service this file knows about". The header in `render.yaml` says the same
+thing to a human reading the file.
+
+Bringing the undeclared services in is its own ticket, owner-ruled and
+sequenced after NOTARY2 Part C. When that lands, this pin's coverage
+becomes the real thing without a line of it changing — which is the
+argument for writing it now.
+"""
+from pathlib import Path
+
+# A HARD import, not `importorskip`. PyYAML is a declared dependency
+# (requirements.txt), so a missing one is a broken environment rather than
+# an absent optional — and `importorskip` would turn this pin into a
+# silent skip, which is the one outcome a pin must never have. A test that
+# can quietly not run is worse than no test, because the green tick still
+# appears.
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+RENDER = REPO / "render.yaml"
+
+# The owner's ruling, as a value rather than a range: 3.12 for wheel
+# coverage across the current dependency set, one minor below the edge.
+# Asserted exactly, because "pinned to something" is a weaker claim than
+# "pinned to the thing we chose" — two services on two pinned versions
+# is the same nondeterminism with extra steps.
+EXPECTED = "3.12.7"
+
+
+def _config():
+    return yaml.safe_load(RENDER.read_text(encoding="utf-8"))
+
+
+def test_render_yaml_parses():
+    """A deploy file that does not parse is a deploy that does not happen,
+    and nothing else in this file means anything if this fails."""
+    assert isinstance(_config(), dict)
+
+
+def test_every_declared_service_pins_python_version():
+    config = _config()
+    offenders = []
+    for service in config.get("services") or []:
+        env = {e.get("key"): e.get("value") for e in (service.get("envVars") or [])}
+        if "PYTHON_VERSION" not in env:
+            offenders.append(f"{service.get('name')} — no PYTHON_VERSION")
+        elif str(env["PYTHON_VERSION"]) != EXPECTED:
+            offenders.append(
+                f"{service.get('name')} — pinned to {env['PYTHON_VERSION']}, "
+                f"expected {EXPECTED}")
+    assert offenders == [], (
+        f"unpinned or divergently-pinned services: {offenders}. An unpinned "
+        "service inherits whatever Render's default is on the day it builds; "
+        "a differently-pinned one is the same nondeterminism with extra steps.")
+
+
+def test_the_file_says_it_is_not_the_deployment_inventory():
+    """It describes one service and production runs more. A config file
+    that lies by OMISSION is harder to catch than one that lies by
+    contents — nothing about a YAML file announces that it is partial —
+    so it announces it in prose until the undeclared services are brought
+    in (owner-ruled, sequenced after NOTARY2 Part C)."""
+    header = RENDER.read_text(encoding="utf-8")[:2000]
+    assert "NOT THE DEPLOYMENT INVENTORY" in header
+    assert "dashboard" in header.lower()
+
+
+def test_the_downgrade_is_recorded_where_somebody_will_see_it():
+    """3.12.7 is BELOW what the main API runs today. A pin that silently
+    changes a running service's interpreter is a deploy-time surprise, so
+    the file says it is deliberate and says what to do about it."""
+    header = RENDER.read_text(encoding="utf-8")[:2500]
+    assert "downgrade" in header.lower()
+    assert "redeploy" in header.lower()

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -616,23 +616,33 @@ two possibilities is true, the fix is the same — the repo should express
 the rule, and an unpinned runtime on the customer-facing API is the same
 latent failure the cron just demonstrated, one Render default bump away.
 
-**HELD, PENDING A VALUE.** The owner is reading the current version off
-`deedpro-main-api`. Not guessed: writing a plausible version into a
-deploy file is how a "fix" becomes an outage on the next deploy, and a
-wrong pin is worse than no pin because it looks deliberate.
+**RESOLVED 2026-08-11: `PYTHON_VERSION = "3.12.7"`, landed.**
 
-**The one-line change, ready to apply** — under `deedpro-main-api`'s
-`envVars`, alongside the existing entries:
+The evidence, since the header line in the build log was truncated: the
+main API's wheel tags read `cp313` on sqlalchemy and greenlet, so it runs
+**3.13**. The cron got **3.14**, today's Render default — which is what
+caused the original failure.
 
-```yaml
-  - key: PYTHON_VERSION
-    value: "3.X.Y"        # ← the value from deedpro-main-api's dashboard
-```
+**The pin is a DELIBERATE DOWNGRADE to 3.12.7** (owner-ruled): broadest
+wheel coverage across the current dependency set, one minor below the
+edge, and — the part that matters more than the number — it removes the
+"whichever default existed the day this service was created"
+nondeterminism entirely. Three services on three Pythons is not a
+configuration; it is an accident with a history.
 
-Landing it together with a pin — a test asserting every service block in
-`render.yaml` carries `PYTHON_VERSION` — so the rule survives the next
-service somebody adds. The pin is written and held with the value rather
-than committed failing.
+**OPEN, AND THE OWNER'S TO CLOSE: redeploy `deedpro-main-api` and watch
+the build.** This changes the interpreter under a service that serves
+every customer, from 3.13 to 3.12.7. The change is safe in expectation —
+3.12 has strictly better wheel coverage than 3.13 for this dependency set
+— but "safe in expectation" is what the cron's first build also was. It
+is not settled until a clean build on the pinned version has been seen.
+
+Pinned by `backend/tests/test_render_service_pins.py`, which asserts
+every service block in `render.yaml` carries the pin AND carries THIS
+value — "pinned to something" is a weaker claim than "pinned to the thing
+we chose", and two services on two pinned versions is the same
+nondeterminism with extra steps. Probed three ways: removing the pin,
+changing the version, and adding a second unpinned service.
 
 ### Which reality we are in: the dashboard is authoritative
 

--- a/render.yaml
+++ b/render.yaml
@@ -12,12 +12,19 @@
 # partial list that does not say so.
 #
 # Owner-ruled 2026-08-11: every service defined here pins PYTHON_VERSION
-# explicitly, matching what `deedpro-main-api` actually runs. An unpinned
-# service inherits whatever Render's default is on the day it builds —
-# which is exactly how the cron's first build died compiling Rust for a
-# pydantic_core with no 3.14 wheel. The value is HELD pending the owner
-# reading it off the dashboard; it is not guessed, because a wrong pin in
-# a deploy file looks deliberate and fails on the next deploy.
+# explicitly. An unpinned service inherits whatever Render's default is
+# on the day it builds, so the runtime can change under a service nobody
+# touched — which is exactly how the cron's first build died compiling
+# Rust for a pydantic_core with no 3.14 wheel.
+#
+# THE PIN IS 3.12.7, AND IT IS A DELIBERATE DOWNGRADE. The main API is
+# currently on 3.13 (read off its build log's cp313 wheel tags); the cron
+# got 3.14, today's Render default. 3.12 is chosen for wheel coverage
+# across the current dependency set — one minor below the edge, where
+# every package we depend on publishes binaries — and, more importantly,
+# because a pinned version removes the "whichever default existed the day
+# this service was created" nondeterminism entirely. Three services on
+# three Pythons is not a configuration, it is an accident with a history.
 #
 # See docs/OWNER_LEDGER.md, "render.yaml — owner ruling".
 
@@ -36,6 +43,11 @@ services:
   buildCommand: pip install -r requirements.txt
   startCommand: uvicorn main:app --host 0.0.0.0 --port $PORT
   envVars:
+  # Pinned, not inherited. See the header: this is a downgrade from the
+  # 3.13 the service runs today, and the main API must be redeployed and
+  # its build watched before this is considered settled.
+  - key: PYTHON_VERSION
+    value: "3.12.7"
   - key: DATABASE_URL
     fromDatabase:
       name: deedpro-db


### PR DESCRIPTION
Your ruling, landed with the test. Independent of #156 (Part C's last piece), which is still open.

## ⚠️ Read this before merging: it is a deliberate downgrade

**3.12.7 is below what `deedpro-main-api` runs today (3.13).** Merging this changes the interpreter under the service that serves every customer, on its next deploy.

It's safe in expectation — 3.12 has strictly better wheel coverage than 3.13 for this dependency set, which is the whole reason you chose it. But **"safe in expectation" is exactly what the cron's first build also was.** Per your instruction, this isn't settled until you've redeployed the main API and watched a clean build on the pinned version. That's recorded in the ledger as an open owner item, not as done.

The header in `render.yaml` says the same thing where a human editing the file will see it.

## The value is evidence-backed now, not held

Your read is in the file: wheel tags `cp313` on sqlalchemy and greenlet → the main API runs 3.13. The cron got 3.14, today's default, which caused the original failure.

And the reasoning I'd underline is the second half of your ruling, not the first: **the number matters less than the fact that it's pinned at all.** "Whichever default existed the day this service was created" is the actual defect — three services on three Pythons isn't a configuration, it's an accident with a history.

## The pin asserts the value, not just the presence

"Pinned to something" is a weaker claim than "pinned to the thing we chose" — two services on two pinned versions is the same nondeterminism with extra steps.

Probed three ways:

| mutation | result |
|---|---|
| remove the pin | `deedpro-main-api — no PYTHON_VERSION` |
| pin 3.13.1 instead | `pinned to 3.13.1, expected 3.12.7` |
| add a second unpinned service | `signer-contact-purge — no PYTHON_VERSION` |

The third matters most: **it proves the pin will cover the cron the moment the cron is brought into the file**, without a line of the test changing. That's the argument for writing it now rather than with that ticket.

## One deliberate choice inside the test

The YAML import is **hard, not `importorskip`**. PyYAML is a declared dependency, so a missing one is a broken environment rather than an absent optional — and `importorskip` would turn this into a silent skip, which is the one outcome a pin must never have. A test that can quietly not run is worse than no test, because the green tick still appears.

## What this cannot prove, stated in the test itself

Only that services **declared in `render.yaml`** carry a pin. The file describes one service; production runs at least three. A green run here means "every service this file knows about", not "every deployed service."

That gap closes with the owner-ruled ticket sequenced after Part C — and when it does, this pin's coverage becomes the real thing for free.

## Gates

| gate | result |
|---|---|
| pytest, no database | 829 passed |
| pytest, with database | 968 passed |
| banned-claims | clean |

One note: the with-database run came back 60-red first pass — local Postgres died again, clean on restart. Flagging rather than silently re-running.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_