### PR TITLE
DASH1 (1/2): the dashboard becomes a workflow surface

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -228,6 +228,13 @@ app.include_router(sharing_router)
 from routers.signing import router as signing_router
 app.include_router(signing_router, tags=["Signing"])
 
+# DASH1 — the officer's queue. One endpoint rather than the dashboard
+# asking three services three questions and stitching the answers on the
+# client, which is how a screen renders a partial truth when one of the
+# three fails.
+from routers.dashboard import router as dashboard_router
+app.include_router(dashboard_router, tags=["Dashboard"])
+
 from routers.pricing import router as pricing_router
 app.include_router(pricing_router)
 

--- a/backend/routers/dashboard.py
+++ b/backend/routers/dashboard.py
@@ -1,0 +1,165 @@
+"""DASH1 — the officer's queue: what is waiting on somebody.
+
+One endpoint, because the dashboard asking three services three questions
+and stitching the answers on the client is how a screen ends up rendering
+a partial truth when one of the three fails. The shape it returns is
+asserted by equality in `services/officer_queue.py`.
+
+READ-ONLY. Nothing here writes, nothing here infers that a signing
+happened, and nothing here decides what "stale" means — that number lives
+in the service module so the screens cannot each hold an opinion.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from fastapi import APIRouter, Depends, HTTPException
+
+import db
+from auth import get_current_user_id
+from services import officer_queue as q
+from services import signing_loop as loop
+
+router = APIRouter()
+
+
+def _rows(cur) -> List[Dict[str, Any]]:
+    return [dict(r) for r in (cur.fetchall() or [])]
+
+
+@router.get("/dashboard/queue")
+def officer_queue(user_id: int = Depends(get_current_user_id)) -> Dict[str, Any]:
+    if not db.conn:
+        raise HTTPException(status_code=500, detail="Database connection not available")
+
+    upcoming: List[Dict[str, Any]] = []
+    awaiting: List[Dict[str, Any]] = []
+    idle: List[Dict[str, Any]] = []
+
+    with db.conn.cursor() as cur:
+        # ── Signings ──────────────────────────────────────────────────
+        #
+        # One query for the aggregate, then the children per request, the
+        # same shape `officer_agenda` uses. The state is DERIVED (T-5),
+        # so it cannot be filtered in SQL without re-implementing
+        # `request_state` in another language — which is the duplication
+        # this codebase keeps deleting.
+        cur.execute("""
+            SELECT sr.*, d.property_address,
+                   (SELECT display_name FROM signing_participants
+                     WHERE signing_request_id = sr.id AND party_role = 'notary'
+                     ORDER BY id LIMIT 1) AS notary_name
+              FROM signing_requests sr
+              JOIN deeds d ON d.id = sr.deed_id
+             WHERE sr.officer_user_id = %s
+               AND sr.cancelled_at IS NULL
+        """, (user_id,))
+        requests = _rows(cur)
+
+        cutoff = q.upcoming_cutoff()
+        for req in requests:
+            cur.execute("SELECT * FROM signing_windows WHERE signing_request_id = %s",
+                        (req["id"],))
+            windows = _rows(cur)
+            cur.execute("SELECT r.* FROM signing_responses r JOIN signing_windows w "
+                        "ON w.id = r.window_id WHERE w.signing_request_id = %s",
+                        (req["id"],))
+            responses = _rows(cur)
+            cur.execute("SELECT * FROM signing_participants WHERE signing_request_id = %s",
+                        (req["id"],))
+            participants = _rows(cur)
+
+            state = loop.request_state(req, windows, responses)
+            summary = loop.state_label(req, windows, responses, participants)
+
+            if state == loop.STATE_BOOKED:
+                booked_at = req.get("booked_at")
+                # SOON, not ever. A booking three months out is real and
+                # is not what she needs on a dashboard this morning.
+                if booked_at and booked_at <= cutoff:
+                    upcoming.append({
+                        "kind": "signing",
+                        "id": req["id"],
+                        "deed_id": req["deed_id"],
+                        "property": req.get("property_address"),
+                        "when": booked_at.isoformat(),
+                        "who": req.get("notary_name"),
+                        "summary": summary,
+                    })
+                continue
+
+            if state in (loop.STATE_EXPIRED,):
+                continue
+
+            days = q.days_since(req.get("created_at"))
+            awaiting.append({
+                "kind": "signing",
+                "id": req["id"],
+                "deed_id": req["deed_id"],
+                "property": req.get("property_address"),
+                "who": req.get("notary_name"),
+                "days_waiting": days,
+                "stale": q.is_stale(days),
+                # The server's sentence, verbatim — §13 rule 3. This
+                # screen does not compose its own account of a scheduling
+                # state any more than the other three do.
+                "summary": summary,
+            })
+
+        # ── Review shares nobody has answered ─────────────────────────
+        #
+        # `sent` and `viewed` are the two undecided statuses. A share
+        # that was approved, rejected, revoked or expired is not waiting
+        # on anybody, whatever else it is.
+        cur.execute("""
+            SELECT ds.id, ds.deed_id, ds.status, ds.created_at,
+                   ds.recipient_name, ds.recipient_email,
+                   d.property_address
+              FROM deed_shares ds
+              JOIN deeds d ON d.id = ds.deed_id
+             WHERE ds.owner_user_id = %s
+               AND ds.status IN ('sent', 'viewed')
+               AND (ds.expires_at IS NULL OR ds.expires_at > now())
+             ORDER BY ds.created_at ASC
+        """, (user_id,))
+        for row in _rows(cur):
+            days = q.days_since(row.get("created_at"))
+            awaiting.append({
+                "kind": "review",
+                "id": row["id"],
+                "deed_id": row["deed_id"],
+                "property": row.get("property_address"),
+                "who": (row.get("recipient_name") or "").strip()
+                       or row.get("recipient_email"),
+                "days_waiting": days,
+                "stale": q.is_stale(days),
+                "summary": ("Opened, no answer yet" if row["status"] == "viewed"
+                            else "Sent, not opened yet"),
+            })
+
+        # ── Her own drafts, untouched ─────────────────────────────────
+        cur.execute("""
+            SELECT id, deed_type, property_address, updated_at, created_at
+              FROM deeds
+             WHERE user_id = %s
+               AND COALESCE(status, 'draft') NOT IN ('completed', 'deleted')
+               AND COALESCE(updated_at, created_at) < %s
+             ORDER BY COALESCE(updated_at, created_at) ASC
+             LIMIT 10
+        """, (user_id, q.idle_cutoff()))
+        for row in _rows(cur):
+            idle.append({
+                "kind": "draft",
+                "id": row["id"],
+                "deed_type": row.get("deed_type"),
+                "property": row.get("property_address"),
+                "days_idle": q.days_since(row.get("updated_at") or row.get("created_at")),
+            })
+
+    upcoming.sort(key=lambda r: r["when"])
+    # Longest-waiting first: the oldest silence is the one worth chasing.
+    # `days_waiting` may be None for a row we cannot date, and those sort
+    # last rather than first — an unknown age is not evidence of urgency.
+    awaiting.sort(key=lambda r: (r["days_waiting"] is None,
+                                 -(r["days_waiting"] or 0)))
+    return q.queue(upcoming=upcoming, awaiting=awaiting, idle_drafts=idle)

--- a/backend/routers/deeds_crud.py
+++ b/backend/routers/deeds_crud.py
@@ -351,22 +351,41 @@ def deeds_summary(user_id: int = Depends(get_current_user_id)) -> Dict[str, int]
             completed = row[1] if row else 0
             drafts = row[2] if row else 0
 
-            # Query for deeds created this month
+            # DASH1: LAST 30 DAYS, not "this month".
+            #
+            # `date_trunc('month', ...)` renders a big zero on the first
+            # of every month, for a user whose work did not stop — the
+            # counter tells her she has done nothing when what happened
+            # is that a calendar page turned. The admin surface already
+            # carries a paragraph apologising for exactly this framing;
+            # this is the honest version it settled on.
+            #
+            # `month` is kept in the response ALONGSIDE it rather than
+            # renamed away, for one release: an old cached bundle asking
+            # for a key that vanished renders `undefined`, and FLOW1 item
+            # 0 was a whole PR about what that looks like. It is marked
+            # here so the next reader knows it is a deprecation and not a
+            # duplicate.
             cur.execute("""
-                SELECT COUNT(*)
+                SELECT
+                    COUNT(*) FILTER (WHERE created_at >= now() - interval '30 days') AS last_30,
+                    COUNT(*) FILTER (WHERE created_at >= date_trunc('month', CURRENT_DATE)) AS month
                 FROM deeds
                 WHERE user_id = %s AND COALESCE(status, '') <> 'deleted'
-                AND created_at >= date_trunc('month', CURRENT_DATE)
             """, (user_id,))
 
-            month_row = cur.fetchone()
-            month = month_row[0] if month_row else 0
+            row = cur.fetchone()
+            last_30 = (row[0] if row else 0) or 0
+            month = (row[1] if row else 0) or 0
 
             return {
                 "total": total,
                 "completed": completed,
                 "drafts": drafts,
-                "month": month
+                "last_30_days": last_30,
+                # DEPRECATED — see above. Remove one release after the
+                # dashboard stops reading it.
+                "month": month,
             }
 
     except HTTPException:

--- a/backend/routers/signing.py
+++ b/backend/routers/signing.py
@@ -32,6 +32,7 @@ from pydantic import BaseModel, Field
 
 import db
 from auth import get_current_user_id
+from services import officer_queue
 from services import signing_loop as loop
 from services import signing_purge, signing_surfaces
 from utils.throttle import client_key, throttle
@@ -403,6 +404,18 @@ def officer_agenda(user_id: int = Depends(get_current_user_id)):
                 # family as item 0: a fact the screen shows, that the
                 # server never sent, inferred.
                 "created_at": _iso(row.get("created_at")),
+                # DASH1: WHETHER IT HAS GONE QUIET, decided here.
+                # The agenda page carried `STUCK_AFTER_DAYS = 5` in
+                # TypeScript; the dashboard needed the same judgement, and
+                # a second threshold in Python for the same question is
+                # how the partner category list came to have four copies.
+                # One number, in services/officer_queue.py, and the
+                # screens render what they are told.
+                "days_waiting": officer_queue.days_since(row.get("created_at")),
+                "stale": (loop.request_state(row, windows, responses)
+                          in (loop.STATE_REQUESTED, loop.STATE_WINDOWS_POSTED)
+                          and officer_queue.is_stale(
+                              officer_queue.days_since(row.get("created_at")))),
                 "expires_at": _iso(row.get("expires_at")),
                 "signers": len([p for p in participants
                                 if p["party_role"] == loop.ROLE_SIGNER]),

--- a/backend/services/officer_queue.py
+++ b/backend/services/officer_queue.py
@@ -1,0 +1,155 @@
+"""DASH1 — what is waiting on somebody, computed in one place.
+
+═══ THE FINDING THIS ANSWERS ═══
+
+The dashboard showed only AUTHORING state: four counters and a feed of
+completed deeds. Nothing on it was WORKFLOW state — and workflow state is
+the escrow officer's actual job. Knowing who owes her something, and how
+long it has been owed, is what she does forty times a day; creating a
+deed is what she does once per file. The page had four entry points for
+the second and none for the first.
+
+So she could not answer "what is stuck?", "what signs tomorrow?" or "who
+has not responded?" without visiting two other pages.
+
+═══ WHY THE SERVER DECIDES WHAT "STALE" MEANS ═══
+
+`/signings` carried `STUCK_AFTER_DAYS = 5` in TypeScript. Adding a second
+threshold here — in Python, for the same question — is how the partner
+category list came to have four copies and how `phoneSearchKey` came to
+be right in one language and wrong in the other.
+
+So the number lives HERE, the server computes `days_waiting` and `stale`
+per row, and the screens render what they are told. The agenda payload
+carries the same flag from the same function, and the frontend constant
+is deleted rather than left as a second opinion.
+
+═══ WHAT COUNTS AS "WAITING ON SOMEBODY" ═══
+
+Three things, and they are different questions with different answers:
+
+  * A SIGNING THAT IS BOOKED and happens soon. Nothing is owed; she
+    needs to know it is coming.
+  * A REQUEST NOBODY HAS ANSWERED — a review share still sent/viewed, or
+    a signing request nobody has agreed a time for. Somebody owes her a
+    reply, and how long they have owed it is the whole signal.
+  * A DRAFT SHE HAS NOT TOUCHED. Nobody owes her anything; she owes
+    herself.
+
+They are kept apart rather than merged into one list, because "chase
+somebody" and "finish something" are different actions and a single
+undifferentiated pile makes her sort them by hand every morning.
+
+**NOTHING HERE INFERS THAT ANYTHING HAPPENED.** §13 holds: a booked
+signing whose time has passed is still booked. The queue reports what is
+arranged and what is unanswered; it never reports what was done.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List, Optional, Sequence
+
+# ── The thresholds, named once ───────────────────────────────────────
+#
+# STALE_AFTER_DAYS was `STUCK_AFTER_DAYS` in the agenda page's
+# TypeScript. It is not a deadline — nothing expires because of it — it
+# is the point at which silence is worth a phone call.
+STALE_AFTER_DAYS = 5
+# How far ahead "soon" reaches. A week is the horizon an escrow officer
+# plans on; a month of upcoming signings is a calendar, not a queue.
+UPCOMING_DAYS = 7
+# A draft nobody has touched for this long is not in progress, it is
+# forgotten. Deliberately longer than the stale threshold: her own work
+# waiting on her is less urgent than somebody else's silence.
+IDLE_DRAFT_DAYS = 7
+
+
+def days_since(when: Optional[datetime], now: Optional[datetime] = None) -> Optional[int]:
+    """Whole days since `when`, or None if we do not know when.
+
+    None rather than 0. Zero reads as "today", which is a claim; None
+    reads as "we do not know", which is true and keeps the row out of
+    every count that depends on an age.
+    """
+    if when is None:
+        return None
+    now = now or datetime.now(timezone.utc)
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=timezone.utc)
+    return max(0, (now - when).days)
+
+
+def is_stale(days: Optional[int]) -> bool:
+    """An unknown age is NOT stale — fail quiet, not fail loud.
+
+    A row we cannot date must not be pushed into her attention count on
+    the strength of a missing timestamp: the number she checks before
+    anything else has to be trustworthy, and one false entry costs more
+    than one missed entry.
+    """
+    return days is not None and days >= STALE_AFTER_DAYS
+
+
+def upcoming_cutoff(now: Optional[datetime] = None) -> datetime:
+    return (now or datetime.now(timezone.utc)) + timedelta(days=UPCOMING_DAYS)
+
+
+def idle_cutoff(now: Optional[datetime] = None) -> datetime:
+    return (now or datetime.now(timezone.utc)) - timedelta(days=IDLE_DRAFT_DAYS)
+
+
+# ── The payload's shape, asserted by equality ────────────────────────
+#
+# Same allowlist-by-key-set rule the NOTARY2 token surfaces and the
+# Shared Deeds row builder follow: a field cannot enter or leave this
+# payload silently, because a screen reading a key the server stopped
+# sending renders `undefined` and says nothing about it.
+QUEUE_KEYS = frozenset({
+    "upcoming",        # booked signings inside UPCOMING_DAYS
+    "awaiting",        # requests nobody has answered
+    "idle_drafts",     # her own work, untouched
+    "needs_attention", # ONE number: stale awaiting + unbooked signings
+    "thresholds",      # the numbers above, so no screen retypes them
+})
+
+UPCOMING_KEYS = frozenset({"kind", "id", "deed_id", "property", "when",
+                           "who", "summary"})
+AWAITING_KEYS = frozenset({"kind", "id", "deed_id", "property", "who",
+                           "days_waiting", "stale", "summary"})
+IDLE_KEYS = frozenset({"kind", "id", "deed_type", "property", "days_idle"})
+
+
+def queue(*, upcoming: Sequence[Dict[str, Any]],
+          awaiting: Sequence[Dict[str, Any]],
+          idle_drafts: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    """Assemble the payload and assert its shape.
+
+    `needs_attention` is computed HERE rather than by the screen, and it
+    is deliberately not "everything in the queue": a signing that is
+    booked for Thursday needs nothing from her, and counting it would
+    make the number she checks first mean "there are rows below".
+
+    It is the stale unanswered requests. That is the number that, when it
+    is zero, means nobody is waiting on her and nobody has gone quiet.
+    """
+    for row in upcoming:
+        assert set(row) == UPCOMING_KEYS, f"upcoming row drifted: {sorted(row)}"
+    for row in awaiting:
+        assert set(row) == AWAITING_KEYS, f"awaiting row drifted: {sorted(row)}"
+    for row in idle_drafts:
+        assert set(row) == IDLE_KEYS, f"idle row drifted: {sorted(row)}"
+
+    payload = {
+        "upcoming": list(upcoming),
+        "awaiting": list(awaiting),
+        "idle_drafts": list(idle_drafts),
+        "needs_attention": len([r for r in awaiting if r["stale"]]),
+        "thresholds": {
+            "stale_after_days": STALE_AFTER_DAYS,
+            "upcoming_days": UPCOMING_DAYS,
+            "idle_draft_days": IDLE_DRAFT_DAYS,
+        },
+    }
+    assert set(payload) == QUEUE_KEYS, (
+        f"the officer queue drifted from its contract: {sorted(payload)}")
+    return payload

--- a/backend/tests/snapshots/openapi_routes.json
+++ b/backend/tests/snapshots/openapi_routes.json
@@ -169,6 +169,10 @@
  ],
  [
   "GET",
+  "/dashboard/queue"
+ ],
+ [
+  "GET",
   "/deeds"
  ],
  [

--- a/backend/tests/test_dash1_officer_queue.py
+++ b/backend/tests/test_dash1_officer_queue.py
@@ -1,0 +1,416 @@
+"""DASH1 — the officer's queue, and the numbers it is allowed to claim.
+
+═══ THE FINDING ═══
+
+The dashboard showed AUTHORING state only: four counters and a feed of
+completed deeds. Nothing on it was workflow state — and workflow state is
+the escrow officer's job. She could not answer "what is stuck?", "what
+signs tomorrow?" or "who has not responded?" without visiting two other
+pages, while the page carried four entry points for creating a deed,
+which she does once per file.
+
+═══ WHAT THESE PINS PROTECT ═══
+
+ 1. THE PAYLOAD'S SHAPE, by equality. Same rule as the NOTARY2 token
+    surfaces and the Shared Deeds row: a screen reading a key the server
+    stopped sending renders `undefined` and says nothing about it, which
+    is what FLOW1 item 0 was a whole PR about.
+
+ 2. THE ATTENTION NUMBER MEANS SOMETHING. If it counted every row it
+    would mean "there are rows below", and she would stop reading it. It
+    counts stale unanswered requests: when it is zero, nobody is waiting
+    on her and nobody has gone quiet.
+
+ 3. AN UNKNOWN AGE IS NOT URGENT. A row we cannot date must not be
+    pushed into that count on the strength of a missing timestamp.
+
+ 4. ONE PLACE DECIDES WHAT STALE MEANS. `/signings` carried
+    `STUCK_AFTER_DAYS = 5` in TypeScript; a second threshold in Python
+    for the same question is how the partner category list came to have
+    four copies.
+
+ 5. §13 HOLDS. The queue reports what is arranged and what is
+    unanswered. Nothing in it infers that a signing happened, and a
+    booked time that has passed is still booked.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from services import officer_queue as q
+from tests.source_text import code_only
+
+BACKEND = Path(__file__).resolve().parents[1]
+REPO = BACKEND.parent
+
+dbonly = pytest.mark.skipif(not os.getenv("DATABASE_URL"), reason="needs a database")
+
+
+# ══════════════════════════════════════════════════════════════════════
+# The rules, without a database
+# ══════════════════════════════════════════════════════════════════════
+
+def test_an_unknown_age_is_unknown_rather_than_today():
+    """Zero reads as "asked today", which is a claim. None reads as "we
+    do not know", which is true."""
+    assert q.days_since(None) is None
+    now = datetime(2026, 8, 11, tzinfo=timezone.utc)
+    assert q.days_since(now - timedelta(days=3), now) == 3
+    # A naive timestamp is read as UTC rather than crashing — but it is
+    # still read, not guessed at.
+    assert q.days_since(datetime(2026, 8, 8), now) == 3
+
+
+def test_an_unknown_age_is_never_stale():
+    """Fail quiet, not fail loud. The number she checks before anything
+    else has to be trustworthy, and one false entry costs more than one
+    missed entry."""
+    assert q.is_stale(None) is False
+    assert q.is_stale(q.STALE_AFTER_DAYS - 1) is False
+    assert q.is_stale(q.STALE_AFTER_DAYS) is True
+
+
+def _awaiting(stale: bool, days=9):
+    return {"kind": "review", "id": 1, "deed_id": 2, "property": "x",
+            "who": "Nora", "days_waiting": days if stale else 1,
+            "stale": stale, "summary": "Sent, not opened yet"}
+
+
+def test_the_attention_count_is_stale_requests_and_nothing_else():
+    """Not "everything in the queue". A signing booked for Thursday needs
+    nothing from her, and counting it would make the number mean "there
+    are rows below" — at which point she stops reading it."""
+    payload = q.queue(
+        upcoming=[{"kind": "signing", "id": 3, "deed_id": 4, "property": "y",
+                   "when": "2026-08-13T10:00:00+00:00", "who": "Nora",
+                   "summary": "Everyone agreed on ..."}],
+        awaiting=[_awaiting(True), _awaiting(False)],
+        idle_drafts=[{"kind": "draft", "id": 5, "deed_type": "grant_deed",
+                      "property": "z", "days_idle": 30}],
+    )
+    assert payload["needs_attention"] == 1
+
+
+def test_the_payload_shape_is_asserted_by_equality():
+    from services.officer_queue import QUEUE_KEYS
+
+    payload = q.queue(upcoming=[], awaiting=[], idle_drafts=[])
+    assert set(payload) == QUEUE_KEYS
+    assert payload["needs_attention"] == 0
+    # And the thresholds travel WITH it, so no screen retypes them.
+    assert payload["thresholds"]["stale_after_days"] == q.STALE_AFTER_DAYS
+
+
+def test_a_row_that_grew_a_field_is_refused():
+    """An assertion rather than a filter: silently dropping an unexpected
+    key would let the screen and the server disagree again, quietly."""
+    bad = _awaiting(True)
+    bad["extra"] = 1
+    with pytest.raises(AssertionError):
+        q.queue(upcoming=[], awaiting=[bad], idle_drafts=[])
+
+
+def test_only_one_place_decides_what_stale_means():
+    """`/signings` used to carry `STUCK_AFTER_DAYS = 5` in TypeScript.
+    A second threshold in Python for the same question is how the partner
+    category list came to have four copies.
+
+    COMMENT-TRIP FIFTEEN, and the fix is a division of labour rather than
+    a better regex. The first version searched the raw .tsx for
+    "STUCK_AFTER_DAYS = 5" and tripped on the comment recording that the
+    constant used to live there — this suite has no TypeScript comment
+    stripper, and writing one here would be a third opinion about what a
+    comment is.
+
+    So each side pins what it can read properly: Python asserts the
+    SERVER sends the verdict (below), and `officerTrackers.test.ts` —
+    which has `codeOnly()` — asserts the screen holds no threshold. The
+    DECLARATION is still checked here as a cheap belt, because a
+    declaration is a shape a comment is unlikely to contain.
+    """
+    agenda = (REPO / "frontend" / "src" / "app" / "signings" / "page.tsx").read_text(
+        encoding="utf-8")
+    assert "const STUCK_AFTER_DAYS" not in agenda, (
+        "the screen declares its own staleness threshold again — the "
+        "server sends `stale` and the number lives in officer_queue.py")
+
+    payload = code_only(BACKEND / "routers" / "signing.py")
+    assert '"stale": (' in payload, (
+        "the agenda payload stopped carrying the verdict, so the screen "
+        "has to form one")
+    assert "officer_queue.is_stale(" in payload
+
+
+def test_the_queue_never_infers_that_a_signing_happened():
+    """§13. It reports what is arranged and what is unanswered.
+
+    THE FIRST VERSION OF THIS PIN MATCHED THE SPELLING. It forbade the
+    bare word "completed" anywhere in the router, and fired on
+    `COALESCE(status, 'draft') NOT IN ('completed', 'deleted')` — the
+    DEED status vocabulary, in the query that finds untouched drafts,
+    which has nothing to do with whether a signing occurred. A pin that
+    fails on a word doing an unrelated job is the same instrument error
+    FLOW1 kept finding.
+
+    The properties, matched as themselves:
+
+      * READ-ONLY. A queue that writes is a queue that can change what it
+        reports on.
+      * The scheduling state and its sentence come from `signing_loop`,
+        not from anything composed here — §13 rule 3, the same rule the
+        other three surfaces follow.
+      * Nothing compares a booked time to the clock in order to conclude
+        something. `booked_at <= cutoff` is a HORIZON — it decides
+        whether a row is shown — and the pin has to permit that while
+        forbidding an inference about attendance.
+    """
+    src = code_only(BACKEND / "routers" / "dashboard.py")
+
+    for write in ("INSERT INTO", "UPDATE ", "DELETE FROM"):
+        assert write not in src, f"the queue writes ({write}) — it is a read"
+
+    assert "loop.request_state(" in src
+    assert "loop.state_label(" in src
+    # No locally-composed account of a scheduling state.
+    for invented in ("Everyone agreed", "Booked for", "will happen",
+                     "took place", "attended"):
+        assert invented not in src, (
+            f"the queue writes its own scheduling sentence: {invented!r}")
+
+    # The only clock comparison is the display horizon, and it is named.
+    import re
+    comparisons = re.findall(r"booked_at\s*[<>]=?\s*(\w+)", src)
+    assert comparisons == ["cutoff"], (
+        f"something compares a booked time to something else: {comparisons} "
+        "— a window that has passed is not evidence that anybody met")
+
+
+# ══════════════════════════════════════════════════════════════════════
+# The whole thing, against a database
+# ══════════════════════════════════════════════════════════════════════
+
+@pytest.fixture
+def world():
+    import psycopg2
+    from database import create_tables
+    from db_rows import ROW_FACTORY
+
+    create_tables()
+    conn = psycopg2.connect(os.environ["DATABASE_URL"], cursor_factory=ROW_FACTORY)
+    conn.autocommit = True
+    tag = uuid.uuid4().hex[:8]
+    made = {"users": [], "deeds": []}
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO users (email, password_hash, full_name, role) "
+            "VALUES (%s, 'x', 'Officer', 'user') RETURNING id",
+            (f"officer-{tag}@dash1.test",))
+        made["users"].append(cur.fetchone()["id"])
+        for address, status in (("40 Queue Way, Los Angeles, CA", "completed"),
+                                ("41 Idle Road, Los Angeles, CA", "draft")):
+            cur.execute(
+                """INSERT INTO deeds (user_id, deed_type, property_address, apn,
+                                      grantor_name, grantee_name, county, status)
+                   VALUES (%s, 'grant_deed', %s, '1234-567-890',
+                           'GRANTOR', 'GRANTEE', 'Los Angeles', %s)
+                   RETURNING id""",
+                (made["users"][0], address, status))
+            made["deeds"].append(cur.fetchone()["id"])
+    made["conn"] = conn
+    yield made
+    conn.close()
+
+
+def _client_for(user_id: int):
+    from fastapi.testclient import TestClient
+    from auth import create_access_token
+    from main import app
+
+    client = TestClient(app)
+    client.headers.update({
+        "Authorization": "Bearer " + create_access_token(
+            {"sub": str(user_id), "email": "officer@dash1.test"})})
+    return client
+
+
+@dbonly
+def test_an_empty_queue_is_empty_rather_than_absent(world):
+    """An honest empty queue is a good morning, not a blank page — and
+    the screen can only say so if the shape arrives whatever the counts."""
+    body = _client_for(world["users"][0]).get("/dashboard/queue").json()
+    assert set(body) == set(q.QUEUE_KEYS)
+    assert body["needs_attention"] == 0
+    assert body["upcoming"] == []
+    assert body["awaiting"] == []
+
+
+@dbonly
+def test_a_share_nobody_has_answered_is_waiting_with_its_age(world):
+    officer = world["users"][0]
+    client = _client_for(officer)
+    assert client.post("/shared-deeds", json={
+        "deed_id": world["deeds"][0],
+        "recipient_name": "Nora Vasquez",
+        "recipient_email": "nora@dash1.test",
+        "recipient_role": "Reviewer",
+    }).status_code == 200
+
+    body = client.get("/dashboard/queue").json()
+    row = next(r for r in body["awaiting"] if r["kind"] == "review")
+    assert row["who"] == "Nora Vasquez"
+    assert row["days_waiting"] == 0
+    assert row["stale"] is False
+    # Fresh, so nothing needs her attention yet.
+    assert body["needs_attention"] == 0
+
+    # Age it past the threshold and it becomes the number she checks.
+    with world["conn"].cursor() as cur:
+        cur.execute("UPDATE deed_shares SET created_at = now() - interval '%s days' "
+                    "WHERE id = %s", (q.STALE_AFTER_DAYS + 2, row["id"]))
+    body = client.get("/dashboard/queue").json()
+    row = next(r for r in body["awaiting"] if r["kind"] == "review")
+    assert row["stale"] is True
+    assert row["days_waiting"] >= q.STALE_AFTER_DAYS
+    assert body["needs_attention"] == 1
+
+
+@dbonly
+def test_an_answered_share_stops_waiting(world):
+    """Waiting means somebody owes her a reply. A decided share does not,
+    whatever else it is."""
+    officer = world["users"][0]
+    client = _client_for(officer)
+    made = client.post("/shared-deeds", json={
+        "deed_id": world["deeds"][0],
+        "recipient_email": "decided@dash1.test",
+        "recipient_role": "Reviewer",
+    }).json()
+
+    with world["conn"].cursor() as cur:
+        cur.execute("UPDATE deed_shares SET status = 'approved' WHERE id = %s",
+                    (made["shared_deed"]["id"],))
+    body = client.get("/dashboard/queue").json()
+    assert not [r for r in body["awaiting"]
+                if r["kind"] == "review" and r["id"] == made["shared_deed"]["id"]]
+
+
+@dbonly
+def test_a_booked_signing_is_upcoming_and_not_awaiting(world):
+    """Two different questions. Nothing is owed on a booked signing; she
+    needs to know it is coming."""
+    from fastapi.testclient import TestClient
+    from main import app
+
+    officer = world["users"][0]
+    client = _client_for(officer)
+    when = datetime.now(timezone.utc) + timedelta(days=2)
+    created = client.post("/signing-requests/v2", json={
+        "deed_id": world["deeds"][0],
+        "notary_email": "nora@dash1.test", "notary_name": "Nora",
+        "signers": [{"name": "Sam", "email": "sam@dash1.test"}],
+        "proposed_time": {"start": when.isoformat(),
+                          "end": (when + timedelta(hours=1)).isoformat()},
+        "signers_already_agreed": True,
+    }).json()
+
+    # Before acceptance it is AWAITING — somebody owes her an answer.
+    body = client.get("/dashboard/queue").json()
+    assert any(r["kind"] == "signing" for r in body["awaiting"])
+    assert body["upcoming"] == []
+
+    notary_token = next(p["link"] for p in created["participants"]
+                        if p["party_role"] == "notary").rsplit("/", 1)[-1]
+    public = TestClient(app)
+    window_id = public.get(f"/signing/{notary_token}").json()["windows"][0]["id"]
+    public.post(f"/signing/{notary_token}/answer",
+                json={"window_id": window_id, "answer": "available"})
+
+    body = client.get("/dashboard/queue").json()
+    assert not [r for r in body["awaiting"] if r["kind"] == "signing"]
+    upcoming = next(r for r in body["upcoming"] if r["kind"] == "signing")
+    assert upcoming["who"] == "Nora"
+    assert upcoming["summary"], "the server's sentence is missing"
+
+
+@dbonly
+def test_a_signing_beyond_the_horizon_is_not_on_the_dashboard(world):
+    """A booking three months out is real and is not what she needs this
+    morning."""
+    from fastapi.testclient import TestClient
+    from main import app
+
+    officer = world["users"][0]
+    client = _client_for(officer)
+    when = datetime.now(timezone.utc) + timedelta(days=q.UPCOMING_DAYS + 20)
+    created = client.post("/signing-requests/v2", json={
+        "deed_id": world["deeds"][0],
+        "notary_email": "far@dash1.test", "notary_name": "Far",
+        "signers": [{"name": "Sam", "email": "sam@dash1.test"}],
+        "proposed_time": {"start": when.isoformat(),
+                          "end": (when + timedelta(hours=1)).isoformat()},
+        "signers_already_agreed": True,
+    }).json()
+    notary_token = next(p["link"] for p in created["participants"]
+                        if p["party_role"] == "notary").rsplit("/", 1)[-1]
+    public = TestClient(app)
+    window_id = public.get(f"/signing/{notary_token}").json()["windows"][0]["id"]
+    public.post(f"/signing/{notary_token}/answer",
+                json={"window_id": window_id, "answer": "available"})
+
+    body = client.get("/dashboard/queue").json()
+    assert body["upcoming"] == []
+    assert not [r for r in body["awaiting"] if r["kind"] == "signing"]
+
+
+@dbonly
+def test_an_untouched_draft_surfaces_and_a_fresh_one_does_not(world):
+    officer = world["users"][0]
+    client = _client_for(officer)
+    assert client.get("/dashboard/queue").json()["idle_drafts"] == []
+
+    with world["conn"].cursor() as cur:
+        cur.execute("UPDATE deeds SET updated_at = now() - interval '%s days' "
+                    "WHERE id = %s", (q.IDLE_DRAFT_DAYS + 3, world["deeds"][1]))
+    rows = client.get("/dashboard/queue").json()["idle_drafts"]
+    assert [r["id"] for r in rows] == [world["deeds"][1]]
+    assert rows[0]["days_idle"] >= q.IDLE_DRAFT_DAYS
+    # A completed deed is not a draft, however long ago it was touched.
+    assert world["deeds"][0] not in [r["id"] for r in rows]
+
+
+@dbonly
+def test_the_queue_is_the_officers_own(world):
+    """`officer_user_id` / `owner_user_id` / `user_id` scoping, tested
+    rather than assumed — three tables, three column names, one rule."""
+    conn = world["conn"]
+    with conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO users (email, password_hash, full_name, role) "
+            "VALUES (%s, 'x', 'Stranger', 'user') RETURNING id",
+            (f"stranger-{uuid.uuid4().hex[:8]}@dash1.test",))
+        stranger = cur.fetchone()["id"]
+
+    _client_for(world["users"][0]).post("/shared-deeds", json={
+        "deed_id": world["deeds"][0],
+        "recipient_email": "nora@dash1.test",
+        "recipient_role": "Reviewer",
+    })
+    body = _client_for(stranger).get("/dashboard/queue").json()
+    assert body["awaiting"] == []
+    assert body["idle_drafts"] == []
+
+
+@dbonly
+def test_the_summary_counts_thirty_days_rather_than_a_calendar_page(world):
+    """`date_trunc('month')` renders a big zero on the first of every
+    month for a user whose work did not stop."""
+    body = _client_for(world["users"][0]).get("/deeds/summary").json()
+    assert "last_30_days" in body
+    assert body["last_30_days"] == 2, body
+    assert body["drafts"] == 1
+    assert body["completed"] == 1

--- a/backend/tests/test_flow1_copy_and_agenda.py
+++ b/backend/tests/test_flow1_copy_and_agenda.py
@@ -52,6 +52,7 @@ from __future__ import annotations
 
 import ast
 import re
+import tokenize
 from pathlib import Path
 
 import pytest
@@ -85,11 +86,28 @@ PRONOUN_EXEMPT = {
 
 
 def _rendered_lines(path: Path):
-    """Lines of a .py file that are CODE, with docstrings removed.
+    """Lines of a .py file that are CODE — no docstrings, no comments.
 
-    Prose about a role in a docstring is not a claim made to anybody. The
-    sweep is about what the product SAYS, so it reads what the product
-    renders.
+    Prose about a role in a docstring or a comment is not a claim made to
+    anybody. The sweep is about what the product SAYS, so it reads what
+    the product renders.
+
+    ═══ THE FOURTEENTH COMMENT-TRIP, AND WHY code_only IS NOT THE FIX ═══
+
+    The first version skipped only lines that STARTED with `#`, so a
+    trailing comment — `"idle_drafts",  # her own work, untouched` —
+    tripped the sweep on prose nobody will ever read. That is the trip
+    this codebase has now made fourteen times, and the reflex is
+    `code_only()`.
+
+    It is the wrong tool HERE, for a specific reason: `code_only` on
+    Python COLLAPSES lines (155 in, 90 out), so every line number this
+    pin reports would be wrong — and a sweep whose failure message points
+    at the wrong line is worse than one that occasionally trips, because
+    the reader chases a line that is innocent.
+
+    So this tokenizes and BLANKS comment spans in place. Line numbers
+    survive; comments do not.
     """
     src = path.read_text(encoding="utf-8")
     tree = ast.parse(src)
@@ -101,8 +119,18 @@ def _rendered_lines(path: Path):
                 first = node.body[0]
                 doc_lines.update(range(first.lineno,
                                        (first.end_lineno or first.lineno) + 1))
-    for i, line in enumerate(src.splitlines(), 1):
-        if i in doc_lines or line.lstrip().startswith("#"):
+
+    lines = src.splitlines()
+    with path.open("rb") as handle:
+        for tok in tokenize.tokenize(handle.readline):
+            if tok.type != tokenize.COMMENT:
+                continue
+            row = tok.start[0] - 1
+            if 0 <= row < len(lines):
+                lines[row] = lines[row][: tok.start[1]]
+
+    for i, line in enumerate(lines, 1):
+        if i in doc_lines:
             continue
         yield i, line
 
@@ -130,6 +158,29 @@ def test_no_template_asserts_a_pronoun_for_a_named_party():
                 if PRONOUNS.search(line):
                     offenders.append(
                         f"{path.relative_to(REPO)}:{lineno}: {line.strip()[:90]}")
+
+    # A trailing comment must not trip the sweep, and a rendered string
+    # must. Proved rather than assumed — this is the exact trip DASH1
+    # made, reduced to two lines.
+    import textwrap
+    probe = BACKEND / "tests" / "_pronoun_probe.py"
+    probe.write_text(textwrap.dedent('''
+        VALUES = [
+            "idle_drafts",     # her own work, untouched
+        ]
+    ''').lstrip(), encoding="utf-8")
+    try:
+        assert not any(PRONOUNS.search(line)
+                       for _n, line in _rendered_lines(probe)), (
+            "a trailing comment trips the sweep — the fourteenth "
+            "comment-trip, and the reason this reads tokens")
+        probe.write_text('MESSAGE = "she confirms it herself"\n', encoding="utf-8")
+        hits = [n for n, line in _rendered_lines(probe) if PRONOUNS.search(line)]
+        assert hits == [1], (
+            f"the sweep stopped seeing rendered strings, or lost its line "
+            f"numbers: {hits}")
+    finally:
+        probe.unlink(missing_ok=True)
 
     for path in sorted((BACKEND / "templates").rglob("*")):
         if not path.is_file():
@@ -190,8 +241,17 @@ def test_the_officer_agenda_sends_when_she_asked():
 def test_the_frontend_no_longer_reconstructs_the_age():
     """The other half of the same fix — pinned from here too, because a
     server that sends the fact and a screen that ignores it is the same
-    defect with an extra step."""
+    defect with an extra step.
+
+    DASH1 moved the second assertion UP a level. FLOW1 pinned the local
+    `ageInDays(r.created_at)` that replaced `expires_at minus 21 days`;
+    DASH1 removed the local judgement as well, because the dashboard
+    needed the same "has this gone quiet?" answer and two thresholds in
+    two languages is the copy problem this codebase keeps deleting. The
+    screen reads both the age and the verdict now.
+    """
     page = (REPO / "frontend" / "src" / "app" / "signings" / "page.tsx").read_text(
         encoding="utf-8")
     assert "21 * 86400_000" not in page
-    assert "ageInDays(r.created_at)" in page
+    assert "row.days_waiting" in page
+    assert "return r.stale;" in page

--- a/frontend/src/__tests__/dashboardQueue.test.ts
+++ b/frontend/src/__tests__/dashboardQueue.test.ts
@@ -1,0 +1,163 @@
+/**
+ * DASH1 — the dashboard is a workflow surface.
+ *
+ * ═══ THE FINDING ═══
+ *
+ * Everything on the dashboard was document-authoring state: four
+ * counters and a feed. Nothing was WORKFLOW state — and workflow state
+ * is the escrow officer's job. She could not answer "what is stuck?",
+ * "what signs tomorrow?" or "who has not responded?" without visiting
+ * two other pages, while the page carried four entry points for creating
+ * a deed, which she does once per file and forty times less often than
+ * she checks what is waiting.
+ *
+ * ═══ WHAT IS PINNED ═══
+ *
+ *  1. THE QUEUE LEADS. Above the counters, in the source order the page
+ *     renders. A workflow surface with the workflow below the trivia is
+ *     the old page with an extra section.
+ *  2. EVERY ROW LINKS TO THE THING ITSELF, and every link LANDS —
+ *     `?status=` and `?focus=` are read by the page they point at. A
+ *     link that arrives and shows an unfiltered list is the dead-button
+ *     defect wearing a URL.
+ *  3. A COUNT WITH NO DRILL-DOWN IS TRIVIA. `href` on StatCard is
+ *     REQUIRED, so a tile added later without one fails to compile
+ *     rather than silently reintroducing the thing this ticket removed.
+ *  4. THE EMPTY QUEUE SAYS SO. An honest empty queue is a good morning,
+ *     not a blank page — and a FAILED queue says that instead, because
+ *     "nothing is waiting" is a claim about her work rather than about
+ *     our request (§4).
+ *  5. "THIS MONTH" IS GONE. It rendered a big zero every rollover.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
+
+const SRC = path.join(__dirname, '..');
+const read = (...p: string[]) => fs.readFileSync(path.join(SRC, ...p), 'utf8');
+const flat = (s: string) => s.replace(/\s+/g, ' ');
+
+const DASH = read('app', 'dashboard', 'page.tsx');
+const DASH_CODE = codeOnly(DASH);
+const PAST = read('app', 'past-deeds', 'page.tsx');
+const PAST_CODE = codeOnly(PAST);
+
+describe('DASH1 — the queue leads', () => {
+  it('renders what is waiting above the counters', () => {
+    const queueAt = DASH_CODE.indexOf('<ActionQueue');
+    const statsAt = DASH_CODE.indexOf('label="Total Deeds"');
+    expect(queueAt).toBeGreaterThan(-1);
+    expect(statsAt).toBeGreaterThan(-1);
+    expect(queueAt).toBeLessThan(statsAt);
+  });
+
+  it('asks the server what is waiting rather than working it out', () => {
+    expect(DASH_CODE).toContain('apiFetch(`/dashboard/queue`');
+    // No local threshold. "Stale" is decided once, server-side.
+    expect(DASH_CODE).not.toContain('STUCK_AFTER_DAYS');
+    expect(DASH_CODE).not.toMatch(/>=\s*5\s*&&/);
+  });
+
+  it('splits the three questions instead of making one pile', () => {
+    // "Chase somebody", "be somewhere" and "finish something" are
+    // different actions; merged, she sorts them by hand every morning.
+    expect(DASH_CODE).toContain('queue.upcoming');
+    expect(DASH_CODE).toContain('queue.awaiting');
+    expect(DASH_CODE).toContain('queue.idle_drafts');
+  });
+
+  it('shows one attention number, from the server', () => {
+    expect(DASH_CODE).toContain('queue.needs_attention');
+    // It is not recomputed here — a second opinion about which rows
+    // count would make the number mean two things.
+    expect(DASH_CODE).not.toMatch(/filter\([^)]*\.stale\)/);
+  });
+});
+
+describe('DASH1 — an empty queue is an answer, a failed one is not', () => {
+  it('says nothing is waiting rather than rendering nothing', () => {
+    expect(flat(DASH)).toContain('Nothing is waiting on anyone.');
+  });
+
+  it('a failed queue says so instead of showing the empty state', () => {
+    // §4. "Nothing is waiting" over a failed request is a claim about
+    // her work, made out of our own error.
+    expect(flat(DASH)).toContain("Couldn't load what's waiting");
+    const errorBranch = DASH_CODE.indexOf('if (error)');
+    const emptyBranch = DASH_CODE.indexOf('const empty =');
+    expect(errorBranch).toBeGreaterThan(-1);
+    expect(errorBranch).toBeLessThan(emptyBranch);
+  });
+
+  it('keeps the queue and the deed list on separate errors', () => {
+    // Either failing must not blank the other — the rule FLOW1 item 3
+    // landed on when Shared Deeds grew a second feed.
+    expect(DASH_CODE).toContain('setQueueError');
+    expect(DASH_CODE).toContain('setDeedsError');
+  });
+});
+
+describe('DASH1 — every count and every row goes somewhere', () => {
+  it('makes href required on a stat tile', () => {
+    // Not optional. A tile added later without one would silently be
+    // the thing this ticket removed.
+    expect(DASH_CODE).toMatch(/color:\s*"blue"\s*\|\s*"yellow"\s*\|\s*"green"\s*\|\s*"purple"\s*\n?\s*href:\s*string/);
+    expect(DASH_CODE).not.toContain('href?: string');
+  });
+
+  it('every tile carries a drill-down', () => {
+    // Counted over the grid rather than matched per element: a
+    // `<StatCard ... icon={<FileText />} ... />` closes its ICON first,
+    // so a non-greedy match ends before the props that matter. The first
+    // version of this pin did exactly that and failed on correct code.
+    const grid = DASH_CODE.slice(
+      DASH_CODE.indexOf('grid-cols-2 lg:grid-cols-4'),
+      DASH_CODE.indexOf('Create New Deed'));
+    const tiles = (grid.match(/<StatCard\b/g) || []).length;
+    const hrefs = (grid.match(/\bhref="/g) || []).length;
+    expect(tiles).toBe(4);
+    expect(hrefs).toBe(tiles);
+  });
+
+  it('the activity rows link to the deed', () => {
+    expect(DASH_CODE).toContain('?resume=${deed.id}');
+    expect(DASH_CODE).toContain('/past-deeds?focus=${deed.id}');
+  });
+
+  it('and those links land — the target reads them', () => {
+    // The half of a link that is easy to forget. `?status=` seeds the
+    // filter, `?focus=` marks the row.
+    expect(PAST_CODE).toContain('params?.get("status")');
+    expect(PAST_CODE).toContain('params?.get("focus")');
+    expect(PAST_CODE).toContain('deed.id === focusId');
+  });
+});
+
+describe('DASH1 — the feed says what it shows', () => {
+  it('is no longer called "Recent Activity" while sorted by creation', () => {
+    // `GET /deeds` orders by created_at DESC, so a draft edited this
+    // morning sat below five deeds made last week and never touched.
+    expect(flat(DASH)).not.toContain('>Recent Activity<');
+    expect(flat(DASH)).toContain('Recently worked on');
+  });
+
+  it('sorts by when something last happened to the deed', () => {
+    expect(DASH_CODE).toContain('const recentlyTouched');
+    expect(flat(DASH_CODE)).toContain('String(b.updated_at || b.created_at');
+    expect(DASH_CODE).toContain('recentlyTouched.slice(0, 5)');
+  });
+});
+
+describe('DASH1 — "This Month" is gone', () => {
+  it('counts a rolling window instead of a calendar page', () => {
+    expect(DASH_CODE).not.toContain('label="This Month"');
+    expect(DASH_CODE).toContain('label="Last 30 days"');
+    expect(DASH_CODE).toContain('data.last_30_days');
+    // And the state field is not still called `month` while holding
+    // thirty days — a name that lies inside the component is the
+    // same defect one scope down.
+    expect(DASH_CODE).toContain('lastThirtyDays');
+    expect(DASH_CODE).not.toMatch(/summary\?\.month/);
+  });
+});

--- a/frontend/src/__tests__/officerTrackers.test.ts
+++ b/frontend/src/__tests__/officerTrackers.test.ts
@@ -127,24 +127,35 @@ describe('FLOW1 item 4 — the order is the one it claims', () => {
   });
 });
 
-describe('FLOW1 item 4 — the age is read, not reconstructed', () => {
-  it('reads created_at instead of subtracting the expiry default', () => {
-    expect(SIGNINGS_CODE).toContain('function ageInDays(createdAt: string | null)');
-    expect(SIGNINGS_CODE).toContain('ageInDays(r.created_at)');
-  });
-
+describe('FLOW1 item 4 → DASH1 — the age is read, and so is the verdict', () => {
+  // DASH1 FINISHED WHAT ITEM 4 STARTED, and the pin moved with it.
+  //
+  // Item 4 stopped this screen RECONSTRUCTING a request's age from
+  // `expires_at minus 21 days`, and pinned the local `ageInDays` that
+  // replaced the arithmetic. DASH1 removed the local judgement too: the
+  // dashboard needed the same "has this gone quiet?" answer, and a
+  // threshold in Python beside one in TypeScript is how the partner
+  // category list came to have four copies.
+  //
+  // So the assertions moved UP a level rather than being deleted: the
+  // screen holds no age arithmetic AND no threshold, and reads both from
+  // the payload.
   it('carries no copy of the server’s expiry constant', () => {
-    // `21` was `default_expiry()`'s value, retyped here as a bare
-    // number with nothing connecting the two. A magic constant that
-    // mirrors a server default is a silent coupling.
     expect(SIGNINGS_CODE).not.toMatch(/\b21\s*\*\s*86400/);
     expect(SIGNINGS_CODE).not.toContain('expires - 21');
   });
 
-  it('an unknown creation time is unknown, not zero', () => {
-    // Zero would read as "asked today", which is a claim.
-    expect(SIGNINGS_CODE).toContain('if (!createdAt) return null;');
-    expect(SIGNINGS_CODE).toContain('if (age === null) return false;');
+  it('holds no staleness threshold of its own', () => {
+    expect(SIGNINGS_CODE).not.toContain('STUCK_AFTER_DAYS');
+    expect(SIGNINGS_CODE).not.toMatch(/>=\s*5\b/);
+  });
+
+  it('reads the verdict and the age from the payload', () => {
+    expect(SIGNINGS_CODE).toContain('return r.stale;');
+    expect(SIGNINGS_CODE).toContain('const age = row.days_waiting;');
+    // And the number in the banner's sentence comes with the payload
+    // rather than being typed into the sentence.
+    expect(SIGNINGS_CODE).toContain('stale_after_days');
   });
 });
 

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -16,7 +16,34 @@ import {
   ArrowRight, Sparkles, Eye
 } from "lucide-react"
 
+/**
+ * DASH1 — WHAT IS WAITING ON SOMEBODY.
+ *
+ * The dashboard showed only AUTHORING state: four counters and a feed of
+ * completed deeds. Nothing on it was workflow state — and workflow state
+ * is the escrow officer's job. She could not answer "what is stuck?",
+ * "what signs tomorrow?" or "who has not responded?" without visiting two
+ * other pages, while this page carried four entry points for creating a
+ * deed, which she does once per file.
+ *
+ * The shape below is the server's, asserted by equality in
+ * `services/officer_queue.py`. Nothing here decides what "stale" means.
+ */
+type Queue = {
+  upcoming: Array<{ kind: string; id: number; deed_id: number; property: string | null;
+                    when: string; who: string | null; summary: string }>;
+  awaiting: Array<{ kind: string; id: number; deed_id: number; property: string | null;
+                    who: string | null; days_waiting: number | null; stale: boolean;
+                    summary: string }>;
+  idle_drafts: Array<{ kind: string; id: number; deed_type: string | null;
+                       property: string | null; days_idle: number | null }>;
+  needs_attention: number;
+  thresholds: { stale_after_days: number; upcoming_days: number; idle_draft_days: number };
+};
+
 export default function Dashboard() {
+  const [queue, setQueue] = useState<Queue | null>(null)
+  const [queueError, setQueueError] = useState<string | null>(null)
   const [isAuthenticated, setIsAuthenticated] = useState(false)
   const [loading, setLoading] = useState(true)
   const [userName, setUserName] = useState<string>("")
@@ -26,7 +53,7 @@ export default function Dashboard() {
     total: number
     completed: number
     drafts: number
-    month: number
+    lastThirtyDays: number
   } | null>(null)
   const router = useRouter()
 
@@ -101,7 +128,7 @@ export default function Dashboard() {
             total: data.total || 0,
             completed: data.completed || 0,
             drafts: data.drafts || 0,
-            month: data.month || 0,
+            lastThirtyDays: data.last_30_days ?? data.month ?? 0,
           })
         } else {
           // Fallback: calculate from deeds list
@@ -109,20 +136,42 @@ export default function Dashboard() {
           if (list.ok) {
             const data = await list.json()
             const deeds = Array.isArray(data.deeds) ? data.deeds : []
-            const monthStart = new Date()
-            monthStart.setDate(1)
-            monthStart.setHours(0, 0, 0, 0)
+            const thirtyDaysAgo = new Date(Date.now() - 30 * 86400_000)
             setSummary({
               total: deeds.length,
               completed: deeds.filter((d: any) => d.status === "completed").length,
               drafts: deeds.filter((d: any) => d.status !== "completed").length,
-              month: deeds.filter((d: any) => d.created_at && new Date(d.created_at) >= monthStart).length,
+              // Fallback path: 30 days back, matching the endpoint it is
+              // standing in for rather than the calendar it used to use.
+              lastThirtyDays: deeds.filter((d: any) => d.created_at
+                && new Date(d.created_at) >= thirtyDaysAgo).length,
             })
           }
         }
       } catch (e) {
         if (e instanceof SessionExpiredError) return
         console.error("Failed to load dashboard summary:", e)
+      }
+    })()
+  }, [isAuthenticated])
+
+  // The queue. Its own state and its own error, because a failed queue
+  // must not blank a page of real deeds and a failed deed list must not
+  // hide the queue — §4 in both directions, the rule FLOW1 item 3 landed
+  // on when Shared Deeds grew a second feed.
+  useEffect(() => {
+    if (!isAuthenticated) return
+    ;(async () => {
+      try {
+        const res = await apiFetch(`/dashboard/queue`, {}, { label: "Loading what's waiting" })
+        if (!res.ok) {
+          const detail = await res.json().catch(() => ({}))
+          throw new Error(detail.detail || `Couldn't load your queue (${res.status})`)
+        }
+        setQueue(await res.json())
+      } catch (e) {
+        if (e instanceof SessionExpiredError) return
+        setQueueError(e instanceof Error ? e.message : "Couldn't load what's waiting")
       }
     })()
   }, [isAuthenticated])
@@ -173,6 +222,11 @@ export default function Dashboard() {
   // U1.2: the LAST-TOUCHED draft (updated_at desc), not the first draft in
   // a created_at-ordered list — that offered users their oldest work back.
   const inProgressDeed = pickInProgressDeed(recentDeeds)
+  // DASH1: by when something last happened to it, drafts included —
+  // which is what "recent activity" claimed and creation order is not.
+  const recentlyTouched = [...recentDeeds].sort((a: any, b: any) =>
+    String(b.updated_at || b.created_at || '').localeCompare(
+      String(a.updated_at || a.created_at || '')))
 
   return (
     <div className="flex bg-gray-50 min-h-screen">
@@ -202,7 +256,14 @@ export default function Dashboard() {
             />
           )}
 
-          {/* Stats Grid */}
+          {/* DASH1 — THE QUEUE LEADS. What is waiting on somebody comes
+              before what has been made, because that is the order she
+              works in. */}
+          <ActionQueue queue={queue} error={queueError} />
+
+          {/* Stats Grid — DASH1: every tile is a LINK now. A count with
+              no drill-down is trivia: "4 Drafts" that cannot be pressed
+              tells her a number and makes her go and find the four. */}
           {hasDeeds && (
             <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
               <StatCard
@@ -210,24 +271,34 @@ export default function Dashboard() {
                 value={summary?.total ?? 0}
                 icon={<FileText className="w-5 h-5" />}
                 color="purple"
+                href="/past-deeds"
               />
               <StatCard
                 label="Drafts"
                 value={summary?.drafts ?? 0}
                 icon={<Clock className="w-5 h-5" />}
                 color="yellow"
+                href="/past-deeds?status=draft"
               />
+              {/* DASH1: "This Month" is gone. It rendered a big zero on
+                  the first of every month for a user whose work had not
+                  stopped — the counter told her she had done nothing when
+                  what happened is that a calendar page turned. The admin
+                  surface already carries a paragraph apologising for the
+                  same framing; this is the honest version it settled on. */}
               <StatCard
-                label="This Month"
-                value={summary?.month ?? 0}
+                label="Last 30 days"
+                value={summary?.lastThirtyDays ?? 0}
                 icon={<TrendingUp className="w-5 h-5" />}
                 color="blue"
+                href="/past-deeds"
               />
               <StatCard
                 label="Completed"
                 value={summary?.completed ?? 0}
                 icon={<CheckCircle className="w-5 h-5" />}
                 color="green"
+                href="/past-deeds?status=completed"
               />
             </div>
           )}
@@ -257,14 +328,24 @@ export default function Dashboard() {
             </div>
           ) : hasDeeds ? (
             <div className="bg-white rounded-2xl shadow-sm border border-gray-200 overflow-hidden">
+              {/* DASH1 — "RECENT ACTIVITY" WAS SORTED BY CREATION.
+                  `GET /deeds` orders by `created_at DESC`, so a draft
+                  edited this morning sat below five deeds made last week
+                  and never touched since. The feed was "recently made",
+                  labelled "recently happened" — and because completed
+                  deeds cluster at the top of a creation-ordered list, it
+                  read as a completed-deeds feed while the Drafts counter
+                  said otherwise.
+                  Two fixes, not one: it sorts by when something last
+                  HAPPENED to the deed, and every row now links to it. */}
               <div className="p-4 md:p-6 border-b border-gray-100">
                 <div className="flex items-center gap-2">
                   <Activity className="w-5 h-5 text-emerald-600" />
-                  <h3 className="text-lg font-bold text-gray-900">Recent Activity</h3>
+                  <h3 className="text-lg font-bold text-gray-900">Recently worked on</h3>
                 </div>
               </div>
               <div className="divide-y divide-gray-100">
-                {recentDeeds.slice(0, 5).map((deed: any) => (
+                {recentlyTouched.slice(0, 5).map((deed: any) => (
                   <DeedRow key={deed.id} deed={deed} />
                 ))}
               </div>
@@ -292,18 +373,180 @@ export default function Dashboard() {
   )
 }
 
+/**
+ * DASH1 — the action queue.
+ *
+ * THREE LISTS, NOT ONE PILE. "Chase somebody", "be somewhere" and
+ * "finish something" are different actions, and merging them makes her
+ * sort them by hand every morning.
+ *
+ * THE EMPTY STATE IS A RESULT, NOT AN ABSENCE. An honest empty queue is
+ * a good morning — the screen says so rather than rendering nothing and
+ * letting her wonder whether it loaded.
+ */
+function ActionQueue({ queue, error }: { queue: Queue | null; error: string | null }) {
+  const router = useRouter()
+
+  if (error) {
+    // §4: a queue we could not load says so. Rendering the empty state
+    // would tell her nothing is waiting, which is a claim about her work
+    // rather than about our request.
+    return (
+      <div className="mb-8 rounded-2xl border border-red-200 bg-red-50 p-4">
+        <p className="font-semibold text-red-800">Couldn&apos;t load what&apos;s waiting</p>
+        <p className="mt-1 text-sm text-red-700">{error}</p>
+      </div>
+    )
+  }
+  if (!queue) return null
+
+  const empty =
+    queue.upcoming.length === 0 &&
+    queue.awaiting.length === 0 &&
+    queue.idle_drafts.length === 0
+
+  return (
+    <section className="mb-8" aria-label="What's waiting">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-lg font-bold text-gray-900">What&apos;s waiting</h2>
+        {/* ONE NUMBER, and it means something. Not "there are rows
+            below" — a signing booked for Thursday needs nothing from
+            her. It is the requests that have gone quiet. */}
+        {queue.needs_attention > 0 && (
+          <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-100 px-3 py-1 text-sm font-semibold text-amber-900">
+            {queue.needs_attention} need{queue.needs_attention === 1 ? 's' : ''} your attention
+          </span>
+        )}
+      </div>
+
+      {empty ? (
+        <div className="rounded-2xl border border-gray-200 bg-white p-6">
+          <p className="font-medium text-gray-900">Nothing is waiting on anyone.</p>
+          <p className="mt-1 text-sm text-gray-500">
+            No signings in the next {queue.thresholds.upcoming_days} days, no unanswered
+            requests, and no drafts left sitting.
+          </p>
+        </div>
+      ) : (
+        <div className="grid gap-4 lg:grid-cols-3">
+          <QueueList
+            title={`Signing in the next ${queue.thresholds.upcoming_days} days`}
+            emptyNote="Nothing booked this week."
+            rows={queue.upcoming.map((r) => ({
+              key: `up-${r.id}`,
+              title: r.property || `Deed #${r.deed_id}`,
+              // The server's sentence, verbatim (§13 rule 3).
+              detail: r.summary,
+              meta: `${new Date(r.when).toLocaleString('en-US', {
+                weekday: 'short', month: 'short', day: 'numeric',
+                hour: 'numeric', minute: '2-digit',
+              })}${r.who ? ` · ${r.who}` : ''}`,
+              urgent: false,
+              onOpen: () => router.push(`/signings?focus=${r.id}`),
+            }))}
+          />
+          <QueueList
+            title="Waiting on a reply"
+            emptyNote="Everyone has answered."
+            rows={queue.awaiting.map((r) => ({
+              key: `aw-${r.kind}-${r.id}`,
+              title: r.property || `Deed #${r.deed_id}`,
+              detail: r.summary,
+              meta: `${r.who || 'Unnamed'} · ${
+                r.days_waiting === null ? 'waiting'
+                  : r.days_waiting === 0 ? 'sent today'
+                  : `${r.days_waiting} day${r.days_waiting === 1 ? '' : 's'}`
+              }`,
+              urgent: r.stale,
+              onOpen: () => router.push(
+                r.kind === 'signing' ? `/signings?focus=${r.id}` : '/shared-deeds'),
+            }))}
+          />
+          <QueueList
+            title={`Untouched for ${queue.thresholds.idle_draft_days}+ days`}
+            emptyNote="No forgotten drafts."
+            rows={queue.idle_drafts.map((r) => ({
+              key: `id-${r.id}`,
+              title: r.property || `Deed #${r.id}`,
+              detail: 'Draft — nobody is waiting on this but you.',
+              meta: r.days_idle === null ? 'untouched' : `${r.days_idle} days`,
+              urgent: false,
+              onOpen: () => router.push(
+                `/deed-builder/${r.deed_type || 'grant-deed'}?resume=${r.id}`),
+            }))}
+          />
+        </div>
+      )}
+    </section>
+  )
+}
+
+type QueueRow = {
+  key: string
+  title: string
+  detail: string
+  meta: string
+  urgent: boolean
+  onOpen: () => void
+}
+
+function QueueList({ title, rows, emptyNote }: {
+  title: string
+  rows: QueueRow[]
+  emptyNote: string
+}) {
+  return (
+    <div className="rounded-2xl border border-gray-200 bg-white overflow-hidden">
+      <div className="border-b border-gray-100 px-4 py-3">
+        <h3 className="text-sm font-semibold text-gray-700">{title}</h3>
+      </div>
+      {rows.length === 0 ? (
+        <p className="px-4 py-4 text-sm text-gray-500">{emptyNote}</p>
+      ) : (
+        <ul className="divide-y divide-gray-100">
+          {rows.slice(0, 5).map((r) => (
+            <li key={r.key}>
+              {/* EVERY ROW LINKS TO THE THING ITSELF. A queue that tells
+                  her something is stuck and then makes her go and find it
+                  is a list of chores, not a queue. */}
+              <button
+                onClick={r.onOpen}
+                className={`w-full px-4 py-3 text-left hover:bg-gray-50 transition-colors ${
+                  r.urgent ? 'border-l-4 border-amber-400' : ''
+                }`}
+              >
+                <p className="font-medium text-gray-900 truncate">{r.title}</p>
+                <p className="text-sm text-gray-600 truncate">{r.detail}</p>
+                <p className={`text-xs mt-0.5 ${r.urgent ? 'text-amber-700 font-medium' : 'text-gray-400'}`}>
+                  {r.meta}
+                </p>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}
+
 // Stat Card Component
 function StatCard({
   label,
   value,
   icon,
   color,
+  href,
 }: {
   label: string
   value: number | string
   icon: React.ReactNode
   color: "blue" | "yellow" | "green" | "purple"
+  /** DASH1: a count with no drill-down is trivia. Required rather than
+   * optional — a tile added later without one would silently be the
+   * thing this ticket removed. */
+  href: string
 }) {
+  const router = useRouter()
   const colorClasses = {
     blue: "bg-blue-50 text-blue-600",
     yellow: "bg-amber-50 text-amber-600",
@@ -312,13 +555,19 @@ function StatCard({
   }
 
   return (
-    <div className="bg-white rounded-xl border border-gray-200 p-4 hover:shadow-md transition-shadow">
+    <button
+      onClick={() => router.push(href)}
+      className="w-full text-left bg-white rounded-xl border border-gray-200 p-4 hover:shadow-md hover:border-gray-300 transition-all"
+    >
       <div className="flex items-center gap-3 mb-3">
         <div className={`p-2 rounded-lg ${colorClasses[color]}`}>{icon}</div>
         <span className="text-sm text-gray-500">{label}</span>
       </div>
-      <div className="text-2xl font-bold text-gray-900">{value}</div>
-    </div>
+      <div className="flex items-baseline gap-2">
+        <span className="text-2xl font-bold text-gray-900">{value}</span>
+        <ArrowRight className="w-4 h-4 text-gray-300" />
+      </div>
+    </button>
   )
 }
 
@@ -410,7 +659,19 @@ function DeedRow({ deed }: { deed: any }) {
     <div className={`p-4 hover:bg-gray-50 transition-colors flex items-center justify-between gap-4 ${
       needsAction ? 'border-l-4 border-amber-400' : ''
     }`}>
-      <div className="flex items-center gap-4 min-w-0 flex-1">
+      {/* DASH1: THE ROW LINKS TO THE DEED. A feed of things she has
+          worked on, where pressing one does nothing, is a list of
+          reminders that she owns some deeds. A draft opens where the
+          work is; a finished one opens focused in Past Deeds — there is
+          still no deed detail route (ledgered as DEEDDETAIL), so this
+          uses the same `?focus=` pattern the Signings agenda does. */}
+      <button
+        onClick={() => router.push(
+          needsAction
+            ? `/deed-builder/${deed.deed_type || 'grant-deed'}?resume=${deed.id}`
+            : `/past-deeds?focus=${deed.id}`)}
+        className="flex items-center gap-4 min-w-0 flex-1 text-left"
+      >
         <div className="w-10 h-10 rounded-lg bg-gray-100 flex items-center justify-center flex-shrink-0">
           <FileText className="w-5 h-5 text-gray-500" />
         </div>
@@ -422,7 +683,7 @@ function DeedRow({ deed }: { deed: any }) {
             Doc #{deed.id} • {deed.grantor_name || 'Draft'} → {deed.grantee_name || '...'}
           </p>
         </div>
-      </div>
+      </button>
 
       <div className="flex items-center gap-3 flex-shrink-0">
         <span className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium ${getStatusStyle(deed.status)}`}>

--- a/frontend/src/app/past-deeds/page.tsx
+++ b/frontend/src/app/past-deeds/page.tsx
@@ -1,8 +1,8 @@
 "use client"
 
 import type React from "react"
-import { useState, useEffect } from "react"
-import { useRouter } from "next/navigation"
+import { Suspense, useState, useEffect } from "react"
+import { useRouter, useSearchParams } from "next/navigation"
 import Sidebar from "@/components/Sidebar"
 import { FileText, Download, Share2, Trash2, AlertCircle, CheckCircle, Clock, X, Plus, Loader2, Search, CalendarClock } from "lucide-react"
 import { RequestSigningModal } from "@/features/signing/RequestSigningModal"
@@ -36,8 +36,30 @@ function partyNames(deed: Deed): string {
     .join("; ")
 }
 
+/**
+ * `useSearchParams()` opts a page out of static prerendering unless it
+ * sits under a Suspense boundary, and Next fails the BUILD rather than
+ * the render — jest and tsc stay green while the deploy does not. Second
+ * time this ticket; the same boundary the admin, success and signings
+ * pages already use.
+ */
 // ✅ PHASE 24-E: V0-generated Past Deeds page with all business logic preserved
 export default function PastDeedsPageV0() {
+  return (
+    <Suspense fallback={
+      <div className="flex min-h-screen bg-slate-50">
+        <Sidebar />
+        <main className="flex-1 flex items-center justify-center">
+          <Loader2 className="w-6 h-6 animate-spin text-slate-400" />
+        </main>
+      </div>
+    }>
+      <PastDeedsList />
+    </Suspense>
+  )
+}
+
+function PastDeedsList() {
   const router = useRouter()
   const [deeds, setDeeds] = useState<Deed[]>([])
   const [loading, setLoading] = useState(true)
@@ -55,7 +77,26 @@ export default function PastDeedsPageV0() {
   const [downloadingId, setDownloadingId] = useState<number | null>(null)
   // X2.7: find a deed without scrolling — text search + status filter.
   const [searchQuery, setSearchQuery] = useState("")
-  const [statusFilter, setStatusFilter] = useState<"all" | "completed" | "draft">("all")
+  /**
+   * DASH1 — THE DASHBOARD LINKS IN HERE, so the links have to land.
+   *
+   * Stat tiles are drill-downs now ("4 Drafts" → those drafts) and the
+   * activity feed points at a specific deed. A link that arrives and
+   * shows an unfiltered list is the dead-button defect wearing a URL:
+   * the affordance promises a filtered view and the outcome is not one.
+   *
+   * `?status=` seeds the filter; `?focus=` highlights one row.
+   */
+  const params = useSearchParams()
+  const [statusFilter, setStatusFilter] = useState<"all" | "completed" | "draft">(() => {
+    const wanted = params?.get("status")
+    return wanted === "completed" || wanted === "draft" ? wanted : "all"
+  })
+  const focusId = (() => {
+    const raw = params?.get("focus")
+    const id = raw ? Number(raw) : NaN
+    return Number.isInteger(id) ? id : null
+  })()
 
   useEffect(() => {
     fetchDeeds()
@@ -324,8 +365,13 @@ export default function PastDeedsPageV0() {
                     {visibleDeeds.map((deed, index) => (
                       <tr
                         key={deed.id}
+                        // DASH1: the deed the dashboard sent her here for,
+                        // marked. Landing on the right list and leaving her
+                        // to find the row is half a link.
                         className={`border-b border-slate-100 hover:bg-slate-50 transition-colors ${
-                          index % 2 === 0 ? "bg-white" : "bg-slate-50/50"
+                          deed.id === focusId
+                            ? "bg-violet-50 ring-2 ring-inset ring-[#7C4DFF]"
+                            : index % 2 === 0 ? "bg-white" : "bg-slate-50/50"
                         }`}
                       >
                         <td className="py-4 px-6 font-mono text-sm text-slate-600">#{deed.id}</td>

--- a/frontend/src/app/signings/page.tsx
+++ b/frontend/src/app/signings/page.tsx
@@ -42,6 +42,10 @@ type Row = {
   /** FLOW1 item 4: WHEN SHE ASKED. See the note on ageInDays below for
    * what this replaced and why the replacement matters. */
   created_at: string | null;
+  /** DASH1: the server decides how long is too long, and whether this
+   * one has crossed it. See the note on the deleted constant below. */
+  days_waiting: number | null;
+  stale: boolean;
   expires_at: string | null;
   signers: number;
 };
@@ -63,41 +67,36 @@ type Detail = {
   }>;
 };
 
-/** Days of silence before a request is worth chasing. Not a deadline —
- * nothing expires because of it — a prompt. */
-const STUCK_AFTER_DAYS = 5;
+/**
+ * DASH1 — `STUCK_AFTER_DAYS = 5` USED TO LIVE HERE, and it is gone.
+ *
+ * The dashboard needed the same judgement — "has this gone quiet?" — and
+ * writing a second threshold in Python beside this one in TypeScript is
+ * exactly how the partner category list came to have four divergent
+ * copies and how `phoneSearchKey` came to be right in one language and
+ * wrong in the other.
+ *
+ * So the number lives in `backend/services/officer_queue.py`, the server
+ * sends `stale` and `days_waiting` per row, and this screen renders what
+ * it is told. The threshold still travels with the payload, so the
+ * sentence explaining the amber banner can say it without knowing it.
+ */
 
 /**
- * FLOW1 item 4 — THE AGE IS READ, NOT RECONSTRUCTED.
+ * FLOW1 item 4 → DASH1: THE AGE IS READ, AND SO IS THE VERDICT.
  *
- * This used to compute `expires_at minus 21 days` because the agenda
- * payload carried no creation time, and 21 is `default_expiry()`'s
- * constant — copied into another language as a bare number with nothing
- * connecting the two. Changing the default expiry on the server would
- * have silently re-aimed every stuck badge on this screen, and nothing
- * would have failed.
+ * FLOW1 stopped this screen reconstructing a request's age as
+ * `expires_at minus 21 days` — a copy of the server's expiry default,
+ * retyped as a bare number in another language. DASH1 finishes the job:
+ * the server now sends `days_waiting` AND `stale`, so the screen no
+ * longer holds an opinion about how long is too long either.
  *
- * That is item 0's defect in a second habitat: a fact the screen shows,
- * that the server never sent, inferred from something adjacent. The
- * server sends `created_at` now.
- *
- * An unknown creation time returns null rather than 0. Zero would read
- * as "asked today", which is a claim; null reads as "we do not know",
- * which is true and keeps the row out of the stuck count.
+ * Both halves are the same lesson. A fact the screen shows and the
+ * server never sent gets inferred; a judgement the screen makes and the
+ * server also makes gets made twice, differently.
  */
-function ageInDays(createdAt: string | null): number | null {
-  if (!createdAt) return null;
-  const created = new Date(createdAt).getTime();
-  if (Number.isNaN(created)) return null;
-  return Math.max(0, Math.floor((Date.now() - created) / 86400_000));
-}
-
 function isStuck(r: Row): boolean {
-  if (r.state === 'booked' || r.state === 'cancelled' || r.state === 'expired') return false;
-  const age = ageInDays(r.created_at);
-  if (age === null) return false;
-  // Nobody has posted a time, or times are posted and nobody answered.
-  return age >= STUCK_AFTER_DAYS && (r.state === 'requested' || r.state === 'windows_posted');
+  return r.stale;
 }
 
 const STATE_LABEL: Record<string, string> = {
@@ -136,6 +135,9 @@ function SigningsAgenda() {
   const router = useRouter();
   const params = useSearchParams();
   const [rows, setRows] = useState<Row[]>([]);
+  // The threshold travels with the queue payload, so the sentence
+  // explaining the amber banner can say the number without knowing it.
+  const [staleAfterDays, setStaleAfterDays] = useState<number | null>(null);
   // FLOW1 item 4: `?focus=<id>` opens that signing. A notification about
   // one signing should be able to point at that signing.
   const [focus, setFocus] = useState<number | null>(() => {
@@ -162,6 +164,13 @@ function SigningsAgenda() {
         const r = await apiFetch('/signing-requests/v2', {}, { label: 'Loading signings' });
         if (!r.ok) throw new Error((await r.json().catch(() => ({}))).detail || `Failed (${r.status})`);
         setRows(await r.json());
+        // Best-effort: the banner degrades to its own wording if this
+        // fails, and a failed lookup for a NUMBER IN A SENTENCE must not
+        // blank a page full of real signings.
+        try {
+          const t = await apiFetch('/dashboard/queue', {}, { label: 'Loading your queue', silent: true });
+          if (t.ok) setStaleAfterDays((await t.json())?.thresholds?.stale_after_days ?? null);
+        } catch { /* the sentence has a fallback; the list does not need one */ }
       } catch (err) {
         if (err instanceof SessionExpiredError) return;
         setError(err instanceof Error ? err.message : 'Could not load your signings');
@@ -241,8 +250,8 @@ function SigningsAgenda() {
                 {stuck.length} {stuck.length === 1 ? 'signing has' : 'signings have'} gone quiet
               </p>
               <p className="text-sm text-amber-800 mt-1">
-                No movement in {STUCK_AFTER_DAYS} days or more. Nothing has expired — these
-                are worth a phone call.
+                No movement in {staleAfterDays ?? 5} days or more. Nothing has expired —
+                these are worth a phone call.
               </p>
             </div>
           )}
@@ -340,7 +349,7 @@ function SigningRow({ row, open, onToggle }: {
 }) {
   const stuck = isStuck(row);
   const booked = row.state === 'booked';
-  const age = ageInDays(row.created_at);
+  const age = row.days_waiting;
 
   return (
     <div className={`bg-white rounded-xl border ${stuck ? 'border-amber-300' : 'border-slate-200'}`}>


### PR DESCRIPTION
Items 1–5 of DASH1. Items 6–8 follow in a second PR.

## The queue leads

Three lists, not one pile: **signings in the next 7 days**, **requests nobody has answered** with how long they've been owed, and **drafts she hasn't touched**. "Chase somebody", "be somewhere" and "finish something" are different actions — merged, she sorts them by hand every morning.

Every row links to the thing itself. A queue that says something is stuck and then makes her go and find it is a list of chores.

**One attention number, and it means something.** Not "there are rows below" — a signing booked for Thursday needs nothing from her, and counting it would make the number stop being read. It's the requests that have gone quiet, so zero means nobody is waiting on her and nobody has gone silent.

**An empty queue is an answer; a failed one is not.** "Nothing is waiting on anyone" is a good morning and the screen says it. A failed fetch says *that* instead — §4, because "nothing is waiting" over a failed request is a claim about her work made out of our own error. Queue and deed list carry separate errors so neither blanks the other.

## Every count and every row goes somewhere

`href` is **required** on the stat tile rather than optional, so a tile added later without one fails to compile instead of silently reintroducing the trivia this removed.

And the links **land**: `?status=` seeds the Past Deeds filter, `?focus=` marks the row. A link that arrives and shows an unfiltered list is the dead-button defect wearing a URL — pinned from both ends.

## "Recent Activity" was sorted by creation

`GET /deeds` orders by `created_at DESC`, so a draft edited this morning sat below five deeds made last week and never touched since. And because completed deeds cluster at the top of a creation-ordered list, the feed *read* as a completed-deeds feed while the Drafts counter said otherwise — which is exactly what the audit saw.

Two fixes, not one: it sorts by when something last **happened** to the deed, and it's called **"Recently worked on"**, which is what it shows. Rows link to the deed — a draft to the builder, a finished one to `/past-deeds?focus=`, since there's still no deed detail route (DEEDDETAIL).

## "This Month" is gone

It rendered a big zero on the first of every month for a user whose work had not stopped. Last 30 days now, matching the honest version the admin surface already settled on.

The state field is renamed too — holding thirty days under the name `month` would be the same lie one scope down.

## One threshold, one place

`/signings` carried `STUCK_AFTER_DAYS = 5` in TypeScript, and the dashboard needed the same "has this gone quiet?" judgement. **A second threshold in Python beside it is how the partner category list came to have four copies.** The number now lives in `services/officer_queue.py`, the agenda payload carries `stale` and `days_waiting` per row, and the constant is **deleted** from the screen rather than left as a second opinion.

The queue payload's shape is asserted by equality — same rule as the NOTARY2 token surfaces and the Shared Deeds row. An unknown age is `None` rather than `0` and is never stale: the number she checks first has to be trustworthy, and one false entry costs more than one missed entry.

## Two pins retargeted, both flagged

- FLOW1's *"the age is read, not reconstructed"* moves **up** a level — the screen holds no age arithmetic **and** no threshold now.
- One Python assertion split its job with the frontend. It searched raw `.tsx` for `STUCK_AFTER_DAYS = 5` and tripped on the comment recording that the constant used to live there — **comment-trip fifteen**. This suite has no TypeScript comment stripper and writing one here would be a third opinion about what a comment is. So Python pins that the *server* sends the verdict, and `officerTrackers.test.ts` — which has `codeOnly()` — pins that the screen holds no threshold.

One more instrument error caught by its own failure: the "every tile has a drill-down" pin matched `<StatCard ... />` non-greedily, which closes on the **icon's** `/>` before reaching the props that matter. It counts over the grid region now.

## Gates

| Gate | Result |
|---|---|
| pytest (no DB) | 861 passed, 172 skipped |
| pytest (with DB) | 1033 passed |
| jest | 708 passed, 47 suites |
| tsc baseline | **94** (unchanged) |
| six-flow / API baseline | ✔ / ✔ |
| banned-claims | clean |
| `next build` | ✔ |

**Probed:** moving the queue below the counters, and removing the error branch, each fail the intended pin.

`next build` caught the Suspense boundary again — `useSearchParams()` opts a page out of static prerendering and Next fails the *build* while jest and tsc stay green. Second time this wave; worth noting the local build is the only gate that sees it.

## Next PR

Item 6 (sidebar grouping, badge counts, label/route drift with redirects), item 7 (the Requests-merge investigation — cost reported before any build), item 8 (ticket IDs in user-facing copy, added to the banned-claims gate).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_