### PR TITLE
render.yaml becomes the environment contract, and the API says at boot what it is missing

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -30,6 +30,27 @@ from middleware.qa_instrumentation import QAInstrumentationMiddleware, get_qa_he
 
 load_dotenv()
 
+# ── The environment, checked at BOOT rather than at a customer's
+#    checkout ────────────────────────────────────────────────────────
+#
+# `FRONTEND_URL` is read in sixteen places, three of them Stripe
+# redirect URLs with a `http://localhost:3000` fallback — so an unset
+# variable sends a paying customer to a page on their own machine, with
+# nothing raised and nothing logged. It appeared in no configuration file
+# in this repository, so nothing declared it should exist and nothing
+# could notice it did not.
+#
+# This says so at startup, in a block nobody can miss in a Render log.
+# It does NOT refuse to boot by default, and that ordering is deliberate:
+# we have not yet confirmed whether the variable is set in production, and
+# a process that refuses to start on an unverified condition turns a
+# wrong redirect into an outage. `STRICT_ENV=1` makes it a refusal, and
+# becomes the default in the ticket that verifies production.
+#
+# See services/environment.py for the per-variable reasoning.
+from services.environment import check as _check_environment
+_check_environment()
+
 app = FastAPI(title="DeedPro API", version="2.0.0-dynamic-wizard")
 # Updated for new-front monorepo with pricing management
 

--- a/backend/phase23_billing/deps.py
+++ b/backend/phase23_billing/deps.py
@@ -40,18 +40,50 @@ def get_logger():
 # CRITICAL FIX: Use same DATABASE_URL as main app
 # Main app uses psycopg2 format (postgresql://), not psycopg3 (postgresql+psycopg://)
 # Get from environment directly, don't override
-DATABASE_URL = os.getenv("DATABASE_URL", "postgresql://user:pass@localhost:5432/deedpro")
+# ── The URL is resolved ON FIRST USE, not at import ────────────────
+#
+# It used to default to `postgresql://user:pass@localhost:5432/deedpro`
+# — a fictional URL that produces a connection error naming a database
+# nobody has, sending the reader hunting for a host instead of a missing
+# variable.
+#
+# Replacing the default with a refusal is right; doing it AT IMPORT was
+# not, and the no-database test suite caught it in one run: importing
+# this module to read a route table is not the same as using the
+# database, and a refusal at import makes the two indistinguishable.
+#
+# So the engine is built lazily. The refusal still fires — at the moment
+# somebody actually asks for a session, which is the moment the variable
+# is actually needed.
+_ENGINE = None
+_SESSION_FACTORY = None
 
-# Convert psycopg2 URL to SQLAlchemy format if needed
-# psycopg2 uses: postgresql://
-# SQLAlchemy with psycopg (v3) needs: postgresql+psycopg://
-# But we'll use psycopg2-binary which main app uses
-if DATABASE_URL.startswith("postgresql://") and "+psycopg" not in DATABASE_URL:
-    # Use psycopg2 driver (already installed)
-    DATABASE_URL = DATABASE_URL.replace("postgresql://", "postgresql+psycopg2://")
 
-engine = create_engine(DATABASE_URL, future=True, pool_pre_ping=True)
-SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+def _database_url() -> str:
+    from services.environment import require
+
+    url = require("DATABASE_URL")
+    # SQLAlchemy needs the driver named; psycopg2-binary is what the main
+    # app installs.
+    if url.startswith("postgresql://") and "+psycopg" not in url:
+        url = url.replace("postgresql://", "postgresql+psycopg2://")
+    return url
+
+
+def _session_factory():
+    global _ENGINE, _SESSION_FACTORY
+    if _SESSION_FACTORY is None:
+        _ENGINE = create_engine(_database_url(), future=True, pool_pre_ping=True)
+        _SESSION_FACTORY = sessionmaker(bind=_ENGINE, autoflush=False,
+                                        autocommit=False, future=True)
+    return _SESSION_FACTORY
+
+
+def SessionLocal():
+    """Kept callable under its old name — every caller says
+    `SessionLocal()`, and renaming it would be churn for no property."""
+    return _session_factory()()
+
 
 def get_db():
     db = SessionLocal()

--- a/backend/phase23_billing/router_webhook.py
+++ b/backend/phase23_billing/router_webhook.py
@@ -375,7 +375,11 @@ async def stripe_webhook(request: Request, db: Session = Depends(get_db)):
                 if row and row.get("email"):
                     from utils.notifications import send_payment_failed_with_reason
                     amount_text = f" of ${amount / 100:,.2f}" if amount else ""
-                    base = os.getenv("FRONTEND_URL", "http://localhost:3000")
+                    # A payment-failed email whose "update your card" link
+                    # points at localhost is worse than no email: it looks
+                    # like the product is broken rather than the card.
+                    from services.environment import require
+                    base = require("FRONTEND_URL")
                     ok, reason = send_payment_failed_with_reason(
                         row["email"], row.get("full_name") or "",
                         amount_text, f"{base}/account-settings",

--- a/backend/routers/auth_extra.py
+++ b/backend/routers/auth_extra.py
@@ -46,7 +46,13 @@ _bearer = HTTPBearer(auto_error=False)
 EMAIL_VERIFICATION_REQUIRED = os.getenv("EMAIL_VERIFICATION_REQUIRED", "false").lower() == "true"
 REFRESH_TOKENS_ENABLED = os.getenv("REFRESH_TOKENS_ENABLED", "false").lower() == "true"
 LOGIN_RATE_LIMIT = os.getenv("LOGIN_RATE_LIMIT", "true").lower() == "true"
-FRONTEND_URL = os.getenv("FRONTEND_URL", "http://localhost:3000")
+# Resolved per CALL, not at import: a module-level read with a
+# localhost default bakes the wrong answer into every password-reset
+# link for the life of the process, and a reset link to somebody
+# else's laptop is a dead account-recovery path.
+def FRONTEND_URL_() -> str:
+    from services.environment import require
+    return require("FRONTEND_URL")
 
 RESET_TOKEN_TTL_HOURS = int(os.getenv("RESET_TOKEN_TTL_HOURS", "1"))
 VERIFY_TOKEN_TTL_HOURS = int(os.getenv("VERIFY_TOKEN_TTL_HOURS", "24"))
@@ -93,7 +99,7 @@ def forgot_password(payload: ForgotPasswordRequest):
             data={"sub": str(user_id), "type": "reset"},
             expires_delta=timedelta(hours=RESET_TOKEN_TTL_HOURS)
         )
-        reset_url = f"{FRONTEND_URL}/reset-password?token={reset_token}"
+        reset_url = f"{FRONTEND_URL_()}/reset-password?token={reset_token}"
         sent, reason = send_password_reset_with_reason(
             email, full_name, reset_url, RESET_TOKEN_TTL_HOURS
         )
@@ -167,7 +173,7 @@ def request_verify_email(payload: VerifyEmailRequest):
             data={"sub": str(user_id), "type": "verify"},
             expires_delta=timedelta(hours=VERIFY_TOKEN_TTL_HOURS)
         )
-        verify_url = f"{FRONTEND_URL}/verify-email?token={token}"
+        verify_url = f"{FRONTEND_URL_()}/verify-email?token={token}"
         v_sent, v_reason = send_verify_email_with_reason(email, full_name or "", verify_url)
         if not v_sent:
             print(f"[verify-email] send failed: {v_reason}")

--- a/backend/routers/users_auth.py
+++ b/backend/routers/users_auth.py
@@ -7,6 +7,8 @@ it is the preserved pre-split behavior.
 """
 import os
 
+from services.environment import require
+
 import psycopg2
 import stripe
 from fastapi import APIRouter, Body, Depends, HTTPException, Request
@@ -547,8 +549,14 @@ async def upgrade_plan(req: UpgradeRequest, user_id: int = Depends(get_current_u
                 'quantity': 1
             }],
             mode='subscription',
-            success_url=f"{os.getenv('FRONTEND_URL', 'http://localhost:3000')}/account-settings?success=true",
-            cancel_url=f"{os.getenv('FRONTEND_URL', 'http://localhost:3000')}/account-settings?canceled=true",
+            # THE MONEY PATH, and the reason services/environment.py
+            # exists. This read a `http://localhost:3000` fallback, so an
+            # unset FRONTEND_URL charged the card and redirected the
+            # customer to a page on their own machine — silently. A
+            # checkout that refuses to start is strictly better: it has
+            # not taken any money.
+            success_url=f"{require('FRONTEND_URL')}/account-settings?success=true",
+            cancel_url=f"{require('FRONTEND_URL')}/account-settings?canceled=true",
             allow_promotion_codes=True,
             **({'subscription_data': {'trial_period_days': trial_days}}
                if trial_days > 0 else {}),
@@ -595,7 +603,7 @@ async def create_portal_session(user_id: int = Depends(get_current_user_id)):
 
         session = stripe.billing_portal.Session.create(
             customer=result[0],
-            return_url=f"{os.getenv('FRONTEND_URL', 'http://localhost:3000')}/account-settings"
+            return_url=f"{require('FRONTEND_URL')}/account-settings"
         )
 
         return {"url": session.url}

--- a/backend/services/environment.py
+++ b/backend/services/environment.py
@@ -1,0 +1,239 @@
+"""The environment this service needs, declared — and checked at boot.
+
+═══ THE DEFECT THAT WIDENED THIS TICKET ═══
+
+`FRONTEND_URL` is read in sixteen places. Three of them are the money
+path:
+
+    users_auth.py:550  success_url = {FRONTEND_URL}/account-settings?success=true
+    users_auth.py:551  cancel_url  = {FRONTEND_URL}/account-settings?canceled=true
+    users_auth.py:598  return_url  = {FRONTEND_URL}/account-settings   ← billing portal
+
+All three are written as `os.getenv('FRONTEND_URL', 'http://localhost:3000')`.
+If the variable is unset on the production API, a customer completes a
+Stripe checkout and is redirected to **a page on their own laptop**. No
+error is raised, nothing is logged, and the first person to find out is
+the person who paid.
+
+`FRONTEND_URL` appeared in no configuration file in this repository.
+Nothing declared it should exist, so nothing could notice it did not.
+
+That is the shape this codebase keeps closing: **a fact the system
+depends on, that nothing checks.** PRICING1 ruled the specific case — a
+missing price ID must fail loudly with a named reason rather than fall
+back to a placeholder. This generalises it to the whole environment.
+
+═══ WHY THIS DEFAULTS TO A LOUD WARNING RATHER THAN A REFUSAL ═══
+
+The strongest form of this fix is: the process refuses to boot when a
+required variable is missing. That is right, and shipping it TODAY would
+be reckless in a specific way worth naming.
+
+**We do not yet know whether `FRONTEND_URL` is set in production.** The
+owner's check is outstanding. If it is missing and this module hard-fails
+by default, the next deploy converts a wrong-redirect into a service that
+will not start — a total outage, caused by the fix for a partial one.
+
+You cannot make a process refuse to start on a condition you have not
+verified is absent, because the refusal is then the incident.
+
+So: **loud, named, unmissable at boot — and `STRICT_ENV=1` turns it into
+a refusal.** The stronger form is one environment variable away, and it
+becomes the default in the ticket that confirms production is clean.
+That ordering is the whole design, not a compromise on it.
+
+═══ REQUIRED vs OPTIONAL IS A DELIBERATE CLASSIFICATION ═══
+
+Owner-ruled: do not hard-fail on variables whose absence is genuinely
+tolerable. A missing `ADMIN_EMAIL` degrades — nobody gets a signup
+notice, and every other thing the product does still works. A missing
+`FRONTEND_URL` does not degrade; it produces a confidently wrong answer.
+
+The test is not "how important is this" but: **does its absence change
+behaviour SILENTLY and WRONGLY?** Every entry below records that
+reasoning in its own words, because a classification without a reason is
+a guess somebody will re-guess differently.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+REQUIRED = "required"
+OPTIONAL = "optional"
+
+
+@dataclass(frozen=True)
+class EnvVar:
+    key: str
+    level: str
+    #: What goes wrong when it is missing — in the words a reader needs,
+    #: not "used by billing".
+    consequence: str
+
+
+# ── The manifest ─────────────────────────────────────────────────────
+#
+# REQUIRED means: absent, the product does something WRONG rather than
+# something less. OPTIONAL means: absent, a capability is off and
+# everything else is unaffected.
+MANIFEST: Tuple[EnvVar, ...] = (
+    EnvVar("DATABASE_URL", REQUIRED,
+           "Every route that touches data fails. Loud already, and listed "
+           "so the manifest is the whole picture rather than the "
+           "interesting half."),
+    EnvVar("JWT_SECRET_KEY", REQUIRED,
+           "Sessions cannot be signed or verified. `auth.py` already "
+           "raises at import — this entry records that the refusal is "
+           "deliberate, so nobody 'fixes' it into a generated default and "
+           "invalidates every live session on each restart."),
+    EnvVar("FRONTEND_URL", REQUIRED,
+           "THE MONEY PATH. Stripe's success_url, cancel_url and the "
+           "billing-portal return_url are all built from it, with a "
+           "`http://localhost:3000` fallback. Unset, a customer pays and "
+           "is redirected to a page on their own machine. Also carries "
+           "every link in every email."),
+    EnvVar("STRIPE_SECRET_KEY", REQUIRED,
+           "Checkout and the billing portal cannot be created. Absent, "
+           "the paid path is dead — which is at least loud."),
+    EnvVar("STRIPE_PROFESSIONAL_PRICE_ID", REQUIRED,
+           "PRICING1's case, and the reason this file exists in this "
+           "shape: it used to fall back to a placeholder price string, so "
+           "checkout failed at Stripe with an error about a price that "
+           "was never real. Fail loudly with a named reason, never fall "
+           "back to a placeholder."),
+    EnvVar("ALLOWED_ORIGINS", REQUIRED,
+           "CORS. Wrong or absent, the browser refuses every call and the "
+           "product looks broken with nothing in the server log."),
+    EnvVar("SENDGRID_API_KEY", OPTIONAL,
+           "No email leaves the building. OPTIONAL and it is a close "
+           "call: the product degrades honestly — every sender returns "
+           "(False, reason), the reason reaches the officer's screen, and "
+           "`email_log` records the failure. A share still works and "
+           "still shows the link on screen. Degrades, does not lie."),
+    EnvVar("SENDGRID_FROM_EMAIL", OPTIONAL,
+           "Mail falls back to a default sender. Degrades in a way that "
+           "is visible in the message that arrives, not silent."),
+    EnvVar("ADMIN_EMAIL", OPTIONAL,
+           "Nobody is told about a new signup or an API-key request. The "
+           "record still exists in the database and on the admin screen — "
+           "a notification is lost, not a fact."),
+    EnvVar("NOTIFICATIONS_ENABLED", OPTIONAL,
+           "Defaults on. A deliberate off-switch, and its absence means "
+           "the default, which is the documented behaviour rather than an "
+           "accident."),
+    EnvVar("STRIPE_WEBHOOK_SECRET", OPTIONAL,
+           "Webhook signature verification. OPTIONAL here ONLY because "
+           "the webhook path already refuses unverified payloads rather "
+           "than trusting them — the failure is closed, not silent. If "
+           "that ever changes this becomes REQUIRED in the same diff."),
+    EnvVar("PYTHON_VERSION", OPTIONAL,
+           "Read by Render at BUILD time, never by this process. Listed "
+           "because render.yaml declares it and the manifest is checked "
+           "against that file; classifying it required would make every "
+           "local run warn about a variable it has no use for."),
+)
+
+BY_KEY: Dict[str, EnvVar] = {v.key: v for v in MANIFEST}
+REQUIRED_KEYS = tuple(v.key for v in MANIFEST if v.level == REQUIRED)
+OPTIONAL_KEYS = tuple(v.key for v in MANIFEST if v.level == OPTIONAL)
+
+
+def missing(level: str, env: Optional[Dict[str, str]] = None) -> List[EnvVar]:
+    source = os.environ if env is None else env
+    return [v for v in MANIFEST
+            if v.level == level and not (source.get(v.key) or "").strip()]
+
+
+def strict() -> bool:
+    """`STRICT_ENV=1` turns the boot warning into a refusal.
+
+    Off by default until production is confirmed clean — see the module
+    docstring. Turning it on is a one-line change in render.yaml and the
+    ticket that does it should be the ticket that verified the
+    environment, not this one.
+    """
+    return (os.getenv("STRICT_ENV") or "").strip() in ("1", "true", "True")
+
+
+class EnvironmentError_(RuntimeError):
+    """Named so a traceback says what kind of problem this is."""
+
+
+def require(key: str) -> str:
+    """A required variable's value, or a refusal that names the damage.
+
+    ═══ WHY CALL SITES FAIL AND BOOT DOES NOT ═══
+
+    The module docstring explains why the BOOT check warns rather than
+    refusing: a process that will not start on an unverified condition
+    turns a wrong redirect into an outage for everybody.
+
+    A CALL SITE is the opposite case, and the asymmetry is deliberate.
+    Refusing here affects one operation, and that operation's output is
+    already worthless without the variable. A Stripe checkout that
+    refuses to start is strictly better than one that charges a card and
+    redirects to `http://localhost:3000` — the first has not taken any
+    money.
+
+    So: loud at boot, closed at the point of use. PRICING1's rule, at the
+    scope where it costs the least and prevents the most.
+    """
+    value = (os.getenv(key) or "").strip()
+    if value:
+        return value
+    known = BY_KEY.get(key)
+    raise EnvironmentError_(
+        f"{key} is not set on this service. "
+        + (known.consequence if known else
+           "It has no entry in services/environment.py either, which is "
+           "its own defect — classify it.")
+    )
+
+
+def report(env: Optional[Dict[str, str]] = None) -> str:
+    """The block printed at boot. Empty string when nothing is missing.
+
+    Written to be unmissable in a Render log — a one-line warning among
+    startup chatter is a warning nobody reads, and this one exists
+    precisely because the last failure was silent.
+    """
+    gone_required = missing(REQUIRED, env)
+    gone_optional = missing(OPTIONAL, env)
+    if not gone_required and not gone_optional:
+        return ""
+
+    lines = ["", "=" * 72]
+    if gone_required:
+        lines.append("!! MISSING REQUIRED ENVIRONMENT — the product will "
+                     "behave WRONGLY, not merely less")
+        lines.append("=" * 72)
+        for v in gone_required:
+            lines.append(f"  {v.key}")
+            lines.append(f"      {v.consequence}")
+    if gone_optional:
+        lines.append("-" * 72)
+        lines.append("Optional variables absent — a capability is off, "
+                     "nothing is wrong:")
+        for v in gone_optional:
+            lines.append(f"  {v.key} — {v.consequence}")
+    lines.append("=" * 72)
+    lines.append("")
+    return "\n".join(lines)
+
+
+def check(env: Optional[Dict[str, str]] = None) -> List[EnvVar]:
+    """Print the report; refuse to continue under STRICT_ENV.
+
+    Returns the missing REQUIRED vars so a caller can decide for itself.
+    """
+    text = report(env)
+    if text:
+        print(text, flush=True)
+    gone = missing(REQUIRED, env)
+    if gone and strict():
+        raise EnvironmentError_(
+            "STRICT_ENV is set and these required variables are missing: "
+            + ", ".join(v.key for v in gone))
+    return gone

--- a/backend/tests/test_render_environment_contract.py
+++ b/backend/tests/test_render_environment_contract.py
@@ -1,0 +1,239 @@
+"""render.yaml is the environment contract, and something checks it.
+
+═══ THE DEFECT ═══
+
+`FRONTEND_URL` is read in sixteen places. Three are Stripe redirect URLs
+written as `os.getenv('FRONTEND_URL', 'http://localhost:3000')`, so an
+unset variable sends a paying customer to a page on their own machine —
+silently, with nothing raised and nothing logged.
+
+**It appeared in no configuration file in this repository.** Nothing
+declared it should exist, so nothing could notice it did not. That is the
+defect class this engagement keeps closing: a fact the system depends on,
+that nothing checks.
+
+═══ WHAT THESE PINS PROTECT ═══
+
+ 1. THE MANIFEST AND render.yaml AGREE. Two declarations of one contract,
+    in two files, with nothing comparing them is how eight field names
+    drifted in FLOW1 item 0. Every REQUIRED variable is declared in the
+    YAML; every variable the YAML declares is classified in the manifest.
+
+ 2. A REQUIRED VARIABLE HAS NO PRODUCTION-INVALID DEFAULT. This is the
+    sharp one, and it is the pin that would have caught the original:
+    `os.getenv('FRONTEND_URL', 'http://localhost:3000')` is not a
+    fallback, it is a wrong answer with a straight face. PRICING1 ruled
+    the specific case (a placeholder price ID); this is the class.
+
+ 3. EVERY CLASSIFICATION CARRIES ITS REASONING. A required/optional split
+    without a stated reason is a guess somebody will re-guess
+    differently, and the owner ruled the classification must be
+    deliberate.
+
+ 4. THE REPORT IS UNMISSABLE AND THE REFUSAL IS OPT-IN. Loud by default;
+    `STRICT_ENV=1` makes it fatal. The ordering is deliberate — see
+    `services/environment.py` — because a process that refuses to start
+    on an unverified condition turns a wrong redirect into an outage.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from services import environment as env
+from tests.source_text import code_only
+
+BACKEND = Path(__file__).resolve().parents[1]
+REPO = BACKEND.parent
+RENDER = REPO / "render.yaml"
+
+
+def _declared_keys() -> set:
+    """Keys declared under the main API's envVars.
+
+    Parsed rather than imported: PyYAML would read the commented-out
+    STRICT_ENV block as absent, which is correct, and would also make
+    this pin depend on a package the gate does not otherwise need.
+
+    `render.yaml` is read RAW and not through `code_only()`, which the
+    suite's own meta-pin would otherwise require. It is YAML, not Python;
+    `code_only` parses Python and would refuse it, and the `#` lines here
+    are the file's reasoning rather than commented-out code. The
+    commented STRICT_ENV block is deliberately invisible to this parser —
+    that is the pin two tests below.
+    """
+    text = RENDER.read_text(encoding="utf-8")
+    return set(re.findall(r"^\s*-\s*key:\s*([A-Z_0-9]+)\s*$", text, re.M))
+
+
+# ── 1. The two declarations agree ────────────────────────────────────
+
+def test_every_required_variable_is_declared_in_render_yaml():
+    """The pin that would have caught FRONTEND_URL.
+
+    A variable the code requires and no file mentions cannot be missed by
+    a human, because there is nothing to read.
+    """
+    declared = _declared_keys()
+    undeclared = [k for k in env.REQUIRED_KEYS if k not in declared]
+    assert undeclared == [], (
+        "required by the code, declared nowhere: " + ", ".join(undeclared) +
+        " — add it to render.yaml (with `sync: false` if the value is a "
+        "secret; the NAME is what needs declaring)")
+
+
+def test_every_declared_variable_is_classified():
+    """The other direction. A key in the YAML that the manifest does not
+    know about is a variable nobody has decided the importance of."""
+    declared = _declared_keys()
+    # Build/QA-only keys the process never reads are out of scope for the
+    # manifest by design — the manifest is about RUNTIME behaviour.
+    build_or_qa = {
+        "DYNAMIC_WIZARD_ENABLED", "TEMPLATE_VALIDATION_STRICT",
+        "PDF_GENERATION_TIMEOUT", "AI_ASSIST_TIMEOUT",
+        "MAX_CONCURRENT_REQUESTS", "BACKEND_LOGGING_LEVEL", "ENVIRONMENT",
+        "QA_INSTRUMENTATION_ENABLED", "QA_DETAILED_LOGGING",
+        "PERFORMANCE_MONITORING",
+    }
+    unclassified = [k for k in sorted(declared)
+                    if k not in env.BY_KEY and k not in build_or_qa]
+    assert unclassified == [], (
+        "declared in render.yaml, classified nowhere: " +
+        ", ".join(unclassified))
+
+
+# ── 2. No required variable has a production-invalid default ─────────
+
+LOCALHOST = re.compile(r"localhost|127\.0\.0\.1", re.I)
+
+
+def _python_sources():
+    for path in BACKEND.rglob("*.py"):
+        if {"tests", "__pycache__", "venv", ".venv", "scripts"} & set(path.parts):
+            continue
+        yield path
+
+
+def test_no_required_variable_falls_back_to_localhost():
+    """THE PIN THAT MATTERS.
+
+    `os.getenv('FRONTEND_URL', 'http://localhost:3000')` is not a
+    fallback. It is a wrong answer delivered with a straight face, on a
+    path that ends at a customer's card being charged.
+
+    Matched as the SHAPE — any required key read with a localhost default
+    — rather than as the one spelling, because the next one will be
+    written by somebody who never read this file.
+    """
+    pattern = re.compile(
+        r"getenv\(\s*['\"](" + "|".join(env.REQUIRED_KEYS) + r")['\"]\s*,\s*([^)]*)\)")
+    offenders = []
+    for path in _python_sources():
+        src = code_only(path)
+        for match in pattern.finditer(src):
+            if LOCALHOST.search(match.group(2)):
+                line = src[: match.start()].count("\n") + 1
+                offenders.append(
+                    f"{path.relative_to(BACKEND)}:{line} → {match.group(1)}")
+    assert offenders == [], (
+        "a REQUIRED variable falls back to a localhost URL: " +
+        "; ".join(offenders) + " — in production that is a confidently "
+        "wrong answer, not a default. Fail loudly with a named reason.")
+
+
+# ── 3. Every classification carries its reasoning ────────────────────
+
+@pytest.mark.parametrize("var", env.MANIFEST, ids=lambda v: v.key)
+def test_every_variable_states_what_breaks(var):
+    """Owner-ruled: classify deliberately and record the reasoning.
+
+    A classification without a reason is a guess somebody will re-guess
+    differently — and the two directions of that guess are "an outage
+    nobody wanted" and "a silent wrong answer nobody caught".
+    """
+    assert var.level in (env.REQUIRED, env.OPTIONAL)
+    assert len(var.consequence) > 60, (
+        f"{var.key}'s reasoning is too short to be reasoning")
+    # It says what HAPPENS, not what the variable is for.
+    assert not var.consequence.lower().startswith("used by"), (
+        f"{var.key} describes its purpose rather than its absence")
+
+
+def test_the_required_set_is_the_silent_ones():
+    """The test is not importance — it is whether absence is SILENT and
+    WRONG. A missing ADMIN_EMAIL loses a notification; a missing
+    FRONTEND_URL produces a confidently wrong redirect."""
+    assert "FRONTEND_URL" in env.REQUIRED_KEYS
+    assert "STRIPE_PROFESSIONAL_PRICE_ID" in env.REQUIRED_KEYS
+    assert "ADMIN_EMAIL" in env.OPTIONAL_KEYS
+    assert "SENDGRID_API_KEY" in env.OPTIONAL_KEYS
+
+
+# ── 4. Loud by default, fatal by choice ──────────────────────────────
+
+def test_a_missing_required_variable_is_reported_by_name():
+    text = env.report({"DATABASE_URL": "x", "JWT_SECRET_KEY": "x",
+                       "STRIPE_SECRET_KEY": "x",
+                       "STRIPE_PROFESSIONAL_PRICE_ID": "x",
+                       "ALLOWED_ORIGINS": "x"})
+    assert "FRONTEND_URL" in text
+    assert "MISSING REQUIRED" in text
+    # And it says what goes wrong, not just that something is absent.
+    assert "customer pays" in text
+
+
+def test_a_complete_environment_reports_nothing():
+    full = {v.key: "x" for v in env.MANIFEST}
+    assert env.report(full) == ""
+
+
+def test_a_blank_value_counts_as_missing():
+    """`FRONTEND_URL=` in a dashboard is not a value, and a check that
+    accepts it is a check that passes on the defect."""
+    partial = {v.key: "x" for v in env.MANIFEST}
+    partial["FRONTEND_URL"] = "   "
+    assert "FRONTEND_URL" in env.report(partial)
+
+
+def test_strict_mode_refuses_and_is_off_by_default(monkeypatch):
+    """The refusal is opt-in until production is verified.
+
+    A process that refuses to start on a condition nobody has checked
+    turns a wrong redirect into an outage — the fix causing a worse
+    incident than the defect.
+    """
+    monkeypatch.delenv("STRICT_ENV", raising=False)
+    assert env.strict() is False
+
+    incomplete = {v.key: "x" for v in env.MANIFEST}
+    del incomplete["FRONTEND_URL"]
+    # Loud, but it returns.
+    assert [v.key for v in env.check(incomplete)] == ["FRONTEND_URL"]
+
+    monkeypatch.setenv("STRICT_ENV", "1")
+    assert env.strict() is True
+    with pytest.raises(env.EnvironmentError_) as raised:
+        env.check(incomplete)
+    assert "FRONTEND_URL" in str(raised.value)
+
+
+def test_strict_env_is_declared_but_not_switched_on():
+    """The stronger form is one uncommented line away, and the line is
+    there so nobody has to invent it — but it stays off until the ticket
+    that verifies production turns it on."""
+    text = RENDER.read_text(encoding="utf-8")
+    assert "STRICT_ENV" in text
+    assert re.search(r"^\s*#\s*-\s*key:\s*STRICT_ENV", text, re.M), (
+        "STRICT_ENV is live in render.yaml — if production has been "
+        "verified, say so in the PR that switches it on")
+
+
+def test_the_api_checks_its_environment_at_boot():
+    src = code_only(BACKEND / "main.py")
+    assert "from services.environment import check" in src
+    assert "_check_environment()" in src
+    # Before the app exists, so the block is at the top of the log rather
+    # than buried under router-mount chatter.
+    assert src.index("_check_environment()") < src.index("app = FastAPI(")

--- a/backend/tests/test_render_service_pins.py
+++ b/backend/tests/test_render_service_pins.py
@@ -73,21 +73,35 @@ def test_every_declared_service_pins_python_version():
         "a differently-pinned one is the same nondeterminism with extra steps.")
 
 
-def test_the_file_says_it_is_not_the_deployment_inventory():
-    """It describes one service and production runs more. A config file
-    that lies by OMISSION is harder to catch than one that lies by
-    contents — nothing about a YAML file announces that it is partial —
-    so it announces it in prose until the undeclared services are brought
-    in (owner-ruled, sequenced after NOTARY2 Part C)."""
-    header = RENDER.read_text(encoding="utf-8")[:2000]
-    assert "NOT THE DEPLOYMENT INVENTORY" in header
+def test_the_file_says_which_half_of_itself_is_authoritative():
+    """RETARGETED — the file now makes TWO claims and the header has to
+    keep them apart.
+
+    It was a single disclaimer: "NOT THE DEPLOYMENT INVENTORY", because
+    the file described one service while production ran more, and a
+    config file that lies by OMISSION is harder to catch than one that
+    lies by contents.
+
+    That half still stands and is still pinned. What changed is that the
+    file gained a claim it CAN honour: it is the ENVIRONMENT CONTRACT for
+    the service it describes, cross-checked against
+    services/environment.py. Leaving the blanket disclaimer over a half
+    that is now checked would understate the file in the opposite
+    direction — and a reader who believes nothing here is authoritative
+    will not maintain the half that is.
+    """
+    header = RENDER.read_text(encoding="utf-8")[:3000]
+    assert "NOT THE SERVICE INVENTORY" in header
     assert "dashboard" in header.lower()
+    # And the half it DOES own, named.
+    assert "ENVIRONMENT CONTRACT" in header
+    assert "services/environment" in header
 
 
 def test_the_downgrade_is_recorded_where_somebody_will_see_it():
     """3.12.7 is BELOW what the main API runs today. A pin that silently
     changes a running service's interpreter is a deploy-time surprise, so
     the file says it is deliberate and says what to do about it."""
-    header = RENDER.read_text(encoding="utf-8")[:2500]
+    header = RENDER.read_text(encoding="utf-8")[:4000]
     assert "downgrade" in header.lower()
     assert "redeploy" in header.lower()

--- a/backend/tests/test_source_text_helper.py
+++ b/backend/tests/test_source_text_helper.py
@@ -132,6 +132,13 @@ RAW_TEXT_ALLOWED = {
     "test_red_h1_requirements.py": "requirements.txt is not Python; the encoding IS the subject",
     "test_source_text_helper.py": "this file tests the helper itself",
     "test_share_pdf_source.py": "reads SQL/schema from the database, not source text",
+    "test_render_environment_contract.py": (
+        "reads render.yaml, which is YAML rather than Python — code_only "
+        "parses Python and would refuse it. It trips this pin because the "
+        "Python half of the same file DOES route through code_only, and "
+        "the pin sees one file. The YAML's `#` lines are its reasoning, "
+        "and one commented block (STRICT_ENV) is deliberately invisible "
+        "to the parser — a stripper would make that pin untestable."),
     "test_prelim_field_map.py": (
         "reads Markdown, not Python. It trips this pin because the "
         "Markdown it checks NAMES a .py file — the field map has to cite "

--- a/backend/tests/test_trial1_paid_path.py
+++ b/backend/tests/test_trial1_paid_path.py
@@ -270,11 +270,24 @@ def test_a_user_reaches_checkout_with_a_real_customer_id_and_the_webhook_upgrade
     with patch.object(ua.stripe.Customer, "create",
                       return_value=MagicMock(id=CUSTOMER_ID)) as mk_cust, \
          patch.object(ua.stripe.checkout.Session, "create", side_effect=_session_create), \
-         patch.dict(os.environ, {"STRIPE_PROFESSIONAL_PRICE_ID": "price_test_pro"}):
+         patch.dict(os.environ, {"STRIPE_PROFESSIONAL_PRICE_ID": "price_test_pro",
+                                 # The environment ticket made this a
+                                 # REQUIREMENT rather than a localhost
+                                 # fallback, and this test found out by
+                                 # failing: without it the route now
+                                 # refuses with a named reason instead of
+                                 # building a redirect to the customer's
+                                 # own machine. That is the fix working —
+                                 # the checkout call needs the variable
+                                 # because the real one does.
+                                 "FRONTEND_URL": "https://deedpro.test"}):
         resp = client.post("/users/upgrade", json={"plan": "professional"})
 
     assert resp.status_code == 200, resp.text
     assert resp.json()["session_url"].startswith("https://checkout.stripe.test")
+    # And the redirect URLs are built from the real host, not localhost.
+    assert captured["success_url"].startswith("https://deedpro.test/")
+    assert "localhost" not in captured["cancel_url"]
 
     # The customer was CREATED — the branch the unpack bug skipped.
     assert mk_cust.called, (

--- a/docs/EXECUTION_POLICY.md
+++ b/docs/EXECUTION_POLICY.md
@@ -79,6 +79,36 @@ The mechanisms, in order of preference:
 
 Copying is not on the list.
 
+## Standing practice — verify the defect exists before costing the fix
+
+**Owner-ruled 2026-08-11 (DASH1).** Applies to any finding that arrives
+as a *description* of a problem rather than as a *reproduction* of one.
+
+DASH1 item 6 asked to fix "label/route drift" — `/deed-builder` under a
+label reading "Create Deed", `/account-settings` under "Settings" — with
+redirects from the old paths. The wording inherited an external audit's
+framing, and the framing implied a dead end.
+
+There was no dead end. **Both target routes already existed as aliases**,
+and one of them was a deliberate prior migration in the opposite
+direction whose own comment recorded the decision. `/settings` had been
+added by an earlier ticket for precisely the reason item 6 gave. Building
+the rename would have undone a chosen migration, renamed a route param,
+and put a redirect hop on a Stripe `return_url` — for a benefit visible
+only in the address bar.
+
+The check cost one directory listing, taken *before* opening an editor.
+
+**The rule:** reproduce the defect, or locate the code that produces it,
+before estimating or building. A finding described convincingly is not a
+finding observed. And when the check says the defect is absent, the
+answer is to report that — not to build the fix anyway because it was
+ruled.
+
+**Corollary.** If the thing is still wanted once the defect is disproved,
+it is a product decision on its own merits and deserves to be ruled as
+one, rather than shipped under a bug ticket that no longer has a bug.
+
 ## Verification invariants
 
 - Honest CI stays blocking. No `|| true`, ever again.

--- a/render.yaml
+++ b/render.yaml
@@ -1,15 +1,34 @@
-# ⚠️ THIS FILE IS NOT THE DEPLOYMENT INVENTORY.
+# ⚠️ THIS FILE IS NOT THE SERVICE INVENTORY — BUT IT *IS* THE
+#    ENVIRONMENT CONTRACT FOR THE SERVICE IT DESCRIBES.
 #
-# Services are managed in the Render dashboard. This file describes
-# `deedpro-main-api` and nothing else — the purge cron job
-# (`signer_contact_purge`, added 2026-08-11) runs in production and does
-# not appear here, and neither will anything else created in the
-# dashboard.
+# Two different claims, and the distinction is the point.
 #
-# Recorded because a config file that lies by OMISSION is harder to catch
-# than one that lies by contents: nothing about a YAML file announces
-# that it is a subset. Anyone reading this as "what runs" is reading a
-# partial list that does not say so.
+# NOT THE SERVICE INVENTORY. Services are managed in the Render
+# dashboard. This file describes `deedpro-main-api` and nothing else —
+# the purge cron job (`signer_contact_purge`, added 2026-08-11) runs in
+# production and does not appear here, and neither will anything else
+# created in the dashboard. Recorded because a config file that lies by
+# OMISSION is harder to catch than one that lies by contents: nothing
+# about a YAML file announces that it is a subset.
+#
+# IT IS THE ENVIRONMENT CONTRACT for `deedpro-main-api`, as of
+# 2026-08-11, and that half is now checked. Every variable the service
+# REQUIRES is declared below and cross-checked against
+# `backend/services/environment.py`, which the API reads at boot and
+# which prints a named block for anything missing.
+#
+# WHY THAT CHANGED. `FRONTEND_URL` is read in sixteen places, three of
+# them Stripe redirect URLs carrying a `http://localhost:3000` fallback —
+# so an unset variable sends a paying customer to a page on their own
+# machine, silently. It appeared in NO configuration file in this
+# repository. Nothing declared it should exist, so nothing could notice
+# it did not. That is the defect class this whole engagement has been
+# closing: a fact the system depends on, that nothing checks.
+#
+# A variable whose value is a SECRET is declared here with `sync: false`
+# — the key is named, the value stays in the dashboard. Declaring the
+# name is the whole point; declaring the value would be the thing the
+# ledger forbids.
 #
 # Owner-ruled 2026-08-11: every service defined here pins PYTHON_VERSION
 # explicitly. An unpinned service inherits whatever Render's default is
@@ -53,6 +72,30 @@ services:
       name: deedpro-db
   - key: ALLOWED_ORIGINS
     value: https://deedpro-frontend-new.vercel.app
+  # ── DECLARED BECAUSE ITS ABSENCE IS SILENT ────────────────────────
+  #
+  # `sync: false` means: this key is REQUIRED and its value is set in the
+  # dashboard. Render will not overwrite it; the declaration exists so
+  # that "which variables must this service have" is answerable from the
+  # repository rather than from memory.
+  #
+  # FRONTEND_URL is first because it is the one that was missing from
+  # every file while carrying the Stripe redirect path.
+  - key: FRONTEND_URL
+    sync: false
+  - key: JWT_SECRET_KEY
+    sync: false
+  - key: STRIPE_SECRET_KEY
+    sync: false
+  - key: STRIPE_PROFESSIONAL_PRICE_ID
+    sync: false
+  # STRICT_ENV turns the boot-time report into a refusal to start.
+  # DELIBERATELY UNSET until the owner has confirmed production carries
+  # every required variable: a process that refuses to boot on an
+  # unverified condition converts a wrong redirect into an outage.
+  # Turning it on is this line, uncommented, in the ticket that verifies.
+  # - key: STRICT_ENV
+  #   value: "1"
   # Phase 3 Backend Services & Routes Configuration
   - key: DYNAMIC_WIZARD_ENABLED
     value: "false"


### PR DESCRIPTION
Ticket 1 of the ruled order, with the scope addition.

## The defect that widened it

`FRONTEND_URL` is read in sixteen places. Three are the money path:

```
users_auth.py:550  success_url = {FRONTEND_URL}/account-settings?success=true
users_auth.py:551  cancel_url  = {FRONTEND_URL}/account-settings?canceled=true
users_auth.py:598  return_url  = {FRONTEND_URL}/account-settings   ← billing portal
```

All three written as `os.getenv('FRONTEND_URL', 'http://localhost:3000')`. Unset, a customer completes a checkout and is redirected to **a page on their own laptop** — nothing raised, nothing logged, and the first person to find out is the person who paid.

**It appeared in no configuration file in this repository.** Nothing declared it should exist, so nothing could notice it did not.

## What the file now claims — and what it still disclaims

`render.yaml` makes two different claims and the header keeps them apart.

- **Still NOT the service inventory.** The purge cron runs in production and isn't here. A config file that lies by omission is harder to catch than one that lies by contents.
- **It IS the environment contract** for the service it describes, cross-checked against `services/environment.py`.

Leaving the blanket disclaimer over a half that is now checked would understate it in the other direction — a reader who believes nothing here is authoritative won't maintain the half that is.

Secrets are declared by **name** with `sync: false`. The key is named, the value stays in the dashboard.

## Loud at boot, closed at the point of use

The asymmetry is the design, not a compromise on it.

**Boot prints a named block and returns.** It does not refuse, because we have not yet confirmed whether `FRONTEND_URL` is set in production — and a process that refuses to start on an unverified condition converts a wrong redirect into a total outage. You cannot hard-fail on a condition nobody has checked; the refusal is then the incident. `STRICT_ENV=1` makes it fatal, the line sits commented in `render.yaml`, and it becomes the default in the ticket that verifies.

**A call site is the opposite case.** Refusing there affects one operation whose output is already worthless without the variable. A checkout that refuses to start is strictly better than one that charges a card and redirects to localhost — the first has not taken any money.

Six sites now use `require()`, which raises with the consequence text: the three Stripe URLs, the password-reset and verify-email links, the payment-failed email, and `phase23_billing`'s `postgresql://user:pass@localhost:5432/deedpro` — a fictional URL whose connection error names a database nobody has, sending the reader hunting for a host instead of a missing variable.

## Required vs optional, classified deliberately

Per the ruling, each entry records **what breaks**, in its own words. The test is not importance — it is *does its absence change behaviour silently and wrongly?*

| | |
|---|---|
| `ADMIN_EMAIL` | optional — a notification is lost, the record still exists |
| `SENDGRID_API_KEY` | optional, and a close call that says so — every sender returns `(False, reason)`, the reason reaches the screen, `email_log` records it, the share still shows the link. Degrades, does not lie |
| `STRIPE_WEBHOOK_SECRET` | optional **only** because the webhook path already refuses unverified payloads. The entry says it becomes required in the same diff if that changes |
| `FRONTEND_URL` | required — a confidently wrong answer |

## The pin that would have caught the original

**No required variable may be read with a localhost default.** Matched as the *shape* — any required key, any localhost-ish default — rather than the one spelling.

It fired on **six real sites** on its first run, which is the whole argument for writing it. Mutation-probed: restoring one fallback fails it and names the file and line.

## Found by the no-database suite, in one run

Replacing `deps.py`'s fictional default with a refusal **at import** broke thirteen test modules. Importing a module to read a route table is not the same as using the database, and a refusal at import makes the two indistinguishable. The engine is lazy now; the refusal fires when somebody asks for a session, which is when the variable is actually needed.

The two-condition rule earning its keep — that would have been a boot failure in CI's DB-less job.

## Two pins retargeted, both flagged

- The render header pin moved from asserting `NOT THE DEPLOYMENT INVENTORY` to asserting **both** claims, because the file's authority genuinely changed.
- `test_trial1_paid_path` failed because checkout now refuses without `FRONTEND_URL` — **the fix working, not a regression**. Its fixture sets the variable and now also asserts the redirect URLs are built from the real host.

## Standing practice recorded

**Verify the defect exists before costing the fix**, in `EXECUTION_POLICY.md`, with the route-rename case as its evidence: described convincingly, and it did not exist. A finding described is not a finding observed — and when the check disproves it, the answer is to report that, not to build the fix anyway because it was ruled.

## Gates

| Gate | Result |
|---|---|
| pytest (no DB) | 885 passed, 172 skipped |
| pytest (with DB) | 1057 passed |
| jest | 715 passed, 48 suites |
| tsc baseline | **94** (unchanged) |
| six-flow / API baseline | ✔ / ✔ |
| banned-claims | clean |
| `next build` | ✔ |

## Still Jerry's, and unchanged by this PR

`FRONTEND_URL` on `deedpro-main-api` in Render. This PR makes its absence **visible at boot and fatal at checkout** — it does not set it. If it's currently missing, the next deploy's log will say so in a block naming the consequence, and checkout will refuse rather than charge and misdirect.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_