### PR TITLE
FLOW1 items 3, 4: the two officer trackers meet, the agenda stops claiming an order it does not have, and a name is not a pronoun

### DIFF
--- a/backend/routers/signing.py
+++ b/backend/routers/signing.py
@@ -305,6 +305,16 @@ def officer_agenda(user_id: int = Depends(get_current_user_id)):
                 "summary": loop.state_label(row, windows, responses, participants),
                 "booked_at": _iso(row.get("booked_at")),
                 "booked_by": row.get("booked_by"),
+                # FLOW1 item 4: WHEN SHE ASKED. The agenda's stuck signal
+                # is "nobody has moved in five days", and until now the
+                # payload carried no created_at — so the screen
+                # reconstructed the age as `expires_at minus 21 days`,
+                # duplicating default_expiry()'s constant as a magic
+                # number in another language. Changing the default expiry
+                # would have silently re-aimed every stuck badge. Same
+                # family as item 0: a fact the screen shows, that the
+                # server never sent, inferred.
+                "created_at": _iso(row.get("created_at")),
                 "expires_at": _iso(row.get("expires_at")),
                 "signers": len([p for p in participants
                                 if p["party_role"] == loop.ROLE_SIGNER]),
@@ -471,6 +481,7 @@ def _officer_payload(world: Dict[str, Any]) -> Dict[str, Any]:
         "booked_at": _iso(req.get("booked_at")),
         "booked_by": req.get("booked_by"),
         "booked_asserted_at": _iso(req.get("booked_asserted_at")),
+        "created_at": _iso(req.get("created_at")),
         "expires_at": _iso(req.get("expires_at")),
         "cancelled_at": _iso(req.get("cancelled_at")),
         "proposals_remaining": max(0, loop.MAX_SIGNER_PROPOSALS

--- a/backend/tests/test_flow1_copy_and_agenda.py
+++ b/backend/tests/test_flow1_copy_and_agenda.py
@@ -1,0 +1,177 @@
+"""FLOW1 item 4 — a name is not a pronoun, and the agenda sends its dates.
+
+═══ THE DEFECT ═══
+
+`share_signing_request` told a notary, in a live email:
+
+    "Picking a time tells {owner_name} you are available then; SHE
+     confirms the appointment with the signers HERSELF."
+
+`owner_name` is a real escrow officer whose pronouns this product has
+never been told and has no way to learn. The message goes to her own
+professional contact. So the product was making a claim about its
+customer, to her colleague, on no information — and the same sentence
+existed twice, once in HTML and once in plain text, because a defect in
+one template is a defect in every rendering of it.
+
+The screen had it too: `RequestSigningModal` said the notary "posts the
+times SHE is free" about somebody the officer picked out of her rolodex
+moments earlier.
+
+This is the same error family as FLOW1's "filed as" constraint. There,
+the product must not infer what a partner is PERMITTED to do from how
+she filed them. Here, it must not infer what a person IS from their
+name or their role. Both are the product asserting something about a
+human being that nobody told it.
+
+═══ WHY THE SWEEP HAS EXEMPTIONS, AND WHY THEY ARE NOT COWARDICE ═══
+
+Two habitats keep gendered pronouns and MUST:
+
+  * The California all-purpose acknowledgement (Civil Code §1189) —
+    "acknowledged to me that he/she/they executed the same in
+    his/her/their authorized capacity". That wording is PRESCRIBED. It
+    is a certificate a notary signs under penalty of perjury, not our
+    prose about a user, and it does not name anybody — it says
+    "person(s)". Rewriting it would be a legal choice auto-applied
+    (§1), on the one kind of text §2 says we never pre-fill.
+
+  * Vesting terms of art — "a married man as his sole and separate
+    property". A legal characterization the officer selects and the
+    recorder expects, not a description of a user.
+
+The distinction the sweep encodes is exactly the owner's wording:
+**pronouns referring to a NAMED PARTY**. The statutory text refers to no
+one; our email named her.
+
+Every exemption is a file plus a stated reason, and a test asserts each
+exempted file still exists — an allowlist that outlives its entries
+grants exemptions nobody decided on.
+"""
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+from tests.source_text import code_only
+
+BACKEND = Path(__file__).resolve().parents[1]
+REPO = BACKEND.parent
+
+PRONOUNS = re.compile(r"\b(she|her|hers|herself|he|him|his|himself)\b", re.I)
+
+# path (relative to repo root) -> why it may keep gendered wording.
+PRONOUN_EXEMPT = {
+    "backend/templates/grant_deed_template.html": (
+        "The California all-purpose acknowledgement, Civil Code §1189. "
+        "'he/she/they' and 'his/her/their' are the prescribed wording of a "
+        "certificate a notary signs under penalty of perjury. It names no "
+        "party — it says 'person(s)'. Editing it would be a legal choice "
+        "auto-applied (§1) to text §2 says we never pre-fill."
+    ),
+}
+
+
+def _rendered_lines(path: Path):
+    """Lines of a .py file that are CODE, with docstrings removed.
+
+    Prose about a role in a docstring is not a claim made to anybody. The
+    sweep is about what the product SAYS, so it reads what the product
+    renders.
+    """
+    src = path.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    doc_lines: set[int] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.FunctionDef, ast.AsyncFunctionDef,
+                             ast.ClassDef)):
+            if ast.get_docstring(node, clean=False) is not None and node.body:
+                first = node.body[0]
+                doc_lines.update(range(first.lineno,
+                                       (first.end_lineno or first.lineno) + 1))
+    for i, line in enumerate(src.splitlines(), 1):
+        if i in doc_lines or line.lstrip().startswith("#"):
+            continue
+        yield i, line
+
+
+def test_no_template_asserts_a_pronoun_for_a_named_party():
+    """Fail-closed across every email template and every Jinja template.
+
+    Sweeping the whole tree rather than the two known sites, because the
+    next one will be written by somebody who never read this file.
+    """
+    offenders = []
+
+    for path in sorted((BACKEND / "utils").glob("*.py")):
+        for lineno, line in _rendered_lines(path):
+            if PRONOUNS.search(line):
+                offenders.append(f"{path.relative_to(REPO)}:{lineno}: {line.strip()[:90]}")
+
+    for path in sorted((BACKEND / "templates").rglob("*")):
+        if not path.is_file():
+            continue
+        rel = str(path.relative_to(REPO))
+        if rel in PRONOUN_EXEMPT:
+            continue
+        text = path.read_text(encoding="utf-8", errors="ignore")
+        for lineno, line in enumerate(text.splitlines(), 1):
+            if PRONOUNS.search(line):
+                offenders.append(f"{rel}:{lineno}: {line.strip()[:90]}")
+
+    assert offenders == [], (
+        "these assert a pronoun in rendered copy — use the name, or "
+        "neutral phrasing:\n" + "\n".join(offenders))
+
+
+@pytest.mark.parametrize("rel,reason", sorted(PRONOUN_EXEMPT.items()))
+def test_every_pronoun_exemption_still_exists_and_is_explained(rel, reason):
+    """An allowlist that outlives its entries quietly grants exemptions
+    nobody decided on."""
+    assert (REPO / rel).exists(), f"stale exemption for {rel}"
+    assert len(reason) > 40, f"exemption for {rel} needs a real reason"
+    assert "§" in reason or "Civil Code" in reason, (
+        f"the exemption for {rel} must cite what makes the wording "
+        "prescribed rather than merely traditional")
+
+
+def test_the_statutory_acknowledgement_is_untouched():
+    """The exemption is only honest if the thing it exempts is still the
+    statutory text, rather than a file that once was."""
+    text = (BACKEND / "templates" / "grant_deed_template.html").read_text(encoding="utf-8")
+    assert "he/she/they" in text
+    assert "his/her/their" in text
+    assert "PENALTY OF PERJURY" in text
+
+
+def test_the_officer_agenda_sends_when_she_asked():
+    """FLOW1 item 4: the stuck signal's input, as a fact rather than an
+    inference.
+
+    The screen used to reconstruct a request's age as
+    `expires_at - 21 days`, duplicating default_expiry()'s constant into
+    TypeScript as a bare number. Changing the default would have silently
+    re-aimed every stuck badge, and nothing would have failed.
+    """
+    source = code_only(BACKEND / "routers" / "signing.py")
+    agenda = source[source.index("def officer_agenda"):]
+    agenda = agenda[: agenda.index("\n@router.")]
+    assert '"created_at": _iso(row.get("created_at"))' in agenda, (
+        "the agenda does not send a creation time, so the screen has to "
+        "guess one")
+
+    payload = source[source.index("def _officer_payload"):]
+    assert '"created_at": _iso(req.get("created_at"))' in payload
+
+
+def test_the_frontend_no_longer_reconstructs_the_age():
+    """The other half of the same fix — pinned from here too, because a
+    server that sends the fact and a screen that ignores it is the same
+    defect with an extra step."""
+    page = (REPO / "frontend" / "src" / "app" / "signings" / "page.tsx").read_text(
+        encoding="utf-8")
+    assert "21 * 86400_000" not in page
+    assert "ageInDays(r.created_at)" in page

--- a/backend/utils/email_templates.py
+++ b/backend/utils/email_templates.py
@@ -362,11 +362,11 @@ def share_signing_request(recipient_name, owner_name, deed_type, property_addres
     wording to drift.
 
     Two things this email must not say, and both are doctrine rather than
-    taste. It does not ask the notary to CONFIRM the signing — she is
-    telling us when she is free, and the difference between availability
-    and attendance is the whole of rule 3. And it names no signer,
-    because the product holds no signer contact and never messages one;
-    the officer arranges that leg herself.
+    taste. It does not ask the notary to CONFIRM the signing — they are
+    telling us when they are free, and the difference between
+    availability and attendance is the whole of rule 3. And it names no
+    signer, because the product holds no signer contact and never
+    messages one; the officer arranges that leg themselves.
     """
     addr = _short_addr(property_address)
     subject = f"Signing request — {addr}" if addr else "Notary signing request"
@@ -386,9 +386,16 @@ def share_signing_request(recipient_name, owner_name, deed_type, property_addres
         + _facts([("Document", deed_type), ("Property", addr),
                   ("Requested by", owner_name), ("Link expires", expires_at or "")])
         + _button(share_link, "Open the request and pick a time")
+        # FLOW1: NAME, NOT PRONOUN. This sentence used to read "she
+        # confirms the appointment with the signers herself" about
+        # `owner_name` — a live email asserting an escrow officer's
+        # pronoun to her own professional contact, on no information
+        # whatsoever. The name is already in the sentence; repeating it
+        # costs nothing and claims nothing.
         + _p('<span style="font-size:13px;color:#8a94a0;">Picking a time tells '
-             f"{_esc(owner_name)} you are available then; she confirms the appointment "
-             "with the signers herself. Calendar files for each proposed time are "
+             f"{_esc(owner_name)} you are available then, and "
+             f"{_esc(owner_name)} confirms the appointment with the signers. "
+             "Calendar files for each proposed time are "
              "attached so you can hold them.</span>")
         + _p('<span style="font-size:13px;color:#8a94a0;">Anyone with this link can open '
              "the document until it expires.</span>")
@@ -399,8 +406,8 @@ def share_signing_request(recipient_name, owner_name, deed_type, property_addres
         "Proposed times:\n"
         + "".join(f"  - {w}\n" for w in (window_texts or []))
         + f"\nOpen the request and pick a time: {share_link}\n\n"
-        f"Picking a time tells {owner_name} you are available then; she confirms the "
-        "appointment with the signers herself."
+        f"Picking a time tells {owner_name} you are available then, and "
+        f"{owner_name} confirms the appointment with the signers."
     )
     return subject, _base(f"{owner_name} asked about your availability — {addr}",
                           content, True), text
@@ -443,9 +450,10 @@ def notary_invited(notary_name, officer_name, officer_company, deed_type,
                    property_address, county, link, expires_at) -> Rendered:
     """NOTARY2 — officer → notary: post the times you are free.
 
-    Professional-to-professional. She gets the address, the instrument
-    and the county because she is going there to notarise that document;
-    what she does NOT get is any way to reach the signers, because she
+    Professional-to-professional. The notary gets the address, the
+    instrument and the county because they are going there to notarise
+    that document; what they do NOT get is any way to reach the
+    signers, because they
     has no reason to and the officer does.
     """
     addr = _short_addr(property_address)

--- a/docs/DOCTRINE_CONFORMANCE.md
+++ b/docs/DOCTRINE_CONFORMANCE.md
@@ -501,6 +501,54 @@ a surname match. It was deleted rather than deprecated because "no code
 path may write a characterization into a confirmed field without an
 acceptance record" includes the paths not currently called.
 
+### §11.1 — The same rule applied to people (FLOW1, 2026-08-11, owner-ruled)
+
+**Statement.** The product never infers a fact about a *person* from
+their name or their role. Not their pronouns, not their licensure, not
+what they are permitted to do.
+
+**Why it belongs here.** §11 says a field's kind is decided by its
+content, not by what it is called. §11.1 is the same argument one level
+up: a human being's attributes are decided by what they told us, not by
+what their name or their job suggests. Both failures look like helpful
+inference and both put a claim in the record that nobody made.
+
+**Findings.** `share_signing_request` told a notary, in a live email,
+*"Picking a time tells {owner_name} you are available then; **she**
+confirms the appointment with the signers **herself**."* `owner_name` is
+a real escrow officer whose pronouns this product has never been told
+and has no way to learn, and the message goes to her own professional
+contact — so the product was making a claim about its customer, to her
+colleague, on nothing. The same sentence existed twice, HTML and plain
+text. `RequestSigningModal` had it on screen too, about a notary the
+officer had picked out of her rolodex moments earlier.
+
+Ruled the same family as FLOW1's **"filed as"** constraint, which came
+from the other direction: a partner's category records how the officer
+*files* them and may never be read as a statement about their authority
+or licensure (`partnerRegistry.ts`). "Nora is filed as a Notary" is true
+about a rolodex. "Marcus is not a notary" would be a claim about Marcus.
+
+**Two habitats keep gendered wording, and must.** The California
+all-purpose acknowledgement (Civil Code §1189) — *"acknowledged to me
+that he/she/they executed the same in his/her/their authorized
+capacity"* — is prescribed wording on a certificate a notary signs under
+penalty of perjury, and it names nobody: it says "person(s)". Rewriting
+it would be a legal choice auto-applied (§1) to the one kind of text §2
+says we never pre-fill. Vesting terms of art ("a married man as his sole
+and separate property") are a legal characterization the officer selects
+and the recorder expects. The rule is *pronouns referring to a **named
+party***; neither of these names one.
+
+**Enforced by.** `backend/tests/test_flow1_copy_and_agenda.py` — a
+fail-closed sweep of every email template (docstrings excluded: prose
+about a role is not a claim made to anybody) and every Jinja template,
+with an allowlist of one file, a cited statutory reason, and a test that
+the exemption still exists and still contains the statutory text.
+Frontend half in `frontend/src/__tests__/officerTrackers.test.ts`.
+
+---
+
 **Habitats checked.**
 - T-6 prelim import (`services/prelim_import.import_prelim`)
 - County-record prefill (`lib/sitexProperty.mapSiteXResponse`)
@@ -816,6 +864,7 @@ their data is not a machine decision.
 
 | Date | Change |
 |---|---|
+| 2026-08-11 | §11.1 added (FLOW1 items 3–4) — the product never infers a fact about a PERSON from their name or role. A live email told a notary that the officer "confirms the appointment with the signers herself", asserting an escrow officer's pronouns to her own professional contact on no information; the screen did the same about the notary. Ruled the same family as the "filed as" constraint, which forbids reading a partner's category as a statement about their authority — one direction infers what someone IS, the other what they MAY DO, and both put a claim in the record nobody made. Swept fail-closed across every template. Two habitats exempted with cited reasons and their own liveness test: the Civil Code §1189 all-purpose acknowledgement (prescribed certificate wording, names no party) and vesting terms of art. Also item 4: the Signings agenda's stuck age was reconstructed as `expires_at − 21 days`, duplicating `default_expiry()`'s constant into TypeScript as a bare number — the server sends `created_at` now. And its "soonest first" claim covered rows sorted by `COALESCE(booked_at, expires_at)`, two orthogonal facts under one sort key (T-5 one layer up); booked and being-arranged are now separated and each sorted by the fact it has. |
 | 2026-08-11 | §4 — FLOW1 item 0. Shared Deeds reported as showing fabricated rows; verdict recorded as NOT fabricated — a real fetch read through eight wrong key names, so `undefined` rendered as blank cells and Invalid Date. Recorded under §4 rather than invariant #4 because nothing was invented and the screen still asserted what it could not support ("Not viewed" under a badge reading "Viewed"). Three absent facts given columns: `recipient_name` (accepted, greeted with, never stored), `responded_at` (`updated_at` was not that fact — a revoke bumps it too), and a real `expires_at` (previously spent on a display string nothing rendered). Contract now pinned from both sides against one corpus; absence crosses the wire as `null`, never `""`. The feedback modal's fallback to a field the list endpoint never sent — a failed fetch reading as "the reviewer left no comments" — removed. |
 | 2026-08-11 | §13.1 — the signer-contact ruling REVERSED (NOTARY2). Signers now participate directly; the notary posts availability, signers pick or propose, convergence books it, and the officer is notified rather than gating. Owner's reasoning recorded: the signers are the scheduling constraint, so routing around them recreated the phone tag the feature exists to kill — Option A had priced the officer's relaying at zero when it is the entire problem. The superseded paragraph is kept verbatim rather than rewritten. §13 otherwise stands unchanged: booked is still not happened. NOTARY1's fail-closed sweep is ANSWERED rather than deleted — retargeted from "no signer contact anywhere" to "one purgeable row, no other table, deleted by a mechanism with a test." The retention rule and a non-user's route to removal become part of the feature, ledgered as owner items. |
 | 2026-08-10 | §13 added (NOTARY1) — an arrangement is not an act. A scheduled signing time is the least legally freighted fact in the product, which is exactly the risk: authority acquired by wording drift rather than by decision. Three pinned rules: nothing infers a signing from a passed window (`scheduling_state()` is AST-pinned type-incapable of a "happened" state), `completed` stays officer-only, and `scheduling_label()` is the single place a scheduling state becomes a sentence. Assertion shape mirrors RED-S4 (`scheduled_at` / `scheduled_by` / `scheduled_asserted_at`), keeping the notary's tap and the officer's phone call apart. State DERIVED, never folded into `deed_shares.status` — T-5's ruling transferred verbatim. No signer contact anywhere, pinned fail-closed across both trees. One expiry semantic per link, applied as a class. Two pre-existing defects fixed in passing: share creation never checked deed ownership (cross-user deed disclosure), and an opened link kept serving the deed after expiry. |

--- a/frontend/src/__tests__/officerTrackers.test.ts
+++ b/frontend/src/__tests__/officerTrackers.test.ts
@@ -1,0 +1,157 @@
+/**
+ * FLOW1 items 3 and 4 — the officer's two trackers, and the Signings page.
+ *
+ * ═══ ITEM 3: TWO SCREENS THAT DID NOT KNOW ABOUT EACH OTHER ═══
+ *
+ * A review lives in `deed_shares`; a signing lives in `signing_requests`.
+ * Shared Deeds read the first, Signings read the second, and neither
+ * mentioned the other — zero cross-references in either direction. So
+ * the page named for sharing showed one of the two things she shares,
+ * and "where is the thing I sent Nora" had two possible answers and no
+ * signpost to either. Its subtitle also said "shared for approval",
+ * committing the whole page to reviewer semantics before asking what she
+ * had actually sent.
+ *
+ * The two feeds are NOT flattened into one row shape, and the pin below
+ * keeps them apart: a review has a viewing and a decision, a signing has
+ * a notary and a set of times. Sharing columns between them would put
+ * two different facts under one heading, which is the defect item 0
+ * spent a whole PR on.
+ *
+ * ═══ ITEM 4: THE SIGNINGS PAGE ═══
+ *
+ * Three things it claimed or did that it should not have:
+ *
+ *  1. Every card navigated to `/past-deeds`, throwing away which signing
+ *     she had pressed — the one gesture on the page discarded the only
+ *     context the page had.
+ *  2. The subtitle said "soonest first" while the server ordered by
+ *     `COALESCE(booked_at, expires_at)` — a signing's time for booked
+ *     rows and the LINK'S DEATH for the rest. Two facts in one sort key,
+ *     described as a schedule. And nothing on screen carried a date to
+ *     check it against.
+ *  3. The stuck age was reconstructed as `expires_at minus 21 days`,
+ *     duplicating `default_expiry()`'s constant into another language as
+ *     a bare number. Changing the default expiry would have silently
+ *     re-aimed every stuck badge, and nothing would have failed.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
+
+const SRC = path.join(__dirname, '..');
+const read = (...p: string[]) => fs.readFileSync(path.join(SRC, ...p), 'utf8');
+const flat = (s: string) => s.replace(/\s+/g, ' ');
+
+const SIGNINGS = read('app', 'signings', 'page.tsx');
+const SHARED = read('app', 'shared-deeds', 'page.tsx');
+const SIGNINGS_CODE = codeOnly(SIGNINGS);
+const SHARED_CODE = codeOnly(SHARED);
+
+describe('FLOW1 item 3 — the two trackers know about each other', () => {
+  it('links in both directions', () => {
+    expect(SIGNINGS_CODE).toContain("router.push('/shared-deeds')");
+    expect(SHARED_CODE).toContain('router.push(`/signings?focus=${signing.id}`)');
+  });
+
+  it('Shared Deeds shows both kinds, filterable, both by default', () => {
+    expect(SHARED_CODE).toContain('TrackerFilter');
+    expect(SHARED_CODE).toContain('useState<TrackerFilter>("all")');
+    expect(SHARED_CODE).toContain('filter !== "signings" && sharedDeeds.map');
+    expect(SHARED_CODE).toContain('filter !== "reviews" && signings.map');
+  });
+
+  it('the subtitle no longer commits the page to reviewer semantics', () => {
+    // Half of what lands here is a signing request, and a notary is not
+    // being asked to approve anything — she is being asked when she is
+    // free.
+    expect(flat(SHARED)).not.toContain('Track deeds shared for approval');
+    expect(flat(SHARED)).toContain('reviews you asked for and signings you arranged');
+  });
+
+  it('a signing row does not borrow a review’s vocabulary', () => {
+    // A signing has no "viewed", no approve/reject and no reviewer. The
+    // cells it cannot fill say so.
+    const rows = SHARED_CODE.slice(SHARED_CODE.indexOf('signings.map'));
+    expect(rows).not.toContain('getStatusBadge(signing');
+    expect(rows).not.toContain('signing.viewed_at');
+    expect(rows).not.toContain('signing.response_date');
+    expect(rows).toContain('{UNKNOWN}');
+  });
+});
+
+describe('FLOW1 item 4 — the card opens the signing', () => {
+  it('no card navigates to /past-deeds any more', () => {
+    // The empty state may still point at her deeds — that is a signpost
+    // for somebody with no signings, not a row throwing away context.
+    const rowRegion = SIGNINGS_CODE.slice(SIGNINGS_CODE.indexOf('function SigningRow'));
+    expect(rowRegion).not.toContain('/past-deeds');
+    expect(SIGNINGS_CODE).not.toContain("onOpen={() => router.push(`/past-deeds`)}");
+  });
+
+  it('the row expands onto the signing itself', () => {
+    expect(SIGNINGS_CODE).toContain('aria-expanded={open}');
+    expect(flat(SIGNINGS_CODE)).toContain('apiFetch(`/signing-requests/v2/${requestId}`');
+  });
+
+  it('is linkable, so a notification can point at one signing', () => {
+    expect(SIGNINGS_CODE).toContain("params?.get('focus')");
+  });
+
+  it('a detail that fails to load says so rather than looking empty', () => {
+    // §4: an empty panel would read as "this signing has no
+    // participants", which is a claim.
+    expect(SIGNINGS_CODE).toContain('Could not load this signing');
+  });
+});
+
+describe('FLOW1 item 4 — the order is the one it claims', () => {
+  it('does not claim "soonest first" over rows with no date', () => {
+    expect(flat(SIGNINGS)).not.toContain('Every signing you have arranged, soonest first');
+  });
+
+  it('sorts each group by the fact that group actually has', () => {
+    // Booked by when it is booked for; being-arranged by how long she
+    // has waited, oldest first — the longest-waiting is the one worth a
+    // phone call. Orthogonal facts, separate keys: T-5 one layer up.
+    expect(flat(SIGNINGS_CODE)).toContain(
+      "(a, b) => (a.booked_at || '').localeCompare(b.booked_at || '')");
+    expect(flat(SIGNINGS_CODE)).toContain(
+      "(a, b) => (a.created_at || '').localeCompare(b.created_at || '')");
+  });
+
+  it('puts a date on the row so the order can be checked', () => {
+    expect(flat(SIGNINGS)).toContain('Booked for ${new Date(row.booked_at)');
+    expect(flat(SIGNINGS)).toContain('Requested ${age} day');
+  });
+});
+
+describe('FLOW1 item 4 — the age is read, not reconstructed', () => {
+  it('reads created_at instead of subtracting the expiry default', () => {
+    expect(SIGNINGS_CODE).toContain('function ageInDays(createdAt: string | null)');
+    expect(SIGNINGS_CODE).toContain('ageInDays(r.created_at)');
+  });
+
+  it('carries no copy of the server’s expiry constant', () => {
+    // `21` was `default_expiry()`'s value, retyped here as a bare
+    // number with nothing connecting the two. A magic constant that
+    // mirrors a server default is a silent coupling.
+    expect(SIGNINGS_CODE).not.toMatch(/\b21\s*\*\s*86400/);
+    expect(SIGNINGS_CODE).not.toContain('expires - 21');
+  });
+
+  it('an unknown creation time is unknown, not zero', () => {
+    // Zero would read as "asked today", which is a claim.
+    expect(SIGNINGS_CODE).toContain('if (!createdAt) return null;');
+    expect(SIGNINGS_CODE).toContain('if (age === null) return false;');
+  });
+});
+
+describe('FLOW1 — a name is not a pronoun', () => {
+  it('the signing modal does not assume the notary’s pronouns', () => {
+    const MODAL = read('features', 'signing', 'RequestSigningModal.tsx');
+    expect(flat(codeOnly(MODAL))).toContain('posts the times they are free');
+    expect(flat(codeOnly(MODAL))).not.toContain('the times she is free');
+  });
+});

--- a/frontend/src/__tests__/sharedDeedsContract.test.ts
+++ b/frontend/src/__tests__/sharedDeedsContract.test.ts
@@ -91,29 +91,72 @@ function interfaceFields(source: string, name: string): string[] {
   return fields;
 }
 
-describe('FLOW1 — Shared Deeds rows come from the share fetch', () => {
-  it('fetches /shared-deeds and fills the table from that response', () => {
-    expect(PAGE_CODE).toContain("apiFetch(`/shared-deeds`");
-    // The state the table maps over is written in exactly one place, and
-    // that place is the handler for the share response.
-    const writes = PAGE_CODE.match(/setSharedDeeds\s*\(/g) || [];
-    expect(writes).toHaveLength(1);
+/**
+ * ═══ RETARGET, 2026-08-11 — READ THIS BEFORE TRUSTING THE PIN BELOW ═══
+ *
+ * This block was written one day before it was changed, and a pin
+ * loosening a pin one day later has to carry its own justification where
+ * the next reader will find it. So:
+ *
+ * **What it said.** "The rows come from the share fetch AND NOTHING
+ * ELSE", enforced as: exactly one `setSharedDeeds(` call, one
+ * `/shared-deeds` fetch, no `/deeds` fetch.
+ *
+ * **Why it said that.** An audit reported this page as synthesising rows
+ * out of the officer's completed-deed list, because the row count
+ * happened to equal the completed-deed count. It was not — the count was
+ * one share per completed deed — but "it isn't doing that today" is an
+ * observation, and the pin turned it into a property.
+ *
+ * **What changed.** FLOW1 item 3 unified the two officer trackers: this
+ * screen now also shows NOTARY2 signings, which live in
+ * `signing_requests` and arrive from `/signing-requests/v2`. Under the
+ * old wording that second fetch is forbidden.
+ *
+ * **Why this is a retarget and not a loosening.** The property was never
+ * "one fetch". It was **every row is a thing that was actually sent to
+ * somebody.** A share was sent. A signing request was sent. A completed
+ * deed sitting in her list was not sent to anyone, and a row for it
+ * would be a tracking screen reporting an event that never happened.
+ *
+ * So the prohibition is unchanged and is now stated as itself, by name,
+ * rather than implied by a fetch count: THE DEEDS LIST IS NOT A SOURCE
+ * OF ROWS. The allowance is explicit and enumerated — two feeds, both of
+ * things that left the building — and adding a third would have to be
+ * written down here, which is the point.
+ */
+describe('FLOW1 — every row on Shared Deeds is a thing that was sent', () => {
+  it('fills the table from the two feeds of things that were sent', () => {
+    expect(PAGE_CODE).toContain('apiFetch(`/shared-deeds`');
+    expect(FLAT).toContain('apiFetch( `/signing-requests/v2`');
+    // Each feed is written into its own state, once. Two feeds, two
+    // writers — not one writer that could be handed anything.
+    expect((PAGE_CODE.match(/setSharedDeeds\s*\(/g) || [])).toHaveLength(1);
+    expect((PAGE_CODE.match(/setSignings\s*\(\s*Array/g) || [])).toHaveLength(1);
   });
 
   it('never derives rows from the deeds list', () => {
-    // The reported hypothesis, forbidden rather than merely absent. A
-    // row on this screen is a SHARE — a thing that was sent to somebody
-    // — and a completed deed is not one. Deriving the second from the
-    // first would put a row on a tracking screen for a share that never
-    // happened, which is invariant #4 on the surface whose whole job is
-    // to say what happened.
+    // The reported hypothesis, forbidden by name rather than by
+    // arithmetic on fetch counts. A completed deed was not sent to
+    // anybody; a row for one would be invariant #4 on the surface whose
+    // whole job is to say what happened.
     for (const forbidden of [
       /apiFetch\(\s*[`'"]\/deeds/,
       /apiFetch\(\s*[`'"]\/api\/deeds/,
       /setSharedDeeds\s*\(\s*deeds/,
+      /setSignings\s*\(\s*deeds/,
     ]) {
       expect(PAGE_CODE).not.toMatch(forbidden);
     }
+  });
+
+  it('a signings feed that fails is neither silent nor destructive', () => {
+    // §4 read in both directions. Throwing would blank a table of
+    // reviews that loaded fine — an error swallowing correct data.
+    // Swallowing would show her no signings and no reason to doubt it.
+    expect(PAGE_CODE).toContain('setSigningError');
+    expect(FLAT).toContain('Your signings could not be loaded');
+    expect(FLAT).toContain('the reviews below are unaffected');
   });
 });
 

--- a/frontend/src/app/shared-deeds/page.tsx
+++ b/frontend/src/app/shared-deeds/page.tsx
@@ -57,6 +57,47 @@ interface SharedDeed {
   scheduled_by: string | null
 }
 
+/**
+ * FLOW1 item 3 — THE OTHER HALF OF WHAT SHE SENDS OUT.
+ *
+ * A signing lives in `signing_requests`; a review lives in `deed_shares`.
+ * This page read one table, was named for the act both of them are, and
+ * did not mention the screen that showed the other — zero cross
+ * references in either direction. So "where is the thing I sent Nora"
+ * had two possible answers and no signpost to either.
+ *
+ * The two feeds are NOT merged into one row shape, and that is
+ * deliberate. A review has a viewing and a decision; a signing has a
+ * notary, a set of times and a state. Flattening them into shared
+ * columns would put two different facts under one heading, which is the
+ * defect item 0 spent a whole PR on. They travel as themselves, in one
+ * table, under a filter, with a badge saying which is which.
+ */
+interface SigningSummaryRow {
+  id: number
+  deed_id: number
+  property_address: string | null
+  deed_type: string | null
+  notary_name: string | null
+  state: string
+  summary: string
+  booked_at: string | null
+  created_at: string | null
+  expires_at: string | null
+  signers: number
+}
+
+const SIGNING_STATE_LABEL: Record<string, string> = {
+  requested: "Waiting on the notary",
+  windows_posted: "Waiting on signers",
+  partially_agreed: "Part-agreed",
+  booked: "Booked",
+  cancelled: "Cancelled",
+  expired: "Expired",
+}
+
+type TrackerFilter = "all" | "reviews" | "signings"
+
 // Issue labels for structured feedback
 const ISSUE_LABELS: Record<string, string> = {
   grantor_name: 'Grantor name incorrect',
@@ -80,6 +121,9 @@ interface StructuredFeedback {
 export default function SharedDeedsPageV0() {
   const router = useRouter()
   const [sharedDeeds, setSharedDeeds] = useState<SharedDeed[]>([])
+  const [signings, setSignings] = useState<SigningSummaryRow[]>([])
+  const [filter, setFilter] = useState<TrackerFilter>("all")
+  const [signingError, setSigningError] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [feedbackModal, setFeedbackModal] = useState<{ 
@@ -103,6 +147,7 @@ export default function SharedDeedsPageV0() {
   const fetchSharedDeeds = async () => {
     setLoading(true)
     setError(null)
+    setSigningError(null)
     try {
       const token = localStorage.getItem("access_token")
       if (!token) {
@@ -120,6 +165,32 @@ export default function SharedDeedsPageV0() {
 
       const data = await response.json()
       setSharedDeeds(Array.isArray(data) ? data : data.shared_deeds || [])
+
+      // FLOW1 item 3: the signings feed, fetched as itself.
+      //
+      // Its failure gets its OWN banner rather than the page-level
+      // error, and the reason is §4 read carefully in both directions.
+      // Throwing here would blank a table of reviews that loaded fine —
+      // an error swallowing correct data is as dishonest as a success
+      // swallowing an error. Swallowing it silently would be worse
+      // still: the officer would see the reviews, no signings, and no
+      // reason to doubt that she has none.
+      try {
+        const signingResponse = await apiFetch(
+          `/signing-requests/v2`, {}, { label: "Loading signings" })
+        if (!signingResponse.ok) {
+          const detail = await signingResponse.json().catch(() => ({}))
+          throw new Error(
+            detail.detail || `Failed to load signings (${signingResponse.status})`)
+        }
+        const signingData = await signingResponse.json()
+        setSignings(Array.isArray(signingData) ? signingData : [])
+      } catch (signingErr) {
+        if (signingErr instanceof SessionExpiredError) return
+        setSignings([])
+        setSigningError(
+          signingErr instanceof Error ? signingErr.message : "Could not load your signings")
+      }
     } catch (err) {
       if (err instanceof SessionExpiredError) return
       console.error("Error fetching shared deeds:", err)
@@ -311,17 +382,43 @@ export default function SharedDeedsPageV0() {
           {/* Header Section */}
           <div className="mb-8">
             <h1 className="text-4xl md:text-5xl font-bold text-slate-800 mb-4 tracking-tight">Shared Deeds</h1>
+            {/* FLOW1 item 3 — THE SUBTITLE SAID "FOR APPROVAL".
+                Which committed the whole page to reviewer semantics
+                before asking what she had sent. Half of what lands here
+                is a signing request, and a notary is not being asked to
+                approve anything — she is being asked when she is free.
+                The page is named for the act both of them are; the
+                sentence under it now describes both. */}
             <p className="text-lg text-slate-600 mb-6">
-              Track deeds shared for approval and manage collaboration with title companies, lenders, and other parties.
+              Everything you have sent out on a deed — reviews you asked for and
+              signings you arranged — and where each one has got to.
             </p>
 
             {/* Subheader Bar */}
             <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4 bg-white rounded-xl p-4 shadow-sm border border-slate-200">
-              <div className="flex items-center gap-2">
-                <Send className="w-5 h-5 text-[#7C4DFF]" />
-                <span className="text-lg font-semibold text-slate-700">
-                  {sharedDeeds.length} shared {sharedDeeds.length === 1 ? "deed" : "deeds"}
-                </span>
+              {/* FLOW1 item 3: the filter. Both kinds by default,
+                  because "what did I send out on this file" is the
+                  question the page exists for and it does not come in
+                  two halves. */}
+              <div className="flex items-center gap-2" role="group" aria-label="Filter by kind">
+                {([
+                  ["all", `All (${sharedDeeds.length + signings.length})`],
+                  ["reviews", `Reviews (${sharedDeeds.length})`],
+                  ["signings", `Signings (${signings.length})`],
+                ] as Array<[TrackerFilter, string]>).map(([key, label]) => (
+                  <button
+                    key={key}
+                    onClick={() => setFilter(key)}
+                    aria-pressed={filter === key}
+                    className={`px-4 py-2 rounded-lg text-sm font-semibold transition-colors ${
+                      filter === key
+                        ? "bg-[#7C4DFF] text-white"
+                        : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+                    }`}
+                  >
+                    {label}
+                  </button>
+                ))}
               </div>
               {/* FLOW1 item 2 — "Share New Deed" IS GONE.
                   It opened a modal titled "Share Deed for Review" whose
@@ -379,8 +476,23 @@ export default function SharedDeedsPageV0() {
             </div>
           )}
 
+          {/* FLOW1 item 3: a signings feed that failed says so, above
+              the reviews that loaded — rather than replacing them, and
+              rather than reading as "you have no signings". */}
+          {!loading && signingError && (
+            <div className="mb-6 rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+              <p className="font-semibold flex items-center gap-2">
+                <AlertCircle className="w-4 h-4" />
+                Your signings could not be loaded
+              </p>
+              <p className="mt-1 text-amber-800">
+                {signingError} — the reviews below are unaffected.
+              </p>
+            </div>
+          )}
+
           {/* Empty State */}
-          {!loading && !error && sharedDeeds.length === 0 && (
+          {!loading && !error && sharedDeeds.length === 0 && signings.length === 0 && (
             <div className="flex flex-col items-center justify-center min-h-[50vh] gap-6 bg-white rounded-2xl p-12 shadow-sm border border-slate-200">
               <div className="w-24 h-24 rounded-full bg-slate-100 flex items-center justify-center ring-4 ring-slate-50">
                 <Send className="w-12 h-12 text-slate-400" />
@@ -399,7 +511,7 @@ export default function SharedDeedsPageV0() {
           )}
 
           {/* Table */}
-          {!loading && !error && sharedDeeds.length > 0 && (
+          {!loading && !error && (sharedDeeds.length > 0 || signings.length > 0) && (
             <div className="bg-white rounded-2xl shadow-md border border-slate-200 overflow-hidden">
               <div className="overflow-x-auto">
                 <table className="w-full">
@@ -416,7 +528,7 @@ export default function SharedDeedsPageV0() {
                     </tr>
                   </thead>
                   <tbody>
-                    {sharedDeeds.map((deed, index) => {
+                    {filter !== "signings" && sharedDeeds.map((deed, index) => {
                       const daysRemaining = calculateDaysRemaining(deed.expires_at)
                       const showCountdown =
                         !!daysRemaining && !["expired", "approved", "rejected"].includes(deed.status)
@@ -521,6 +633,67 @@ export default function SharedDeedsPageV0() {
                         </tr>
                       )
                     })}
+                    {/* FLOW1 item 3 — SIGNINGS, AS THEMSELVES.
+                        A signing is not a review with different words:
+                        it has a notary and a set of times, and it has no
+                        "viewed" and no approve/reject. So the cells it
+                        cannot fill say "—" rather than borrowing a
+                        review's vocabulary — the same rule item 0 landed
+                        on, one row-kind over. The Expires column is
+                        shared honestly: both are link expiries. */}
+                    {filter !== "reviews" && signings.map((signing, index) => (
+                      <tr
+                        key={`signing-${signing.id}`}
+                        className={`border-b border-slate-100 hover:bg-slate-50 transition-colors ${
+                          index % 2 === 0 ? "bg-white" : "bg-slate-50/50"
+                        }`}
+                      >
+                        <td className="py-4 px-6 font-medium text-slate-800">
+                          {signing.property_address || `Deed #${signing.deed_id}`}
+                        </td>
+                        <td className="py-4 px-6 text-slate-600">{signing.deed_type || UNKNOWN}</td>
+                        <td className="py-4 px-6">
+                          <div className="flex flex-col">
+                            <span className="font-medium text-slate-800">
+                              {signing.notary_name || "No notary named"}
+                            </span>
+                            <span className="text-xs text-slate-500">
+                              {signing.signers} signer{signing.signers === 1 ? "" : "s"}
+                            </span>
+                          </div>
+                        </td>
+                        <td className="py-4 px-6">
+                          <div className="flex flex-col gap-2">
+                            <span className="inline-flex w-fit items-center gap-1.5 rounded-full border border-slate-200 bg-slate-50 px-2.5 py-0.5 text-[11px] font-semibold text-slate-600">
+                              <CalendarClock className="h-3 w-3" />
+                              Signing
+                            </span>
+                            <span className="text-xs font-medium text-slate-700">
+                              {SIGNING_STATE_LABEL[signing.state] || signing.state}
+                            </span>
+                            {/* state_label() wrote this sentence. This
+                                screen does not compose its own account
+                                of a scheduling state (§13 rule 3). */}
+                            <span className="text-xs text-slate-500">{signing.summary}</span>
+                          </div>
+                        </td>
+                        <td className="py-4 px-6 text-sm text-slate-600">
+                          {formatDate(signing.created_at)}
+                        </td>
+                        <td className="py-4 px-6 text-sm text-slate-600">
+                          {formatDate(signing.expires_at)}
+                        </td>
+                        <td className="py-4 px-6 text-sm text-slate-400">{UNKNOWN}</td>
+                        <td className="py-4 px-6">
+                          <button
+                            onClick={() => router.push(`/signings?focus=${signing.id}`)}
+                            className="px-4 py-2 bg-slate-600 hover:bg-slate-700 text-white text-sm font-medium rounded-lg transition-colors"
+                          >
+                            Open in Signings
+                          </button>
+                        </td>
+                      </tr>
+                    ))}
                   </tbody>
                 </table>
               </div>

--- a/frontend/src/app/signings/page.tsx
+++ b/frontend/src/app/signings/page.tsx
@@ -23,8 +23,8 @@
  * label, rendered in the REQUEST's timezone.
  */
 
-import { useEffect, useMemo, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { Suspense, useEffect, useMemo, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import Sidebar from '@/components/Sidebar';
 import { AlertCircle, CalendarClock, CheckCircle2, Clock, Loader2 } from 'lucide-react';
 import { SessionExpiredError, apiFetch } from '@/lib/apiClient';
@@ -39,26 +39,63 @@ type Row = {
   summary: string;
   booked_at: string | null;
   booked_by: string | null;
+  /** FLOW1 item 4: WHEN SHE ASKED. See the note on ageInDays below for
+   * what this replaced and why the replacement matters. */
+  created_at: string | null;
   expires_at: string | null;
   signers: number;
+};
+
+/** What `GET /signing-requests/v2/{id}` returns for one signing. */
+type Detail = {
+  participants: Array<{
+    id: number;
+    party_role: string;
+    name: string | null;
+    viewed_at: string | null;
+    revoked: boolean;
+  }>;
+  windows: Array<{
+    id: number;
+    label: string;
+    declined: boolean;
+    waiting_on: string[];
+  }>;
 };
 
 /** Days of silence before a request is worth chasing. Not a deadline —
  * nothing expires because of it — a prompt. */
 const STUCK_AFTER_DAYS = 5;
 
-function daysSince(iso: string | null, expiresAt: string | null): number {
-  // The request's age is inferred from its expiry, since that is the only
-  // timestamp the agenda payload carries. 21 days is the create default.
-  if (!expiresAt) return 0;
-  const expires = new Date(expiresAt).getTime();
-  const created = expires - 21 * 86400_000;
+/**
+ * FLOW1 item 4 — THE AGE IS READ, NOT RECONSTRUCTED.
+ *
+ * This used to compute `expires_at minus 21 days` because the agenda
+ * payload carried no creation time, and 21 is `default_expiry()`'s
+ * constant — copied into another language as a bare number with nothing
+ * connecting the two. Changing the default expiry on the server would
+ * have silently re-aimed every stuck badge on this screen, and nothing
+ * would have failed.
+ *
+ * That is item 0's defect in a second habitat: a fact the screen shows,
+ * that the server never sent, inferred from something adjacent. The
+ * server sends `created_at` now.
+ *
+ * An unknown creation time returns null rather than 0. Zero would read
+ * as "asked today", which is a claim; null reads as "we do not know",
+ * which is true and keeps the row out of the stuck count.
+ */
+function ageInDays(createdAt: string | null): number | null {
+  if (!createdAt) return null;
+  const created = new Date(createdAt).getTime();
+  if (Number.isNaN(created)) return null;
   return Math.max(0, Math.floor((Date.now() - created) / 86400_000));
 }
 
 function isStuck(r: Row): boolean {
   if (r.state === 'booked' || r.state === 'cancelled' || r.state === 'expired') return false;
-  const age = daysSince(null, r.expires_at);
+  const age = ageInDays(r.created_at);
+  if (age === null) return false;
   // Nobody has posted a time, or times are posted and nobody answered.
   return age >= STUCK_AFTER_DAYS && (r.state === 'requested' || r.state === 'windows_posted');
 }
@@ -72,9 +109,40 @@ const STATE_LABEL: Record<string, string> = {
   expired: 'Expired',
 };
 
+/**
+ * `useSearchParams()` opts a page out of static prerendering unless it
+ * sits under a Suspense boundary — Next fails the BUILD, not the render,
+ * so jest and tsc both stayed green while `next build` did not. Same
+ * boundary the admin and success pages already use.
+ */
 export default function SigningsPage() {
+  return (
+    <Suspense fallback={
+      <div className="flex min-h-screen bg-slate-50">
+        <Sidebar />
+        <main className="flex-1 p-6 md:p-10">
+          <div className="max-w-4xl mx-auto flex items-center gap-3 text-slate-500 py-16 justify-center">
+            <Loader2 className="w-5 h-5 animate-spin" /> Loading…
+          </div>
+        </main>
+      </div>
+    }>
+      <SigningsAgenda />
+    </Suspense>
+  );
+}
+
+function SigningsAgenda() {
   const router = useRouter();
+  const params = useSearchParams();
   const [rows, setRows] = useState<Row[]>([]);
+  // FLOW1 item 4: `?focus=<id>` opens that signing. A notification about
+  // one signing should be able to point at that signing.
+  const [focus, setFocus] = useState<number | null>(() => {
+    const raw = params?.get('focus');
+    const id = raw ? Number(raw) : NaN;
+    return Number.isInteger(id) ? id : null;
+  });
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -104,8 +172,37 @@ export default function SigningsPage() {
   }, []);
 
   const stuck = useMemo(() => rows.filter(isStuck), [rows]);
-  const active = useMemo(
-    () => rows.filter((r) => !['cancelled', 'expired'].includes(r.state)), [rows]);
+
+  /**
+   * FLOW1 item 4 — "SOONEST FIRST" WAS HALF TRUE, WHICH IS THE BAD HALF.
+   *
+   * The server orders by `COALESCE(booked_at, expires_at)`. For a booked
+   * signing that is the signing's time. For an unbooked one it is when
+   * the LINK DIES — a fact with no relationship to when anybody will
+   * meet. So two facts shared one sort key, and the subtitle described
+   * the result as a schedule.
+   *
+   * That is T-5's ruling one layer up: orthogonal facts must not share
+   * one column. A booked signing has a date; a request being arranged
+   * does not have one yet, and inventing an order for it out of its
+   * expiry is how a screen ends up claiming to be a calendar.
+   *
+   * So they are separated and each is sorted by the fact it actually
+   * has — booked by when, in progress by how long she has been waiting,
+   * oldest first, because the oldest is the one that needs a call. The
+   * subtitle now says exactly this instead of "soonest first".
+   */
+  const bookedRows = useMemo(
+    () => rows
+      .filter((r) => r.state === 'booked')
+      .sort((a, b) => (a.booked_at || '').localeCompare(b.booked_at || '')),
+    [rows]);
+  const arranging = useMemo(
+    () => rows
+      .filter((r) => !['booked', 'cancelled', 'expired'].includes(r.state))
+      // Oldest first: longest-waiting is the one worth chasing.
+      .sort((a, b) => (a.created_at || '').localeCompare(b.created_at || '')),
+    [rows]);
   const closed = useMemo(
     () => rows.filter((r) => ['cancelled', 'expired'].includes(r.state)), [rows]);
 
@@ -115,8 +212,26 @@ export default function SigningsPage() {
       <main className="flex-1 p-6 md:p-10">
         <div className="max-w-4xl mx-auto">
           <h1 className="text-3xl font-bold text-slate-900 mb-1">Signings</h1>
-          <p className="text-slate-600 mb-6">
-            Every signing you have arranged, soonest first.
+          <p className="text-slate-600 mb-2">
+            Booked signings first, soonest first. Then the ones still being
+            arranged, longest-waiting first — those are the ones to chase.
+          </p>
+          {/* FLOW1 item 3 — THE TWO TRACKERS KNOW ABOUT EACH OTHER.
+              Reviews live in `deed_shares` and signings in
+              `signing_requests`, and until now neither screen mentioned
+              the other: the page named for sharing showed one of the two
+              things she shares, and this one showed the other, with zero
+              cross-references between them. */}
+          <p className="text-sm text-slate-500 mb-6">
+            Sent a deed out for review instead?{' '}
+            <button
+              type="button"
+              onClick={() => router.push('/shared-deeds')}
+              className="font-medium text-[#7C4DFF] hover:underline"
+            >
+              Shared Deeds
+            </button>{' '}
+            tracks those.
           </p>
 
           {stuck.length > 0 && (
@@ -153,10 +268,32 @@ export default function SigningsPage() {
             </div>
           )}
 
-          {active.length > 0 && (
-            <div className="space-y-3">
-              {active.map((r) => <SigningRow key={r.id} row={r} onOpen={() => router.push(`/past-deeds`)} />)}
-            </div>
+          {bookedRows.length > 0 && (
+            <>
+              <h2 className="text-sm font-semibold text-slate-500 uppercase tracking-wide mb-3">
+                Booked
+              </h2>
+              <div className="space-y-3">
+                {bookedRows.map((r) => (
+                  <SigningRow key={r.id} row={r} open={focus === r.id}
+                              onToggle={() => setFocus(focus === r.id ? null : r.id)} />
+                ))}
+              </div>
+            </>
+          )}
+
+          {arranging.length > 0 && (
+            <>
+              <h2 className="text-sm font-semibold text-slate-500 uppercase tracking-wide mt-8 mb-3">
+                Being arranged
+              </h2>
+              <div className="space-y-3">
+                {arranging.map((r) => (
+                  <SigningRow key={r.id} row={r} open={focus === r.id}
+                              onToggle={() => setFocus(focus === r.id ? null : r.id)} />
+                ))}
+              </div>
+            </>
           )}
 
           {closed.length > 0 && (
@@ -165,7 +302,10 @@ export default function SigningsPage() {
                 Closed
               </h2>
               <div className="space-y-3 opacity-70">
-                {closed.map((r) => <SigningRow key={r.id} row={r} onOpen={() => router.push(`/past-deeds`)} />)}
+                {closed.map((r) => (
+                  <SigningRow key={r.id} row={r} open={focus === r.id}
+                              onToggle={() => setFocus(focus === r.id ? null : r.id)} />
+                ))}
               </div>
             </>
           )}
@@ -175,37 +315,173 @@ export default function SigningsPage() {
   );
 }
 
-function SigningRow({ row, onOpen }: { row: Row; onOpen: () => void }) {
+/**
+ * FLOW1 item 4 — THE CARD OPENS THE SIGNING.
+ *
+ * It used to `router.push('/past-deeds')`. Every card. So pressing the
+ * row for a signing that has gone quiet took her to a list of deeds with
+ * no indication of which one she had just been looking at — the one
+ * gesture on this page threw away the only context the page had.
+ *
+ * There is no officer-facing route for a single signing (`/deeds/{id}`
+ * and its neighbours all 404 — ledgered as DEEDDETAIL), so the row
+ * EXPANDS rather than navigating: same page, same scroll position, and
+ * the detail comes from `GET /signing-requests/v2/{id}`, which already
+ * returns the participants, their links, whether each has opened theirs,
+ * and every window with who is still outstanding on it.
+ *
+ * `?focus=<id>` makes it linkable, so a notification can point at the
+ * signing it is about rather than at the list.
+ */
+function SigningRow({ row, open, onToggle }: {
+  row: Row;
+  open: boolean;
+  onToggle: () => void;
+}) {
   const stuck = isStuck(row);
   const booked = row.state === 'booked';
+  const age = ageInDays(row.created_at);
+
   return (
-    <button onClick={onOpen}
-            className={`w-full text-left bg-white rounded-xl border p-4 hover:shadow-sm transition-shadow ${
-              stuck ? 'border-amber-300' : 'border-slate-200'
-            }`}>
-      <div className="flex items-start justify-between gap-4">
-        <div className="min-w-0">
-          <p className="font-medium text-slate-900 truncate">
-            {row.property_address || `Deed #${row.deed_id}`}
-          </p>
-          <p className="text-sm text-slate-500 truncate">
-            {row.notary_name || 'No notary named'} · {row.signers} signer{row.signers === 1 ? '' : 's'}
-          </p>
-          {/* The server's sentence, verbatim — this screen never composes
-              its own account of a scheduling state (§13 rule 3). */}
-          <p className="text-sm text-slate-600 mt-2">{row.summary}</p>
+    <div className={`bg-white rounded-xl border ${stuck ? 'border-amber-300' : 'border-slate-200'}`}>
+      <button
+        onClick={onToggle}
+        aria-expanded={open}
+        className="w-full text-left p-4 hover:bg-slate-50 rounded-xl transition-colors"
+      >
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <p className="font-medium text-slate-900 truncate">
+              {row.property_address || `Deed #${row.deed_id}`}
+            </p>
+            <p className="text-sm text-slate-500 truncate">
+              {row.notary_name || 'No notary named'} · {row.signers} signer{row.signers === 1 ? '' : 's'}
+            </p>
+            {/* The server's sentence, verbatim — this screen never composes
+                its own account of a scheduling state (§13 rule 3). */}
+            <p className="text-sm text-slate-600 mt-2">{row.summary}</p>
+            {/* FLOW1 item 4: THE DATES ARE ON THE ROW NOW. The subtitle
+                claimed an order and nothing on screen carried a date to
+                justify it. A booked signing shows when; one being
+                arranged shows how long she has been waiting, which is
+                the fact it actually has. */}
+            <p className="text-xs text-slate-400 mt-1">
+              {booked && row.booked_at
+                ? `Booked for ${new Date(row.booked_at).toLocaleString('en-US', {
+                    month: 'short', day: 'numeric', year: 'numeric',
+                    hour: 'numeric', minute: '2-digit',
+                  })}`
+                : age === null
+                  ? 'Requested — date unknown'
+                  : age === 0
+                    ? 'Requested today'
+                    : `Requested ${age} day${age === 1 ? '' : 's'} ago`}
+            </p>
+          </div>
+          <span className={`shrink-0 inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold ${
+            stuck ? 'bg-amber-100 text-amber-800'
+            : booked ? 'bg-slate-100 text-slate-700'
+            : 'bg-slate-50 text-slate-600'
+          }`}>
+            {stuck ? <AlertCircle className="w-3.5 h-3.5" />
+              : booked ? <CheckCircle2 className="w-3.5 h-3.5" />
+              : <Clock className="w-3.5 h-3.5" />}
+            {stuck ? 'Gone quiet' : STATE_LABEL[row.state] || row.state}
+          </span>
         </div>
-        <span className={`shrink-0 inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold ${
-          stuck ? 'bg-amber-100 text-amber-800'
-          : booked ? 'bg-slate-100 text-slate-700'
-          : 'bg-slate-50 text-slate-600'
-        }`}>
-          {stuck ? <AlertCircle className="w-3.5 h-3.5" />
-            : booked ? <CheckCircle2 className="w-3.5 h-3.5" />
-            : <Clock className="w-3.5 h-3.5" />}
-          {stuck ? 'Gone quiet' : STATE_LABEL[row.state] || row.state}
-        </span>
-      </div>
-    </button>
+      </button>
+      {open && <SigningDetail requestId={row.id} />}
+    </div>
+  );
+}
+
+/** The detail, fetched when she opens it. Read-only: this ticket links
+ * the card to its signing; it does not move the officer's actions here. */
+function SigningDetail({ requestId }: { requestId: number }) {
+  const [detail, setDetail] = useState<Detail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const r = await apiFetch(`/signing-requests/v2/${requestId}`, {},
+                                 { label: 'Loading this signing' });
+        if (!r.ok) {
+          throw new Error((await r.json().catch(() => ({}))).detail || `Failed (${r.status})`);
+        }
+        setDetail(await r.json());
+      } catch (err) {
+        if (err instanceof SessionExpiredError) return;
+        // §4: a detail we could not load says so. An empty panel would
+        // read as "this signing has no participants".
+        setError(err instanceof Error ? err.message : 'Could not load this signing');
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [requestId]);
+
+  return (
+    <div className="border-t border-slate-100 p-4">
+      {loading && (
+        <p className="flex items-center gap-2 text-sm text-slate-500">
+          <Loader2 className="w-4 h-4 animate-spin" /> Loading this signing…
+        </p>
+      )}
+      {error && !loading && (
+        <p className="text-sm text-red-700">{error}</p>
+      )}
+      {detail && !loading && !error && (
+        <div className="space-y-4">
+          <div>
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-2">
+              Who is involved
+            </h3>
+            <ul className="space-y-1.5">
+              {detail.participants.map((p) => (
+                <li key={p.id} className="text-sm text-slate-700 flex flex-wrap gap-x-2">
+                  <span className="font-medium">{p.name || 'Unnamed'}</span>
+                  <span className="text-slate-400">·</span>
+                  <span className="text-slate-500">{p.party_role}</span>
+                  <span className="text-slate-400">·</span>
+                  <span className="text-slate-500">
+                    {p.revoked ? 'Link revoked'
+                      : p.viewed_at ? 'Opened their link'
+                      : 'Has not opened their link'}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-2">
+              Times on the table
+            </h3>
+            {detail.windows.length === 0 ? (
+              <p className="text-sm text-slate-500">No times posted yet.</p>
+            ) : (
+              <ul className="space-y-1.5">
+                {detail.windows.map((w) => (
+                  <li key={w.id} className="text-sm text-slate-700">
+                    {/* window_label() wrote this, in the request's own
+                        timezone. This screen formats no signing time. */}
+                    <span className={w.declined ? 'line-through text-slate-400' : ''}>{w.label}</span>
+                    {w.declined && <span className="ml-2 text-xs text-slate-400">declined</span>}
+                    {!w.declined && w.waiting_on.length > 0 && (
+                      <span className="ml-2 text-xs text-amber-700">
+                        waiting on {w.waiting_on.join(', ')}
+                      </span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
   );
 }

--- a/frontend/src/features/signing/RequestSigningModal.tsx
+++ b/frontend/src/features/signing/RequestSigningModal.tsx
@@ -152,8 +152,12 @@ export function RequestSigningModal({
         {done ? (
           <div className="space-y-4 overflow-y-auto">
             <p className="text-slate-700">
+              {/* FLOW1: "the times she is free" — about a notary the
+                  officer picked out of her rolodex moments ago, whose
+                  pronouns this product has never been told. A name is
+                  not a pronoun. */}
               The request is on the record. <strong>{notary?.name || 'The notary'}</strong> posts
-              the times she is free; your signers pick from them. When they all agree on
+              the times they are free; your signers pick from them. When they all agree on
               one, it books and you are told.
             </p>
             <p className="text-sm text-slate-500">


### PR DESCRIPTION
## Item 3 — the two trackers know about each other

A review lives in `deed_shares`, a signing in `signing_requests`. Shared Deeds read the first, Signings read the second, and neither mentioned the other — zero cross-references in either direction. The page named for sharing showed one of the two things she shares, and *"where is the thing I sent Nora"* had two possible answers and no signpost to either.

Shared Deeds shows **both kinds under a filter**, both by default — "what did I send out on this file" does not come in halves — and each page links to the other.

**The subtitle said "Track deeds shared for approval."** That committed the whole page to reviewer semantics before asking what she had sent. Half of what lands there is a signing request, and a notary is not being asked to approve anything — she is being asked when she is free.

**The two feeds are not flattened into one row shape.** A review has a viewing and a decision; a signing has a notary, a set of times and a state. Sharing columns between them would put two different facts under one heading, which is exactly what item 0 spent a PR on. They travel as themselves, with a badge, and the cells a signing cannot fill say `—` rather than borrowing a review's vocabulary.

**A failed signings fetch gets its own banner.** Throwing would blank a table of reviews that loaded fine; swallowing would show her no signings and no reason to doubt it. §4 read in both directions — an error swallowing correct data is as dishonest as a success swallowing an error.

## Item 4 — "soonest first" was half true, which is the bad half

The server orders by `COALESCE(booked_at, expires_at)`: a signing's time for booked rows, and **when the link dies** for everything else. Two orthogonal facts sharing one sort key, described to the officer as a schedule — T-5's ruling one layer up. And nothing on screen carried a date to check it against.

Booked and being-arranged are separated now, each sorted by the fact it actually has: booked by *when*, being-arranged by *how long she has waited*, oldest first, because the longest-waiting is the one worth a phone call. The dates are on the rows.

## Item 4 — the card opens the signing

Every card used to `router.push('/past-deeds')` — the one gesture on the page discarded the only context the page had. There is no officer route for a single signing (ledgered as DEEDDETAIL), so the row **expands**: same page, same scroll, detail from `GET /signing-requests/v2/{id}` — participants, whether each has opened their link, every window and who is still outstanding on it. `?focus=<id>` makes it linkable, so a notification can point at the signing it is about.

## Item 4 — the age is read, not reconstructed

The stuck signal computed `expires_at − 21 days`, and `21` is `default_expiry()`'s constant retyped into TypeScript as a bare number. **Changing the server default would have silently re-aimed every stuck badge and nothing would have failed** — item 0's defect in a second habitat. The agenda sends `created_at` now. An unknown creation time is `null`, not `0`: zero reads as "asked today", which is a claim.

## A name is not a pronoun — §11.1, new

`share_signing_request` told a notary, in a live email:

> "Picking a time tells **{owner_name}** you are available then; **she** confirms the appointment with the signers **herself**."

A real escrow officer's pronouns, asserted to her own professional contact, on no information — twice, once in HTML and once in plain text. `RequestSigningModal` did the same about a notary the officer had picked out of her rolodex moments earlier.

Swept fail-closed across every email template and every Jinja file. Ruled the same family as the **"filed as"** constraint: one infers what someone *is*, the other what they *may do*, and both put a claim in the record nobody made.

**Two habitats keep gendered wording and must.** The Civil Code §1189 all-purpose acknowledgement — *"acknowledged to me that he/she/they executed the same in his/her/their authorized capacity"* — is prescribed certificate wording signed under penalty of perjury, and it names nobody: it says "person(s)". Rewriting it would be a legal choice auto-applied (§1) to the one kind of text §2 says we never pre-fill. Vesting terms of art ("a married man as his sole and separate property") are a characterization the officer selects and the recorder expects.

The rule as ruled is *pronouns referring to a **named party***, and neither of these names one. Both are exempted with a **cited** statutory reason, plus a test that each exemption still exists *and still contains the statutory text* — an exemption for a file that has since changed is not an exemption.

## Item 0's pin retargeted, with its justification in the docstring

"Rows come from the share fetch and nothing else" forbade the second feed. The property was never "one fetch" — it was **every row is a thing that was actually sent to somebody**. A share was sent; a signing request was sent; a completed deed sitting in her list was not.

The deeds-list prohibition is now stated **by name** rather than implied by a fetch count, and the allowed feeds are enumerated so a third would have to be written down. The retarget carries a block comment explaining what it said, why, what changed, and why this is a retarget and not a loosening — a pin loosening a pin one day later has to justify itself where the next reader will find it.

## Gates

| Gate | Result |
|---|---|
| pytest (no DB) | 840 passed, 156 skipped |
| pytest (with DB) | 996 passed |
| jest | 693 passed, 46 suites |
| tsc baseline | **94** (unchanged) |
| six-flow baseline | ✔ |
| API baseline | ✔ |
| banned-claims | clean |
| `next build` | ✔ |

**`next build` caught what jest and tsc did not.** `useSearchParams()` opts a page out of static prerendering unless it sits under a `<Suspense>` boundary, and Next fails the *build* rather than the render — both other gates were green while the deploy would have failed. Same boundary the admin and success pages already use.

**Probed:** reintroducing a pronoun into a template fails the sweep and names the line.

## Remaining

**Item 6 is blocked on your side** — retiring NOTARY1's write path was ruled "after confirming a zero migration count", from `migrate_notary1_signings.py --dry-run` against production. **Item 7 (dispatch, ~4d)** is next.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_