### PR TITLE
FLOW1 item 7: dispatch — the officer proposes, the notary accepts, and the record says who spoke

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -408,6 +408,37 @@ def create_tables():
                 asserted_at TIMESTAMPTZ NOT NULL DEFAULT now(),
                 UNIQUE (window_id, participant_id)
             )""",
+            # ── FLOW1 item 7 (DISPATCH): WHO SAID SO ──────────────────
+            #
+            # `signing_responses` records that a participant answered.
+            # Dispatch needs to record that the OFFICER answered ON THEIR
+            # BEHALF — she rang her signers, they said Tuesday works, and
+            # she is putting that on the record so the notary's
+            # acceptance is the last answer needed.
+            #
+            # WITHOUT THIS COLUMN THE ROW WOULD LIE. A response row with
+            # no asserter says "this signer answered", and in dispatch
+            # that is false: the officer answered. This is exactly the
+            # distinction `booked_by` and RED-S4's
+            # `recording_asserted_by` exist to preserve, one level down —
+            # the same argument, applied to the answers a booking is
+            # built from rather than to the booking.
+            #
+            # DEFAULT 'participant' because every row that exists today
+            # was written by the person it is about, and a backfill that
+            # guessed otherwise would be inventing provenance.
+            #
+            # The trio is complete: `answer` (the value), `asserted_by`
+            # (who), `asserted_at` (when).
+            "ALTER TABLE signing_responses ADD COLUMN IF NOT EXISTS "
+            "asserted_by VARCHAR(16) NOT NULL DEFAULT 'participant'",
+            # A window the OFFICER proposed was not proposed by any
+            # participant, and `proposed_by` used to be NOT NULL — so the
+            # #156 migration pointed officer-origin windows at the NOTARY,
+            # which reads as the notary having offered a time she has not
+            # seen. `origin` carried the truth and this column contradicted
+            # it. NULL now means "not a participant — read `origin`".
+            "ALTER TABLE signing_windows ALTER COLUMN proposed_by DROP NOT NULL",
             "CREATE INDEX IF NOT EXISTS idx_signing_requests_deed ON signing_requests(deed_id)",
             "CREATE INDEX IF NOT EXISTS idx_signing_requests_officer ON signing_requests(officer_user_id, created_at DESC)",
             "CREATE INDEX IF NOT EXISTS idx_signing_participants_request ON signing_participants(signing_request_id)",

--- a/backend/routers/sharing.py
+++ b/backend/routers/sharing.py
@@ -1297,7 +1297,9 @@ def _tell_the_officer(row: dict, window: dict, asserted_by: str) -> None:
         window,
         summary=f"Notary signing — {address}",
         location=address or None,
-        description=(f"{notary} said she is available at this time. "
+        # §11.1: a name is not a pronoun. This calendar file went into
+        # the officer's own diary asserting the notary's pronouns.
+        description=(f"{notary} said they are available at this time. "
                      "DeedPro has not contacted the signers."),
         uid=f"share-{row.get('id')}-scheduled@deedpro",
     )

--- a/backend/routers/signing.py
+++ b/backend/routers/signing.py
@@ -57,6 +57,18 @@ class SignerIn(BaseModel):
     phone: Optional[str] = None
 
 
+class ProposedTime(BaseModel):
+    """FLOW1 item 7 — the time the OFFICER is proposing (dispatch).
+
+    Both ends carry a UTC offset, same as every other time in this
+    feature: a bare wall-clock time makes the server guess a zone, which
+    is how a calendar entry lands an hour out and somebody arrives at an
+    empty office.
+    """
+    start: str
+    end: str
+
+
 class CreateSigningRequest(BaseModel):
     deed_id: int
     notary_email: str
@@ -69,6 +81,25 @@ class CreateSigningRequest(BaseModel):
     # involved reads the clock on the wall where they are going.
     tz_name: str = "America/Los_Angeles"
     expires_in_days: int = 21
+    # ── DISPATCH ──────────────────────────────────────────────────────
+    #
+    # Present  → the officer has a time and has already spoken to her
+    #            signers. The notary is asked to ACCEPT an assignment.
+    # Absent   → the availability loop, unchanged: the notary posts times
+    #            and the signers pick.
+    #
+    # This is a FIELD rather than a mode flag because the presence of a
+    # time IS the difference. A `mode: "dispatch" | "negotiate"` selector
+    # would make her classify her own intent for the database's benefit
+    # before acting on it — the same objection that kept `share_kind` off
+    # the share modals.
+    proposed_time: Optional[ProposedTime] = None
+    # Dispatch only. She is asserting that she already has her signers'
+    # agreement; the product records WHO said so rather than pretending
+    # the signers answered it. Defaults to False so that a client which
+    # sends a time without thinking about this gets a window the signers
+    # must still answer — the safe half of the fork.
+    signers_already_agreed: bool = False
 
 
 class WindowIn(BaseModel):
@@ -189,6 +220,27 @@ def create_signing_request(payload: CreateSigningRequest,
                             detail="At most six signers on one request")
 
     expires = datetime.now(timezone.utc) + timedelta(days=max(1, min(90, payload.expires_in_days)))
+
+    # Parsed BEFORE anything is written. A time we would refuse must not
+    # leave a half-made request behind, and `parse_windows` refuses a
+    # naive time outright rather than assuming a zone.
+    dispatch_window = None
+    if payload.proposed_time is not None:
+        try:
+            dispatch_window = loop.parse_windows(
+                [{"start": payload.proposed_time.start,
+                  "end": payload.proposed_time.end}])[0]
+        except loop.SigningLoopError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+    elif payload.signers_already_agreed:
+        # An assertion about a time, with no time. Refused rather than
+        # ignored: silently dropping it would record nothing and tell her
+        # nothing, and she would believe her signers were on the record.
+        raise HTTPException(
+            status_code=400,
+            detail="You can only record the signers' agreement alongside a "
+                   "proposed time")
+
     try:
         with db.conn.cursor() as cur:
             cur.execute(
@@ -215,6 +267,40 @@ def create_signing_request(payload: CreateSigningRequest,
                     (request_id, role, name, company, email, phone,
                      partner_id, token, expires))
                 tokens[cur.fetchone()["id"]] = (role, token, name, email)
+
+            # ── DISPATCH: the officer's time, and who agreed to it ─────
+            if dispatch_window is not None:
+                cur.execute(
+                    """INSERT INTO signing_windows
+                           (signing_request_id, starts_at, ends_at, origin,
+                            proposed_by)
+                       VALUES (%s, %s, %s, %s, NULL) RETURNING id""",
+                    (request_id, dispatch_window["starts_at"],
+                     dispatch_window["ends_at"], loop.ORIGIN_OFFICER))
+                window_id = cur.fetchone()["id"]
+                # `proposed_by` is NULL because the officer is not a
+                # participant. #156's migration pointed officer windows at
+                # the NOTARY, which reads as her having offered a time she
+                # has never seen; `origin` carried the truth and the column
+                # contradicted it.
+
+                if payload.signers_already_agreed:
+                    # THE ROW SAYS WHO SPOKE. She rang them; they said
+                    # this works; she is putting that on the record so the
+                    # notary's acceptance is the last answer needed. It is
+                    # written as HER assertion, not as theirs — which is
+                    # the entire reason `asserted_by` exists.
+                    for pid, (role, _t, _n, _e) in tokens.items():
+                        if role != loop.ROLE_SIGNER:
+                            continue
+                        cur.execute(
+                            """INSERT INTO signing_responses
+                                   (window_id, participant_id, answer, asserted_by)
+                               VALUES (%s, %s, %s, %s)""",
+                            (window_id, pid, loop.ANSWER_AVAILABLE,
+                             loop.ASSERTED_BY_OFFICER))
+                # The NOTARY gets no such row. She has not been asked yet,
+                # and an assignment nobody has accepted is not a booking.
         db.conn.commit()
     except HTTPException:
         raise
@@ -228,10 +314,14 @@ def create_signing_request(payload: CreateSigningRequest,
         # link to a row that does not exist.
         raise HTTPException(status_code=500, detail="Could not create the signing request")
 
-    # Ask the notary. The SIGNERS are not emailed yet — there is nothing
-    # for them to answer until she posts times, and "pick a time" with no
-    # times is asking a consumer to do nothing.
-    _invite_notary(request_id)
+    # Ask the notary. The SIGNERS are not emailed yet — in EITHER flow,
+    # and for the same reason each time: there is nothing for them to do.
+    # Under negotiation there are no times to pick from; under dispatch
+    # the time is not settled until the notary accepts, and telling a
+    # consumer their signing is at 10am on Tuesday before anybody has
+    # agreed to attend is §13's error committed by email. They are told
+    # when it books.
+    _invite_notary(request_id, dispatched=dispatch_window is not None)
 
     return {
         "success": True,
@@ -242,11 +332,9 @@ def create_signing_request(payload: CreateSigningRequest,
              "link": f"{APP_URL()}/signing/{token}"}
             for pid, (role, token, name, _email) in tokens.items()
         ],
-        # The notary is asked first: she posts availability, and the
-        # signers are invited once there is something to answer. Emailing
-        # a consumer "pick a time" before any time exists would be asking
-        # them to do nothing.
-        "next": "the notary posts her availability",
+        "next": ("the notary accepts or declines the time you proposed"
+                 if dispatch_window is not None
+                 else "the notary posts the times they are free"),
     }
 
 
@@ -666,16 +754,40 @@ def signer_propose(token: str, payload: ProposeIn, http_request: Request):
 
 @router.post("/signing/{token}/decline/{window_id}")
 def notary_decline(token: str, window_id: int, http_request: Request):
-    """The notary declines a signer's proposal. Notary-only."""
+    """The notary declines a time somebody else proposed. Notary-only.
+
+    FLOW1 item 7 widened this from signer proposals to OFFICER windows
+    too, and the fallback it opens is the point of the whole design.
+
+    A declined assignment leaves a request with no live window — which is
+    exactly the state a fresh request is in. So `request_state` returns
+    to `requested`, the label goes back to "waiting on the notary to post
+    the times they are free", and `POST /signing/{token}/windows` works
+    unchanged. Dispatch failing degrades into the negotiation loop that
+    was already built, at the cost of no new code, which is why the
+    fallback was estimated at nearly free.
+
+    HER OWN WINDOWS STAY OUT OF IT. Declining a time she posted herself
+    would be a retraction, not a refusal, and it has a different meaning
+    and a different audience.
+    """
     me = _participant_by_token(token, http_request)
     if me["party_role"] != loop.ROLE_NOTARY:
         raise HTTPException(status_code=403, detail="Only the notary declines a proposal")
     with db.conn.cursor() as cur:
         cur.execute("""UPDATE signing_windows SET declined_at = now()
                         WHERE id = %s AND signing_request_id = %s
-                          AND origin = %s AND declined_at IS NULL""",
-                    (window_id, me["signing_request_id"], loop.ORIGIN_SIGNER_PROPOSAL))
+                          AND origin = ANY(%s) AND declined_at IS NULL
+                    RETURNING origin""",
+                    (window_id, me["signing_request_id"],
+                     [loop.ORIGIN_SIGNER_PROPOSAL, loop.ORIGIN_OFFICER]))
+        declined = cur.fetchone()
     db.conn.commit()
+    if declined and declined["origin"] == loop.ORIGIN_OFFICER:
+        # She proposed it; she is the one who needs to know it is off.
+        # Best-effort, like every other notification here: a decline that
+        # happened must not be undone because a mail server was slow.
+        _tell_officer_dispatch_declined(me["signing_request_id"])
     return token_view(token, http_request)
 
 
@@ -767,13 +879,25 @@ def _officer_bits(world: Dict[str, Any]):
     return officer.get("full_name") or "Your escrow officer", officer.get("company_name")
 
 
-def _invite_notary(request_id: int) -> None:
+def _invite_notary(request_id: int, dispatched: bool = False) -> None:
+    """Ask the notary — and ask the right question.
+
+    DISPATCH AND NEGOTIATION ARE DIFFERENT QUESTIONS, so they are
+    different emails rather than one email with a conditional clause.
+    "When are you free?" and "can you take this, at this time, at this
+    address?" want different answers and different buttons, and a
+    professional deciding whether to accept an assignment should not have
+    to work out which one she has been sent.
+    """
     try:
         world = _load(request_id)
         notary = next(iter(_party(world, loop.ROLE_NOTARY)), None)
         if not notary or not notary.get("email"):
             return
         name, company = _officer_bits(world)
+        if dispatched:
+            _dispatch_notary(world, notary, name, company)
+            return
         from utils.notifications import send_notary_invited
         ok, reason = send_notary_invited(
             recipient_email=notary["email"],
@@ -789,6 +913,66 @@ def _invite_notary(request_id: int) -> None:
             print(f"[NOTARY2] ⚠️ notary invite not sent: {reason}")
     except Exception as e:
         print(f"[NOTARY2] ⚠️ notary invite failed (non-blocking): {e}")
+
+
+def _dispatch_notary(world, notary, officer_name, officer_company) -> None:
+    """The assignment email: one time, a place, accept or decline."""
+    from utils.notifications import send_notary_dispatched
+
+    window = next((w for w in world["windows"]
+                   if w.get("origin") == loop.ORIGIN_OFFICER
+                   and not w.get("declined_at")), None)
+    if window is None:
+        return
+    ok, reason = send_notary_dispatched(
+        recipient_email=notary["email"],
+        notary_name=notary.get("display_name") or "",
+        officer_name=officer_name, officer_company=officer_company,
+        deed_type=world["deed"].get("deed_type") or "deed",
+        property_address=world["deed"].get("property_address"),
+        county=world["deed"].get("county"),
+        # window_label() writes every time this product shows. A template
+        # that formatted its own would be a second place for the wording
+        # to drift, and the .ics bug proved how that ends.
+        when_text=loop.window_label(window, world["request"].get("tz_name")),
+        location=world["request"].get("location"),
+        link=_link(notary),
+        expires_at=_fmt_day(world["request"].get("expires_at")),
+    )
+    if not ok:
+        print(f"[NOTARY2] ⚠️ dispatch not sent: {reason}")
+
+
+def _tell_officer_dispatch_declined(request_id: int) -> None:
+    """The notary said no to the time. Tell the officer, in app.
+
+    An in-app notification rather than a nineteenth email template: she
+    is a logged-in user with a notifications surface, the request is
+    already on her agenda, and the state there tells the rest of the
+    story. §4's rule is that the event must be visible, not that it must
+    arrive by post.
+    """
+    try:
+        world = _load(request_id)
+        notary = next(iter(_party(world, loop.ROLE_NOTARY)), None)
+        who = (notary or {}).get("display_name") or "The notary"
+        from utils.notifications import create_notification
+        create_notification(
+            db.conn,
+            user_id=world["request"]["officer_user_id"],
+            ntype="signing_dispatch_declined",
+            title="A notary declined the time you proposed",
+            message=(f"{who} cannot make the time you proposed for "
+                     f"{world['deed'].get('property_address') or 'your deed'}. "
+                     "They can post the times they are free instead."),
+            link=f"/signings?focus={request_id}",
+        )
+    except Exception as e:
+        try:
+            db.conn.rollback()
+        except Exception:
+            pass
+        print(f"[NOTARY2] ⚠️ decline notice failed (non-blocking): {e}")
 
 
 def _tell_signers_windows_posted(request_id: int) -> None:

--- a/backend/services/signing_loop.py
+++ b/backend/services/signing_loop.py
@@ -62,6 +62,48 @@ BOOKED_BY_CONVERGENCE = "convergence"
 BOOKED_BY_OFFICER = "officer"
 BOOKERS = (BOOKED_BY_CONVERGENCE, BOOKED_BY_OFFICER)
 
+# ── DISPATCH (FLOW1 item 7): who actually said it ────────────────────
+#
+# A response row used to mean one thing: this participant answered. In
+# dispatch the officer answers on her signers' behalf — she rang them,
+# they said Tuesday, and she is putting that on the record so the
+# notary's acceptance is the last answer needed.
+#
+# Without this distinction the row would CLAIM A SIGNER SPOKE when the
+# officer did. That is the same error `booked_by` exists to prevent, one
+# level down: applied to the answers a booking is built from rather than
+# to the booking itself.
+ASSERTED_BY_PARTICIPANT = "participant"
+ASSERTED_BY_OFFICER = "officer"
+ASSERTERS = (ASSERTED_BY_PARTICIPANT, ASSERTED_BY_OFFICER)
+
+
+def asserted_by(response: Dict[str, Any]) -> str:
+    """Read the asserter, defaulting to the participant.
+
+    A row written before this column existed was written by the person it
+    is about, so the default is a fact rather than a guess — and reading
+    it through one function means no call site has to remember that.
+    """
+    return response.get("asserted_by") or ASSERTED_BY_PARTICIPANT
+
+
+def rests_on_an_officer_assertion(responses: Sequence[Dict[str, Any]],
+                                  window_id: int) -> bool:
+    """Did any counted `available` on this window come from the officer?
+
+    THE SURFACES NEED THIS AND SO DOES THE COPY. A window everybody
+    personally agreed to and a window the officer vouched for are both
+    booked, and they are not the same claim — so nothing may describe
+    the second as "everyone agreed".
+    """
+    return any(
+        int(r["window_id"]) == int(window_id)
+        and r.get("answer") == ANSWER_AVAILABLE
+        and asserted_by(r) == ASSERTED_BY_OFFICER
+        for r in responses
+    )
+
 # Owner ruling: three, AGGREGATE across the request. Not per signer —
 # two signers alternating twice each is six emails and the same deadlock
 # a cap exists to prevent.
@@ -129,6 +171,14 @@ def converged_window_id(participants: Sequence[Dict[str, Any]],
     hold the others hostage — and a request with no signers cannot
     converge on the notary alone, because a signing with nobody to sign
     is not an arrangement anybody made.
+
+    DISPATCH (FLOW1 item 7) DOES NOT CHANGE THAT RULE. An officer-
+    asserted signer row counts, because it is an answer on the record —
+    the officer rang them and is saying so. What it does NOT do is
+    disappear: `asserted_by` travels with it, every surface can say who
+    spoke, and `state_label` refuses to call such a booking "everyone
+    agreed". The count is the same question; the provenance is a
+    different one, and conflating them is what this column prevents.
 
     Earliest wins when two windows qualify. Not "the most recently
     answered": if three people are free at two times, the sooner one is
@@ -201,19 +251,85 @@ def state_label(request: Dict[str, Any], windows: Sequence[Dict[str, Any]],
         when = _fmt_instant(request.get("booked_at"), request.get("tz_name"))
         if request.get("booked_by") == BOOKED_BY_OFFICER:
             return f"You recorded a signing time of {when}"
+        # DISPATCH, and this branch is the reason `asserted_by` exists.
+        #
+        # "Everyone agreed" is a claim about who spoke. When the officer
+        # recorded her signers' agreement and the notary accepted, the
+        # booking is real and that sentence is not: the signers did not
+        # answer this product, she did. So the sentence says what
+        # actually happened, and the fact that it CAN say it is the whole
+        # of the column's justification.
+        booked_window = _booked_window_id(request, windows, responses)
+        if booked_window is not None and rests_on_an_officer_assertion(
+                responses, booked_window):
+            notary = next((p for p in participants
+                           if p.get("party_role") == ROLE_NOTARY), None)
+            who = (notary or {}).get("display_name") or "the notary"
+            return (f"Booked for {when} — you recorded the signers' "
+                    f"agreement and {who} accepted")
         return f"Everyone agreed on {when}"
     if state == STATE_REQUESTED:
         notary = next((p for p in participants
                        if p.get("party_role") == ROLE_NOTARY), None)
         who = (notary or {}).get("display_name") or "The notary"
-        return f"Waiting on {who} to post the times she is free"
+        # §11.1: a name is not a pronoun. This said "the times SHE is
+        # free" about a notary whose pronouns nobody has told us — the
+        # same defect FLOW1 swept out of the email templates, surviving
+        # in the one function that writes every surface's sentence
+        # because that sweep read utils/ and templates/ and not services/.
+        return f"Waiting on {who} to post the times they are free"
     live = [w for w in windows if not w.get("declined_at")]
+
+    # DISPATCH, before the notary has answered. Without this branch the
+    # officer's agenda would read "1 times offered — waiting on 1 more
+    # person" about a request where she chose the time, told her signers,
+    # and is waiting on one specific professional to accept. True, and
+    # useless, and it describes her own dispatch back to her as though
+    # somebody else had offered it.
+    dispatch = next((w for w in live
+                     if w.get("origin") == ORIGIN_OFFICER
+                     and rests_on_an_officer_assertion(responses, int(w["id"]))),
+                    None)
+    if dispatch is not None:
+        notary = next((p for p in participants
+                       if p.get("party_role") == ROLE_NOTARY), None)
+        notary_id = int(notary["id"]) if notary else None
+        accepted = any(
+            int(r["window_id"]) == int(dispatch["id"])
+            and notary_id is not None and int(r["participant_id"]) == notary_id
+            and r.get("answer") == ANSWER_AVAILABLE
+            for r in responses)
+        if not accepted:
+            who = (notary or {}).get("display_name") or "the notary"
+            when = _fmt_instant(dispatch.get("starts_at"), request.get("tz_name"))
+            return f"You proposed {when} — waiting on {who} to accept"
+
     if state == STATE_PARTIALLY_AGREED:
         pending = _pending_count(participants, live, responses)
         if pending == 1:
             return f"{len(live)} times offered — waiting on 1 more person"
         return f"{len(live)} times offered — waiting on {pending} more people"
     return f"{len(live)} times offered — nobody has answered yet"
+
+
+def _booked_window_id(request: Dict[str, Any],
+                      windows: Sequence[Dict[str, Any]],
+                      responses: Sequence[Dict[str, Any]]) -> Optional[int]:
+    """Which window a booked request settled on.
+
+    `signing_requests` records WHEN it booked, not WHICH — the window is
+    recoverable because a booked request has exactly one window whose
+    start matches `booked_at`. Kept as a lookup rather than a new column
+    on purpose: a second place to write the same fact is a second place
+    for it to disagree with itself.
+    """
+    booked_at = request.get("booked_at")
+    if not booked_at:
+        return None
+    for w in windows:
+        if w.get("starts_at") == booked_at:
+            return int(w["id"])
+    return None
 
 
 def _pending_count(participants: Sequence[Dict[str, Any]],

--- a/backend/services/signing_surfaces.py
+++ b/backend/services/signing_surfaces.py
@@ -110,7 +110,18 @@ def signer_package(*, request: Dict[str, Any], me: Dict[str, Any],
     tz = request.get("tz_name")
     notary = next((p for p in participants
                    if p.get("party_role") == loop.ROLE_NOTARY), {})
-    mine = {int(r["window_id"]): r["answer"] for r in responses
+    # FLOW1 item 7: AN ANSWER CARRIES WHO GAVE IT.
+    #
+    # Under dispatch the officer answers on her signers' behalf. A
+    # consumer opening their link and seeing themselves marked available
+    # on a time they never answered would be this product telling them
+    # they said something they did not say — to the one audience with no
+    # account, no history and no way to check. So the answer travels as
+    # {answer, asserted_by} rather than as a bare string, in both places
+    # it appears.
+    mine = {int(r["window_id"]): {"answer": r["answer"],
+                                  "asserted_by": loop.asserted_by(r)}
+            for r in responses
             if int(r["participant_id"]) == int(me["id"])}
     live = [w for w in windows if not w.get("declined_at")]
     used = int(request.get("signer_proposals") or 0)
@@ -150,7 +161,9 @@ def notary_package(*, request: Dict[str, Any], me: Dict[str, Any],
     names and the package. She does not get signer contact details —
     she has no reason to reach them directly and the officer does."""
     tz = request.get("tz_name")
-    mine = {int(r["window_id"]): r["answer"] for r in responses
+    mine = {int(r["window_id"]): {"answer": r["answer"],
+                                  "asserted_by": loop.asserted_by(r)}
+            for r in responses
             if int(r["participant_id"]) == int(me["id"])}
     package = {
         "party_role": loop.ROLE_NOTARY,

--- a/backend/tests/test_admin3_email_outcomes.py
+++ b/backend/tests/test_admin3_email_outcomes.py
@@ -77,7 +77,11 @@ def test_every_template_routes_through_send():
     DOWNWARD for the first time when FLOW1 item 6 retired NOTARY1's write
     path and `share_signing_request` lost its only caller (19 -> 18). A
     trip-wire that only counts upward would let a deletion pass
-    unremarked, which is the same silence it exists to break."""
+    unremarked, which is the same silence it exists to break. Back to 19
+    with FLOW1 item 7's `notary_dispatched` — a second notary email
+    because dispatch asks a different question than availability does,
+    and one template with a conditional clause would have made the
+    subject line lie about one of the two cases."""
     import sys
     sys.path.insert(0, str(BACKEND))
     from utils.notifications import TEMPLATES
@@ -88,7 +92,7 @@ def test_every_template_routes_through_send():
         f"declared TEMPLATES and actual _send labels disagree: "
         f"only-declared={set(TEMPLATES) - named}, only-used={named - set(TEMPLATES)}"
     )
-    assert len(TEMPLATES) == 18
+    assert len(TEMPLATES) == 19
 
 
 # ── The recorder's two constraints ───────────────────────────────────

--- a/backend/tests/test_flow1_copy_and_agenda.py
+++ b/backend/tests/test_flow1_copy_and_agenda.py
@@ -65,6 +65,15 @@ PRONOUNS = re.compile(r"\b(she|her|hers|herself|he|him|his|himself)\b", re.I)
 
 # path (relative to repo root) -> why it may keep gendered wording.
 PRONOUN_EXEMPT = {
+    "backend/services/vesting_split.py": (
+        "A REGEX that MATCHES recorded vesting language — "
+        "'AS (HIS|HER|THEIR) SOLE AND SEPARATE PROPERTY'. Matching text "
+        "somebody else wrote onto a recorded instrument is not writing "
+        "text about a person. §11 governs it: the characterization is a "
+        "legal term of art the officer selects and the recorder expects, "
+        "and narrowing the pattern would make the splitter stop "
+        "recognising real title. Nothing here is rendered to anybody."
+    ),
     "backend/templates/grant_deed_template.html": (
         "The California all-purpose acknowledgement, Civil Code §1189. "
         "'he/she/they' and 'his/her/their' are the prescribed wording of a "
@@ -106,10 +115,21 @@ def test_no_template_asserts_a_pronoun_for_a_named_party():
     """
     offenders = []
 
-    for path in sorted((BACKEND / "utils").glob("*.py")):
-        for lineno, line in _rendered_lines(path):
-            if PRONOUNS.search(line):
-                offenders.append(f"{path.relative_to(REPO)}:{lineno}: {line.strip()[:90]}")
+    # FLOW1 item 7 WIDENED THIS, because the first version missed a live
+    # one. It read `utils/` and `templates/` — where the email copy is —
+    # and `services/signing_loop.state_label()` kept "waiting on {who} to
+    # post the times SHE is free". That function is the ONE place a
+    # scheduling state becomes a sentence for every surface in the
+    # product, so it is the last file that should have been outside a
+    # copy sweep. Habitats are now every directory that can emit prose.
+    for folder in ("utils", "services", "routers"):
+        for path in sorted((BACKEND / folder).glob("*.py")):
+            if str(path.relative_to(REPO)) in PRONOUN_EXEMPT:
+                continue
+            for lineno, line in _rendered_lines(path):
+                if PRONOUNS.search(line):
+                    offenders.append(
+                        f"{path.relative_to(REPO)}:{lineno}: {line.strip()[:90]}")
 
     for path in sorted((BACKEND / "templates").rglob("*")):
         if not path.is_file():

--- a/backend/tests/test_flow1_dispatch.py
+++ b/backend/tests/test_flow1_dispatch.py
@@ -1,0 +1,445 @@
+"""FLOW1 item 7 — DISPATCH: the officer proposes, the notary accepts.
+
+═══ THE MODEL, AND WHY IT IS THE PRIMARY ONE ═══
+
+Owner research into escrow practice: the officer knows when the documents
+are ready, schedules with the signers directly — usually by phone — and
+then dispatches a notary for that time, who accepts or declines. The
+notary is a contractor receiving an assignment.
+
+NOTARY2's loop inverts that: the notary posts availability, the signers
+converge, it books. That is the right model for FINDING a time among
+people with no prior contact. It is the wrong one for the ordinary case,
+where she already has her clients on the phone and needs somebody to show
+up.
+
+§13.1 IS UNTOUCHED AND THIS IS WORTH BEING PRECISE ABOUT. Its argument
+was that routing AROUND the signers recreated phone tag. Dispatch does
+not route around them — the officer talks to them FIRST, which is the leg
+she was always going to do herself. What changes is who proposes the
+time, not who is included.
+
+═══ THE ONE GAP, AND THE ONE COLUMN THAT CLOSES IT ═══
+
+`converged_window_id` requires the notary AND every live signer to have
+answered `available`. Under dispatch the signers never answer this
+product — the officer already spoke to them — so convergence could never
+fire and the request would sit in `partially_agreed` forever while
+everyone involved believed it was booked.
+
+`signing_responses.asserted_by` closes it. An officer-asserted signer row
+COUNTS toward convergence, because it is an answer on the record. What it
+does not do is disappear: the asserter travels with the row, every
+surface can say who spoke, and `state_label` refuses to call such a
+booking "everyone agreed".
+
+WITHOUT THE COLUMN THE ROW WOULD LIE — it would say a signer answered
+when the officer did. That is exactly the distinction `booked_by` and
+RED-S4's `recording_asserted_by` exist to preserve, one level down: the
+same argument applied to the answers a booking is built from rather than
+to the booking itself.
+
+═══ THE FALLBACK IS NEARLY FREE, AND THAT IS NOT A COINCIDENCE ═══
+
+A declined assignment leaves a request with no live window — which is
+exactly the state a fresh request is in. So the state returns to
+`requested`, the label goes back to "waiting on the notary to post the
+times they are free", and the availability loop resumes unchanged.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from services import signing_loop as loop
+from tests.source_text import code_only
+
+BACKEND = Path(__file__).resolve().parents[1]
+
+dbonly = pytest.mark.skipif(not os.getenv("DATABASE_URL"), reason="needs a database")
+
+
+# ══════════════════════════════════════════════════════════════════════
+# The vocabulary and the convergence rule — no database needed
+# ══════════════════════════════════════════════════════════════════════
+
+def test_an_answer_with_no_asserter_is_the_participants_own():
+    """Every row written before this column existed was written by the
+    person it is about, so the default is a fact rather than a guess."""
+    assert loop.asserted_by({}) == loop.ASSERTED_BY_PARTICIPANT
+    assert loop.asserted_by({"asserted_by": None}) == loop.ASSERTED_BY_PARTICIPANT
+    assert loop.asserted_by({"asserted_by": "officer"}) == loop.ASSERTED_BY_OFFICER
+
+
+def _world(asserter: str):
+    """A notary, one signer, one officer window, both said available."""
+    participants = [{"id": 1, "party_role": loop.ROLE_NOTARY},
+                    {"id": 2, "party_role": loop.ROLE_SIGNER,
+                     "display_name": "Sam"}]
+    windows = [{"id": 10, "starts_at": datetime(2026, 9, 1, 17, tzinfo=timezone.utc),
+                "ends_at": datetime(2026, 9, 1, 18, tzinfo=timezone.utc),
+                "origin": loop.ORIGIN_OFFICER}]
+    responses = [
+        {"window_id": 10, "participant_id": 2, "answer": loop.ANSWER_AVAILABLE,
+         "asserted_by": asserter},
+        {"window_id": 10, "participant_id": 1, "answer": loop.ANSWER_AVAILABLE,
+         "asserted_by": loop.ASSERTED_BY_PARTICIPANT},
+    ]
+    return participants, windows, responses
+
+
+def test_an_officer_asserted_answer_counts_toward_convergence():
+    """It is an answer on the record. She rang them and is saying so."""
+    participants, windows, responses = _world(loop.ASSERTED_BY_OFFICER)
+    assert loop.converged_window_id(participants, windows, responses) == 10
+
+
+def test_convergence_still_needs_the_notary_to_have_accepted():
+    """Dispatch does not let the officer book on her own say-so. That is
+    what the override is for, and the override records itself as hers."""
+    participants, windows, responses = _world(loop.ASSERTED_BY_OFFICER)
+    without_notary = [r for r in responses if r["participant_id"] != 1]
+    assert loop.converged_window_id(participants, windows, without_notary) is None
+
+
+def test_the_booking_sentence_refuses_to_say_everyone_agreed():
+    """THE POINT OF THE COLUMN, as a sentence.
+
+    A window everybody personally agreed to and a window the officer
+    vouched for are both booked, and they are not the same claim.
+    """
+    participants, windows, responses = _world(loop.ASSERTED_BY_OFFICER)
+    participants[0]["display_name"] = "Nora"
+    request = {"booked_at": windows[0]["starts_at"],
+               "booked_by": loop.BOOKED_BY_CONVERGENCE,
+               "tz_name": "America/Los_Angeles"}
+    label = loop.state_label(request, windows, responses, participants)
+    assert "everyone agreed" not in label.lower()
+    assert "you recorded the signers' agreement" in label.lower()
+    assert "nora" in label.lower()
+
+    # And when they really did all answer, it says so.
+    participants2, windows2, responses2 = _world(loop.ASSERTED_BY_PARTICIPANT)
+    label2 = loop.state_label(request, windows2, responses2, participants2)
+    assert "everyone agreed" in label2.lower()
+
+
+def test_a_dispatch_awaiting_acceptance_says_so():
+    """Without this branch the officer's own agenda would describe her
+    dispatch back to her as "1 times offered — waiting on 1 more person",
+    which is true and useless."""
+    participants, windows, responses = _world(loop.ASSERTED_BY_OFFICER)
+    participants[0]["display_name"] = "Nora"
+    responses = [r for r in responses if r["participant_id"] != 1]
+    request = {"tz_name": "America/Los_Angeles",
+               "expires_at": datetime(2027, 1, 1, tzinfo=timezone.utc)}
+    label = loop.state_label(request, windows, responses, participants)
+    assert "waiting on nora to accept" in label.lower()
+    assert "you proposed" in label.lower()
+
+
+def test_the_label_never_promises_a_dispatched_signing_will_happen():
+    """§13 at the moment it is most tempting to break."""
+    participants, windows, responses = _world(loop.ASSERTED_BY_OFFICER)
+    request = {"booked_at": windows[0]["starts_at"],
+               "booked_by": loop.BOOKED_BY_CONVERGENCE,
+               "tz_name": "America/Los_Angeles"}
+    label = loop.state_label(request, windows, responses, participants).lower()
+    for promise in ("will happen", "will take place", "will be signed",
+                    "is confirmed", "guaranteed", "completed"):
+        assert promise not in label, f"the label promises: {label}"
+
+
+def test_a_name_is_not_a_pronoun_in_the_sentence_writer():
+    """§11.1. `state_label` said "the times SHE is free" about a notary
+    whose pronouns nobody has told us — the FLOW1 sweep read `utils/` and
+    `templates/` and not `services/`, so the one function that writes
+    every surface's sentence kept it."""
+    src = code_only(BACKEND / "services" / "signing_loop.py")
+    import re
+    offenders = [line.strip() for line in src.splitlines()
+                 if re.search(r"\b(she|her|hers|herself|he|him|his|himself)\b",
+                              line, re.I)]
+    assert offenders == [], offenders
+
+
+# ══════════════════════════════════════════════════════════════════════
+# The whole path, against a database
+# ══════════════════════════════════════════════════════════════════════
+
+@pytest.fixture
+def world():
+    import psycopg2
+    from database import create_tables
+    from db_rows import ROW_FACTORY
+
+    create_tables()
+    conn = psycopg2.connect(os.environ["DATABASE_URL"], cursor_factory=ROW_FACTORY)
+    conn.autocommit = True
+    tag = uuid.uuid4().hex[:8]
+    made = {"users": [], "deeds": []}
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO users (email, password_hash, full_name, role) "
+            "VALUES (%s, 'x', 'Officer', 'user') RETURNING id",
+            (f"officer-{tag}@dispatch.test",))
+        made["users"].append(cur.fetchone()["id"])
+        cur.execute(
+            """INSERT INTO deeds (user_id, deed_type, property_address, apn,
+                                  grantor_name, grantee_name, county, status)
+               VALUES (%s, 'grant_deed', '30 Dispatch Way, Los Angeles, CA',
+                       '1234-567-890', 'GRANTOR', 'GRANTEE', 'Los Angeles',
+                       'completed') RETURNING id""",
+            (made["users"][0],))
+        made["deeds"].append(cur.fetchone()["id"])
+    made["conn"] = conn
+    yield made
+    conn.close()
+
+
+def _client_for(user_id: int):
+    from fastapi.testclient import TestClient
+    from auth import create_access_token
+    from main import app
+
+    client = TestClient(app)
+    client.headers.update({
+        "Authorization": "Bearer " + create_access_token(
+            {"sub": str(user_id), "email": "officer@dispatch.test"})})
+    return client
+
+
+def _times(days_out: int = 4):
+    base = datetime.now(timezone.utc) + timedelta(days=days_out)
+    return {"start": base.isoformat(), "end": (base + timedelta(hours=1)).isoformat()}
+
+
+def _dispatch(world, *, agreed: bool = True):
+    return _client_for(world["users"][0]).post("/signing-requests/v2", json={
+        "deed_id": world["deeds"][0],
+        "notary_email": "nora@dispatch.test",
+        "notary_name": "Nora",
+        "signers": [{"name": "Sam Signer", "email": "sam@dispatch.test"}],
+        "proposed_time": _times(),
+        "signers_already_agreed": agreed,
+    })
+
+
+@dbonly
+def test_the_whole_dispatch(world):
+    """Officer proposes → notary accepts → it books, and the record says
+    who actually spoke."""
+    from fastapi.testclient import TestClient
+    from main import app
+
+    made = _dispatch(world)
+    assert made.status_code == 200, made.text
+    body = made.json()
+    assert "accepts or declines" in body["next"]
+
+    request_id = body["signing_request_id"]
+    notary_link = next(p["link"] for p in body["participants"]
+                       if p["party_role"] == "notary")
+    notary_token = notary_link.rsplit("/", 1)[-1]
+
+    # Before she answers: proposed, not booked, and the officer's own
+    # surface says what it is waiting on.
+    officer = _client_for(world["users"][0])
+    view = officer.get(f"/signing-requests/v2/{request_id}").json()
+    assert view["booked_at"] is None
+    assert "waiting on nora to accept" in view["summary"].lower()
+    assert view["windows"][0]["origin"] == "officer"
+
+    public = TestClient(app)
+    seen = public.get(f"/signing/{notary_token}").json()
+    window_id = seen["windows"][0]["id"]
+    accepted = public.post(f"/signing/{notary_token}/answer",
+                           json={"window_id": window_id, "answer": "available"})
+    assert accepted.status_code == 200, accepted.text
+
+    booked = officer.get(f"/signing-requests/v2/{request_id}").json()
+    assert booked["booked_at"] is not None
+    assert booked["state"] == "booked"
+    # The sentence tells the truth about who spoke.
+    assert "everyone agreed" not in booked["summary"].lower()
+    assert "you recorded the signers' agreement" in booked["summary"].lower()
+
+
+@dbonly
+def test_the_signer_sees_who_answered_for_them(world):
+    """A consumer opening their link must not be told they said something
+    they did not say. The one audience with no account, no history and no
+    way to check is the one that most needs this."""
+    from fastapi.testclient import TestClient
+    from main import app
+
+    body = _dispatch(world).json()
+    signer_token = next(p["link"] for p in body["participants"]
+                        if p["party_role"] == "signer").rsplit("/", 1)[-1]
+    pkg = TestClient(app).get(f"/signing/{signer_token}").json()
+    answers = list(pkg["my_answers"].values())
+    assert answers, "the officer's assertion is not on the signer's surface"
+    assert answers[0]["answer"] == "available"
+    assert answers[0]["asserted_by"] == "officer"
+
+
+@dbonly
+def test_without_the_assertion_the_signers_must_still_answer(world):
+    """The safe half of the fork: a time proposed without the tick is a
+    time the signers have to agree to themselves."""
+    from fastapi.testclient import TestClient
+    from main import app
+
+    body = _dispatch(world, agreed=False).json()
+    request_id = body["signing_request_id"]
+    notary_token = next(p["link"] for p in body["participants"]
+                        if p["party_role"] == "notary").rsplit("/", 1)[-1]
+    public = TestClient(app)
+    window_id = public.get(f"/signing/{notary_token}").json()["windows"][0]["id"]
+    public.post(f"/signing/{notary_token}/answer",
+                json={"window_id": window_id, "answer": "available"})
+
+    view = _client_for(world["users"][0]).get(
+        f"/signing-requests/v2/{request_id}").json()
+    assert view["booked_at"] is None, (
+        "it booked on the notary's answer alone — the signers never agreed")
+
+
+@dbonly
+def test_an_assertion_with_no_time_is_refused(world):
+    """Silently dropping it would record nothing and tell her nothing,
+    and she would believe her signers were on the record."""
+    r = _client_for(world["users"][0]).post("/signing-requests/v2", json={
+        "deed_id": world["deeds"][0],
+        "notary_email": "nora@dispatch.test",
+        "signers": [{"name": "Sam", "email": "sam@dispatch.test"}],
+        "signers_already_agreed": True,
+    })
+    assert r.status_code == 400
+    assert "alongside a proposed time" in r.text
+
+
+@dbonly
+def test_a_naive_time_is_refused_before_anything_is_written(world):
+    """A time we would refuse must not leave a half-made request behind.
+
+    And a wall-clock time with no zone is not a time — #149's rule,
+    which exists because the alternative produced a calendar file up to
+    eight hours out.
+    """
+    officer = _client_for(world["users"][0])
+    before = len(officer.get("/signing-requests/v2").json())
+    r = officer.post("/signing-requests/v2", json={
+        "deed_id": world["deeds"][0],
+        "notary_email": "nora@dispatch.test",
+        "signers": [{"name": "Sam", "email": "sam@dispatch.test"}],
+        "proposed_time": {"start": "2026-09-01T10:00:00",
+                          "end": "2026-09-01T11:00:00"},
+    })
+    assert r.status_code == 400, r.text
+    assert len(officer.get("/signing-requests/v2").json()) == before, (
+        "a refused time left a request behind")
+
+
+@dbonly
+def test_a_declined_dispatch_falls_back_to_negotiation(world):
+    """The fallback, and it is nearly free because it is the flow that
+    already exists: a declined assignment leaves a request with no live
+    window, which is exactly the state a fresh request is in."""
+    from fastapi.testclient import TestClient
+    from main import app
+
+    body = _dispatch(world).json()
+    request_id = body["signing_request_id"]
+    notary_token = next(p["link"] for p in body["participants"]
+                        if p["party_role"] == "notary").rsplit("/", 1)[-1]
+
+    public = TestClient(app)
+    window_id = public.get(f"/signing/{notary_token}").json()["windows"][0]["id"]
+    declined = public.post(f"/signing/{notary_token}/decline/{window_id}")
+    assert declined.status_code == 200, declined.text
+
+    officer = _client_for(world["users"][0])
+    view = officer.get(f"/signing-requests/v2/{request_id}").json()
+    assert view["state"] == "requested", view["state"]
+    assert "post the times they are free" in view["summary"].lower()
+    assert view["booked_at"] is None
+
+    # And the loop resumes with no new code: she posts availability.
+    base = datetime.now(timezone.utc) + timedelta(days=9)
+    posted = public.post(f"/signing/{notary_token}/windows", json={
+        "windows": [{"start": base.isoformat(),
+                     "end": (base + timedelta(hours=1)).isoformat()}]})
+    assert posted.status_code == 200, posted.text
+    resumed = officer.get(f"/signing-requests/v2/{request_id}").json()
+    assert resumed["state"] in ("windows_posted", "partially_agreed")
+
+
+@dbonly
+def test_the_officer_is_told_when_a_dispatch_is_declined(world):
+    """She proposed it; she is the one who needs to know it is off."""
+    from fastapi.testclient import TestClient
+    from main import app
+
+    body = _dispatch(world).json()
+    notary_token = next(p["link"] for p in body["participants"]
+                        if p["party_role"] == "notary").rsplit("/", 1)[-1]
+    public = TestClient(app)
+    window_id = public.get(f"/signing/{notary_token}").json()["windows"][0]["id"]
+    public.post(f"/signing/{notary_token}/decline/{window_id}")
+
+    # `notifications` holds the message; `user_notifications` holds who
+    # it is for. Two tables, joined — reading `notifications.user_id`
+    # would be reading a column that does not exist, which is how the
+    # first version of this test failed and earned the join.
+    with world["conn"].cursor() as cur:
+        cur.execute("""SELECT n.type, n.link FROM notifications n
+                         JOIN user_notifications un ON un.notification_id = n.id
+                        WHERE un.user_id = %s
+                        ORDER BY n.id DESC LIMIT 1""", (world["users"][0],))
+        row = cur.fetchone()
+    assert row and row["type"] == "signing_dispatch_declined"
+    # And it points at the signing, not at a list — FLOW1 item 4's route.
+    assert row["link"].startswith("/signings?focus=")
+
+
+@dbonly
+def test_an_officer_window_is_not_attributed_to_the_notary(world):
+    """#156's migration pointed officer-origin windows at the NOTARY
+    because `proposed_by` was NOT NULL, which reads as her having offered
+    a time she has never seen. `origin` carried the truth and the column
+    contradicted it."""
+    body = _dispatch(world).json()
+    with world["conn"].cursor() as cur:
+        cur.execute("SELECT origin, proposed_by FROM signing_windows "
+                    "WHERE signing_request_id = %s",
+                    (body["signing_request_id"],))
+        row = cur.fetchone()
+    assert row["origin"] == "officer"
+    assert row["proposed_by"] is None
+
+
+@dbonly
+def test_the_signers_are_not_emailed_a_time_nobody_has_accepted(world):
+    """§13 by email. Telling a consumer their signing is at 10am on
+    Tuesday, before the person who has to show up has answered, is the
+    arrangement-is-not-an-act error committed to somebody's inbox."""
+    with world["conn"].cursor() as cur:
+        cur.execute("SELECT COALESCE(MAX(id), 0) AS high FROM email_log")
+        high = cur.fetchone()["high"]
+
+    _dispatch(world)
+
+    with world["conn"].cursor() as cur:
+        cur.execute("SELECT template, recipient FROM email_log WHERE id > %s",
+                    (high,))
+        sent = cur.fetchall()
+    assert sent, "the notary was not emailed at all"
+    assert all(r["recipient"] != "sam@dispatch.test" for r in sent), (
+        "a signer was emailed about a time nobody has accepted")
+    assert any(r["template"] == "notary_dispatched" for r in sent), (
+        "the notary got the availability email, not the assignment")

--- a/backend/utils/email_templates.py
+++ b/backend/utils/email_templates.py
@@ -400,9 +400,8 @@ def notary_invited(notary_name, officer_name, officer_company, deed_type,
 
     Professional-to-professional. The notary gets the address, the
     instrument and the county because they are going there to notarise
-    that document; what they do NOT get is any way to reach the
-    signers, because they
-    has no reason to and the officer does.
+    that document; what they do NOT get is any way to reach the signers,
+    because they have no reason to and the officer does.
     """
     addr = _short_addr(property_address)
     subject = f"Signing request — {addr}" if addr else "Notary signing request"
@@ -426,6 +425,62 @@ def notary_invited(notary_name, officer_name, officer_company, deed_type,
         "The signers pick from the times you post."
     )
     return subject, _base(f"{officer_name} asked about your availability", content, True), text
+
+
+def notary_dispatched(notary_name, officer_name, officer_company, deed_type,
+                      property_address, county, when_text, location, link,
+                      expires_at) -> Rendered:
+    """FLOW1 item 7 — officer → notary: can you take this, at this time?
+
+    ═══ WHY THIS IS A SECOND TEMPLATE AND NOT A BRANCH ═══
+
+    `notary_invited` asks "when are you free?". This asks "can you be at
+    this address at this time?". They want different answers and
+    different buttons, and a professional deciding whether to accept an
+    assignment should not have to work out which question she has been
+    sent. One template with a conditional clause would have made the
+    subject line and the button lie about one of the two cases.
+
+    ═══ WHAT IT MUST NOT SAY ═══
+
+    Not that the signing is BOOKED, and not that it is CONFIRMED. Nothing
+    is booked until she accepts — she is the party who has not answered
+    yet. §13's rule reaching the one email most tempted to break it: the
+    officer has a time, the signers have agreed, and every word here
+    still has to treat the arrangement as incomplete, because it is.
+
+    And it does not say the officer "confirmed" anything on the signers'
+    behalf in a way that implies they spoke to us. She rang them. The
+    email says she did.
+    """
+    addr = _short_addr(property_address)
+    subject = f"Signing assignment — {addr}" if addr else "Notary signing assignment"
+    content = (
+        _p(f"Hi {_esc(notary_name) or 'there'},")
+        + _p(f"<strong>{_esc(officer_name)}</strong>"
+             + (f" at {_esc(officer_company)}" if officer_company else "")
+             + " is asking whether you can take a signing at a set time.")
+        + _facts([("When", when_text), ("Where", location or addr),
+                  ("Document", deed_type), ("County", county),
+                  ("Link expires", expires_at or "")])
+        + _button(link, "Accept or decline this time")
+        + _p('<span style="font-size:13px;color:#8a94a0;">'
+             f"{_esc(officer_name)} has already agreed this time with the "
+             "signers. Nothing is booked until you accept — and if the time "
+             "does not work, decline it and post the times you are free "
+             "instead.</span>")
+    )
+    text = (
+        f"{officer_name} is asking whether you can take a signing at a set time.\n\n"
+        f"When: {when_text}\nWhere: {location or addr}\n"
+        f"Document: {deed_type}\nCounty: {county}\n"
+        f"Link expires: {expires_at or ''}\n\n"
+        f"Accept or decline: {link}\n\n"
+        f"{officer_name} has already agreed this time with the signers. "
+        "Nothing is booked until you accept. If it does not work, decline "
+        "it and post the times you are free instead."
+    )
+    return subject, _base(f"{officer_name} asked you to take a signing", content, True), text
 
 
 def signing_windows_posted(signer_name, officer_name, officer_company, notary_name,

--- a/backend/utils/notifications.py
+++ b/backend/utils/notifications.py
@@ -28,7 +28,7 @@ TEMPLATES = (
     # NOTARY1 — the two ends of the signing handoff. Officer→notary asks
     # about availability; notary→officer (or officer→herself) records a
     # time. There is deliberately no third: no signer is ever emailed.
-    "signing_time_recorded",
+    "signing_time_recorded", "notary_dispatched",
     # NOTARY2 — the coordination loop. Five, and the count is the point:
     # ask the notary, ask the signers, tell the signers when there is
     # something to answer, tell the notary when a signer proposes, and
@@ -225,6 +225,21 @@ def send_notary_invited(recipient_email: str, notary_name: str, officer_name: st
         notary_name, officer_name, officer_company, deed_type,
         property_address, county, link, expires_at),
         context={"deed_type": deed_type})
+
+
+def send_notary_dispatched(recipient_email: str, notary_name: str,
+                           officer_name: str, officer_company: Optional[str],
+                           deed_type: str, property_address: Optional[str],
+                           county: Optional[str], when_text: str,
+                           location: Optional[str], link: str,
+                           expires_at: Optional[str]) -> SendResult:
+    """FLOW1 item 7 — the assignment. One time, a place, accept or decline."""
+    return _send("notary_dispatched", recipient_email,
+                 email_templates.notary_dispatched(
+                     notary_name, officer_name, officer_company, deed_type,
+                     property_address, county, when_text, location, link,
+                     expires_at),
+                 context={"deed_type": deed_type, "dispatched": True})
 
 
 def send_signing_windows_posted(recipient_email: str, signer_name: str,

--- a/docs/DOCTRINE_CONFORMANCE.md
+++ b/docs/DOCTRINE_CONFORMANCE.md
@@ -860,10 +860,81 @@ their data is not a machine decision.
 
 ---
 
+### §13.2 — Who asserted the answer (FLOW1 item 7, 2026-08-11, owner-ruled)
+
+**Statement.** A recorded answer carries who gave it. When the escrow
+officer records her signers' agreement to a time she arranged with them
+by phone, the record says **she** asserted it — never that the signers
+answered.
+
+**Why this needed a column.** Owner research into escrow practice: the
+officer knows when the documents are ready, schedules with the signers
+directly, and dispatches a notary for that time, who accepts or declines.
+NOTARY2's loop inverts that — the notary posts availability, the signers
+converge — which is right for *finding* a time among people with no prior
+contact and wrong for the ordinary case.
+
+`converged_window_id` required the notary **and every live signer** to
+have answered `available`. Under dispatch the signers never answer this
+product, so convergence could never fire and a request would sit in
+`partially_agreed` forever while everyone involved believed it was
+booked.
+
+Two ways to close that, and they are not equivalent. The officer's
+existing override works today with no code at all — she creates the
+request, the notary accepts, she presses override, and `booked_by =
+'officer'` is *true*. It is clunky and nothing about it is dishonest.
+The alternative is to let convergence count a signer row the officer
+wrote — and **without a column saying so, that row would claim a signer
+answered when the officer did.** That is precisely the distinction
+`booked_by` and RED-S4's `recording_asserted_by` exist to preserve, one
+level down: the same argument applied to the answers a booking is built
+from rather than to the booking itself.
+
+So `asserted_by` is **one additive column whose justification is
+doctrinal, not technical**. `answer` / `asserted_by` / `asserted_at` is
+RED-S4's trio, complete.
+
+**§13.1 IS UNTOUCHED, and the precision matters.** Its argument was that
+routing *around* the signers recreated the phone tag the feature exists
+to kill. Dispatch does not route around them — the officer talks to them
+*first*, which is the leg she was always going to do herself. What
+changes is who proposes the time, not who is included. Signer contact
+still lives on one purgeable row and nowhere else.
+
+**§13 IS UNTOUCHED TOO.** Nothing is booked until the notary accepts;
+`state_label` refuses to call an officer-vouched booking "everyone
+agreed" and says what actually happened instead; the signers are not
+emailed a time nobody has accepted, because telling a consumer their
+signing is at 10am on Tuesday before the person who has to show up has
+answered is booked-is-not-happened committed to somebody's inbox.
+
+**The consumer surface carries it.** A signer opening their link sees
+"{officer} told us this time works for you — tap to change it" rather
+than a silent tick. The one audience with no account, no history and no
+way to check is the one that most needs to be told who spoke for them,
+and the control stays live so they can say otherwise.
+
+**The fallback is nearly free, which is not a coincidence.** A declined
+assignment leaves a request with no live window — exactly the state a
+fresh request is in — so the availability loop resumes with no new code.
+
+**Enforced by.** `backend/tests/test_flow1_dispatch.py` — an
+officer-asserted answer counts toward convergence; the notary's
+acceptance is still required; the booking sentence refuses "everyone
+agreed"; a dispatch awaiting acceptance says so; an assertion with no
+time is refused; a naive time is refused before anything is written; a
+declined dispatch returns to `requested` and the loop resumes; no signer
+is emailed before acceptance; an officer window is not attributed to the
+notary.
+
+---
+
 ## Change log
 
 | Date | Change |
 |---|---|
+| 2026-08-11 | §13.2 added (FLOW1 item 7, DISPATCH) — `signing_responses.asserted_by`. See the section for the full reasoning; the short version is that convergence had to be able to count an officer-asserted signer answer without any surface being able to call it the signer's. Also: the §11.1 sweep was WIDENED after it missed two live habitats it should have caught — `services/signing_loop.state_label()` (the one function that turns a scheduling state into a sentence for every surface) and the `.ics` description that lands in the officer's own diary. Both said "she" about a notary. `services/vesting_split.py` exempted with a cited reason: it MATCHES recorded vesting language rather than writing prose about anybody. |
 | 2026-08-11 | §11.1 added (FLOW1 items 3–4) — the product never infers a fact about a PERSON from their name or role. A live email told a notary that the officer "confirms the appointment with the signers herself", asserting an escrow officer's pronouns to her own professional contact on no information; the screen did the same about the notary. Ruled the same family as the "filed as" constraint, which forbids reading a partner's category as a statement about their authority — one direction infers what someone IS, the other what they MAY DO, and both put a claim in the record nobody made. Swept fail-closed across every template. Two habitats exempted with cited reasons and their own liveness test: the Civil Code §1189 all-purpose acknowledgement (prescribed certificate wording, names no party) and vesting terms of art. Also item 4: the Signings agenda's stuck age was reconstructed as `expires_at − 21 days`, duplicating `default_expiry()`'s constant into TypeScript as a bare number — the server sends `created_at` now. And its "soonest first" claim covered rows sorted by `COALESCE(booked_at, expires_at)`, two orthogonal facts under one sort key (T-5 one layer up); booked and being-arranged are now separated and each sorted by the fact it has. |
 | 2026-08-11 | §4 — FLOW1 item 0. Shared Deeds reported as showing fabricated rows; verdict recorded as NOT fabricated — a real fetch read through eight wrong key names, so `undefined` rendered as blank cells and Invalid Date. Recorded under §4 rather than invariant #4 because nothing was invented and the screen still asserted what it could not support ("Not viewed" under a badge reading "Viewed"). Three absent facts given columns: `recipient_name` (accepted, greeted with, never stored), `responded_at` (`updated_at` was not that fact — a revoke bumps it too), and a real `expires_at` (previously spent on a display string nothing rendered). Contract now pinned from both sides against one corpus; absence crosses the wire as `null`, never `""`. The feedback modal's fallback to a field the list endpoint never sent — a failed fetch reading as "the reviewer left no comments" — removed. |
 | 2026-08-11 | §13.1 — the signer-contact ruling REVERSED (NOTARY2). Signers now participate directly; the notary posts availability, signers pick or propose, convergence books it, and the officer is notified rather than gating. Owner's reasoning recorded: the signers are the scheduling constraint, so routing around them recreated the phone tag the feature exists to kill — Option A had priced the officer's relaying at zero when it is the entire problem. The superseded paragraph is kept verbatim rather than rewritten. §13 otherwise stands unchanged: booked is still not happened. NOTARY1's fail-closed sweep is ANSWERED rather than deleted — retargeted from "no signer contact anywhere" to "one purgeable row, no other table, deleted by a mechanism with a test." The retention rule and a non-user's route to removal become part of the feature, ledgered as owner items. |

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -312,6 +312,32 @@ we reach it.
 
 ## Parked tickets (scoped, not scheduled)
 
+- **Retire NOTARY1's read-side routes** (FLOW1 item 6 follow-up,
+  owner-ruled 2026-08-11: leave them for now). Three routes survive the
+  write path's retirement and are now unreachable by construction —
+  `POST /approve/{token}/schedule`, `POST /shared-deeds/{id}/schedule`,
+  `GET /approve/{token}/pcor(.pdf)`. `_signing_share_by_token` 404s
+  anything that is not a signing share, and nothing can create one.
+  **Trigger:** the confirmed zero-row count (already had — production
+  `deedpro` at 10.26.62.147, found 0) PLUS a decision that no other
+  database holds NOTARY1 shares. Until then a pin asserts the source
+  note explaining why they cannot fire is still present, because an
+  endpoint that cannot fire with nothing saying why is
+  indistinguishable from one nobody has looked at. The `deed_shares`
+  columns stay regardless — a column drop is irreversible and the
+  migration script must keep being able to read a row it might find.
+
+- **Sweep for pins reading files nothing imports** (FLOW1 item 6
+  finding, owner-ruled as its own category). `shareEntryPoints.test.ts`
+  spent two tickets asserting properties of `SigningRequestModal.tsx`
+  while the page rendered `RequestSigningModal` — the test file's own
+  comment said so. **A pin reading a file with no importers is passing
+  for a reason unrelated to the property it claims to guard**, which is
+  worse than a failing pin: it is green and meaningless. Ruled to be
+  swept opportunistically rather than as a scheduled ticket. Heuristic:
+  any source file a test reads that no non-test file imports is
+  suspect.
+
 - **DEEDDETAIL — there is no deed detail route** (FLOW1 finding, owner
   ruled: scope and ledger as its own ticket, not FLOW1's). `/deeds/{id}`,
   `/deed/{id}` and `/past-deeds/{id}` all 404. Every deed-level action —

--- a/frontend/src/__tests__/signerSurface.test.ts
+++ b/frontend/src/__tests__/signerSurface.test.ts
@@ -19,6 +19,8 @@ const flat = (s: string) => s.replace(/\s+/g, ' ');
 const TOKEN_PAGE = read('app', 'signing', '[token]', 'page.tsx');
 const CREATE = read('features', 'signing', 'RequestSigningModal.tsx');
 const AGENDA = read('app', 'signings', 'page.tsx');
+/** FLOW1 item 7: the one place a wall-clock time gets its offset. */
+const HELPER = read('lib', 'wallClock.ts');
 
 describe('the signer page speaks to a person, not to the industry', () => {
   it('uses no jargon a buyer would have to look up', () => {
@@ -83,9 +85,22 @@ describe('no surface composes its own account of a scheduling state', () => {
 
   it('times sent to the server carry their offset', () => {
     // #149's parse_window REFUSES a naive time rather than guessing.
-    expect(TOKEN_PAGE).toContain('getTimezoneOffset');
+    //
+    // FLOW1 item 7 moved the stamping into `lib/wallClock.ts`, because
+    // the officer's dispatch form needed it too and the first instinct
+    // was to copy the eight lines — which is how `phoneSearchKey` came
+    // to be wrong in one language and right in the other. So the pin
+    // asks the question in two parts now: the helper does the stamping,
+    // and every surface that sends a time calls it.
+    expect(HELPER).toContain('getTimezoneOffset');
     expect(TOKEN_PAGE).toContain('withOffset(start)');
     expect(TOKEN_PAGE).toContain('withOffset(r.start)');
+    expect(CREATE).toContain('withOffset(start)');
+    // And nobody keeps a private copy.
+    for (const src of [TOKEN_PAGE, CREATE]) {
+      expect(codeOnly(src)).not.toContain('getTimezoneOffset');
+      expect(src).toContain("from '@/lib/wallClock'");
+    }
   });
 });
 
@@ -95,13 +110,63 @@ describe('the officer create flow asks the right questions', () => {
     expect(CREATE).toContain('suggestCategory="notary"');
   });
 
-  it('does not ask her for times', () => {
-    // NOTARY1 made her propose windows because the notary had no way to
-    // speak. §13.1 reversed that; asking anyway would be asking her to do
-    // the work the reversal removed. The field is GONE, not optional.
+  it('never asks her to guess at the notary\'s availability', () => {
+    // ═══ THIS PIN'S PREMISE WAS PARTLY OVERTURNED — READ BEFORE
+    //     TRUSTING IT ═══
+    //
+    // It used to assert `datetime-local` was ABSENT from the create
+    // form. The reasoning was §13.1's: NOTARY1 made the officer propose
+    // three windows because the notary had no way to speak, and once the
+    // notary could speak, asking the officer anyway was asking her to do
+    // the work the reversal removed.
+    //
+    // FLOW1 item 7 (DISPATCH) reverses HALF of that, on owner research
+    // into escrow practice: the officer schedules with her signers
+    // directly, usually by phone, and dispatches a notary for that time.
+    // She is not guessing at anybody's availability — she is stating an
+    // arrangement she has already made.
+    //
+    // So the property is NOT "she never sees a time field". It is:
+    //
+    //   SHE IS NEVER ASKED TO PROPOSE A SET OF CANDIDATE TIMES ON
+    //   SOMEBODY ELSE'S BEHALF.
+    //
+    // ONE time she has arranged is a fact. THREE windows she hopes suit
+    // a notary she has not asked is the guesswork §13.1 removed, and it
+    // stays removed: `proposed_windows` — NOTARY1's plural field — is
+    // still forbidden, and there is no way to add a second time.
     const code = codeOnly(CREATE);
     expect(code).not.toContain('proposed_windows');
-    expect(code).not.toContain('datetime-local');
+    expect(code).not.toContain('MAX_WINDOWS');
+    // Exactly one start and one end. A repeater here would be NOTARY1
+    // arriving by a different door.
+    expect((code.match(/datetime-local/g) || [])).toHaveLength(2);
+  });
+
+  it('offers dispatch first and availability second, both reachable', () => {
+    const text = flat(CREATE);
+    expect(text).toContain('I have a time');
+    expect(text).toContain('Ask for availability');
+    // Dispatch is the DEFAULT — she reaches the ordinary case by doing
+    // nothing — and the fallback is one press away, never removed.
+    expect(codeOnly(CREATE)).toContain("useState<'dispatch' | 'availability'>('dispatch')");
+  });
+
+  it('asks for the signers agreement in words, and records it as hers', () => {
+    // Ticking the box writes an answer on the signers' behalf. That is a
+    // question with words, not a silent consequence of typing a time —
+    // and the copy says whose word it is.
+    const text = flat(CREATE);
+    expect(text).toContain('I have already agreed this time with the signers');
+    expect(text).toContain('Recorded as your word, not theirs');
+    expect(codeOnly(CREATE)).toContain('signers_already_agreed');
+  });
+
+  it('promises nothing is booked until the notary accepts', () => {
+    // §13 at the moment it is most tempting to break: she has a time,
+    // her signers have agreed, and the arrangement is still incomplete
+    // because the person who has to show up has not answered.
+    expect(flat(CREATE)).toContain('Nothing is booked until the notary accepts');
   });
 
   it('defaults the location and the timezone rather than leaving blanks', () => {

--- a/frontend/src/__tests__/signingHandoff.test.ts
+++ b/frontend/src/__tests__/signingHandoff.test.ts
@@ -134,7 +134,11 @@ describe('NOTARY1 — times carry their offset', () => {
     // how a calendar entry lands an hour out and somebody arrives at an
     // empty office. Pinned where times are ENTERED — which is the
     // notary's token page since §13.1, not the officer's modal.
-    expect(TOKEN_PAGE).toContain('getTimezoneOffset');
+    // FLOW1 item 7 moved the stamping into `lib/wallClock.ts` when the
+    // officer's dispatch form needed it too. Copying the eight lines is
+    // how `phoneSearchKey` came to be right in one language and wrong in
+    // the other, so the rule lives once and the surfaces call it.
+    expect(read('lib', 'wallClock.ts')).toContain('getTimezoneOffset');
     expect(TOKEN_PAGE).toContain('withOffset(start)');
     expect(TOKEN_PAGE).toContain('withOffset(r.start)');
     expect(TOKEN_PAGE).toContain('withOffset(r.end)');

--- a/frontend/src/app/signing/[token]/page.tsx
+++ b/frontend/src/app/signing/[token]/page.tsx
@@ -39,12 +39,23 @@ import { useParams } from 'next/navigation';
 import {
   AlertCircle, CalendarClock, Check, Clock, Download, FileText, Loader2, MapPin, Plus, Users, X,
 } from 'lucide-react';
+import { withOffset } from '@/lib/wallClock';
 
 const API = () => process.env.NEXT_PUBLIC_API_URL || 'https://deedpro-main-api.onrender.com';
 
 type Person = { name: string | null; company: string | null };
 type Window = {
-  id: number; label: string; start: string; mine?: string | null;
+  id: number; label: string; start: string;
+  /**
+   * FLOW1 item 7 — AN ANSWER CARRIES WHO GAVE IT.
+   *
+   * Under dispatch the officer answers on her signers' behalf, having
+   * rung them. A consumer opening this link and seeing themselves ticked
+   * against a time they never answered would be the product telling them
+   * they said something they did not say — to the one audience with no
+   * account, no history and no way to check.
+   */
+  mine?: { answer: string; asserted_by: string } | null;
   origin?: string; declined?: boolean; agreed_by?: string[];
 };
 
@@ -218,7 +229,8 @@ function SignerView({ pkg, busy, post, error }: {
 
         <div className="space-y-2">
           {pkg.windows.map((w) => {
-            const chosen = w.mine === 'available';
+            const chosen = w.mine?.answer === 'available';
+            const answeredByOfficer = chosen && w.mine?.asserted_by === 'officer';
             return (
               <button
                 key={w.id}
@@ -228,7 +240,18 @@ function SignerView({ pkg, busy, post, error }: {
                   chosen ? 'border-[#7C4DFF] bg-purple-50' : 'border-slate-300 hover:bg-slate-50'
                 }`}
               >
-                <span className="font-medium text-slate-800">{w.label}</span>
+                <span className="min-w-0">
+                  <span className="block font-medium text-slate-800">{w.label}</span>
+                  {answeredByOfficer && (
+                    // Plain language, and it names her. "Confirmed" would
+                    // be the product claiming they answered; this says who
+                    // actually did, and leaves the button live so they can
+                    // say otherwise.
+                    <span className="block text-xs text-slate-500 mt-0.5">
+                      {who} told us this time works for you — tap to change it
+                    </span>
+                  )}
+                </span>
                 {busy === w.id
                   ? <Loader2 className="w-5 h-5 animate-spin shrink-0 text-slate-400" />
                   : chosen ? <Check className="w-5 h-5 text-[#7C4DFF] shrink-0" /> : null}
@@ -349,12 +372,25 @@ function NotaryView({ pkg, busy, post, error }: {
               <div className="flex items-start justify-between gap-2">
                 <div className="min-w-0">
                   <p className="text-sm font-medium text-slate-800">{w.label}</p>
+                  {/* FLOW1 item 7: THREE ORIGINS, NOT TWO. This read
+                      `signer_proposal ? 'Suggested by a signer' : 'You
+                      offered this'`, so a time the OFFICER dispatched
+                      would have told the notary she had offered a time
+                      she has never seen. The binary was correct until
+                      officer windows became reachable from a screen. */}
                   <p className="text-xs text-slate-500">
-                    {w.origin === 'signer_proposal' ? 'Suggested by a signer' : 'You offered this'}
+                    {w.origin === 'signer_proposal' ? 'Suggested by a signer'
+                      : w.origin === 'officer' ? `Proposed by ${pkg.coordinator.name || 'the escrow officer'}`
+                      : 'You offered this'}
                     {w.agreed_by?.length ? ` · ${w.agreed_by.length} agreed` : ' · nobody has answered'}
                   </p>
                 </div>
-                {w.origin === 'signer_proposal' && !w.declined && (
+                {/* Accept/decline belongs on any time SOMEBODY ELSE
+                    proposed — a signer's suggestion or the officer's
+                    assignment. Not on her own windows: declining a time
+                    she posted herself is a retraction, which is a
+                    different act with a different audience. */}
+                {(w.origin === 'signer_proposal' || w.origin === 'officer') && !w.declined && (
                   <div className="flex gap-1 shrink-0">
                     <button onClick={() => post('/answer', { window_id: w.id, answer: 'available' }, w.id)}
                             disabled={busy !== null}
@@ -419,12 +455,4 @@ function NotaryView({ pkg, busy, post, error }: {
  * deliberately, because guessing a zone is how a calendar entry lands
  * eight hours out. This is where the offset comes from.
  */
-function withOffset(local: string): string {
-  const parsed = new Date(local);
-  if (Number.isNaN(parsed.getTime())) return local;
-  const minutes = -parsed.getTimezoneOffset();
-  const sign = minutes >= 0 ? '+' : '-';
-  const abs = Math.abs(minutes);
-  const pad = (n: number) => String(n).padStart(2, '0');
-  return `${local}:00${sign}${pad(Math.floor(abs / 60))}:${pad(abs % 60)}`;
-}
+

--- a/frontend/src/features/signing/RequestSigningModal.tsx
+++ b/frontend/src/features/signing/RequestSigningModal.tsx
@@ -32,6 +32,7 @@
 import { useMemo, useState } from 'react';
 import { CalendarClock, Info, Loader2, Plus, Trash2, X } from 'lucide-react';
 import { apiFetch } from '@/lib/apiClient';
+import { withOffset } from '@/lib/wallClock';
 import { PartnerRecipientPicker, Recipient } from '@/features/partners/PartnerRecipientPicker';
 import {
   RecipientMismatchNotice,
@@ -75,6 +76,28 @@ export function RequestSigningModal({
     (suggestedSigners.length ? suggestedSigners : ['']).slice(0, MAX_SIGNERS)
       .map((name) => ({ name, email: '', phone: '' })),
   );
+  /**
+   * FLOW1 item 7 — DISPATCH IS THE DEFAULT, NEGOTIATION IS THE
+   * ALTERNATIVE.
+   *
+   * Owner research into escrow practice: the officer knows when the docs
+   * are ready, schedules with the signers directly — usually by phone —
+   * and then dispatches a notary for that time, who accepts or declines.
+   * The notary is a contractor receiving an assignment.
+   *
+   * NOTARY2's loop inverted that: notary posts availability, signers
+   * converge. That is the right model for FINDING a time among people
+   * with no prior contact, and the wrong one for the ordinary case where
+   * she already has her clients on the phone and needs somebody to show
+   * up. §13.1's reversal is untouched — it was about routing AROUND the
+   * signers, and dispatch does not: she talks to them first, which is
+   * the leg she was always going to do herself. What changes is who
+   * proposes the time, not who is included.
+   */
+  const [mode, setMode] = useState<'dispatch' | 'availability'>('dispatch');
+  const [start, setStart] = useState('');
+  const [end, setEnd] = useState('');
+  const [signersAgreed, setSignersAgreed] = useState(false);
   const [location, setLocation] = useState(propertyAddress || '');
   const [tz, setTz] = useState(ZONES[0].id);
   const [submitting, setSubmitting] = useState(false);
@@ -82,8 +105,10 @@ export function RequestSigningModal({
   const [done, setDone] = useState<{ id: number; links: Array<{ role: string; name: string; link: string }> } | null>(null);
 
   const ready = useMemo(
-    () => !!notary?.email && signers.some((s) => s.name.trim() && s.email.trim()),
-    [notary, signers],
+    () => !!notary?.email
+      && signers.some((s) => s.name.trim() && s.email.trim())
+      && (mode === 'availability' || (!!start && !!end)),
+    [notary, signers, mode, start, end],
   );
 
   const setSigner = (i: number, patch: Partial<SignerRow>) =>
@@ -116,6 +141,15 @@ export function RequestSigningModal({
                            phone: s.phone.trim() || undefined })),
           location: location || undefined,
           tz_name: tz,
+          ...(mode === 'dispatch' && start && end
+            ? {
+                // withOffset: a bare wall-clock time makes the server
+                // guess a zone, which is how a calendar entry lands an
+                // hour out and somebody arrives at an empty office.
+                proposed_time: { start: withOffset(start), end: withOffset(end) },
+                signers_already_agreed: signersAgreed,
+              }
+            : {}),
         }),
       }, { label: 'Creating the signing request' });
       const data = await response.json().catch(() => ({}));
@@ -156,9 +190,19 @@ export function RequestSigningModal({
                   officer picked out of her rolodex moments ago, whose
                   pronouns this product has never been told. A name is
                   not a pronoun. */}
-              The request is on the record. <strong>{notary?.name || 'The notary'}</strong> posts
-              the times they are free; your signers pick from them. When they all agree on
-              one, it books and you are told.
+              {mode === 'dispatch' ? (
+                <>
+                  The request is on the record. <strong>{notary?.name || 'The notary'}</strong>{' '}
+                  has been asked to take the time you proposed. Nothing is booked until
+                  they accept — your signers are told when it is.
+                </>
+              ) : (
+                <>
+                  The request is on the record. <strong>{notary?.name || 'The notary'}</strong>{' '}
+                  posts the times they are free; your signers pick from them. When they all
+                  agree on one, it books and you are told.
+                </>
+              )}
             </p>
             <p className="text-sm text-slate-500">
               You do not have to approve the time — but you can change it later if you
@@ -225,6 +269,79 @@ export function RequestSigningModal({
                   }
                 />
               )}
+
+              {/* FLOW1 item 7 — DISPATCH FIRST, NEGOTIATION SECOND.
+                  Not a mode selector wearing equal weight: the two
+                  options are ordered, the first is chosen, and the
+                  second says what it is for. She reaches the ordinary
+                  case by doing nothing. */}
+              <div className="rounded-xl border border-slate-200 p-4">
+                <p className="text-sm font-medium text-slate-700 mb-3">When</p>
+                <div className="space-y-2">
+                  <label className="flex items-start gap-2 cursor-pointer">
+                    <input type="radio" name="signing-mode" className="mt-1"
+                           checked={mode === 'dispatch'}
+                           onChange={() => setMode('dispatch')} />
+                    <span className="text-sm">
+                      <span className="font-medium text-slate-800">I have a time</span>
+                      <span className="block text-xs text-slate-500">
+                        Propose it to the notary — they accept or decline.
+                      </span>
+                    </span>
+                  </label>
+                  <label className="flex items-start gap-2 cursor-pointer">
+                    <input type="radio" name="signing-mode" className="mt-1"
+                           checked={mode === 'availability'}
+                           onChange={() => setMode('availability')} />
+                    <span className="text-sm">
+                      <span className="font-medium text-slate-800">Ask for availability</span>
+                      <span className="block text-xs text-slate-500">
+                        The notary posts times, your signers pick one.
+                      </span>
+                    </span>
+                  </label>
+                </div>
+
+                {mode === 'dispatch' && (
+                  <div className="mt-4 space-y-3">
+                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+                      <div>
+                        <label className="block text-xs text-slate-500 mb-1">Starts</label>
+                        <input type="datetime-local" value={start}
+                               onChange={(e) => setStart(e.target.value)} className={input} />
+                      </div>
+                      <div>
+                        <label className="block text-xs text-slate-500 mb-1">Ends</label>
+                        <input type="datetime-local" value={end}
+                               onChange={(e) => setEnd(e.target.value)} className={input} />
+                      </div>
+                    </div>
+                    {/* THE ASSERTION, ASKED FOR EXPLICITLY.
+                        Ticking this writes an answer on the signers'
+                        behalf, recorded as HERS — so it is a question
+                        with words, not a silent consequence of typing a
+                        time. Unticked, the signers still have to answer,
+                        which is the safe half of the fork. */}
+                    <label className="flex items-start gap-2 cursor-pointer">
+                      <input type="checkbox" className="mt-1" checked={signersAgreed}
+                             onChange={(e) => setSignersAgreed(e.target.checked)} />
+                      <span className="text-sm">
+                        <span className="text-slate-800">
+                          I have already agreed this time with the signers
+                        </span>
+                        <span className="block text-xs text-slate-500">
+                          Recorded as your word, not theirs. They can still change it
+                          from their own link.
+                        </span>
+                      </span>
+                    </label>
+                    <p className="text-xs text-slate-500">
+                      Nothing is booked until the notary accepts. Your signers are told
+                      when it is.
+                    </p>
+                  </div>
+                )}
+              </div>
 
               <div>
                 <div className="flex items-center justify-between mb-2">

--- a/frontend/src/lib/wallClock.ts
+++ b/frontend/src/lib/wallClock.ts
@@ -1,0 +1,40 @@
+/**
+ * `withOffset` — a wall-clock string, stamped with the browser's zone.
+ *
+ * ═══ WHY THIS EXISTS AT ALL ═══
+ *
+ * An `<input type="datetime-local">` yields `2026-09-01T10:00`: a time
+ * with no zone attached. Sending that to the server makes the server
+ * guess, and the guess is UTC. NOTARY1 shipped exactly that, and the
+ * consequence was not an off-by-one in a log — it was a calendar file up
+ * to eight hours out, on the one artifact whose entire job is to be at
+ * the right moment. `parse_windows()` now REFUSES a naive time rather
+ * than assuming one, so this is the client's half of that contract.
+ *
+ * ═══ WHY IT IS A MODULE ═══
+ *
+ * FLOW1 item 7 needed it in a second place — the officer's dispatch form
+ * — and the first instinct was to copy the eight lines. That is how
+ * `phoneSearchKey` came to be wrong in one language and right in the
+ * other, and how the partner category list ended up with four
+ * divergent copies. A rule that exists twice is a rule that will
+ * eventually disagree with itself.
+ */
+
+/**
+ * Append the local UTC offset to a `datetime-local` value.
+ *
+ * An unparseable value is returned UNCHANGED rather than defaulted: the
+ * server refuses a time it cannot read, which is a better outcome than a
+ * client quietly inventing one.
+ */
+export function withOffset(local: string): string {
+  if (!local) return local;
+  const parsed = new Date(local);
+  if (Number.isNaN(parsed.getTime())) return local;
+  const minutes = -parsed.getTimezoneOffset();
+  const sign = minutes >= 0 ? '+' : '-';
+  const abs = Math.abs(minutes);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${local}:00${sign}${pad(Math.floor(abs / 60))}:${pad(abs % 60)}`;
+}


### PR DESCRIPTION
The last of FLOW1.

## The model

The officer knows when the documents are ready, schedules with the signers directly — usually by phone — and dispatches a notary for that time, who accepts or declines. NOTARY2's loop inverts that, which is right for *finding* a time among people with no prior contact and wrong for the ordinary case where she already has her clients on the phone and needs somebody to show up.

**§13.1 is untouched, and the precision matters.** Its argument was that routing *around* the signers recreated phone tag. Dispatch does not route around them — she talks to them **first**, which is the leg she was always going to do herself. What changes is who proposes the time, not who is included.

## The gap, and why the column is doctrinal rather than technical

`converged_window_id` required the notary **and every live signer** to have answered. Under dispatch the signers never answer this product, so convergence could never fire and a request would sit in `partially_agreed` forever while everyone involved believed it was booked.

`signing_responses.asserted_by` closes it. The justification is not "convergence needs a count" — it is that **without the column the row would lie**. A response row with no asserter says *this signer answered*, and in dispatch that is false: the officer answered. Exactly what `booked_by` and RED-S4's `recording_asserted_by` exist to preserve, one level down — the same argument applied to the answers a booking is built from rather than to the booking.

The trio is complete: `answer` / `asserted_by` / `asserted_at`. Default `'participant'`, because every row that exists today *was* written by the person it is about — a backfill guessing otherwise would be inventing provenance.

## It counts, and it does not disappear

Convergence counts an officer-asserted answer — it is an answer on the record. What it cannot do is vanish:

| state | sentence |
|---|---|
| dispatched, unaccepted | "You proposed *X* — waiting on **Nora** to accept" |
| booked on her assertion | "Booked for *X* — you recorded the signers' agreement and **Nora** accepted" |
| booked on everyone's own answers | "Everyone agreed on *X*" |

The pre-acceptance sentence exists because otherwise her own agenda described her dispatch back to her as *"1 times offered — waiting on 1 more person"* — true, and useless.

**The consumer surface carries it too.** An answer travels as `{answer, asserted_by}`, and a signer opening their link sees *"{officer} told us this time works for you — tap to change it"* rather than a silent tick. The one audience with no account, no history and no way to check is the one that most needs telling who spoke for them — and the control stays live so they can say otherwise.

**Nothing is booked until the notary accepts, and the signers are not emailed before that.** Telling a consumer their signing is at 10am Tuesday before the person who has to show up has answered is booked-is-not-happened, committed to somebody's inbox. Pinned against the `email_log` with a high-water mark.

## The fallback is nearly free, which is not a coincidence

A declined assignment leaves a request with **no live window** — exactly the state a fresh request is in. So the state returns to `requested`, the label goes back to "waiting on the notary to post the times they are free", and the availability loop resumes with no new code. The officer is told in-app, pointing at the signing via item 4's `?focus=`.

## Two corrections found by building this

- **`proposed_by` was `NOT NULL`**, so #156's migration pointed officer-origin windows at the **notary** — reading as her having offered a time she has never seen, while `origin` carried the truth. `NULL` now means "not a participant, read `origin`". The notary's own page had the same binary (`signer_proposal ? 'Suggested by a signer' : 'You offered this'`) and would have told her she offered the officer's time.
- **The §11.1 pronoun sweep missed two live habitats.** It read `utils/` and `templates/` — where the *email* copy is — and missed `services/signing_loop.state_label()`, the **one function that turns a scheduling state into a sentence for every surface in the product** ("waiting on {who} to post the times **she** is free"), and the `.ics` description landing in the officer's own diary ("{notary} said **she** is available"). Both fixed; the sweep now covers `services/` and `routers/`. `services/vesting_split.py` exempted with a cited reason — it *matches* recorded vesting language rather than writing prose about anybody.

## One pin's premise was partly overturned, and it says so

*"The officer create flow does not ask her for times"* was §13.1's, and dispatch reverses half of it. The surviving property is **not** "she never sees a time field" — it is:

> She is never asked to propose a set of *candidate* times on somebody else's behalf.

One time she has arranged is a fact. Three windows she hopes suit a notary she has not asked is the guesswork §13.1 removed, and it stays removed: `proposed_windows` is still forbidden, there is no repeater, and the pin asserts **exactly two** datetime inputs.

## `withOffset` extracted rather than copied

The dispatch form needed it and the instinct was to copy the eight lines — which is how `phoneSearchKey` came to be wrong in one language and right in the other. One module (`lib/wallClock.ts`), both callers, and a pin that neither keeps a private copy.

## Gates

| Gate | Result |
|---|---|
| pytest (no DB) | 854 passed, 164 skipped |
| pytest (with DB) | 1018 passed |
| jest | 694 passed, 46 suites |
| tsc baseline | **94** (unchanged) |
| six-flow baseline | ✔ |
| API baseline | ✔ |
| banned-claims | clean |
| `next build` | ✔ |

**Mutation-probed.** Making convergence ignore officer-asserted rows, making the sentence stop distinguishing them, and emailing the signers at dispatch time each fail the intended pin.

## Recorded

**§13.2** in `DOCTRINE_CONFORMANCE.md`, alongside RED-S4's reasoning as ruled — including why the officer's existing override was the honest zero-code alternative and what the column buys over it.

**Ledgered:** "retire NOTARY1 read-side routes" with its trigger (confirmed zero rows **plus** a decision that no other database holds NOTARY1 shares), and the pins-reading-unimported-files sweep as its own category with a heuristic.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_