### PR TITLE
DASH1 (2/2): grouped navigation with the waiting-signal on it, the ticket-ID gate, and the merge costed

### DIFF
--- a/backend/services/officer_queue.py
+++ b/backend/services/officer_queue.py
@@ -107,9 +107,10 @@ def idle_cutoff(now: Optional[datetime] = None) -> datetime:
 QUEUE_KEYS = frozenset({
     "upcoming",        # booked signings inside UPCOMING_DAYS
     "awaiting",        # requests nobody has answered
-    "idle_drafts",     # her own work, untouched
-    "needs_attention", # ONE number: stale awaiting + unbooked signings
+    "idle_drafts",     # untouched drafts
+    "needs_attention", # ONE number, and it is the stale ones
     "thresholds",      # the numbers above, so no screen retypes them
+    "badges",          # per-page waiting counts for the sidebar
 })
 
 UPCOMING_KEYS = frozenset({"kind", "id", "deed_id", "property", "when",
@@ -144,6 +145,21 @@ def queue(*, upcoming: Sequence[Dict[str, Any]],
         "awaiting": list(awaiting),
         "idle_drafts": list(idle_drafts),
         "needs_attention": len([r for r in awaiting if r["stale"]]),
+        # DASH1 item 6 — THE AMBIENT SIGNAL.
+        #
+        # Counted here rather than by the sidebar, for the same reason
+        # `needs_attention` is: a screen filtering the list itself would
+        # be a second opinion about what counts as waiting, and two
+        # numbers claiming to answer one question is the disease this
+        # ticket spent its first half removing.
+        #
+        # These are NOT the attention count. A badge says "there are
+        # things here"; the attention number says "these have gone
+        # quiet". Different claims, deliberately different numbers.
+        "badges": {
+            "signings": len([r for r in awaiting if r["kind"] == "signing"]),
+            "shared_deeds": len([r for r in awaiting if r["kind"] == "review"]),
+        },
         "thresholds": {
             "stale_after_days": STALE_AFTER_DAYS,
             "upcoming_days": UPCOMING_DAYS,

--- a/backend/tests/test_dash1_officer_queue.py
+++ b/backend/tests/test_dash1_officer_queue.py
@@ -96,6 +96,26 @@ def test_the_attention_count_is_stale_requests_and_nothing_else():
     assert payload["needs_attention"] == 1
 
 
+def test_a_badge_counts_presence_and_the_attention_number_counts_silence():
+    """Two numbers, two claims, and neither is the other.
+
+    A badge on Signings says "there are things here". The attention
+    number says "these have gone quiet". Collapsing them would make the
+    badge alarming and the attention number decorative.
+    """
+    payload = q.queue(
+        upcoming=[],
+        awaiting=[
+            dict(_awaiting(False), kind="signing"),
+            dict(_awaiting(True), kind="review"),
+            dict(_awaiting(False), kind="review"),
+        ],
+        idle_drafts=[],
+    )
+    assert payload["badges"] == {"signings": 1, "shared_deeds": 2}
+    assert payload["needs_attention"] == 1
+
+
 def test_the_payload_shape_is_asserted_by_equality():
     from services.officer_queue import QUEUE_KEYS
 

--- a/docs/DASH1_REQUESTS_MERGE.md
+++ b/docs/DASH1_REQUESTS_MERGE.md
@@ -1,0 +1,129 @@
+# DASH1 item 7 — merging Signings and Shared Deeds into "Requests"
+
+**Investigation. Cost reported before building, as ruled.** Verified
+against `main` at the DASH1 (1/2) merge.
+
+---
+
+## The recommendation, first
+
+**Do it — but as a rename and a redirect, not a rebuild.** ~1 day.
+
+FLOW1 item 3 already did the expensive half. Shared Deeds fetches both
+feeds, renders both kinds under a filter, and cross-links to Signings.
+What remains is mostly naming, one page's worth of detail rendering, and
+the redirect obligations below.
+
+The alternative — leave them separate — is now the more expensive
+option, because the seam it leaves has to be re-explained on every
+surface that links to either.
+
+---
+
+## What is actually left
+
+| Piece | Est. | Note |
+|---|---|---|
+| Rename `/shared-deeds` → `/requests`, permanent redirect | 0.25 d | see the constraint below |
+| Fold the agenda's *upcoming/being-arranged* grouping in | 0.25 d | the merged page currently sorts signings by nothing |
+| Move the expandable signing detail across | 0.25 d | `SigningDetail` lifts as-is |
+| Retire `/signings`, redirect to `/requests?kind=signings` | 0.1 d | |
+| Update inbound links, pins, sidebar | 0.15 d | 37 references, mechanical |
+| **Total** | **≈ 1 day** | |
+
+---
+
+## The constraint that decides HOW, not whether
+
+**Both routes are in links that have already been sent.**
+
+```
+backend/routers/sharing.py:799   view_link = {app}/shared-deeds?focus={id}   ← approval EMAIL
+backend/routers/sharing.py:1320  view_link = {app}/shared-deeds?focus={id}   ← schedule EMAIL
+backend/routers/sharing.py:779   link      = /shared-deeds?focus={id}        ← in-app notification
+backend/routers/sharing.py:867   link      = /shared-deeds?focus={id}        ← in-app notification
+backend/routers/signing.py:862   link      = /signings?focus={id}            ← in-app notification
+backend/routers/signing.py:981   link      = /signings?focus={id}            ← in-app notification
+backend/routers/signing.py:1088  {APP}/signings                              ← reminder EMAIL
+```
+
+An email in somebody's inbox is immutable. So the redirects are
+**permanent aliases, not a migration window** — they never come out, and
+the ticket that adds them should say so in the config rather than
+leaving a future reader to assume they are transitional.
+
+The same constraint applies to the `/deed-builder` and
+`/account-settings` renames in item 6 — see the deviation note below.
+
+---
+
+## What a merge closes, beyond tidiness
+
+1. **The seam where a signing vanishes.** FLOW1 item 3 papered over this
+   by showing both kinds; a single page removes the question rather than
+   answering it twice.
+2. **One `?focus=` contract instead of two.** Today `/signings?focus=`
+   and `/shared-deeds?focus=` are different id spaces (`signing_requests.id`
+   vs `deed_shares.id`) reached by the same-looking URL. A merged page
+   needs `?kind=` alongside, and *that is a small schema decision worth
+   making deliberately* rather than discovering later.
+3. **The officer's own vocabulary.** She does not think "shares" and
+   "signings" — she thinks "what have I got out". The page name is the
+   feature.
+
+## What a merge does NOT close
+
+**The two row shapes stay different, and must.** A review has a viewing
+and a decision; a signing has a notary, a set of times and a state.
+FLOW1 item 3 deliberately refused to flatten them into shared columns —
+that would put two facts under one heading, which is what item 0 spent a
+whole PR on. A merged page is one page with two row renderers, not one
+row type. Anybody costing this as "one table" is costing the wrong thing.
+
+---
+
+## Found while measuring, and fixed in this PR
+
+**`?focus=` was being sent to Shared Deeds from five places — including
+two emails — and the page had never read it.**
+
+Every "your deed was approved" email the officer has ever clicked landed
+her on an unfiltered list of every share she has, with no indication of
+which one it was about. That is the same defect DASH1 item 6 fixed on the
+dashboard's own links, arriving from the other end and older than any of
+them.
+
+It is fixed here rather than deferred to the merge, because a link that
+does not land is a live defect and the merge is a plan.
+
+---
+
+## Deviation flagged — item 6's route renames
+
+**Item 6 asked to align routes to labels** (`/deed-builder` →
+`/create-deed`, `/account-settings` → `/settings`) with redirects from
+the old paths. **Held, not done, and here is why.**
+
+Measuring it surfaced something that changes the shape of the work:
+
+- `email_templates.py:318,322` — the welcome email's "Create your first
+  document" button points at `{url}/deed-builder`.
+- `users_auth.py:550,551,598` — **Stripe checkout `success_url`,
+  `cancel_url` and the billing-portal `return_url`** point at
+  `/account-settings`. In-flight checkout sessions carry these.
+- `router_webhook.py:381` — the payment-failed email.
+
+So these are not internal renames with a courtesy redirect. They are
+**permanent aliases with a money path running through one of them**, and
+a Stripe return URL that 404s is a customer who paid and landed nowhere.
+
+That is squarely inside the Tier 3 line — *anything touching money* — and
+it arrived as a discovery rather than as part of the ruling, so it is
+flagged rather than decided. The rename is otherwise mechanical: 29
+frontend references, 14 files.
+
+**Recommendation:** do it as its own small PR, with the permanent-alias
+reasoning in `next.config`, and verify the Stripe URLs against a live
+checkout before the old paths are considered safe. The sidebar grouping
+and badges — the rest of item 6 — are shipped in this PR and do not
+depend on it.

--- a/docs/EXECUTION_POLICY.md
+++ b/docs/EXECUTION_POLICY.md
@@ -51,9 +51,46 @@ substantively incomplete deed; the legal-choice doctrine was unchanged.
 - Stop-and-report gates are non-negotiable.
 - Evidence claims carry `file:line` citations.
 
+## Standing practice — when a new surface needs an existing judgment
+
+**The answer is never a second copy.** Owner-ruled 2026-08-11 (DASH1).
+
+`/signings` held `STUCK_AFTER_DAYS = 5` in TypeScript. The dashboard
+needed the same "has this gone quiet?" judgement, and the obvious move
+was a matching threshold in Python. That would have been the FOURTH
+instance of one disease in this codebase: the DTT city rates, the partner
+category list (four divergent copies), the Shared Deeds row keys, and
+this.
+
+So the number moved server-side, the payload carries the verdict per row,
+and the client constant was **deleted**. The ticket ended with one fewer
+copy than it started with, and that is the bar: a ticket that adds a
+surface should not add a copy of a judgement, and where it can, it should
+remove one.
+
+The mechanisms, in order of preference:
+
+1. **Move it server-side and send the answer** — the screen renders what
+   it is told (`officer_queue.is_stale`, `signing_loop.state_label`).
+2. **One shared corpus both suites read** — when both languages must
+   genuinely hold the logic (`phone_cases.json`,
+   `shared_deed_row_keys.json`, `vesting_cases.json`).
+3. **One module, both callers** — within a language (`lib/wallClock.ts`).
+
+Copying is not on the list.
+
 ## Verification invariants
 
 - Honest CI stays blocking. No `|| true`, ever again.
+- **`next build` runs locally before every frontend PR, and never becomes
+  optional or advisory.** Owner-ruled 2026-08-11 (DASH1). It is the only
+  gate that sees a whole class: `useSearchParams()` opts a page out of
+  static prerendering unless it sits under a `<Suspense>` boundary, and
+  Next fails the BUILD rather than the render — jest and tsc both stay
+  green while the deploy dies. It caught this twice in one wave
+  (`/signings`, then `/past-deeds`). The lesson generalises past that one
+  API: **gate diversity matters more than gate count**, because gates of
+  the same kind fail in the same direction.
 - The OpenAPI route-contract test and the six-flow behavioral baseline
   (`backend/scripts/six_flow_baseline.py`) must stay green. Neither is
   re-recorded to make a failure pass without an approved, documented reason

--- a/frontend/src/__tests__/navigationGroups.test.ts
+++ b/frontend/src/__tests__/navigationGroups.test.ts
@@ -1,0 +1,92 @@
+/**
+ * DASH1 item 6 — the sidebar, grouped, with the waiting-signal on it.
+ *
+ * ═══ WHY GROUPS ═══
+ *
+ * A flat list of seven destinations says they are all the same kind of
+ * visit. They are not. WORK is where she makes and finds documents;
+ * TRACKING is where she checks what other people owe her; SETUP is where
+ * she goes twice a year. The grouping tells her where to look before she
+ * has read a single label.
+ *
+ * ═══ WHY BADGES ON TRACKING ONLY ═══
+ *
+ * Ambient waiting-signal does more for at-a-glance awareness than
+ * anything the dashboard carried before DASH1, because she sees it from
+ * every page rather than only from the one she starts on. It belongs on
+ * the two pages that hold other people's replies and nowhere else — a
+ * badge on Past Deeds would be counting documents, which is the trivia
+ * this ticket removed from the tiles.
+ *
+ * ═══ AND THE COUNT COMES FROM THE SERVER ═══
+ *
+ * Same reason `needs_attention` does: the sidebar filtering the queue
+ * itself would be a second opinion about what counts as waiting.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
+
+const SRC = path.join(__dirname, '..');
+const SIDEBAR = fs.readFileSync(path.join(SRC, 'components', 'Sidebar.tsx'), 'utf8');
+const CODE = codeOnly(SIDEBAR);
+
+describe('DASH1 item 6 — three groups, in the order she works', () => {
+  it('groups Work, Tracking and Setup', () => {
+    for (const title of ["title: 'Work'", "title: 'Tracking'", "title: 'Setup'"]) {
+      expect(CODE).toContain(title);
+    }
+    expect(CODE.indexOf("title: 'Work'"))
+      .toBeLessThan(CODE.indexOf("title: 'Tracking'"));
+    expect(CODE.indexOf("title: 'Tracking'"))
+      .toBeLessThan(CODE.indexOf("title: 'Setup'"));
+  });
+
+  it('loses nobody in the regrouping', () => {
+    // The flat list had seven items. A group structure that quietly
+    // dropped one would be a page that still exists and cannot be
+    // reached — the same defect as a dead button, arriving by omission.
+    for (const href of ['/dashboard', '/deed-builder', '/past-deeds',
+                        '/signings', '/shared-deeds', '/partners',
+                        '/account-settings']) {
+      expect(CODE).toContain(`href: '${href}'`);
+    }
+  });
+
+  it('keeps admin gated and out of the standing groups', () => {
+    expect(CODE).toContain('ADMIN_ITEM');
+    expect(CODE).toContain('isAdmin');
+  });
+});
+
+describe('DASH1 item 6 — the waiting-signal is ambient and honest', () => {
+  it('badges only the two tracking destinations', () => {
+    const badges = CODE.match(/badge: '(\w+)'/g) || [];
+    expect(badges.sort()).toEqual(["badge: 'shared_deeds'", "badge: 'signings'"]);
+  });
+
+  it('takes the counts from the server rather than counting itself', () => {
+    expect(CODE).toContain("apiFetch('/dashboard/queue'");
+    expect(CODE).toContain('?.badges');
+    // No local filtering of the queue — a second opinion about what
+    // counts as waiting is two numbers answering one question.
+    expect(CODE).not.toContain('.filter(');
+  });
+
+  it('renders nothing at zero', () => {
+    // A badge saying "0" is a thing to read that says there is nothing
+    // to read.
+    expect(CODE).toContain('count > 0 &&');
+  });
+
+  it('a badge that cannot load is absent, not an error banner', () => {
+    // The one place in this codebase where silence is right, and it is
+    // deliberate: a badge is an enrichment, not a claim. An error banner
+    // in the navigation of every page, because one background request
+    // failed, is noise she cannot act on and cannot dismiss. The pages
+    // themselves report their own failures loudly.
+    expect(CODE).toContain('silent: true');
+    expect(SIDEBAR).toContain('a badge that cannot load is a badge that is absent');
+  });
+});

--- a/frontend/src/app/admin/components/Overview.tsx
+++ b/frontend/src/app/admin/components/Overview.tsx
@@ -122,7 +122,8 @@ export default function OverviewTab(){
         <div style={{ fontSize: 12, opacity: 0.7, marginTop: -4 }}>
           The two deed counts measure different windows and are expected to
           disagree — early in a month the calendar figure is a fraction of the
-          rolling one. Neither is a trend; trends arrive with ADMIN6.
+          rolling one. Neither is a trend — this screen shows counts, not
+          direction over time.
         </div>
       )}
 

--- a/frontend/src/app/admin/components/VerificationTab.tsx
+++ b/frontend/src/app/admin/components/VerificationTab.tsx
@@ -159,7 +159,8 @@ export default function VerificationTab() {
           Verification codes are issued by the partner API. Deeds created in the
           wizard are stored with a PDF hash but no short code, so they never
           appear here and are not counted below. Public verification for wizard
-          deeds is an open product decision (VERIFY1), not a gap in this table.
+          deeds has not been decided yet, so this table is complete as it
+          stands rather than missing rows.
         </div>
       </div>
 

--- a/frontend/src/app/shared-deeds/page.tsx
+++ b/frontend/src/app/shared-deeds/page.tsx
@@ -1,6 +1,6 @@
 "use client"
-import { useState, useEffect } from "react"
-import { useRouter } from "next/navigation"
+import { Suspense, useState, useEffect } from "react"
+import { useRouter, useSearchParams } from "next/navigation"
 import Sidebar from "@/components/Sidebar"
 import { Send, Eye, Clock, CheckCircle, XCircle, AlertCircle, RotateCw, X, FileText, MessageSquare, CalendarClock } from "lucide-react"
 import { toast } from "sonner"
@@ -117,9 +117,49 @@ interface StructuredFeedback {
   timestamp?: string
 }
 
+/**
+ * DASH1 — `?focus=` WAS BEING SENT HERE AND NOBODY WAS LISTENING.
+ *
+ * Found while costing the Signings/Shared Deeds merge. Five places link
+ * to `/shared-deeds?focus={share_id}` — the approval notification, the
+ * rejection notification, the NOTARY1 schedule notice, and TWO EMAILS
+ * (`send_share_approved_with_reason` and `send_share_rejected_with_reason`
+ * both put it in the officer's inbox). This page has never read the
+ * parameter.
+ *
+ * So every "your deed was approved" email she has ever clicked landed
+ * her on an unfiltered list of every share she has, with no indication
+ * of which one the email was about. Exactly the defect DASH1 item 6
+ * fixed on the dashboard's own links — arriving from the other end, and
+ * older.
+ *
+ * The Suspense boundary is `useSearchParams()`'s: without it Next fails
+ * the BUILD rather than the render. Third time this wave.
+ */
 // ✅ PHASE 24-E: V0-generated Shared Deeds page with feedback modal and expiry countdown
 export default function SharedDeedsPageV0() {
+  return (
+    <Suspense fallback={
+      <div className="flex min-h-screen bg-gradient-to-br from-slate-50 via-white to-slate-50">
+        <Sidebar />
+        <main className="flex-1 flex items-center justify-center">
+          <div className="w-12 h-12 rounded-full border-4 border-purple-100 animate-spin border-t-[#7C4DFF]" />
+        </main>
+      </div>
+    }>
+      <SharedDeedsTracker />
+    </Suspense>
+  )
+}
+
+function SharedDeedsTracker() {
   const router = useRouter()
+  const params = useSearchParams()
+  const focusId = (() => {
+    const raw = params?.get("focus")
+    const id = raw ? Number(raw) : NaN
+    return Number.isInteger(id) ? id : null
+  })()
   const [sharedDeeds, setSharedDeeds] = useState<SharedDeed[]>([])
   const [signings, setSignings] = useState<SigningSummaryRow[]>([])
   const [filter, setFilter] = useState<TrackerFilter>("all")
@@ -543,7 +583,9 @@ export default function SharedDeedsPageV0() {
                         <tr
                           key={deed.id}
                           className={`border-b border-slate-100 hover:bg-slate-50 transition-colors ${
-                            index % 2 === 0 ? "bg-white" : "bg-slate-50/50"
+                            deed.id === focusId
+                              ? "bg-violet-50 ring-2 ring-inset ring-[#7C4DFF]"
+                              : index % 2 === 0 ? "bg-white" : "bg-slate-50/50"
                           }`}
                         >
                           <td className="py-4 px-6 font-medium text-slate-800">{deed.property}</td>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -10,6 +10,7 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import React, { useState, useEffect } from 'react';
 import { AuthManager } from '../utils/auth';
+import { apiFetch } from '@/lib/apiClient';
 import { LogoLockup, LogoMark } from '@/components/brand/Logo';
 import {
   CalendarClock,
@@ -27,17 +28,53 @@ import {
   ChevronRight,
 } from 'lucide-react';
 
-const NAV_ITEMS = [
-  { href: '/dashboard', icon: LayoutDashboard, label: 'Dashboard' },
-  { href: '/deed-builder', icon: FilePlus2, label: 'Create Deed' },
-  { href: '/past-deeds', icon: Files, label: 'Past Deeds' },
-  { href: '/shared-deeds', icon: Share2, label: 'Shared Deeds' },
-  // NOTARY2 Part D. A page nothing links to is a page nobody uses —
-  // the agenda's whole job is being the place she checks what is stuck,
-  // and that only works if it is one click from everywhere.
-  { href: '/signings', icon: CalendarClock, label: 'Signings' },
-  { href: '/partners', icon: Users, label: 'Partners' },
-  { href: '/account-settings', icon: Settings, label: 'Settings' },
+/**
+ * DASH1 item 6 — THREE GROUPS, BECAUSE THEY ARE THREE KINDS OF VISIT.
+ *
+ * A flat list of seven says every destination is the same kind of thing.
+ * They are not: WORK is where she makes and finds documents, TRACKING is
+ * where she checks what other people owe her, and SETUP is where she
+ * goes twice a year. Grouping is not decoration — it tells her where to
+ * look before she has read the labels.
+ *
+ * `badge` names which count from `/dashboard/queue` rides on the item.
+ * Ambient waiting-signal does more for at-a-glance awareness than
+ * anything the dashboard carried before this ticket, because she sees it
+ * from every page rather than only from the one she starts on.
+ */
+type NavItem = {
+  href: string;
+  icon: typeof LayoutDashboard;
+  label: string;
+  badge?: 'signings' | 'shared_deeds';
+};
+
+const NAV_GROUPS: Array<{ title: string; items: NavItem[] }> = [
+  {
+    title: 'Work',
+    items: [
+      { href: '/dashboard', icon: LayoutDashboard, label: 'Dashboard' },
+      { href: '/deed-builder', icon: FilePlus2, label: 'Create Deed' },
+      { href: '/past-deeds', icon: Files, label: 'Past Deeds' },
+    ],
+  },
+  {
+    title: 'Tracking',
+    items: [
+      // NOTARY2 Part D. A page nothing links to is a page nobody uses —
+      // the agenda's whole job is being the place she checks what is
+      // stuck, and that only works if it is one click from everywhere.
+      { href: '/signings', icon: CalendarClock, label: 'Signings', badge: 'signings' },
+      { href: '/shared-deeds', icon: Share2, label: 'Shared Deeds', badge: 'shared_deeds' },
+    ],
+  },
+  {
+    title: 'Setup',
+    items: [
+      { href: '/partners', icon: Users, label: 'Partners' },
+      { href: '/account-settings', icon: Settings, label: 'Settings' },
+    ],
+  },
 ];
 
 const ADMIN_ITEM = { href: '/admin', icon: ShieldCheck, label: 'Admin' };
@@ -47,6 +84,31 @@ export default function Sidebar() {
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [isMobileOpen, setIsMobileOpen] = useState(false);
   const [isAdmin, setIsAdmin] = useState(false);
+  /**
+   * DASH1 item 6 — the ambient waiting-signal.
+   *
+   * Best-effort and SILENT on failure, which is the opposite of the rule
+   * everywhere else in this codebase and is deliberate: a badge is an
+   * enrichment, not a claim. A missing badge says nothing; an error
+   * banner in the navigation of every page, because one background
+   * request failed, would be noise she cannot act on and cannot dismiss.
+   * The pages themselves report their own failures loudly.
+   */
+  const [badges, setBadges] = useState<Record<string, number> | null>(null);
+
+  useEffect(() => {
+    if (!localStorage.getItem('access_token')) return;
+    (async () => {
+      try {
+        const res = await apiFetch('/dashboard/queue', {}, {
+          label: 'Loading waiting counts', silent: true,
+        });
+        if (res.ok) setBadges((await res.json())?.badges ?? null);
+      } catch {
+        // See above: a badge that cannot load is a badge that is absent.
+      }
+    })();
+  }, []);
 
   // Check admin status on mount (localStorage isn't available during SSR)
   useEffect(() => {
@@ -63,41 +125,70 @@ export default function Sidebar() {
   const isActive = (href: string) =>
     pathname === href || !!pathname?.startsWith(`${href}/`);
 
-  const items = isAdmin ? [...NAV_ITEMS, ADMIN_ITEM] : NAV_ITEMS;
+  const groups = isAdmin
+    ? [...NAV_GROUPS, { title: 'Admin', items: [ADMIN_ITEM] }]
+    : NAV_GROUPS;
+
+  const navItem = (item: NavItem, collapsed: boolean) => {
+    const Icon = item.icon;
+    const active = isActive(item.href);
+    const count = item.badge ? badges?.[item.badge] ?? 0 : 0;
+    return (
+      <li key={item.href}>
+        <Link
+          href={item.href}
+          onClick={() => setIsMobileOpen(false)}
+          aria-current={active ? 'page' : undefined}
+          title={collapsed ? item.label : undefined}
+          className={`relative flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors ${
+            collapsed ? 'justify-center' : ''
+          } ${
+            active
+              ? 'bg-brand-50 text-brand-600'
+              : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
+          }`}
+        >
+          <span
+            className={`absolute left-0 top-1/2 -translate-y-1/2 h-6 w-1 rounded-r-full bg-brand-500 transition-opacity ${
+              active ? 'opacity-100' : 'opacity-0'
+            }`}
+            aria-hidden="true"
+          />
+          <Icon className="w-5 h-5 flex-shrink-0" />
+          {!collapsed && <span className="truncate flex-1">{item.label}</span>}
+          {/* The badge counts what is WAITING, not what exists. Zero
+              renders nothing rather than a "0" — a badge saying zero is
+              a thing to read that says there is nothing to read. */}
+          {count > 0 && (
+            <span
+              className={`shrink-0 rounded-full bg-brand-100 text-brand-700 text-xs font-semibold ${
+                collapsed ? 'absolute top-1 right-1 px-1.5' : 'px-2 py-0.5'
+              }`}
+              aria-label={`${count} waiting`}
+            >
+              {count}
+            </span>
+          )}
+        </Link>
+      </li>
+    );
+  };
 
   const navList = (collapsed: boolean) => (
-    <ul className="flex-1 px-3 py-4 space-y-1 overflow-y-auto" aria-label="Primary">
-      {items.map((item) => {
-        const Icon = item.icon;
-        const active = isActive(item.href);
-        return (
-          <li key={item.href}>
-            <Link
-              href={item.href}
-              onClick={() => setIsMobileOpen(false)}
-              aria-current={active ? 'page' : undefined}
-              title={collapsed ? item.label : undefined}
-              className={`relative flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors ${
-                collapsed ? 'justify-center' : ''
-              } ${
-                active
-                  ? 'bg-brand-50 text-brand-600'
-                  : 'text-gray-600 hover:bg-gray-100 hover:text-gray-900'
-              }`}
-            >
-              <span
-                className={`absolute left-0 top-1/2 -translate-y-1/2 h-6 w-1 rounded-r-full bg-brand-500 transition-opacity ${
-                  active ? 'opacity-100' : 'opacity-0'
-                }`}
-                aria-hidden="true"
-              />
-              <Icon className="w-5 h-5 flex-shrink-0" />
-              {!collapsed && <span className="truncate">{item.label}</span>}
-            </Link>
-          </li>
-        );
-      })}
-    </ul>
+    <nav className="flex-1 px-3 py-4 overflow-y-auto" aria-label="Primary">
+      {groups.map((group) => (
+        <div key={group.title} className="mb-4 last:mb-0">
+          {!collapsed && (
+            <p className="px-3 pb-1 text-[11px] font-semibold uppercase tracking-wide text-gray-400">
+              {group.title}
+            </p>
+          )}
+          <ul className="space-y-1">
+            {group.items.map((item) => navItem(item, collapsed))}
+          </ul>
+        </div>
+      ))}
+    </nav>
   );
 
   const brand = (collapsed: boolean) => (

--- a/scripts/check_banned_claims.py
+++ b/scripts/check_banned_claims.py
@@ -73,6 +73,47 @@ RULES = [
     Rule("HIPAA", r"\bHIPAA\b", "Not applicable and never assessed."),
     Rule("GDPR/CCPA compliance claim", r"\b(?:GDPR|CCPA)[\s\-]*(?:compliant|certified)\b",
          "No compliance assessment has been performed against either."),
+    # ── DASH1 item 8: OUR TICKET NUMBERS ARE NOT HER VOCABULARY ───────
+    #
+    # The admin Overview told the customer, in rendered text: "Neither is
+    # a trend; trends arrive with ADMIN6." ADMIN6 is an internal ticket
+    # identifier. It names nothing she can look up, promises a date
+    # nobody gave her, and reads as a defect number on a screen she paid
+    # for. Same species as a dead button — a surface referring to
+    # something that does not exist from where she is standing — and it
+    # arrived the same way: a note to the next developer, written in a
+    # string the customer reads.
+    #
+    # ═══ THIS RULE ENUMERATES, AND THAT IS DELIBERATE ═══
+    #
+    # Every other rule in this file matches a SHAPE, because guarding a
+    # spelling is how "enterprise-grade security" walked past two rules
+    # written for "bank-level" and "military-grade". The reflex here was
+    # the same: match `[A-Z]{2,}[0-9]+` — capitals then a digit, standing
+    # as a word — and be done.
+    #
+    # It was tried. It matched ADDRESS1, ADDRESS2 and SHA256 on the first
+    # run, and it would match ISO27001, UTF8, LINE2 and every form field
+    # anybody names that way. The shape of a ticket identifier is
+    # genuinely indistinguishable from the shape of a field name, and
+    # this file's own doctrine says what to do about that: a pattern
+    # smart enough to tell them apart is a classifier, and a classifier
+    # in a BLOCKING gate fails in whichever direction nobody predicted.
+    #
+    # So the prefixes are listed. Adding a ticket family means adding a
+    # word here, which is a real cost and a small one — and unlike the
+    # security-claim rules, the thing being guarded is OUR OWN
+    # vocabulary, which we control and can therefore enumerate honestly.
+    # Single-letter prefixes (S1, T5, X2, H2) are deliberately absent:
+    # one letter and a digit is a heading level, a form field or a
+    # version, and a gate that fires on `H2` is worse than the leak.
+    Rule("internal ticket identifier",
+         r"\b(?:ADMIN|DASH|DOCTRINE|DX|FLOW|NOTARY|PARTNER|PRICING|RED|TP|TRIAL|VERIFY)"
+         r"[0-9]+(?:\.[0-9]+)?[a-z]?\b",
+         "Internal ticket identifiers name nothing a customer can look "
+         "up and promise dates nobody gave them. Say what the screen "
+         "does today, or say the capability does not exist yet — "
+         "'trends arrive with ADMIN6' is a dead button in prose."),
     # ── THE PROPERTY, not the spellings (owner-ruled, PRICING1) ───────
     #
     # This started as two rules for two phrasings: "bank-level security"


### PR DESCRIPTION
Items 6 and 8 built; item 7 costed. **One part of item 6 is flagged and held** — see the deviation section.

## Item 6 — three groups, and the signal on them

**Work** (Dashboard, Create Deed, Past Deeds) · **Tracking** (Signings, Shared Deeds) · **Setup** (Partners, Settings). A flat list of seven says every destination is the same kind of visit; the grouping tells her where to look before she's read a label. A pin asserts nobody was lost in the regrouping — a page that still exists and cannot be reached is a dead button arriving by omission.

**Badges on the two Tracking destinations, counted server-side.** The sidebar filtering the queue itself would be a second opinion about what counts as waiting — the disease the first half of this ticket removed. A badge and the attention number are deliberately different numbers: a badge says *"there are things here"*, the attention number says *"these have gone quiet"*. Zero renders nothing.

**The badge fetch is silent on failure**, which inverts the rule everywhere else in this codebase and is the point: a badge is an enrichment, not a claim. An error banner in the navigation of *every page* because one background request failed is noise she can't act on and can't dismiss. The pages report their own failures loudly.

## Item 8 — two ticket IDs, not one

The gate found one I hadn't:

- Admin Overview: *"Neither is a trend; trends arrive with **ADMIN6**."*
- Verification tab: *"…is an open product decision (**VERIFY1**), not a gap in this table."*

Both name nothing a customer can look up and promise dates nobody gave them. Both rewritten to say what the screen does today.

**The rule enumerates its prefixes, which reverses this file's usual preference — so it says why.** Every other banned-claims rule matches a *shape*, because guarding a spelling is how "enterprise-grade security" walked past rules written for "bank-level" and "military-grade". The shape was tried here: `[A-Z]{2,}[0-9]+` matched `ADDRESS1`, `ADDRESS2` and `SHA256` on the first run, and would match `ISO27001`, `UTF8` and every form field named that way. A ticket identifier and a field name have the same shape — and this file's own doctrine says a pattern smart enough to tell them apart is a classifier, and a classifier in a blocking gate fails in whichever direction nobody predicted. Single-letter prefixes (`S1`, `T5`, `H2`) are deliberately absent: a gate that fires on `H2` is worse than the leak.

## Found while costing item 7 — and fixed here

**`?focus=` was being sent to Shared Deeds from five places — including two emails — and the page had never read it.**

```
sharing.py:799   view_link = {app}/shared-deeds?focus={id}   ← approval EMAIL
sharing.py:1320  view_link = {app}/shared-deeds?focus={id}   ← schedule EMAIL
sharing.py:779   link      = /shared-deeds?focus={id}        ← notification
sharing.py:867   link      = /shared-deeds?focus={id}        ← notification
sharing.py:1284  link      = /shared-deeds?focus={id}        ← notification
```

Every *"your deed was approved"* email the officer has ever clicked landed her on an unfiltered list of every share she has, with no indication of which one it was about. Same defect item 6 fixed on the dashboard's own links — arriving from the other end, and older than any of them. Fixed rather than deferred to the merge: a link that doesn't land is a live defect, and the merge is a plan.

## Item 7 — costed, not built

`docs/DASH1_REQUESTS_MERGE.md`. **Recommend doing it, ~1 day**, as a rename and a redirect rather than a rebuild — FLOW1 item 3 already did the expensive half (both feeds, one filter, cross-links).

The load-bearing caveat: **the two row shapes stay different, and must.** A review has a viewing and a decision; a signing has a notary, times and a state. Anybody costing this as "one table" is costing the wrong thing.

## Deviation — flagged and held

**Item 6's route renames are not in this PR.** Aligning routes to labels turned out to touch links that have already been sent:

- `email_templates.py:318,322` — the welcome email's "Create your first document" button → `/deed-builder`
- `users_auth.py:550,551,598` — Stripe checkout **`success_url`**, **`cancel_url`**, and the billing-portal **`return_url`** → `/account-settings`
- `router_webhook.py:381` — the payment-failed email

These aren't internal renames with a courtesy redirect. They're **permanent aliases with a money path through one of them**, and a Stripe return URL that 404s is a customer who paid and landed nowhere. That is inside the Tier 3 line, and it arrived as a discovery rather than as part of the ruling — so it's flagged rather than decided in either direction.

The rename is otherwise mechanical (29 references, 14 files). Recommendation: its own small PR, with the permanent-alias reasoning written into `next.config`, and the Stripe URLs verified against a live checkout before the old paths are considered safe. Nothing else in item 6 depends on it.

## Two standing rules recorded

`EXECUTION_POLICY.md`, as ruled:

- **When a new surface needs an existing judgment, the answer is never a second copy** — with the three mechanisms in order of preference (move it server-side · one shared corpus · one module, both callers) and the bar stated as *"the ticket ends with one fewer copy"*.
- **`next build` runs locally before every frontend PR and never becomes optional or advisory** — it's the only gate that sees the Suspense class, and it caught it three times in this wave. The generalisation is recorded too: *gate diversity matters more than gate count, because gates of the same kind fail in the same direction.*

## Gates

| Gate | Result |
|---|---|
| pytest (no DB) | 862 passed, 172 skipped |
| pytest (with DB) | 1034 passed |
| jest | 715 passed, 48 suites |
| tsc baseline | **94** (unchanged) |
| six-flow / API baseline | ✔ / ✔ |
| banned-claims | clean (**14** rules) |
| `next build` | ✔ |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_