### PR TITLE
FLOW1 items 1, 2, 5: the twins get labels, the flows ask who they are talking to, two dead buttons go

### DIFF
--- a/frontend/src/__tests__/flowInterrupts.test.ts
+++ b/frontend/src/__tests__/flowInterrupts.test.ts
@@ -1,0 +1,201 @@
+/**
+ * FLOW1 items 1, 2 and 5 — the officer picking the right action, and the
+ * right person, without being told she cannot.
+ *
+ * ═══ THE FAILURE ═══
+ *
+ * A notary received a REVIEW request. Every component behaved as built:
+ * two identical slate icon-squares sit on a deed row, distinguished only
+ * by `Share2` vs `CalendarClock` and a `title` attribute that requires a
+ * hover; the Share icon opens the review flow; the review flow's picker
+ * lists every partner with nothing to say one of them is a mistake here.
+ * So a notary was picked from a reviewer's picker, got a reviewer's
+ * email, and landed on a page offering Approve and Request Changes and
+ * no way to say when she was free.
+ *
+ * ═══ THE THREE PROPERTIES ═══
+ *
+ * 1. **A tooltip is not a label** (item 1). The two actions carry their
+ *    words on their faces. Pinned in `shareEntryPoints.test.ts`, which
+ *    was retargeted from `title=` to visible text rather than having a
+ *    new pin bolted beside it.
+ *
+ * 2. **The flow asks who it is talking to — and does not decide**
+ *    (items 1 and 5). Picking across the flows raises a question with
+ *    BOTH answers attached. It never disables submit, never removes
+ *    anybody from a list, and never blocks. Suggest, never hide; ask,
+ *    never block.
+ *
+ * 3. **The wording is a FILING OBSERVATION, never a capability claim.**
+ *    `partnerRegistry.ts` is explicit: "A partner's category says how
+ *    the officer FILES them. It says nothing about their authority,
+ *    their licensure, or what they are permitted to do, and no code may
+ *    read it as though it did." "Nora is filed as a Notary" is a true
+ *    statement about her rolodex. "Marcus is not a notary" would be a
+ *    statement about Marcus that this product has no basis for — he may
+ *    hold a commission and be filed under his title company. The sweep
+ *    below is fail-closed across the whole tree for that reason.
+ *
+ * And item 2: **two dead buttons are gone**, and cannot come back as
+ * a modal whose body is directions to the real feature.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
+
+const SRC = path.join(__dirname, '..');
+const read = (...p: string[]) => fs.readFileSync(path.join(SRC, ...p), 'utf8');
+const flat = (s: string) => s.replace(/\s+/g, ' ');
+
+const PAST_DEEDS = read('app', 'past-deeds', 'page.tsx');
+const SHARED_DEEDS = read('app', 'shared-deeds', 'page.tsx');
+const DASHBOARD = read('app', 'dashboard', 'page.tsx');
+const REVIEW = read('features', 'signing', 'ShareForReviewModal.tsx');
+const SIGNING = read('features', 'signing', 'RequestSigningModal.tsx');
+const PICKER = read('features', 'partners', 'PartnerRecipientPicker.tsx');
+const QUICKADD = read('features', 'partners', 'QuickAddPartnerModal.tsx');
+const MISMATCH = read('features', 'partners', 'RecipientMismatch.tsx');
+
+/** Every .ts/.tsx under src, so a capability claim cannot arrive in a
+ * file this test did not think to name. */
+function allSources(dir: string = SRC): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === '__tests__') continue;
+      out.push(...allSources(full));
+    } else if (/\.tsx?$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('FLOW1 item 1 — the review flow asks who it is talking to', () => {
+  it('notices a notary picked out of the review picker', () => {
+    expect(codeOnly(REVIEW)).toContain("recipient?.category === NOTARY_CATEGORY");
+    expect(flat(REVIEW)).toContain('Did you mean to request a signing?');
+  });
+
+  it('offers BOTH answers, and switching actually switches', () => {
+    // Asking "did you mean a signing?" and then making her close the
+    // modal, find the row again and press the other button would be a
+    // scolding rather than a suggestion.
+    expect(REVIEW).toContain('Request a signing instead');
+    expect(REVIEW).toContain('No — send it for review');
+    expect(REVIEW).toContain('onSwitchToSigning');
+    // And the page wires it to the signing modal for the SAME deed.
+    expect(flat(PAST_DEEDS)).toContain('onSwitchToSigning={() => { setSigningDeedId(reviewDeedId); setReviewDeedId(null); }}');
+  });
+
+  it('never blocks the review it is asking about', () => {
+    // The submit button's disabled condition may depend on having a
+    // recipient and on being mid-flight. It may not depend on the
+    // interrupt: "suggest, never hide" extends to "ask, never block".
+    const code = codeOnly(REVIEW);
+    const disabled = /disabled=\{([^}]*)\}/g;
+    for (const m of code.matchAll(disabled)) {
+      expect(m[1]).not.toContain('Interrupt');
+      expect(m[1]).not.toContain('interrupt');
+      expect(m[1]).not.toContain('category');
+    }
+  });
+});
+
+describe('FLOW1 item 5 — the signing fallback is acknowledged, not equal-weight', () => {
+  it('notices a non-notary picked out of the signing picker', () => {
+    const code = codeOnly(SIGNING);
+    expect(code).toContain("notary.category !== NOTARY_CATEGORY");
+    expect(flat(SIGNING)).toContain('This request asks them to take the acknowledgement.');
+  });
+
+  it('keeps the fallback: acknowledge and continue is one press', () => {
+    expect(SIGNING).toContain('Yes — send it to them');
+    expect(SIGNING).toContain('Pick someone else');
+    const code = codeOnly(SIGNING);
+    for (const m of code.matchAll(/disabled=\{([^}]*)\}/g)) {
+      expect(m[1]).not.toContain('Acknowledged');
+      expect(m[1]).not.toContain('category');
+    }
+  });
+
+  it('still hides nobody from the list', () => {
+    // Item 5 said make the fallback explicit, NOT remove it. The picker
+    // keeps sorting suggested-first and filtering nobody out.
+    expect(PICKER).toContain("hits.filter((p) => p.category !== suggestCategory)");
+    expect(PICKER).toContain('Everyone else');
+  });
+
+  it('a typed address raises nothing, because it has no filing', () => {
+    // A one-off recipient was never filed, so there is no observation to
+    // make. `category` is undefined and both notices stay closed.
+    expect(codeOnly(SIGNING)).toContain('!!notary?.category');
+    expect(codeOnly(PICKER)).toContain('category: p.category');
+  });
+
+  it('a partner created mid-flow carries its filing too', () => {
+    // Otherwise creating a notary from inside the review modal is the
+    // one path that slips past the interrupt.
+    expect(flat(QUICKADD)).toContain('email: formData.email || undefined, category,');
+    expect(flat(PICKER)).toContain('category: created.category,');
+  });
+});
+
+describe('FLOW1 — the notice states a FILING, never a capability', () => {
+  it('the shared sentence says "is filed as"', () => {
+    expect(MISMATCH).toContain('is filed as a');
+  });
+
+  it('no source anywhere claims what a partner may or may not do', () => {
+    // Fail-closed across the tree. A category is how she FILED somebody;
+    // reading it as licensure would be the registry quietly making a
+    // legal characterization, which is §1's whole subject.
+    const CLAIMS = [
+      /is not a notary/i,
+      /isn'?t a notary/i,
+      /not a licensed/i,
+      /not qualified/i,
+      /cannot notarize/i,
+      /can'?t notarize/i,
+      /not commissioned/i,
+      /unlicensed/i,
+    ];
+    const offenders: string[] = [];
+    for (const file of allSources()) {
+      const code = codeOnly(fs.readFileSync(file, 'utf8'));
+      for (const claim of CLAIMS) {
+        if (claim.test(code)) offenders.push(`${path.relative(SRC, file)} :: ${claim}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+});
+
+describe('FLOW1 item 2 — the dead buttons are gone', () => {
+  it('Shared Deeds has no "Share New Deed" and no placeholder modal', () => {
+    const code = codeOnly(SHARED_DEEDS);
+    expect(code).not.toContain('Share New Deed');
+    expect(code).not.toContain('shareModalOpen');
+    // The modal's body was a sentence telling her to go elsewhere and
+    // press a different button. Forbidden as a SHAPE, not as a spelling:
+    // a dialog whose content is directions to the real feature.
+    expect(code).not.toContain('please go to the Past Deeds page');
+    expect(code).not.toContain('Share Deed for Review');
+  });
+
+  it('the header action it left behind promises navigation and delivers it', () => {
+    // Not a dead button traded for a differently-dead button: the label
+    // and the act agree now.
+    expect(flat(SHARED_DEEDS)).toContain('onClick={() => router.push("/past-deeds")}');
+    expect(SHARED_DEEDS).toContain('Go to Past Deeds');
+  });
+
+  it('the dashboard row has no share icon that does not share', () => {
+    const code = codeOnly(DASHBOARD);
+    expect(code).not.toContain('Share from Past Deeds');
+    // And no remaining control on that row carries a share glyph.
+    expect(code).not.toContain('<Share2');
+  });
+});

--- a/frontend/src/__tests__/shareEntryPoints.test.ts
+++ b/frontend/src/__tests__/shareEntryPoints.test.ts
@@ -39,8 +39,22 @@ const PICKER = read('features', 'partners', 'PartnerRecipientPicker.tsx');
 
 describe('Part B — two distinct actions on the deed', () => {
   it('the deed offers "Share for review" and "Request signing", separately', () => {
-    expect(PAGE).toContain('title="Share for review"');
-    expect(PAGE).toContain('title="Request signing"');
+    // FLOW1 item 1 RETARGETED THIS PIN, and the retarget is the point.
+    // It used to assert `title="Share for review"` — a TOOLTIP. That was
+    // the spelling, not the property: the property is that the two
+    // actions are separately named where she can read them. A tooltip is
+    // invisible until you already suspect you need it and absent
+    // entirely on touch, which is how the owner pressed the wrong one of
+    // two identical slate squares and sent a notary a reviewer's email.
+    //
+    // So the assertion moved UP in strength, not sideways: visible text,
+    // and the titles that used to carry it are gone rather than kept as
+    // a second copy of the same words.
+    const flat = PAGE.replace(/\s+/g, ' ');
+    expect(flat).toContain('<span className="whitespace-nowrap">Share for review</span>');
+    expect(flat).toContain('<span className="whitespace-nowrap">Request signing</span>');
+    expect(PAGE).not.toContain('title="Share for review"');
+    expect(PAGE).not.toContain('title="Request signing"');
     // The generic one is gone, not relabelled alongside them.
     expect(PAGE).not.toContain('title="Share deed"');
   });
@@ -125,7 +139,10 @@ describe('Part B — the rolodex is the default, typing is the fallback', () => 
     expect(PICKER).toContain('QuickAddPartnerModal');
     expect(PICKER).toContain('Add a new partner');
     // And the newly-created partner is selected immediately.
-    expect(PICKER).toContain('onChange({ email: created.email');
+    // FLOW1 reformatted this call across lines when `category` joined it,
+    // so the assertion flattens rather than pinning where the formatter
+    // chose to break.
+    expect(PICKER.replace(/\s+/g, ' ')).toContain('onChange({ email: created.email,');
   });
 
   it('a partner created without an email does not become a silent recipient', () => {

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -444,15 +444,18 @@ function DeedRow({ deed }: { deed: any }) {
               <Download className="w-4 h-4" />
             </button>
           )}
-          {deed.status === 'completed' && (
-            <button
-              onClick={() => router.push('/past-deeds')}
-              className="p-2 hover:bg-gray-100 rounded-lg transition-colors text-gray-400 hover:text-gray-600"
-              title="Share from Past Deeds"
-            >
-              <Share2 className="w-4 h-4" />
-            </button>
-          )}
+          {/* FLOW1 item 2: the share icon that used to sit here is
+              DELETED. It carried a Share2 glyph and the hover title
+              "Share from Past Deeds", and it did not share — it routed
+              to /past-deeds and left her to find the row again and press
+              a different button. An icon that means "share" attached to
+              an act that means "navigate" is the twins problem in
+              miniature: the affordance and the outcome disagree.
+
+              Deleted rather than wired up, per the ruling's "prefer
+              deleting". Wiring it would mean mounting both share modals
+              and a PartnersProvider on the dashboard — a third surface
+              for two flows, on a page whose job is a glance. */}
           {needsAction && (
             <button
               onClick={() => router.push(`/deed-builder/${deed.deed_type || 'grant-deed'}?resume=${deed.id}`)}

--- a/frontend/src/app/past-deeds/page.tsx
+++ b/frontend/src/app/past-deeds/page.tsx
@@ -378,19 +378,38 @@ export default function PastDeedsPageV0() {
                                     button quietly meant "review" without ever
                                     saying so. `share_kind` is set by which
                                     button she pressed, never inferred. */}
+                                {/* FLOW1 item 1 — THE TWINS GET LABELS.
+                                    These were the same size, the same
+                                    slate, adjacent, and distinguished
+                                    only by `Share2` vs `CalendarClock`
+                                    plus a `title` attribute that
+                                    requires a hover. On a row of icon
+                                    buttons, "the one that means signing"
+                                    is not discoverable — it is
+                                    remembered, and the owner remembered
+                                    wrong, which is how a notary came to
+                                    receive a reviewer's email.
+
+                                    A tooltip is not a label. It is
+                                    invisible until you already suspect
+                                    you need it, and absent entirely on
+                                    touch. The words are on the buttons
+                                    now; the icons stay as recognition
+                                    aids rather than as the only
+                                    distinction. */}
                                 <button
                                   onClick={() => setReviewDeedId(deed.id)}
-                                  className="p-2 bg-slate-600 hover:bg-slate-700 text-white rounded-lg transition-colors"
-                                  title="Share for review"
+                                  className="inline-flex items-center gap-1.5 px-3 py-2 bg-slate-600 hover:bg-slate-700 text-white text-sm font-medium rounded-lg transition-colors"
                                 >
-                                  <Share2 className="w-4 h-4" />
+                                  <Share2 className="w-4 h-4 shrink-0" />
+                                  <span className="whitespace-nowrap">Share for review</span>
                                 </button>
                                 <button
                                   onClick={() => setSigningDeedId(deed.id)}
-                                  className="p-2 bg-slate-600 hover:bg-slate-700 text-white rounded-lg transition-colors"
-                                  title="Request signing"
+                                  className="inline-flex items-center gap-1.5 px-3 py-2 bg-slate-600 hover:bg-slate-700 text-white text-sm font-medium rounded-lg transition-colors"
                                 >
-                                  <CalendarClock className="w-4 h-4" />
+                                  <CalendarClock className="w-4 h-4 shrink-0" />
+                                  <span className="whitespace-nowrap">Request signing</span>
                                 </button>
                               </>
                             )}
@@ -445,7 +464,18 @@ export default function PastDeedsPageV0() {
             );
           })()}
           {reviewDeedId !== null && (
-            <ShareForReviewModal deedId={reviewDeedId} onClose={() => setReviewDeedId(null)} />
+            <ShareForReviewModal
+              deedId={reviewDeedId}
+              onClose={() => setReviewDeedId(null)}
+              // FLOW1 item 1: the interrupt's other half. Asking "did
+              // you mean a signing?" and then making her close the modal,
+              // find the row again and press the other button would be a
+              // scolding rather than a suggestion.
+              onSwitchToSigning={() => {
+                setSigningDeedId(reviewDeedId);
+                setReviewDeedId(null);
+              }}
+            />
           )}
         </PartnersProvider>
       )}

--- a/frontend/src/app/shared-deeds/page.tsx
+++ b/frontend/src/app/shared-deeds/page.tsx
@@ -2,7 +2,7 @@
 import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import Sidebar from "@/components/Sidebar"
-import { Send, Eye, Clock, CheckCircle, XCircle, AlertCircle, RotateCw, X, Plus, FileText, MessageSquare, CalendarClock } from "lucide-react"
+import { Send, Eye, Clock, CheckCircle, XCircle, AlertCircle, RotateCw, X, FileText, MessageSquare, CalendarClock } from "lucide-react"
 import { toast } from "sonner"
 import { SessionExpiredError, apiFetch } from "@/lib/apiClient"
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog"
@@ -91,7 +91,6 @@ export default function SharedDeedsPageV0() {
     text: "",
     structured: null,
   })
-  const [shareModalOpen, setShareModalOpen] = useState(false)
   const [revokeConfirm, setRevokeConfirm] = useState<{ isOpen: boolean; shareId: number | null }>({
     isOpen: false,
     shareId: null,
@@ -324,12 +323,28 @@ export default function SharedDeedsPageV0() {
                   {sharedDeeds.length} shared {sharedDeeds.length === 1 ? "deed" : "deeds"}
                 </span>
               </div>
+              {/* FLOW1 item 2 — "Share New Deed" IS GONE.
+                  It opened a modal titled "Share Deed for Review" whose
+                  entire body was a sentence telling her to go to Past
+                  Deeds and press a different button. Three things were
+                  wrong and only one was cosmetic: it did nothing; it
+                  said "for Review", so the one entry point on this page
+                  committed to reviewer semantics before asking what she
+                  wanted; and from her seat the signpost/action
+                  distinction is academic — she pressed a button and got
+                  told to go elsewhere.
+
+                  Deleted rather than turned into a chooser, per the
+                  ruling, because a chooser here would first have to ask
+                  WHICH DEED — this page has no deed context, only
+                  shares. The empty state already points at Past Deeds,
+                  which is the honest version of what this button was. */}
               <button
-                onClick={() => setShareModalOpen(true)}
-                className="flex items-center gap-2 px-6 py-3 bg-[#7C4DFF] hover:bg-[#6a3de8] text-white font-semibold rounded-xl shadow-md hover:shadow-lg transition-all duration-200 transform hover:scale-105"
+                onClick={() => router.push("/past-deeds")}
+                className="flex items-center gap-2 px-6 py-3 border border-slate-300 text-slate-700 font-semibold rounded-xl hover:bg-slate-50 transition-colors"
               >
-                <Plus className="w-5 h-5" />
-                Share New Deed
+                <FileText className="w-5 h-5" />
+                Go to Past Deeds
               </button>
             </div>
           </div>
@@ -587,37 +602,13 @@ export default function SharedDeedsPageV0() {
         </div>
       )}
 
-      {/* Share New Deed Modal (Placeholder) */}
-      {shareModalOpen && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
-          <div className="bg-white rounded-2xl shadow-2xl max-w-[600px] w-full p-8">
-            <div className="flex items-center justify-between mb-6">
-              <h2 className="text-2xl font-bold text-slate-800">Share Deed for Review</h2>
-              <button
-                onClick={() => setShareModalOpen(false)}
-                className="p-2 hover:bg-slate-100 rounded-lg transition-colors"
-              >
-                <X className="w-5 h-5 text-slate-400 hover:text-slate-600" />
-              </button>
-            </div>
-            <div className="text-center py-12">
-              <FileText className="w-16 h-16 text-slate-300 mx-auto mb-4" />
-              <p className="text-slate-600 mb-6">
-                To share a deed, please go to the Past Deeds page and click the Share button on a completed deed.
-              </p>
-              <button
-                onClick={() => {
-                  setShareModalOpen(false)
-                  router.push("/past-deeds")
-                }}
-                className="px-6 py-3 bg-[#7C4DFF] hover:bg-[#6a3de8] text-white font-medium rounded-lg transition-colors"
-              >
-                Go to Past Deeds
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      {/* FLOW1 item 2: the placeholder modal that used to live here is
+          DELETED, not hidden behind a flag. Its entire body was a
+          sentence telling the officer to go to Past Deeds and press a
+          different button — a modal whose content is instructions for
+          reaching the real feature is a signpost wearing a dialog's
+          clothes. The header button now navigates directly, and says so.
+          Pinned in __tests__/flowInterrupts.test.ts. */}
 
       {/* Revoke Confirmation Dialog */}
       <ConfirmDialog

--- a/frontend/src/features/partners/PartnerRecipientPicker.tsx
+++ b/frontend/src/features/partners/PartnerRecipientPicker.tsx
@@ -48,6 +48,21 @@ export interface Recipient {
   company?: string;
   /** Set when she picked from the rolodex; absent for a typed address. */
   partnerId?: string;
+  /**
+   * FLOW1: HOW SHE FILED THEM, so a flow can notice it was handed
+   * somebody it did not expect — a notary picked out of the review
+   * picker, or a title officer picked out of the signing picker.
+   *
+   * Absent for a typed address, and that is not an oversight: a one-off
+   * recipient has no filing, so there is nothing to observe.
+   *
+   * READ IT AS A FILING AND NOTHING ELSE. `partnerRegistry.ts`: "A
+   * partner's category says how the officer FILES them. It says nothing
+   * about their authority, their licensure, or what they are permitted
+   * to do, and no code may read it as though it did." Nothing branches
+   * on this except to say a sentence she can dismiss.
+   */
+  category?: string;
 }
 
 export function PartnerRecipientPicker({
@@ -99,6 +114,7 @@ export function PartnerRecipientPicker({
       name: p.contact_name || p.company_name || p.label,
       company: p.company_name || (p.contact_name ? p.label : undefined),
       partnerId: p.id,
+      category: p.category,
     });
     setOpen(false);
     setQuery('');
@@ -251,7 +267,12 @@ export function PartnerRecipientPicker({
         onCreated={(created) => {
           setQuickAdd(false);
           if (created.email) {
-            onChange({ email: created.email, name: created.label, partnerId: created.id });
+            onChange({
+              email: created.email,
+              name: created.label,
+              partnerId: created.id,
+              category: created.category,
+            });
           } else {
             // Created without an address: say so instead of selecting a
             // recipient we cannot reach.

--- a/frontend/src/features/partners/QuickAddPartnerModal.tsx
+++ b/frontend/src/features/partners/QuickAddPartnerModal.tsx
@@ -13,7 +13,12 @@ interface QuickAddPartnerModalProps {
   /** PARTNER2/B: the email rides along, because the caller is now a
    * RECIPIENT picker — a partner created mid-flow should be selectable
    * immediately rather than requiring her to go and find it. */
-  onCreated: (partner: { id: string; label: string; email?: string }) => void;
+  /** FLOW1: the CATEGORY rides along too. A partner created mid-flow
+   * is filed the moment she creates them, and the flow that receives
+   * the pick has to be able to notice a mismatch — otherwise creating
+   * a notary from inside the review modal is the one path that slips
+   * past the interrupt. */
+  onCreated: (partner: { id: string; label: string; email?: string; category?: string }) => void;
   initialName?: string;
   /** Named `initialCategory` because it SEEDS the form; the old name
    * `category` read like it constrained what could be created. */
@@ -62,6 +67,7 @@ export function QuickAddPartnerModal({
           id: newPartner.id,
           label: formData.contact_name || formData.company_name || '',
           email: formData.email || undefined,
+          category,
         });
         onClose();
       }

--- a/frontend/src/features/partners/RecipientMismatch.tsx
+++ b/frontend/src/features/partners/RecipientMismatch.tsx
@@ -1,0 +1,106 @@
+'use client';
+
+/**
+ * FLOW1 items 1 and 5 — "you picked somebody filed under a different
+ * category" said out loud, once, in one component.
+ *
+ * ═══ THE FAILURE THIS ANSWERS ═══
+ *
+ * The owner sent a notary a REVIEW request. Every piece of that worked as
+ * built: the Share icon opens the review flow, the review flow's picker
+ * lists every partner with nothing to distinguish them, so the notary
+ * arrived at a page with Approve and Request Changes buttons and no way
+ * to say when she was free. The defect was that **the review path never
+ * asked who it was talking to.**
+ *
+ * ═══ SUGGEST, NEVER HIDE — AND NEVER BLOCK ═══
+ *
+ * The picker has always sorted a suggested category first without hiding
+ * anybody, because a mobile notary filed under "other" three months ago
+ * is still the person she wants. That stays. What is added is a NOTICE
+ * after the pick: the flows are not interchangeable, so choosing across
+ * them should be a thing she did on purpose rather than a thing she
+ * discovers from the recipient's confused reply.
+ *
+ * Both notices are dismissible and neither disables the submit button.
+ * A picker that knows better than the officer about her own contacts is
+ * a picker she works around.
+ *
+ * ═══ THE DOCTRINE CONSTRAINT ON THE WORDING ═══
+ *
+ * `partnerRegistry.ts` states it and it is load-bearing here:
+ *
+ *   "A partner's category says how the officer FILES them. It says
+ *    nothing about their authority, their licensure, or what they are
+ *    permitted to do, and no code may read it as though it did."
+ *
+ * So the copy is a FILING OBSERVATION and never a capability claim.
+ * "Nora is filed as a notary" is a true statement about her rolodex.
+ * "Marcus is not a notary" would be a statement about Marcus that this
+ * product has no basis for and no business making — he may hold a
+ * commission and be filed under his title company. Every string below
+ * says *filed*, and the pin in `flowInterrupts.test.ts` keeps it that
+ * way.
+ */
+
+import { AlertCircle, X } from 'lucide-react';
+import { categoryLabel } from '@/lib/partnerRegistry';
+import type { Recipient } from './PartnerRecipientPicker';
+
+/**
+ * Did she pick somebody filed under a category this flow did not expect?
+ *
+ * `null` for a typed address on purpose: a one-off recipient has no
+ * filing, so there is nothing to observe and nothing to interrupt. And
+ * `undefined` expectation means the flow has no expectation.
+ */
+export function filedCategoryOf(recipient: Recipient | null): string | null {
+  return recipient?.category || null;
+}
+
+export function RecipientMismatchNotice({
+  recipient,
+  headline,
+  question,
+  actions,
+  onDismiss,
+}: {
+  recipient: Recipient;
+  /** One sentence stating the FILING. Never a capability claim. */
+  headline: string;
+  /** What she might have meant instead. */
+  question: string;
+  actions: React.ReactNode;
+  onDismiss: () => void;
+}) {
+  return (
+    <div
+      role="status"
+      className="rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-900"
+    >
+      <div className="flex items-start gap-2">
+        <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+        <div className="min-w-0 flex-1">
+          <p className="font-medium">{headline}</p>
+          <p className="mt-0.5 text-amber-800">{question}</p>
+          <div className="mt-2 flex flex-wrap gap-2">{actions}</div>
+        </div>
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="Dismiss"
+          className="rounded p-1 text-amber-500 hover:bg-amber-100 hover:text-amber-700"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/** "Nora Vasquez is filed as a Notary." — the shared sentence, so the
+ * two flows cannot drift into describing a filing two different ways. */
+export function filedAsSentence(recipient: Recipient, category: string): string {
+  const who = recipient.name?.trim() || recipient.email;
+  return `${who} is filed as a ${categoryLabel(category)}.`;
+}

--- a/frontend/src/features/signing/RequestSigningModal.tsx
+++ b/frontend/src/features/signing/RequestSigningModal.tsx
@@ -33,8 +33,13 @@ import { useMemo, useState } from 'react';
 import { CalendarClock, Info, Loader2, Plus, Trash2, X } from 'lucide-react';
 import { apiFetch } from '@/lib/apiClient';
 import { PartnerRecipientPicker, Recipient } from '@/features/partners/PartnerRecipientPicker';
+import {
+  RecipientMismatchNotice,
+  filedAsSentence,
+} from '@/features/partners/RecipientMismatch';
 
 const MAX_SIGNERS = 6;
+const NOTARY_CATEGORY = 'notary';
 
 /** The zones a California title product actually needs. Not the full
  * IANA list — a dropdown of six hundred zones is a worse question than a
@@ -65,6 +70,7 @@ export function RequestSigningModal({
   onCreated?: (id: number) => void;
 }) {
   const [notary, setNotary] = useState<Recipient | null>(null);
+  const [fallbackAcknowledged, setFallbackAcknowledged] = useState(false);
   const [signers, setSigners] = useState<SignerRow[]>(() =>
     (suggestedSigners.length ? suggestedSigners : ['']).slice(0, MAX_SIGNERS)
       .map((name) => ({ name, email: '', phone: '' })),
@@ -82,6 +88,13 @@ export function RequestSigningModal({
 
   const setSigner = (i: number, patch: Partial<SignerRow>) =>
     setSigners((prev) => prev.map((s, n) => (n === i ? { ...s, ...patch } : s)));
+
+  // A TYPED address has no filing, so there is nothing to observe and
+  // nothing to ask about — `category` is undefined and this stays false.
+  const showFallbackNotice =
+    !fallbackAcknowledged &&
+    !!notary?.category &&
+    notary.category !== NOTARY_CATEGORY;
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -167,10 +180,47 @@ export function RequestSigningModal({
             <div className="space-y-5 overflow-y-auto flex-1 pr-1">
               <PartnerRecipientPicker
                 value={notary}
-                onChange={setNotary}
+                onChange={(r) => { setNotary(r); setFallbackAcknowledged(false); }}
                 suggestCategory="notary"
                 label="Notary"
               />
+
+              {/* FLOW1 item 5 — THE FALLBACK STAYS, AND STOPS BEING
+                  EQUAL-WEIGHT.
+                  The picker floats notaries up and hides nobody, which
+                  is right: a mobile notary filed under "other" three
+                  months ago is still the person she wants. But "hidden
+                  from nobody" had become "indistinguishable from
+                  anybody", and this field's whole job is to name the
+                  person who will take the acknowledgement.
+                  So the pick is ACKNOWLEDGED, not prevented — no
+                  disabled submit, no removal from the list. */}
+              {showFallbackNotice && notary && (
+                <RecipientMismatchNotice
+                  recipient={notary}
+                  headline={filedAsSentence(notary, notary.category!)}
+                  question="This request asks them to take the acknowledgement. Send it to them anyway?"
+                  onDismiss={() => setFallbackAcknowledged(true)}
+                  actions={
+                    <>
+                      <button
+                        type="button"
+                        onClick={() => setFallbackAcknowledged(true)}
+                        className="rounded-lg bg-amber-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-amber-700"
+                      >
+                        Yes — send it to them
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => setNotary(null)}
+                        className="rounded-lg border border-amber-300 bg-white px-3 py-1.5 text-xs font-semibold text-amber-800 hover:bg-amber-50"
+                      >
+                        Pick someone else
+                      </button>
+                    </>
+                  }
+                />
+              )}
 
               <div>
                 <div className="flex items-center justify-between mb-2">

--- a/frontend/src/features/signing/ShareForReviewModal.tsx
+++ b/frontend/src/features/signing/ShareForReviewModal.tsx
@@ -24,6 +24,15 @@ import { useState } from 'react';
 import { FileText, Loader2, X } from 'lucide-react';
 import { apiFetch } from '@/lib/apiClient';
 import { PartnerRecipientPicker, Recipient } from '@/features/partners/PartnerRecipientPicker';
+import {
+  RecipientMismatchNotice,
+  filedAsSentence,
+} from '@/features/partners/RecipientMismatch';
+
+/** The category whose presence in a REVIEW picker is worth a question.
+ * A signing is the only flow a notary is filed for; everyone else in the
+ * rolodex is a plausible reviewer. */
+const NOTARY_CATEGORY = 'notary';
 
 const EXPIRY_CHOICES = [
   { hours: 72, label: '3 days' },
@@ -34,11 +43,19 @@ const EXPIRY_CHOICES = [
 export function ShareForReviewModal({
   deedId,
   onClose,
+  onSwitchToSigning,
 }: {
   deedId: number;
   onClose: () => void;
+  /** FLOW1 item 1: the other half of the interrupt. Offering "did you
+   * mean a signing?" without a way to act on it would be a scolding
+   * rather than a suggestion. Optional so the modal still renders in
+   * surfaces that have no signing flow to switch to — the notice then
+   * shows the acknowledge option alone. */
+  onSwitchToSigning?: () => void;
 }) {
   const [recipient, setRecipient] = useState<Recipient | null>(null);
+  const [interruptDismissed, setInterruptDismissed] = useState(false);
   const [message, setMessage] = useState('');
   const [expiresInHours, setExpiresInHours] = useState(168);
   const [submitting, setSubmitting] = useState(false);
@@ -49,6 +66,9 @@ export function ShareForReviewModal({
     emailError?: string;
   } | null>(null);
   const [copied, setCopied] = useState(false);
+
+  const showNotaryInterrupt =
+    !interruptDismissed && recipient?.category === NOTARY_CATEGORY;
 
   const submit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -152,9 +172,48 @@ export function ShareForReviewModal({
             <div className="space-y-5 overflow-y-auto flex-1 pr-1">
             <PartnerRecipientPicker
               value={recipient}
-              onChange={setRecipient}
+              onChange={(r) => { setRecipient(r); setInterruptDismissed(false); }}
               label="Ask for a review from"
             />
+
+            {/* FLOW1 item 1 — THE INTERRUPT.
+                This is the exact failure the ticket opened on: a notary
+                picked out of the review picker, sent a reviewer's email,
+                landed on a page with Approve and Request Changes and no
+                way to say when she was free. Every piece worked as built;
+                the review path just never asked who it was talking to.
+
+                It ASKS. It does not decide: both options are here, the
+                notice dismisses, and the submit button is never disabled
+                by it. Suggest, never hide — and never block. */}
+            {showNotaryInterrupt && recipient && (
+              <RecipientMismatchNotice
+                recipient={recipient}
+                headline={filedAsSentence(recipient, recipient.category!)}
+                question="Did you mean to request a signing? A review asks them to approve or ask for changes — it never asks for a time."
+                onDismiss={() => setInterruptDismissed(true)}
+                actions={
+                  <>
+                    {onSwitchToSigning && (
+                      <button
+                        type="button"
+                        onClick={onSwitchToSigning}
+                        className="rounded-lg bg-amber-600 px-3 py-1.5 text-xs font-semibold text-white hover:bg-amber-700"
+                      >
+                        Request a signing instead
+                      </button>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => setInterruptDismissed(true)}
+                      className="rounded-lg border border-amber-300 bg-white px-3 py-1.5 text-xs font-semibold text-amber-800 hover:bg-amber-50"
+                    >
+                      No — send it for review
+                    </button>
+                  </>
+                }
+              />
+            )}
 
             <div>
               <label className="block text-sm font-medium text-slate-700 mb-1">


### PR DESCRIPTION
Items 1, 2 and 5 together, because they are one story: the officer picking the right action, and the right person, without being told she cannot.

## Item 1 — a tooltip is not a label

The two share actions on a deed row were the same size, the same slate, adjacent, and distinguished only by `Share2` vs `CalendarClock` plus a `title` attribute that requires a hover. A tooltip is invisible until you already suspect you need it, and absent entirely on touch. On a row of icon buttons, "the one that means signing" is not discoverable — it is *remembered*, and remembering wrong is how a notary came to receive a reviewer's email.

The words are on the buttons now. The icons stay as recognition aids rather than as the only distinction.

## Item 1 — the picker interrupt

Picking a notary out of the **review** picker now raises:

> **Nora Vasquez is filed as a Notary.**
> Did you mean to request a signing? A review asks them to approve or ask for changes — it never asks for a time.
>
> [ Request a signing instead ] [ No — send it for review ]

"Request a signing instead" **actually switches** — same deed, straight into the signing modal. Offering the question and then making her close the modal, find the row again and press the other button would be a scolding rather than a suggestion.

**It asks and does not decide.** The notice dismisses, the submit button is never disabled by it, nobody is removed from any list. That's pinned by scanning every `disabled={...}` expression in both modals for any dependence on the interrupt — "suggest, never hide" extended to "ask, never block".

## Item 5 — the signing fallback, explicit rather than equal-weight

The picker floats notaries up and hides nobody, which is right: a mobile notary filed under "other" three months ago is still the person she wants. But *hidden from nobody* had become *indistinguishable from anybody*, in the one field whose job is to name who takes the acknowledgement.

Picking across it is now acknowledged in one press — "Yes — send it to them" / "Pick someone else". **The fallback stays**, and the picker still filters nobody out (pinned).

## The wording is a filing observation, never a capability claim

`partnerRegistry.ts` states it and it is load-bearing here:

> "A partner's category says how the officer **files** them. It says nothing about their authority, their licensure, or what they are permitted to do, and no code may read it as though it did."

So *"Nora is filed as a Notary"* is a true statement about her rolodex. *"Marcus is not a notary"* would be a statement about Marcus that this product has no basis for — he may hold a commission and be filed under his title company. One shared sentence builds the copy, and a **fail-closed sweep across every `.ts`/`.tsx`** forbids `is not a notary`, `not qualified`, `cannot notarize`, `unlicensed` and their neighbours tree-wide.

A partner created mid-flow carries its category out of `QuickAddPartnerModal` — otherwise creating a notary from inside the review modal is the one path that slips past the interrupt. A **typed** address raises nothing, because a one-off recipient has no filing and there is nothing to observe.

## Item 2 — two dead buttons

- **"Share New Deed"** (Shared Deeds) opened a modal whose entire body was a sentence telling her to go to Past Deeds and press a different button. **Deleted**, not made a chooser, per the ruling — a chooser there would first have to ask *which deed*, and that page has no deed context, only shares. The header action left in its place navigates and says so: the label and the act agree now.
- **"Share from Past Deeds"** (dashboard activity row) carried a share glyph and did not share. **Deleted**, not wired — wiring it means mounting both share modals and a `PartnersProvider` on a page whose job is a glance.

The placeholder modal is forbidden as a *shape*, not a spelling: a dialog whose content is directions to the real feature.

## One existing pin retargeted — upward

`shareEntryPoints.test.ts` asserted `title="Share for review"`. That was the *spelling* of the property, not the property — and it was the spelling this ticket exists to remove. It now asserts **visible text** and **forbids the titles**, so the pin can no longer pass on the arrangement that caused the bug. Flagging the direction explicitly: this makes the pin stricter, not looser.

## Gates

| Gate | Result |
|---|---|
| pytest (no DB) | 835 passed, 156 skipped |
| jest | 677 passed, 45 suites |
| tsc baseline | **94** (unchanged) |
| banned-claims | clean |
| `next build` | ✔ |

**Mutation-probed.** Disabling submit on the interrupt, rewording the notice as a capability claim, and reverting the buttons to tooltip-only each fail the intended pin and only that pin.

## Still to come in FLOW1

Items 3 and 4 (unify the trackers, Signings page fixes) next, then 6 and 7. **Item 6 has an owner-side precondition** — retiring NOTARY1's write path was ruled "after confirming a zero migration count", and that count comes from `migrate_notary1_signings.py --dry-run` against production, which is yours to run.

## Branch note

`claude/flow1-twins-and-picker` off current `main`, per the standing per-ticket convention.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_