### PR TITLE
FLOW1 item 0: Shared Deeds was not fabricating rows — it was reading them by the wrong names

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -270,6 +270,34 @@ def create_tables():
             "ALTER TABLE deed_shares ADD COLUMN IF NOT EXISTS scheduled_by VARCHAR(16)",
             "ALTER TABLE deed_shares ADD COLUMN IF NOT EXISTS scheduled_asserted_at TIMESTAMPTZ",
             "CREATE INDEX IF NOT EXISTS idx_deed_shares_kind ON deed_shares(share_kind, created_at DESC)",
+            # ── FLOW1 item 0: two facts the tracking screen displays and
+            # the table never held ──────────────────────────────────────
+            #
+            # `recipient_name` was already ACCEPTED by POST /shared-deeds
+            # and used for the email greeting, then discarded — there was
+            # nowhere to put it. So the officer picks a partner out of her
+            # rolodex by name and the Shared Deeds screen has a column
+            # headed "Shared With" with no source for it.
+            #
+            # `responded_at` is WHEN the recipient approved or rejected.
+            # `updated_at` was not usable for this and must not be
+            # substituted: a revoke bumps it too, so a screen reading it
+            # would report a response on the day access was withdrawn.
+            # Shares decided before this ticket have no stamp and stay
+            # NULL — the screen shows the status and no date, which is
+            # what we actually know. The one exception is backfilled
+            # below because it is a recorded fact rather than a guess.
+            "ALTER TABLE deed_shares ADD COLUMN IF NOT EXISTS recipient_name TEXT",
+            "ALTER TABLE deed_shares ADD COLUMN IF NOT EXISTS responded_at TIMESTAMPTZ",
+            # `feedback_at` is stamped in exactly one place — the reject
+            # branch of POST /approve/{token} — so for a rejected share it
+            # IS the response time, not an inference about one. Idempotent
+            # on `responded_at IS NULL`, so re-running the DDL never
+            # overwrites a real stamp.
+            """UPDATE deed_shares SET responded_at = feedback_at
+                WHERE responded_at IS NULL
+                  AND status = 'rejected'
+                  AND feedback_at IS NOT NULL""",
             # ══ NOTARY2: the coordination loop ═══════════════════
             #
             # WHY NOT MORE COLUMNS ON deed_shares. NOTARY1 put the signing

--- a/backend/routers/sharing.py
+++ b/backend/routers/sharing.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel, field_validator
 import db
 from auth import get_current_user_id
 from services import signing
+from services.shared_deed_row import shared_deed_row
 # NOTARY1: the attachment CONSTRUCTOR only. The transport itself stays
 # behind utils.notifications — see the ADMIN3 pin, which exists because a
 # second module reaching for the sender is how the ledger loses rows.
@@ -161,14 +162,19 @@ def share_deed_for_approval(share_data: ShareDeedCreate, user_id: int = Depends(
             # Insert into deed_shares table
             cur.execute("""
                 INSERT INTO deed_shares (
-                    deed_id, owner_user_id, recipient_email, token,
-                    status, expires_at, created_at, updated_at
+                    deed_id, owner_user_id, recipient_name, recipient_email,
+                    token, status, expires_at, created_at, updated_at
                 )
-                VALUES (%s, %s, %s, %s, %s, %s, NOW(), NOW())
+                VALUES (%s, %s, %s, %s, %s, %s, %s, NOW(), NOW())
                 RETURNING id
             """, (
                 share_data.deed_id,
                 user_id,
+                # FLOW1 item 0: the name the officer chose them by. It was
+                # already being collected and greeted with; it was never
+                # STORED, which is why the tracking screen's "Shared With"
+                # column had nothing in it.
+                share_data.recipient_name,
                 share_data.recipient_email,
                 approval_token,
                 'sent',
@@ -252,63 +258,40 @@ def list_shared_deeds(user_id: int = Depends(get_current_user_id)):
                 SELECT
                     ds.id,
                     ds.deed_id,
-                    ds.owner_user_id,
+                    ds.recipient_name,
                     ds.recipient_email,
                     ds.status,
-                    ds.token,
                     ds.expires_at,
                     ds.created_at,
-                    ds.updated_at,
+                    ds.viewed_at,
+                    ds.responded_at,
                     d.property_address,
                     d.deed_type,
-                    u.full_name as owner_name,
                     ds.share_kind,
                     ds.proposed_windows,
                     ds.scheduled_at,
                     ds.scheduled_by
                 FROM deed_shares ds
                 JOIN deeds d ON ds.deed_id = d.id
-                JOIN users u ON ds.owner_user_id = u.id
                 WHERE ds.owner_user_id = %s
                 ORDER BY ds.created_at DESC
             """, (user_id,))
 
             rows = cur.fetchall()
 
-            # Phase 7.5 FIX: Map deed_shares columns (RealDictCursor returns dicts)
-            shared_deeds = []
-            for row in rows:
-                # RealDictCursor returns dictionaries, not tuples
-                expires_at = row.get('expires_at') if isinstance(row, dict) else row[6]
-                created_at = row.get('created_at') if isinstance(row, dict) else row[7]
-                updated_at = row.get('updated_at') if isinstance(row, dict) else row[8]
-
-                shared_deeds.append({
-                    "id": row.get('id') if isinstance(row, dict) else row[0],
-                    "deed_id": row.get('deed_id') if isinstance(row, dict) else row[1],
-                    "shared_by_id": row.get('owner_user_id') if isinstance(row, dict) else row[2],
-                    "shared_with_email": row.get('recipient_email') if isinstance(row, dict) else row[3],
-                    "status": row.get('status') if isinstance(row, dict) else row[4],
-                    "message": f"Shared via link - expires {expires_at.strftime('%Y-%m-%d') if expires_at else 'never'}",
-                    # NOTARY1: was hardcoded "review", which was true until
-                    # this ticket and would have quietly stayed "true" for
-                    # every signing request afterwards.
-                    "share_type": (row.get('share_kind') if isinstance(row, dict) else None) or signing.SHARE_KIND_REVIEW,
-                    # The status LINE for the deed surface. Null for a
-                    # review; for a signing it is the one sentence
-                    # scheduling_label() writes, so this screen cannot
-                    # invent its own phrasing for an arrangement.
-                    "signing_summary": signing.scheduling_label(dict(row)) if isinstance(row, dict) else None,
-                    "scheduled_at": (lambda s: s.isoformat() if hasattr(s, 'isoformat') else s)(
-                        row.get('scheduled_at') if isinstance(row, dict) else None),
-                    "scheduled_by": row.get('scheduled_by') if isinstance(row, dict) else None,
-                    "date": created_at.isoformat() if created_at else "",
-                    "updated_at": updated_at.isoformat() if updated_at else "",
-                    "property": (row.get('property_address') if isinstance(row, dict) else row[9]) or "",
-                    "type": (row.get('deed_type') if isinstance(row, dict) else row[10]) or "",
-                    "shared_by": (row.get('owner_name') if isinstance(row, dict) else row[11]) or "Unknown User",
-                    "approval_token": row.get('token') if isinstance(row, dict) else row[5]
-                })
+            # FLOW1 item 0: ONE builder, one named key set, asserted by
+            # equality — see services/shared_deed_row.py for the eight
+            # mismatched field names that made this screen read as though
+            # it were inventing rows.
+            #
+            # The tuple fallbacks that used to live here are gone with
+            # it. They indexed by position into a SELECT above them, so
+            # every column added to that query silently re-aimed them;
+            # and db.py has used RealDictCursor throughout, so the branch
+            # they guarded had not run in a long time. A fallback that
+            # cannot run is not a safety net, it is a second definition
+            # of the payload that nothing checks.
+            shared_deeds = [shared_deed_row(row) for row in rows]
 
             print(f"[Phase 7.5] ✅ Fetched {len(shared_deeds)} shared deeds for user {user_id}")
             return shared_deeds
@@ -773,7 +756,7 @@ def submit_approval_response(approval_token: str, response: ApprovalResponse):
             if response.approved:
                 cur.execute("""
                     UPDATE deed_shares
-                    SET status = 'approved', updated_at = NOW()
+                    SET status = 'approved', responded_at = NOW(), updated_at = NOW()
                     WHERE id = %s
                 """, (share_id,))
                 db.conn.commit()
@@ -838,6 +821,7 @@ def submit_approval_response(approval_token: str, response: ApprovalResponse):
                     feedback = %s,
                     feedback_at = NOW(),
                     feedback_by = %s,
+                    responded_at = NOW(),
                     updated_at = NOW()
                 WHERE id = %s
             """, (comments, recipient_email, share_id))

--- a/backend/services/shared_deed_row.py
+++ b/backend/services/shared_deed_row.py
@@ -1,0 +1,150 @@
+"""FLOW1 item 0 — one place builds a Shared Deeds row, with a named key set.
+
+═══ WHAT WENT WRONG ═══
+
+An external audit reported the Shared Deeds page as showing FABRICATED
+rows: "Invalid Date" in Shared Date, "NaN days left" under Expires, blank
+Deed Type, blank Shared With, and a Status of "Viewed" sitting beside a
+Response of "Not viewed". The row count happened to equal the number of
+completed deeds, which read as synthesis from the deeds list.
+
+It was not synthesis. The page fetches `GET /shared-deeds` on mount and
+renders exactly the rows the server sent. What it did NOT do was read
+them by the names the server used. Eight of fifteen fields were wrong:
+
+    server sent          screen looked for      what you saw
+    ─────────────────────────────────────────────────────────────
+    type                 deed_type              (blank)
+    shared_with_email    recipient_email        (blank)
+    — (never sent)       shared_with            (blank)
+    date                 shared_date            Invalid Date
+    — (baked into a      expires_at             Invalid Date /
+       "message" string)                        NaN days left
+    — (never sent)       viewed_at              "Not viewed", always
+    — (never sent)       response_date          "Pending", always
+    — (never sent)       feedback               (blank)
+
+Every symptom in the report is one of those rows. "Viewed" contradicting
+"Not viewed" is the clearest: the badge reads `status`, which arrived;
+the line under it reads `viewed_at`, which never did.
+
+═══ WHY IT SURVIVED ═══
+
+Nothing compared the two declarations. The response shape lived in a
+dict literal inside a route handler; the screen's shape lived in a
+TypeScript interface; neither had ever read the other, and TypeScript
+cannot type-check a `fetch` it did not author. A missing key in JS is not
+an error — it is `undefined`, and `undefined` formats as a blank cell or
+an Invalid Date. **The failure mode of this defect class is a page that
+looks like it is lying.**
+
+So the fix is not eight renames. It is:
+
+  1. ONE function builds the row — this one — instead of a dict literal
+     buried mid-handler where the next field gets appended by whoever is
+     passing.
+  2. The key set is NAMED (`SHARED_DEED_KEYS`) and asserted by EQUALITY
+     at runtime, the same allowlist-by-key-set-equality the NOTARY2 token
+     surfaces use. A field cannot enter or leave the payload silently.
+  3. The names live in a SHARED CORPUS (`shared_deed_row_keys.json`) that
+     the frontend suite reads too, so the screen's interface and the
+     server's payload are pinned to the same list from both sides. This
+     is the phone_cases.json pattern; it exists because a contract
+     declared twice in two languages is a contract that drifts.
+
+═══ THREE FIELDS DID NOT EXIST AND NOW DO ═══
+
+`shared_with`, `response_date` and a real `expires_at` were not renames —
+the data was absent.
+
+* `recipient_name` was ACCEPTED by `POST /shared-deeds`, used for the
+  email greeting, and then dropped on the floor: there was no column. So
+  the officer picks "Nora Vasquez" out of her rolodex and the tracking
+  screen has a Shared With column with nowhere to get her name from. It
+  is a column now.
+
+* `responded_at` records when the recipient approved or rejected.
+  `updated_at` was NOT usable for this — a revoke bumps it too, and a
+  screen that says "responded 4 Aug" because somebody revoked access on
+  4 Aug is a worse defect than a blank cell. Rows that responded before
+  this ticket have no such stamp and report `null`; the screen renders
+  that as unknown rather than inventing "Pending" over a decided share.
+
+* `expires_at` was a real column all along, SELECTed and then spent on
+  the string `"Shared via link - expires 2026-08-18"` in a `message`
+  field nothing renders. The countdown had nothing to count.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, Mapping, Optional
+
+from services import signing
+
+# The contract, read from the corpus rather than retyped here — a second
+# copy of a list is the thing this whole module exists to prevent.
+_CORPUS = json.loads(
+    (Path(__file__).parent / "shared_deed_row_keys.json").read_text(encoding="utf-8")
+)
+SHARED_DEED_KEYS = frozenset(_CORPUS["keys"])
+
+
+def _iso(value: Any) -> Optional[str]:
+    """Timestamps cross the wire as ISO-8601 or as nothing.
+
+    NOT as `""`. The empty string was the old handler's answer for a
+    missing date and it is the direct cause of "Invalid Date" on the
+    screen: `new Date("")` is a Date object, it is just not a valid one,
+    so every JS guard shaped `if (d)` waves it through. `null` fails that
+    guard honestly.
+    """
+    if value is None:
+        return None
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return str(value)
+
+
+def shared_deed_row(row: Mapping[str, Any]) -> Dict[str, Any]:
+    """One row of the officer's Shared Deeds list.
+
+    `row` is a `deed_shares` record joined to its deed. The returned key
+    set is asserted equal to `SHARED_DEED_KEYS` before it leaves — an
+    assertion rather than a filter on purpose: silently dropping an
+    unexpected key would let the screen and the server disagree again,
+    quietly, which is exactly what happened last time.
+    """
+    out: Dict[str, Any] = {
+        "id": row.get("id"),
+        "deed_id": row.get("deed_id"),
+        "property": row.get("property_address") or "",
+        "deed_type": row.get("deed_type") or "",
+        # The name the officer chose them by, when we have one. Falling
+        # back to the address is honest — it is who she sent it to — and
+        # beats an empty cell in the column headed "Shared With".
+        "shared_with": (row.get("recipient_name") or "").strip()
+                       or (row.get("recipient_email") or ""),
+        "recipient_email": row.get("recipient_email") or "",
+        "status": row.get("status"),
+        "shared_date": _iso(row.get("created_at")),
+        "expires_at": _iso(row.get("expires_at")),
+        "viewed_at": _iso(row.get("viewed_at")),
+        "response_date": _iso(row.get("responded_at")),
+        # NOTARY1: the real kind, not the constant "review" this used to
+        # be — which was true until signings existed and would have
+        # stayed "true" for every signing request afterwards.
+        "share_type": row.get("share_kind") or signing.SHARE_KIND_REVIEW,
+        # The status LINE, written by scheduling_label() and rendered
+        # verbatim. This screen does not compose its own sentence for an
+        # arrangement, so "scheduled" cannot drift into "will happen".
+        "signing_summary": signing.scheduling_label(dict(row)),
+        "scheduled_at": _iso(row.get("scheduled_at")),
+        "scheduled_by": row.get("scheduled_by"),
+    }
+    assert set(out) == SHARED_DEED_KEYS, (
+        "the Shared Deeds row no longer matches its contract: "
+        f"extra={sorted(set(out) - SHARED_DEED_KEYS)} "
+        f"missing={sorted(SHARED_DEED_KEYS - set(out))}"
+    )
+    return out

--- a/backend/services/shared_deed_row_keys.json
+++ b/backend/services/shared_deed_row_keys.json
@@ -1,0 +1,43 @@
+{
+  "_why": [
+    "FLOW1 item 0. The Shared Deeds screen was reported as showing fabricated",
+    "rows: Invalid Date, NaN days left, blank Deed Type, blank Shared With, a",
+    "Status of 'Viewed' beside a Response of 'Not viewed'. It was not",
+    "fabricating anything. It fetched real rows from GET /shared-deeds and",
+    "then read them with the WRONG KEY NAMES, so every field it could not find",
+    "rendered as undefined and every date it could not find rendered as",
+    "Invalid Date. Eight of fifteen fields were wrong.",
+    "",
+    "Nothing failed, because nothing compared the two declarations. The server",
+    "declared its keys in Python and the screen declared its keys in",
+    "TypeScript and neither had ever read the other.",
+    "",
+    "This file is that comparison, made mandatory. It is the SHARED CORPUS",
+    "pattern already used by services/phone_cases.json: one list, read from",
+    "both languages, so drift needs two edits in two places instead of one",
+    "silent one. The backend asserts its emitted key set equals this by",
+    "EQUALITY (services/shared_deed_row.py); the frontend suite asserts the",
+    "SharedDeed interface declares exactly these fields.",
+    "",
+    "Adding a field to the screen without adding it here fails the frontend",
+    "pin. Adding a field to the response without adding it here fails the",
+    "backend pin. Adding it here without wiring either fails both."
+  ],
+  "keys": [
+    "id",
+    "deed_id",
+    "property",
+    "deed_type",
+    "shared_with",
+    "recipient_email",
+    "status",
+    "shared_date",
+    "expires_at",
+    "viewed_at",
+    "response_date",
+    "share_type",
+    "signing_summary",
+    "scheduled_at",
+    "scheduled_by"
+  ]
+}

--- a/backend/tests/test_flow1_shared_deeds_contract.py
+++ b/backend/tests/test_flow1_shared_deeds_contract.py
@@ -1,0 +1,350 @@
+"""FLOW1 item 0 — the Shared Deeds list, from the server's side.
+
+═══ THE VERDICT THESE TESTS ENCODE ═══
+
+The page was reported as showing FABRICATED rows. It does not fabricate
+anything: it calls `GET /shared-deeds` on mount and renders exactly what
+comes back. What it did was read that response with EIGHT WRONG KEY
+NAMES — `type` vs `deed_type`, `date` vs `shared_date`,
+`shared_with_email` vs `recipient_email`, and five fields the server
+never sent at all. A missing key in JavaScript is `undefined`; an
+undefined date is `Invalid Date`; an undefined expiry is `NaN days left`.
+
+So the class is not "eight typos". The class is **a response shape and a
+screen's shape, declared separately in two languages, with nothing
+comparing them.** That is what the corpus and these pins close.
+
+═══ THE PINS ═══
+
+  1. The emitted key set equals `shared_deed_row_keys.json` BY EQUALITY —
+     allowlist, not denylist, the same rule the NOTARY2 token surfaces
+     follow. A field cannot enter or leave the payload silently.
+  2. The frontend's `interface SharedDeed` declares exactly those names.
+     The frontend suite pins this too; it is pinned from both sides on
+     purpose, because a corpus only one side reads is a corpus one side
+     can forget.
+  3. Real rows through the real route agree — not just the builder in
+     isolation, which would pass while the handler returned something
+     else entirely (it did, for months).
+  4. No date field is ever the empty string. `""` was the old handler's
+     answer for a date it did not have, and it is the direct cause of
+     Invalid Date: `new Date("")` is a Date object, just not a valid one,
+     so every JS guard shaped `if (d)` waves it through.
+  5. The two facts that had no column now have one, and are recorded:
+     the recipient's name, and when they responded.
+"""
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+
+from tests.source_text import code_only
+
+BACKEND = Path(__file__).resolve().parents[1]
+REPO = BACKEND.parent
+
+CORPUS = json.loads(
+    (BACKEND / "services" / "shared_deed_row_keys.json").read_text(encoding="utf-8")
+)
+CONTRACT = set(CORPUS["keys"])
+
+dbonly = pytest.mark.skipif(
+    not __import__("os").getenv("DATABASE_URL"),
+    reason="needs a database",
+)
+
+
+# ── 1. The builder ───────────────────────────────────────────────────
+
+def test_the_builder_emits_exactly_the_contract():
+    from services.shared_deed_row import SHARED_DEED_KEYS, shared_deed_row
+
+    assert set(SHARED_DEED_KEYS) == CONTRACT
+    row = shared_deed_row({})
+    assert set(row) == CONTRACT
+
+
+def test_the_builder_refuses_to_grow_a_field_quietly():
+    """The assertion is the point — a filter would have let the payload
+    and the screen disagree again, silently, which is the whole defect.
+
+    Mutation-checked: this fails if the `assert set(out) == ...` in
+    shared_deed_row is removed or softened to a filter.
+    """
+    from services import shared_deed_row as mod
+
+    # code_only(): this module's docstring quotes the very key names the
+    # pins below forbid elsewhere, and a pin that greps prose eventually
+    # trips on the comment explaining the thing it forbids.
+    source = code_only(BACKEND / "services" / "shared_deed_row.py")
+    assert "assert set(out) == SHARED_DEED_KEYS" in source
+    # And the keys are READ from the corpus rather than retyped, so the
+    # two lists cannot drift by someone editing only one.
+    assert "shared_deed_row_keys.json" in source
+    assert mod.SHARED_DEED_KEYS is not None
+
+
+def test_no_date_field_is_ever_the_empty_string():
+    """`new Date("")` is Invalid Date and `if (value)` does not catch it.
+
+    Absence must be `null`, which every guard in every language treats as
+    absent.
+    """
+    from services.shared_deed_row import shared_deed_row
+
+    row = shared_deed_row({})
+    for key in ("shared_date", "expires_at", "viewed_at", "response_date",
+                "scheduled_at"):
+        assert row[key] is None, f"{key} reported absence as {row[key]!r}"
+
+
+def test_shared_with_falls_back_to_the_address_not_to_blank():
+    from services.shared_deed_row import shared_deed_row
+
+    named = shared_deed_row({"recipient_name": "Nora Vasquez",
+                             "recipient_email": "nora@example.test"})
+    assert named["shared_with"] == "Nora Vasquez"
+
+    # No name on file is not a licence for an empty cell in a column
+    # headed "Shared With" — she sent it to an address, and that is who.
+    anonymous = shared_deed_row({"recipient_email": "nora@example.test"})
+    assert anonymous["shared_with"] == "nora@example.test"
+
+    # Whitespace is not a name.
+    blank = shared_deed_row({"recipient_name": "   ",
+                             "recipient_email": "nora@example.test"})
+    assert blank["shared_with"] == "nora@example.test"
+
+
+# ── 2. The screen's declaration ──────────────────────────────────────
+
+PAGE = REPO / "frontend" / "src" / "app" / "shared-deeds" / "page.tsx"
+
+
+def _interface_fields(source: str, name: str) -> list[str]:
+    start = source.index(f"interface {name} {{")
+    depth = 0
+    end = -1
+    for i in range(source.index("{", start), len(source)):
+        if source[i] == "{":
+            depth += 1
+        elif source[i] == "}":
+            depth -= 1
+            if depth == 0:
+                end = i
+                break
+    assert end > start, f"unbalanced braces in interface {name}"
+    body = source[start:end]
+    # Strip block and line comments — a doc comment naming a field must
+    # not count as declaring it.
+    body = re.sub(r"/\*.*?\*/", "", body, flags=re.S)
+    body = re.sub(r"^[^\S\n]*//.*$", "", body, flags=re.M)
+    return re.findall(r"^  ([A-Za-z_][A-Za-z0-9_]*)\??\s*:", body, flags=re.M)
+
+
+def test_the_screens_interface_declares_exactly_the_contract():
+    """The pin that would have caught the original defect on the day it
+    landed, from either side of the wire."""
+    fields = _interface_fields(PAGE.read_text(encoding="utf-8"), "SharedDeed")
+    assert set(fields) == CONTRACT, (
+        f"screen-only={sorted(set(fields) - CONTRACT)} "
+        f"server-only={sorted(CONTRACT - set(fields))}"
+    )
+    assert len(fields) == len(set(fields))
+
+
+def test_the_old_wrong_names_are_gone_from_the_route():
+    """Renaming the emitted keys while leaving the old ones beside them
+    would pass an equality pin on the SCREEN and leave two contracts."""
+    source = code_only(BACKEND / "routers" / "sharing.py")
+    handler = source[source.index("def list_shared_deeds"):]
+    handler = handler[: handler.index("\n@router.")]
+    for dead in ('"shared_with_email"', '"shared_by_id"', '"approval_token"',
+                 '"type"', '"date"'):
+        assert dead not in handler, f"{dead} still emitted by the list route"
+    # And the handler builds rows through the one builder, rather than a
+    # dict literal that the next field gets appended to.
+    assert "shared_deed_row(row)" in handler
+
+
+# ── 3. Real rows through the real route ──────────────────────────────
+
+@pytest.fixture
+def world():
+    """One officer, two of their deeds — the second is never shared, so
+    "did this row come from a share or from a deed?" has an answer."""
+    import os
+    import uuid
+
+    import psycopg2
+    from database import create_tables
+    from db_rows import ROW_FACTORY
+
+    create_tables()
+    conn = psycopg2.connect(os.environ["DATABASE_URL"], cursor_factory=ROW_FACTORY)
+    conn.autocommit = True
+    tag = uuid.uuid4().hex[:8]
+    made = {"users": [], "deeds": []}
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO users (email, password_hash, full_name, role) "
+            "VALUES (%s, 'x', 'Officer', 'user') RETURNING id",
+            (f"officer-{tag}@flow1.test",))
+        made["users"].append(cur.fetchone()["id"])
+        for address in ("11 Contract Way, Los Angeles, CA",
+                        "12 Unshared Road, Los Angeles, CA"):
+            cur.execute(
+                """INSERT INTO deeds (user_id, deed_type, property_address, apn,
+                                      grantor_name, grantee_name, county, status)
+                   VALUES (%s, 'grant_deed', %s, '1234-567-890',
+                           'GRANTOR', 'GRANTEE', 'Los Angeles', 'completed')
+                   RETURNING id""",
+                (made["users"][0], address))
+            made["deeds"].append(cur.fetchone()["id"])
+    made["conn"] = conn
+    yield made
+    conn.close()
+
+
+def _client_for(user_id: int):
+    from fastapi.testclient import TestClient
+    from auth import create_access_token
+    from main import app
+
+    client = TestClient(app)
+    client.headers.update({
+        "Authorization": "Bearer " + create_access_token(
+            {"sub": str(user_id), "email": "officer@flow1.test"})
+    })
+    return client
+
+
+@dbonly
+def test_the_live_response_matches_the_contract(world):
+    """The builder passing in isolation proves nothing about the route.
+
+    For months the builder-equivalent lived inline in the handler and the
+    screen disagreed with it; a unit test of a function nobody called
+    would have been green throughout.
+    """
+    officer = world["users"][0]
+    client = _client_for(officer)
+    made = client.post("/shared-deeds", json={
+        "deed_id": world["deeds"][0],
+        "recipient_name": "Nora Vasquez",
+        "recipient_email": "nora@flow1.test",
+        "recipient_role": "Reviewer",
+    })
+    assert made.status_code == 200, made.text
+
+    rows = client.get("/shared-deeds").json()
+    assert rows, "the share we just created is not in the officer's list"
+    for row in rows:
+        assert set(row) == CONTRACT, (
+            f"extra={sorted(set(row) - CONTRACT)} "
+            f"missing={sorted(CONTRACT - set(row))}"
+        )
+
+    fresh = rows[0]
+    # Every field the audit reported as blank or Invalid, populated.
+    assert fresh["shared_with"] == "Nora Vasquez"
+    assert fresh["recipient_email"] == "nora@flow1.test"
+    assert fresh["deed_type"], "Deed Type is blank"
+    assert fresh["property"], "Property is blank"
+    for key in ("shared_date", "expires_at"):
+        from datetime import datetime
+        assert fresh[key], f"{key} is absent"
+        datetime.fromisoformat(fresh[key])  # raises if unparseable
+    # Not yet opened, not yet answered — absent, and absent as null.
+    assert fresh["viewed_at"] is None
+    assert fresh["response_date"] is None
+
+
+@dbonly
+def test_status_and_viewed_at_cannot_contradict_each_other(world):
+    """The audit's sharpest symptom: a badge reading "Viewed" beside a
+    line reading "Not viewed". The badge read `status`, which arrived;
+    the line read `viewed_at`, which never did. They are stamped by the
+    same statement, so the surface can no longer show one without the
+    other."""
+    from fastapi.testclient import TestClient
+    import main
+
+    officer = world["users"][0]
+    client = _client_for(officer)
+    made = client.post("/shared-deeds", json={
+        "deed_id": world["deeds"][0],
+        "recipient_email": "viewer@flow1.test",
+        "recipient_role": "Reviewer",
+    }).json()
+    token = made["shared_deed"]["approval_token"]
+
+    assert TestClient(main.app).get(f"/approve/{token}").status_code == 200
+
+    row = next(r for r in _client_for(officer).get("/shared-deeds").json()
+               if r["recipient_email"] == "viewer@flow1.test")
+    assert row["status"] == "viewed"
+    assert row["viewed_at"] is not None, (
+        "the row says viewed and carries no viewing time — the exact "
+        "contradiction this ticket was opened for")
+
+
+@dbonly
+def test_a_response_records_when_it_happened(world):
+    """`updated_at` was NOT usable for this and must not be substituted:
+    a revoke bumps it too, so a screen reading it would report a response
+    on the day access was withdrawn."""
+    from fastapi.testclient import TestClient
+    import main
+
+    officer = world["users"][0]
+    client = _client_for(officer)
+    made = client.post("/shared-deeds", json={
+        "deed_id": world["deeds"][0],
+        "recipient_email": "approver@flow1.test",
+        "recipient_role": "Reviewer",
+    }).json()
+    token = made["shared_deed"]["approval_token"]
+
+    public = TestClient(main.app)
+    assert public.get(f"/approve/{token}").status_code == 200
+    assert public.post(f"/approve/{token}",
+                       json={"approved": True}).status_code == 200
+
+    row = next(r for r in _client_for(officer).get("/shared-deeds").json()
+               if r["recipient_email"] == "approver@flow1.test")
+    assert row["status"] == "approved"
+    assert row["response_date"] is not None, "approved with no response time"
+
+
+@dbonly
+def test_a_deed_that_was_never_shared_produces_no_row(world):
+    """The report's hypothesis, tested rather than argued away.
+
+    The audit observed that the row count equalled the number of
+    completed deeds, and concluded the page was synthesising rows from
+    the deeds list. It was not — but "it isn't doing that today" is not a
+    property, it is an observation. This is the property: the officer
+    owns two completed deeds and shares ONE. A list derived from deeds
+    returns two rows; a list derived from shares returns one.
+    """
+    officer = world["users"][0]
+    shared, never_shared = world["deeds"]
+    client = _client_for(officer)
+
+    assert client.get("/shared-deeds").json() == [], (
+        "rows exist for an officer who has shared nothing")
+
+    assert client.post("/shared-deeds", json={
+        "deed_id": shared,
+        "recipient_email": "one@flow1.test",
+        "recipient_role": "Reviewer",
+    }).status_code == 200
+
+    rows = client.get("/shared-deeds").json()
+    assert len(rows) == 1
+    assert rows[0]["deed_id"] == shared
+    assert never_shared not in {r["deed_id"] for r in rows}

--- a/backend/tests/test_notary1_signing.py
+++ b/backend/tests/test_notary1_signing.py
@@ -40,6 +40,7 @@ from tests.source_text import code_only  # noqa: E402
 from services import signing  # noqa: E402
 
 SHARING = BACKEND / "routers" / "sharing.py"
+ROW_BUILDER = BACKEND / "services" / "shared_deed_row.py"
 
 
 # ══════════════════════════════════════════════════════════════════════
@@ -230,11 +231,22 @@ def test_the_label_never_promises_the_signing_will_happen():
 
 def test_every_surface_takes_its_words_from_one_place():
     """`scheduling_label` exists so the wording cannot drift screen by
-    screen. A router that composed its own sentence would defeat it."""
-    src = code_only(SHARING)
-    assert src.count("signing.scheduling_label(") >= 4
-    assert not re.search(r'f?"[^"]*[Ss]cheduled for', src), (
-        "a router is writing its own scheduling sentence")
+    screen. A router that composed its own sentence would defeat it.
+
+    FLOW1 note: the count spans the ROUTER AND THE ROW BUILDER, because
+    the officer's list moved its row construction into
+    services/shared_deed_row.py. A count pinned to one file would have
+    read that move as a regression — it is the opposite — and the
+    property being pinned was never "four calls in sharing.py". It is
+    "every surface that says something about a scheduling state got the
+    sentence from the one function that writes them".
+    """
+    sources = [code_only(SHARING), code_only(ROW_BUILDER)]
+    calls = sum(s.count("signing.scheduling_label(") for s in sources)
+    assert calls >= 4, f"only {calls} surfaces take their words from one place"
+    for src in sources:
+        assert not re.search(r'f?"[^"]*[Ss]cheduled for', src), (
+            "a surface is writing its own scheduling sentence")
 
 
 # ══════════════════════════════════════════════════════════════════════

--- a/docs/DOCTRINE_CONFORMANCE.md
+++ b/docs/DOCTRINE_CONFORMANCE.md
@@ -141,10 +141,49 @@ celebrating, and the post-generation page shows an honest "PDF Not Ready"
 state. **Lesson recorded:** resilience without surfacing is camouflage —
 every non-blocking catch must emit a caller-visible signal.
 
+**Findings (FLOW1 item 0 — the Shared Deeds contract, 2026-08-11).** An
+external audit reported the Shared Deeds page as rendering **fabricated
+rows**: Invalid Date, NaN days left, blank Deed Type, blank Shared With,
+and a Status of "Viewed" beside a Response of "Not viewed", with a row
+count equal to the number of completed deeds. **The verdict was: not
+fabricated.** The page fetches `GET /shared-deeds` on mount and renders
+the real rows — through eight wrong key names. `undefined` is not an
+error in JavaScript; it is a blank cell, and `new Date(undefined)` is
+Invalid Date. Every symptom was one of those eight.
+
+That makes this a §4 finding rather than an invariant-#4 one, and the
+distinction matters: **nothing was invented, and the screen still made
+claims it could not support.** "Not viewed" beneath a badge reading
+"Viewed" is a false statement about a real share. The failure mode of
+this class is a page that *looks like it is lying* while behaving
+exactly as written.
+
+Three things it also found, each a fact the surface displayed and the
+system never held: `recipient_name` was accepted by the create route,
+used to greet the recipient, and then discarded — no column, so the
+"Shared With" column had no source; there was no record of **when** a
+recipient responded (`updated_at` is not that fact — a revoke bumps it
+too); and the feedback modal fell back to a row field the list endpoint
+has never sent, so a failed fetch opened a modal reading "(No comments
+provided)" — a swallowed error presented as the reviewer's answer.
+
+**Lesson recorded:** two declarations of one contract, in two languages,
+with nothing comparing them, will drift — and TypeScript cannot check a
+`fetch` it did not author, so the compiler is not the thing that
+notices. The fix is a **shared corpus both suites read**
+(`backend/services/shared_deed_row_keys.json`, the phone_cases.json
+pattern), a single row builder asserting its key set by equality, and a
+surface that renders "—" for a date it does not have rather than
+whatever `Date` makes of nothing.
+
 **Enforced by.**
 - `frontend/src/__tests__/proxyErrorHonesty.test.ts` — source-scans every
   proxy route: no empty-array response bodies; no `success: true` in any
   catch block; every catch that returns JSON carries an explicit 4xx/5xx.
+- `backend/tests/test_flow1_shared_deeds_contract.py` +
+  `frontend/src/__tests__/sharedDeedsContract.test.ts` — the same corpus
+  read from both sides; absence crosses the wire as `null` and never as
+  `""`; a deed that was never shared produces no row.
 - `frontend/src/__tests__/integration/fault-injection.test.ts`
 - One schema authority: `scripts/six_flow_baseline.py::ensure_schema`
   contains no ALTER/CREATE statements — schema comes only from
@@ -777,6 +816,7 @@ their data is not a machine decision.
 
 | Date | Change |
 |---|---|
+| 2026-08-11 | §4 — FLOW1 item 0. Shared Deeds reported as showing fabricated rows; verdict recorded as NOT fabricated — a real fetch read through eight wrong key names, so `undefined` rendered as blank cells and Invalid Date. Recorded under §4 rather than invariant #4 because nothing was invented and the screen still asserted what it could not support ("Not viewed" under a badge reading "Viewed"). Three absent facts given columns: `recipient_name` (accepted, greeted with, never stored), `responded_at` (`updated_at` was not that fact — a revoke bumps it too), and a real `expires_at` (previously spent on a display string nothing rendered). Contract now pinned from both sides against one corpus; absence crosses the wire as `null`, never `""`. The feedback modal's fallback to a field the list endpoint never sent — a failed fetch reading as "the reviewer left no comments" — removed. |
 | 2026-08-11 | §13.1 — the signer-contact ruling REVERSED (NOTARY2). Signers now participate directly; the notary posts availability, signers pick or propose, convergence books it, and the officer is notified rather than gating. Owner's reasoning recorded: the signers are the scheduling constraint, so routing around them recreated the phone tag the feature exists to kill — Option A had priced the officer's relaying at zero when it is the entire problem. The superseded paragraph is kept verbatim rather than rewritten. §13 otherwise stands unchanged: booked is still not happened. NOTARY1's fail-closed sweep is ANSWERED rather than deleted — retargeted from "no signer contact anywhere" to "one purgeable row, no other table, deleted by a mechanism with a test." The retention rule and a non-user's route to removal become part of the feature, ledgered as owner items. |
 | 2026-08-10 | §13 added (NOTARY1) — an arrangement is not an act. A scheduled signing time is the least legally freighted fact in the product, which is exactly the risk: authority acquired by wording drift rather than by decision. Three pinned rules: nothing infers a signing from a passed window (`scheduling_state()` is AST-pinned type-incapable of a "happened" state), `completed` stays officer-only, and `scheduling_label()` is the single place a scheduling state becomes a sentence. Assertion shape mirrors RED-S4 (`scheduled_at` / `scheduled_by` / `scheduled_asserted_at`), keeping the notary's tap and the officer's phone call apart. State DERIVED, never folded into `deed_shares.status` — T-5's ruling transferred verbatim. No signer contact anywhere, pinned fail-closed across both trees. One expiry semantic per link, applied as a class. Two pre-existing defects fixed in passing: share creation never checked deed ownership (cross-user deed disclosure), and an opened link kept serving the deed after expiry. |
 | 2026-08-06 | §12 added (Doctrine B) — the AI boundary, explain-yes/select-no; closes RED0 R3-5. The third citizen: earlier sections legislate facts and legal choices, and the assistant emits PROSE, which had neither a suggestion marker nor a confirmation nor (until H1.3) a record. Three layers: the system prompt STATES the boundary (prevents), a server-side scanner pairs recommendation cues with instrument names and records findings in `ai_exchange_log.boundary_flags` (detects, does not block — a flagged response still reaches the officer, and blocking on a pattern would let a false positive swallow a correct answer), transcript-style tests ask the forbidden questions. `deed_type_advisor` REWRITTEN to explain-only, not deleted: the boundary decides the prompt regardless of usage evidence, and deleting would remove the permitted half. H1.3's flag-and-pin retired in the same diff that cured its condition. Usage-evidence tuning deferred with a trigger (OWNER_LEDGER) — the log was two days old and empty. |

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -312,6 +312,20 @@ we reach it.
 
 ## Parked tickets (scoped, not scheduled)
 
+- **DEEDDETAIL — there is no deed detail route** (FLOW1 finding, owner
+  ruled: scope and ledger as its own ticket, not FLOW1's). `/deeds/{id}`,
+  `/deed/{id}` and `/past-deeds/{id}` all 404. Every deed-level action —
+  share for review, request a signing, download, view — exists only as a
+  control inside a list row, so there is nowhere to LINK a deed from.
+  This is why the Signings agenda card points at `/past-deeds` and loses
+  which signing you were looking at, and why an approval notification's
+  `?focus=` parameter has nothing to focus. It is a structural gap rather
+  than a bug: nothing is broken, and several things cannot be built
+  correctly until it exists. Scoping this properly means deciding what a
+  deed's page IS (the instrument? its history? its people?) before
+  building one, which is why it is parked and not folded into a UX
+  ticket.
+
 - ~~**Deed supersession model**~~ — **BUILT AND SHIPPED, T-5 (PR #124).**
   Corrected 2026-08-04; this entry was stale for a day and is left
   visible rather than deleted, because a parked list that quietly loses

--- a/frontend/src/__tests__/sharedDeedsContract.test.ts
+++ b/frontend/src/__tests__/sharedDeedsContract.test.ts
@@ -1,0 +1,182 @@
+/**
+ * FLOW1 item 0 — the Shared Deeds screen, from the screen's side.
+ *
+ * ═══ THE DEFECT THESE PINS EXIST FOR ═══
+ *
+ * An audit reported this page as rendering FABRICATED rows: Invalid
+ * Date, NaN days left, blank Deed Type, blank Shared With, and a Status
+ * of "Viewed" beside a Response of "Not viewed" — with a row count that
+ * happened to equal the number of completed deeds, which reads like the
+ * page synthesising rows out of the deeds list.
+ *
+ * It was not synthesising anything. It fetched `GET /shared-deeds` and
+ * rendered the real rows — through EIGHT WRONG KEY NAMES. A key that
+ * does not exist is `undefined`, `undefined` renders as an empty cell,
+ * and `new Date(undefined)` renders as Invalid Date. Every symptom in
+ * that report is one of those eight.
+ *
+ * ═══ WHAT IS PINNED, AND WHY THOSE THINGS ═══
+ *
+ *  1. THE ROWS COME FROM THE SHARE FETCH AND NOTHING ELSE. This is the
+ *     owner's ruling written as a test. The report's hypothesis was
+ *     synthesis; the hypothesis was wrong today and the pin is what
+ *     keeps it wrong tomorrow. `sharedDeeds` may be filled from the
+ *     `/shared-deeds` response and from no other source.
+ *
+ *  2. THE INTERFACE MATCHES THE SERVER'S PAYLOAD BY EQUALITY, against
+ *     the corpus the backend row builder asserts itself against. Two
+ *     declarations of one contract, in two languages, neither reading
+ *     the other, is exactly how eight fields drifted unnoticed. Now they
+ *     read the same list.
+ *
+ *  3. NO DATE REACHES THE SCREEN UNGUARDED. "Invalid Date" is not a
+ *     cosmetic bug on a tracking surface — it is the screen asserting a
+ *     fact it does not hold, in the same typeface as the facts it does.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
+
+const SRC = path.join(__dirname, '..');
+const PAGE_PARTS = ['app', 'shared-deeds', 'page.tsx'];
+const PAGE = fs.readFileSync(path.join(SRC, ...PAGE_PARTS), 'utf8');
+const PAGE_CODE = codeOnly(PAGE);
+/** JSX wraps wherever the formatter chose to, so a sentence in the
+ * source is not a sentence in a string. Flatten before asserting on a
+ * multi-line expression — otherwise the pin passes or fails on
+ * whitespace. */
+const FLAT = PAGE_CODE.replace(/\s+/g, ' ');
+
+/** The corpus the BACKEND row builder also reads — same referee, two
+ * languages. `backend/services/shared_deed_row.py` asserts its emitted
+ * key set equals this; the test below asserts the interface does. */
+const CONTRACT: string[] = JSON.parse(
+  fs.readFileSync(
+    path.join(SRC, '..', '..', 'backend', 'services', 'shared_deed_row_keys.json'),
+    'utf8',
+  ),
+).keys;
+
+/** Field names declared by `interface SharedDeed { ... }`.
+ *
+ * Read from the RAW source, not `codeOnly()` — the interface carries
+ * doc comments and stripping them is unnecessary here, while the brace
+ * matching below needs the block intact. */
+function interfaceFields(source: string, name: string): string[] {
+  const start = source.indexOf(`interface ${name} {`);
+  expect(start).toBeGreaterThan(-1);
+  let depth = 0;
+  let end = -1;
+  for (let i = source.indexOf('{', start); i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') {
+      depth--;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+  expect(end).toBeGreaterThan(start);
+  const body = codeOnly(source.slice(start, end));
+  // Only top-level members: a nested object type would indent further,
+  // and there are none today — if one appears, this pin should be the
+  // thing that notices.
+  const fields: string[] = [];
+  for (const line of body.split('\n')) {
+    const m = /^\s{2}([a-z_][a-z0-9_]*)\??\s*:/i.exec(line);
+    if (m) fields.push(m[1]);
+  }
+  return fields;
+}
+
+describe('FLOW1 — Shared Deeds rows come from the share fetch', () => {
+  it('fetches /shared-deeds and fills the table from that response', () => {
+    expect(PAGE_CODE).toContain("apiFetch(`/shared-deeds`");
+    // The state the table maps over is written in exactly one place, and
+    // that place is the handler for the share response.
+    const writes = PAGE_CODE.match(/setSharedDeeds\s*\(/g) || [];
+    expect(writes).toHaveLength(1);
+  });
+
+  it('never derives rows from the deeds list', () => {
+    // The reported hypothesis, forbidden rather than merely absent. A
+    // row on this screen is a SHARE — a thing that was sent to somebody
+    // — and a completed deed is not one. Deriving the second from the
+    // first would put a row on a tracking screen for a share that never
+    // happened, which is invariant #4 on the surface whose whole job is
+    // to say what happened.
+    for (const forbidden of [
+      /apiFetch\(\s*[`'"]\/deeds/,
+      /apiFetch\(\s*[`'"]\/api\/deeds/,
+      /setSharedDeeds\s*\(\s*deeds/,
+    ]) {
+      expect(PAGE_CODE).not.toMatch(forbidden);
+    }
+  });
+});
+
+describe('FLOW1 — the interface and the server agree by equality', () => {
+  it('declares exactly the fields the server sends', () => {
+    const fields = interfaceFields(PAGE, 'SharedDeed');
+    expect([...fields].sort()).toEqual([...CONTRACT].sort());
+  });
+
+  it('has no duplicate declarations', () => {
+    const fields = interfaceFields(PAGE, 'SharedDeed');
+    expect(new Set(fields).size).toBe(fields.length);
+  });
+
+  it('reads every row field through a name in the contract', () => {
+    // `deed.something` where `something` is not a contract key is the
+    // exact shape of the original defect — a field name that reads fine,
+    // type-checks fine (it does not: it fails tsc, which is why this
+    // pin is a second line and not the first), and is undefined at run
+    // time. Kept as a sweep anyway because `any` anywhere upstream turns
+    // the compiler's answer off.
+    const reads = new Set<string>();
+    for (const m of PAGE_CODE.matchAll(/\bdeed\.([a-z_][a-z0-9_]*)/gi)) {
+      reads.add(m[1]);
+    }
+    expect([...reads].filter((r) => !CONTRACT.includes(r))).toEqual([]);
+  });
+});
+
+describe('FLOW1 — no unguarded date reaches the screen', () => {
+  it('parses dates through a guard that can answer "unknown"', () => {
+    expect(PAGE_CODE).toMatch(/Number\.isNaN\(\s*parsed\.getTime\(\)\s*\)/);
+    // formatDate returns the unknown marker rather than "Invalid Date".
+    expect(PAGE_CODE).toMatch(/const UNKNOWN = /);
+  });
+
+  it('constructs no Date outside the guard', () => {
+    // `new Date(...)` is allowed in exactly two places: the guard itself,
+    // and the feedback modal's own timestamp (which is already inside a
+    // truthiness check on a value the server minted). Anywhere else and
+    // an unparseable value reaches toLocaleDateString again.
+    const constructions = (PAGE_CODE.match(/new Date\(/g) || []).length;
+    expect(constructions).toBeLessThanOrEqual(2);
+  });
+
+  it('does not treat a decided share as still pending', () => {
+    // A share the recipient approved before `responded_at` existed has a
+    // status and no date. "Pending" would be a claim about a share that
+    // was decided; the unknown marker is a claim about our records.
+    expect(FLAT).toContain('const decided = ');
+    expect(FLAT).toContain(
+      'deed.response_date ? formatDate(deed.response_date) : decided ? UNKNOWN : "Pending"',
+    );
+  });
+});
+
+describe('FLOW1 — a failed feedback fetch is not an answer', () => {
+  it('raises instead of falling back to a field that does not exist', () => {
+    // §4. The old fallback read `deed.feedback` — never sent by the list
+    // endpoint — so a failed request opened a modal reading "(No
+    // comments provided)": the officer told the reviewer left no
+    // comments, when what happened is that we could not fetch them.
+    expect(PAGE_CODE).not.toMatch(/deed\?\.feedback/);
+    expect(PAGE_CODE).toMatch(/Failed to load feedback/);
+  });
+});

--- a/frontend/src/app/shared-deeds/page.tsx
+++ b/frontend/src/app/shared-deeds/page.tsx
@@ -7,18 +7,40 @@ import { toast } from "sonner"
 import { SessionExpiredError, apiFetch } from "@/lib/apiClient"
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog"
 
+/**
+ * FLOW1 item 0 — THESE FIELD NAMES ARE A CONTRACT, NOT A PREFERENCE.
+ *
+ * This screen was reported as showing fabricated rows: Invalid Date,
+ * NaN days left, blank Deed Type, blank Shared With, and a Status of
+ * "Viewed" beside a Response of "Not viewed". It invents nothing — it
+ * fetches `GET /shared-deeds` on mount and renders what came back. It
+ * was reading that response with EIGHT WRONG KEY NAMES, and a missing
+ * key in JavaScript is not an error, it is `undefined`: a blank cell, or
+ * `new Date(undefined)`, which is where Invalid Date and NaN came from.
+ *
+ * Nothing caught it because nothing compared this interface to the
+ * server's payload. Now something does: the field names below are pinned
+ * by EQUALITY against `backend/services/shared_deed_row_keys.json`, the
+ * same list the server's row builder asserts itself against. Adding a
+ * field here without adding it there fails the suite from both sides.
+ *
+ * Timestamps are `string | null` rather than optional strings on
+ * purpose. The server used to send `""` for a date it did not have, and
+ * `new Date("")` is a Date object — just an invalid one — so every guard
+ * shaped `if (d)` waved it straight through to the screen.
+ */
 interface SharedDeed {
   id: number
+  deed_id: number
   property: string
   deed_type: string
   shared_with: string
   recipient_email: string
   status: "sent" | "viewed" | "approved" | "rejected" | "expired" | "revoked"
-  shared_date: string
-  expires_at: string
-  viewed_at?: string
-  response_date?: string
-  feedback?: string
+  shared_date: string | null
+  expires_at: string | null
+  viewed_at: string | null
+  response_date: string | null
   /**
    * NOTARY1. `share_type` is now the real kind ("review" or
    * "signing_request") rather than the constant "review" it used to be.
@@ -29,10 +51,10 @@ interface SharedDeed {
    * can never drift into a claim that the signing will happen. This
    * screen does not compose its own version, and must not start.
    */
-  share_type?: string
-  signing_summary?: string | null
-  scheduled_at?: string | null
-  scheduled_by?: string | null
+  share_type: string
+  signing_summary: string | null
+  scheduled_at: string | null
+  scheduled_by: string | null
 }
 
 // Issue labels for structured feedback
@@ -114,15 +136,19 @@ export default function SharedDeedsPageV0() {
       
       const response = await apiFetch(`/shared-deeds/${shareId}/feedback`, {}, { label: "Loading feedback" })
 
-      if (response.ok) {
-        const data = await response.json()
-        feedbackText = data.feedback || ""
-      } else {
-        // Fallback to deed's feedback field
-        const deed = sharedDeeds.find((d) => d.id === shareId)
-        feedbackText = deed?.feedback || ""
+      // §4. This used to fall back to a `feedback` field on the row —
+      // which the list endpoint has never sent, so the fallback resolved
+      // to undefined and the modal opened saying "(No comments
+      // provided)". A failed request presented as an answer is worse
+      // than a failed request: the officer reads "the reviewer left no
+      // comments" when what happened is that we could not fetch them.
+      if (!response.ok) {
+        const detail = await response.json().catch(() => ({}))
+        throw new Error(detail?.detail || `Failed to load feedback (${response.status})`)
       }
-      
+      const data = await response.json()
+      feedbackText = data.feedback || ""
+
       // Try to parse as structured feedback
       let structured: StructuredFeedback | null = null
       try {
@@ -221,11 +247,30 @@ export default function SharedDeedsPageV0() {
     )
   }
 
+  /**
+   * FLOW1 item 0. Both helpers below now REFUSE to render a date they do
+   * not have, instead of handing an unparseable value to `Date` and
+   * printing whatever falls out.
+   *
+   * "Invalid Date" and "NaN days left" are not cosmetic bugs on a
+   * tracking screen. They are the screen asserting it holds a fact it
+   * does not hold, in the same typeface as the facts it does. An em dash
+   * says "we don't know", which is true and is a different claim.
+   */
+  const UNKNOWN = "—"
+
+  const parseDate = (value: string | null | undefined): Date | null => {
+    if (!value) return null
+    const parsed = new Date(value)
+    return Number.isNaN(parsed.getTime()) ? null : parsed
+  }
+
   // ✅ PHASE 24-E: Expiry countdown logic with red text when ≤3 days
-  const calculateDaysRemaining = (expiresAt: string) => {
-    const now = new Date()
-    const expiry = new Date(expiresAt)
-    const diffTime = expiry.getTime() - now.getTime()
+  const calculateDaysRemaining = (expiresAt: string | null) => {
+    const expiry = parseDate(expiresAt)
+    if (!expiry) return null
+
+    const diffTime = expiry.getTime() - Date.now()
     const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24))
 
     if (diffDays < 0) return { text: "Expired", isUrgent: true }
@@ -234,8 +279,10 @@ export default function SharedDeedsPageV0() {
     return { text: `${diffDays} days left`, isUrgent: false }
   }
 
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString("en-US", {
+  const formatDate = (dateString: string | null | undefined) => {
+    const parsed = parseDate(dateString)
+    if (!parsed) return UNKNOWN
+    return parsed.toLocaleDateString("en-US", {
       month: "2-digit",
       day: "2-digit",
       year: "numeric",
@@ -356,7 +403,14 @@ export default function SharedDeedsPageV0() {
                   <tbody>
                     {sharedDeeds.map((deed, index) => {
                       const daysRemaining = calculateDaysRemaining(deed.expires_at)
-                      const showCountdown = !["expired", "approved", "rejected"].includes(deed.status)
+                      const showCountdown =
+                        !!daysRemaining && !["expired", "approved", "rejected"].includes(deed.status)
+                      // Whether this share has been decided is carried by
+                      // `status`; WHEN it was decided is `response_date`,
+                      // and shares decided before that column existed do
+                      // not have one. "Pending" over a share the recipient
+                      // already approved is a worse answer than no date.
+                      const decided = ["approved", "rejected"].includes(deed.status)
 
                       return (
                         <tr
@@ -399,7 +453,7 @@ export default function SharedDeedsPageV0() {
                           <td className="py-4 px-6">
                             <div className="flex flex-col">
                               <span className="text-sm text-slate-600">{formatDate(deed.expires_at)}</span>
-                              {showCountdown && (
+                              {daysRemaining && showCountdown && (
                                 <span
                                   className={`text-xs font-medium ${
                                     daysRemaining.isUrgent ? "text-red-500" : "text-slate-500"
@@ -413,12 +467,17 @@ export default function SharedDeedsPageV0() {
                           <td className="py-4 px-6">
                             <div className="flex flex-col">
                               <span className="text-sm text-slate-600">
-                                {deed.response_date ? formatDate(deed.response_date) : "Pending"}
+                                {deed.response_date
+                                  ? formatDate(deed.response_date)
+                                  : decided
+                                    ? UNKNOWN
+                                    : "Pending"}
                               </span>
-                              {deed.viewed_at && (
+                              {deed.viewed_at ? (
                                 <span className="text-xs text-slate-500">Viewed: {formatDate(deed.viewed_at)}</span>
+                              ) : (
+                                <span className="text-xs text-slate-400">Not viewed</span>
                               )}
-                              {!deed.viewed_at && <span className="text-xs text-slate-400">Not viewed</span>}
                             </div>
                           </td>
                           <td className="py-4 px-6">


### PR DESCRIPTION
## Verdict first, as ruled

**The page is not fabricating rows.** It calls `GET /shared-deeds` in a `useEffect` on mount and renders exactly the rows the server sent. There is no synthesis from the deeds list, and there is no Next route handler in between — `apiFetch` goes straight to the FastAPI backend.

What it did was read that response through **eight wrong key names**. A missing key in JavaScript is not an error, it is `undefined`; `undefined` renders as a blank cell, and `new Date(undefined)` renders as Invalid Date. Every symptom in the audit is one of those eight:

| server sent | screen looked for | what you saw |
|---|---|---|
| `type` | `deed_type` | (blank) |
| `shared_with_email` | `recipient_email` | (blank) |
| *never sent* | `shared_with` | (blank) |
| `date` | `shared_date` | **Invalid Date** |
| *baked into a `message` string* | `expires_at` | **Invalid Date / NaN days left** |
| *never sent* | `viewed_at` | "Not viewed", always |
| *never sent* | `response_date` | "Pending", always |
| *never sent* | `feedback` | (blank) |

"Viewed" beside "Not viewed" is the clearest of them: the badge reads `status`, which arrived; the line under it reads `viewed_at`, which never did.

Two notes on the report itself, since a verdict that only confirms is not worth much:

- **The row count matching the completed-deed count** is one share per completed deed, not synthesis. That is an observation rather than a property, so it is now a test: the officer owns two completed deeds and shares one, and the list returns one row.
- **I could not reproduce "no network request on page load."** The fetch is unconditional on mount. I am reporting that as unreproduced rather than explaining it away — it may have been a failed request that the old code swallowed into an empty render, which is the same family as the `feedback` defect below.

## Three fields were not renames — the data was absent

- **`recipient_name`** was *accepted* by `POST /shared-deeds`, used to greet the recipient in the email, and then dropped: there was no column. So the officer picks a partner out of her rolodex by name, and the column headed "Shared With" has nowhere to get it from. It is a column now, stored on create.
- **`responded_at`** records *when* a recipient approved or rejected. `updated_at` was not usable for this and must not be substituted — a revoke bumps it too, so a screen reading it would report a response on the day access was withdrawn. Shares decided before this ticket report `null` and render as unknown rather than "Pending"; rejections are backfilled from `feedback_at`, which is stamped in exactly one place and *is* the response time rather than an inference about one.
- **`expires_at`** was a real column all along — SELECTed, then spent on the string `"Shared via link - expires 2026-08-18"` in a `message` field nothing renders. The countdown had nothing to count.

## Why it survived, and what now catches it

The response shape lived in a dict literal buried mid-handler. The screen's shape lived in a TypeScript interface. Neither had ever read the other, and `tsc` cannot type-check a `fetch` it did not author. **Two declarations of one contract, in two languages, with nothing comparing them.**

So the fix is not eight renames:

1. **One builder** — `backend/services/shared_deed_row.py` — instead of a literal where the next field gets appended by whoever is passing.
2. Its key set is **named and asserted by equality** at runtime, the same allowlist-by-key-set-equality the NOTARY2 token surfaces use.
3. The names live in a **shared corpus** both suites read — `backend/services/shared_deed_row_keys.json`, the `phone_cases.json` pattern. Adding a field on either side without the corpus fails from **both** sides.
4. Absence crosses the wire as `null`, never `""`. `new Date("")` is a Date object, just an invalid one, so every guard shaped `if (d)` waved it through.

## Also fixed in passing (§4)

The feedback modal fell back to a `feedback` field on the row — which the list endpoint has never sent — so a **failed** fetch opened a modal reading "(No comments provided)". The officer is told the reviewer left no comments when what happened is that we could not fetch them. It raises now.

The tuple-index fallbacks in the list handler are gone with the literal. They indexed by *position* into the SELECT above them, so every column added to that query silently re-aimed them — and `db.py` has used `RealDictCursor` throughout, so the branch they guarded had not run in a long time. A fallback that cannot run is not a safety net; it is a second definition of the payload that nothing checks.

## One existing pin retargeted, not lowered

NOTARY1's `test_every_surface_takes_its_words_from_one_place` counted `scheduling_label` calls in `sharing.py` alone. Moving row construction into the builder dropped that count from 4 to 3. The property being pinned was never "four calls in one file" — it is "every surface that says something about a scheduling state got the sentence from the one function that writes them". The pin now spans the router *and* the builder. Flagging it explicitly because lowering a threshold to make a diff pass is the failure mode this is adjacent to.

## Gates

| Gate | Result |
|---|---|
| pytest (no DB) | 835 passed, 156 skipped |
| pytest (with DB) | 991 passed |
| jest | 664 passed, 44 suites |
| tsc baseline | **94** (unchanged) |
| six-flow baseline | ✔ |
| API baseline | ✔ |
| OpenAPI snapshot | ✔ |
| banned-claims | clean |
| `next build` | ✔ |

**Mutation-probed.** Renaming an interface field, dropping a key from the builder, returning `""` for an absent date, un-stamping `responded_at`, and deriving rows from the deeds list each fail the intended pin — and only that pin.

## Ledgered

**DEEDDETAIL** — no deed detail route exists (`/deeds/{id}`, `/deed/{id}`, `/past-deeds/{id}` all 404); deed-level actions live only inside list rows, so there is nowhere to *link* a deed from. Parked as its own ticket per the ruling, not folded in here.

## Branch note

Developed on `claude/flow1-shared-deeds-contract` off `main`, matching the per-ticket convention of the last fifteen PRs. The session's configured branch (`claude/docs-archive-regenerate-ehj87q`) already carries unrelated docs/dead-code commits from another session, and pushing FLOW1 onto it would have mixed this ticket into that work.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_