### PR TITLE
A job that writes says which database it is in, and refuses the wrong one

### DIFF
--- a/backend/scripts/backfill_plan_sync.py
+++ b/backend/scripts/backfill_plan_sync.py
@@ -30,6 +30,8 @@ from datetime import datetime, timezone
 
 import psycopg2
 from db_rows import ROW_FACTORY
+from services.db_identity import (WrongDatabase, assert_tables, describe,
+                                  expected_database)
 import stripe
 
 
@@ -112,6 +114,25 @@ def main():
                 expected[customer] = (plan, created)
 
     conn = psycopg2.connect(db_url, cursor_factory=ROW_FACTORY)
+
+    # WHICH DATABASE, BEFORE READING A PLAN OUT OF IT.
+    #
+    # This script is run by hand from a Render shell, with `--apply`, and
+    # it rewrites `users.plan` — what a customer is paying for. Pointed at
+    # the wrong Postgres it would either fail with a bare "relation does
+    # not exist" or, worse, report every Stripe subscriber as a missed
+    # upgrade because their row is not in THIS database, and `--apply`
+    # would then write those plans somewhere they do not belong.
+    #
+    # Naming the database on the way in costs one query and makes the
+    # printed report self-describing: the reader can tell from the report
+    # alone which database it is a report ABOUT.
+    try:
+        assert_tables(conn, "users", expect_database=expected_database())
+    except WrongDatabase as wrong:
+        sys.exit(str(wrong))
+    print(f"database: {describe(conn)}\n")
+
     missed_upgrades = []   # (user_id, email, current_plan, expected_plan, sub_created)
     downgrade_candidates = []  # (user_id, email, current_plan)
     with conn.cursor() as cur:

--- a/backend/scripts/migrate_notary1_signings.py
+++ b/backend/scripts/migrate_notary1_signings.py
@@ -26,16 +26,30 @@ def main() -> int:
     from db_rows import ROW_FACTORY
     from services.signing_migration import migrate
 
+    from services.db_identity import (WrongDatabase, assert_tables, describe,
+                                      expected_database)
+
     dry = "--dry-run" in sys.argv
     conn = psycopg2.connect(url, cursor_factory=ROW_FACTORY)
     try:
         # Standing rule: verify the database before trusting it. A
         # migration pointed at the wrong Postgres reports "nothing to
         # migrate" and looks like success.
-        with conn.cursor() as cur:
-            cur.execute("SELECT current_database() AS db, inet_server_addr() AS host")
-            ident = cur.fetchone()
-        print(f"database: {ident['db']} on {ident['host']}")
+        #
+        # This block used to be its own two-line copy of the identity
+        # query, printing the database and host and nothing else. It is
+        # now `services/db_identity` — one module, three callers — and it
+        # gained the half it was missing: the tables it reads and writes
+        # are asserted, so a wrong database says so instead of reporting
+        # a confident zero.
+        try:
+            assert_tables(conn, "deed_shares", "signing_requests",
+                          "signing_participants",
+                          expect_database=expected_database())
+        except WrongDatabase as wrong:
+            print(str(wrong), file=sys.stderr)
+            return 1
+        print(f"database: {describe(conn)}")
 
         report = migrate(conn, dry_run=dry)
         if dry:

--- a/backend/scripts/purge_signer_contact.py
+++ b/backend/scripts/purge_signer_contact.py
@@ -15,11 +15,18 @@ Usage:
     DATABASE_URL=postgresql://... python backend/scripts/purge_signer_contact.py
     DATABASE_URL=... python backend/scripts/purge_signer_contact.py --status
     DATABASE_URL=... python backend/scripts/purge_signer_contact.py --dry-run
+    DATABASE_URL=... python backend/scripts/purge_signer_contact.py --verify
 
 Suggested Render Cron Job (owner-side, Tier 3):
     schedule:      0 4 * * *          # daily, 4am UTC
     command:       python backend/scripts/purge_signer_contact.py
     env:           DATABASE_URL from the deedpro-db database
+                   EXPECTED_DATABASE=deedpro   ← name the database this
+                   job is FOR. Staging has every table the assertion
+                   below checks, so the tables alone would let a
+                   misconfigured cron delete real contact details out of
+                   the wrong copy. The name is the only thing that
+                   distinguishes them.
 
 Exit codes: 0 on success, 1 on failure — so a cron service's own
 alerting sees a failed purge rather than a silent one.
@@ -43,11 +50,46 @@ def main() -> int:
     from db_rows import ROW_FACTORY
     from services.signing_purge import purge_signer_contact, purge_status
 
+    from services.db_identity import (WrongDatabase, assert_tables, describe,
+                                      expected_database)
+
     status_only = "--status" in sys.argv
     dry_run = "--dry-run" in sys.argv
+    verify_only = "--verify" in sys.argv
 
     conn = psycopg2.connect(url, cursor_factory=ROW_FACTORY)
     try:
+        # ── WHICH DATABASE, BEFORE ANYTHING ELSE ──────────────────────
+        #
+        # `relation "signing_participants" does not exist` cost an
+        # afternoon and two redeploys on an untested hypothesis: it sent
+        # us hunting for a schema that had never run, when the schema was
+        # fine and the service was pointed at the wrong database.
+        #
+        # This asserts first and names both the database it found and the
+        # tables it wanted, so the same failure ends the investigation
+        # instead of starting one. A purge that runs against the wrong
+        # database is also the one job here where being wrong is
+        # irreversible — it deletes contact details.
+        #
+        # And because THIS is the irreversible job, it is also the one
+        # that most wants `EXPECTED_DATABASE`: a staging database has
+        # every table this asserts, so the tables alone would let the
+        # purge run happily against the wrong copy of real data.
+        try:
+            who = assert_tables(conn, "signing_participants", "signing_requests",
+                                expect_database=expected_database())
+        except WrongDatabase as wrong:
+            print(str(wrong), file=sys.stderr)
+            return 1
+
+        if verify_only:
+            # The question that started the afternoon, answerable without
+            # a psql session.
+            print(describe(conn))
+            return 0
+        print(f"[purge] running against {describe(conn)}")
+
         if status_only:
             print(json.dumps(purge_status(conn), indent=2, default=str))
             return 0

--- a/backend/services/db_identity.py
+++ b/backend/services/db_identity.py
@@ -1,0 +1,194 @@
+"""Which database is this, and does it have what I need.
+
+═══ THE AFTERNOON THIS COST ═══
+
+    relation "signing_participants" does not exist
+
+That message sent us hunting for a schema that had never run — a
+migration to re-check, a `create_tables` call to audit, two redeploys on
+an untested hypothesis. The schema was fine. The service was pointed at
+the wrong database.
+
+The same failure, phrased with its context:
+
+    signing_participants not found in deedpro_database on 10.26.62.99:5432
+    — expected one of: signing_participants, signing_windows
+
+ends the investigation in one run and names the actual defect.
+
+═══ INVARIANT #4, APPLIED TO DIAGNOSTICS ═══
+
+The rule everywhere else in this codebase is that a failure must surface
+with its reason. This is the same rule pointed at the failure itself: **an
+error that names its context is a different quality of error.** Both
+messages above are technically true and only one of them is useful, and
+the difference is four values Postgres will hand over for free.
+
+═══ TWO DIFFERENT WRONG DATABASES ═══
+
+A database missing the tables is the loud kind of wrong, and the tables
+are enough to catch it. **Staging is the quiet kind** — every table
+present, every query succeeding, the purge deleting real contact details
+out of the wrong copy and reporting a cheerful count.
+
+Nothing about the connection distinguishes those two databases except
+their names, so `EXPECTED_DATABASE` lets a deployment state which one it
+means and `assert_tables(..., expect_database=...)` holds the job to it.
+It is optional because a local run and CI both legitimately point
+somewhere else; it is worth having because the one place it would be set
+is the one place being wrong is unrecoverable.
+
+═══ WHY A MECHANISM RATHER THAN A HABIT ═══
+
+The specific defect is fixed and the standing rule is recorded. This is
+the difference between a rule people must remember and a mechanism that
+remembers for them — the same distinction the purge itself was held to,
+and the same one `services/environment.py` just applied to the
+environment.
+
+The identity block is also useful when nothing is wrong: `--verify`
+answers "which database is this service actually on" without a psql
+session, which is the question that started the afternoon.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Sequence
+
+
+class WrongDatabase(RuntimeError):
+    """A missing table, reported with the database it is missing FROM.
+
+    Named rather than a bare RuntimeError so a traceback says what kind
+    of problem this is before anybody reads the message.
+    """
+
+
+def identity(conn) -> Dict[str, Any]:
+    """Who am I connected to.
+
+    `inet_server_addr()` returns NULL over a unix socket — that is not an
+    error and the caller must not read it as one, so it is reported as
+    "local socket" rather than as an empty string that looks like a
+    lookup that failed.
+    """
+    with conn.cursor() as cur:
+        cur.execute("SELECT current_database() AS db, "
+                    "inet_server_addr() AS host, "
+                    "inet_server_port() AS port, "
+                    "current_user AS who, "
+                    "version() AS version")
+        row = cur.fetchone()
+
+    # RealDictCursor gives a dict; a plain cursor gives a tuple. This
+    # module is called from scripts that may configure either, and a
+    # diagnostic that crashes on the cursor factory is a diagnostic that
+    # fails exactly when it is needed.
+    def field(name: str, index: int):
+        if row is None:
+            return None
+        try:
+            return row[name]
+        except (TypeError, KeyError, IndexError):
+            return row[index]
+
+    host = field("host", 1)
+    return {
+        "database": field("db", 0),
+        "host": str(host) if host is not None else "local socket",
+        "port": field("port", 2),
+        "user": field("who", 3),
+        "version": (field("version", 4) or "").split(" on ")[0],
+    }
+
+
+def describe(conn) -> str:
+    """The identity block, one line, for a log or a --verify flag."""
+    who = identity(conn)
+    return (f"{who['database']} on {who['host']}:{who['port']} "
+            f"as {who['user']} ({who['version']})")
+
+
+def missing_tables(conn, names: Sequence[str]) -> list:
+    """Which of `names` this database does not have.
+
+    Asks the catalog rather than SELECTing from each table: a permission
+    error and an absent table are different problems, and a probe query
+    conflates them. `to_regclass` returns NULL for "not there" and does
+    not care whether you could read it.
+    """
+    absent = []
+    with conn.cursor() as cur:
+        for name in names:
+            cur.execute("SELECT to_regclass(%s) IS NULL AS gone", (name,))
+            row = cur.fetchone()
+            try:
+                gone = row["gone"]
+            except (TypeError, KeyError, IndexError):
+                gone = row[0]
+            if gone:
+                absent.append(name)
+    return absent
+
+
+def expected_database() -> str:
+    """The database this job was told it is for, if anybody said.
+
+    `EXPECTED_DATABASE` is read here rather than in each script, so the
+    three callers share one spelling and one default. Unset means "run
+    wherever DATABASE_URL points", which is what a local run and CI both
+    need — and it is why this is a declaration a deployment makes, not a
+    check the code can insist on by itself.
+    """
+    return (os.getenv("EXPECTED_DATABASE") or "").strip()
+
+
+def assert_tables(conn, *names: str, expect_database: str = "") -> Dict[str, Any]:
+    """Refuse to proceed against a database that lacks what we need.
+
+    Returns the identity dict on success, so a caller that wants to log
+    "running against X" gets it without a second round trip.
+
+    THE MESSAGE IS THE POINT. It names the database it is looking at, the
+    host it is on, and every table it expected — so the reader learns in
+    one line whether the schema is missing or the connection is.
+
+    ═══ WHY THE NAME CHECK EXISTS AS WELL ═══
+
+    Missing tables catch the loud case: the wrong database, empty. They
+    cannot catch the quiet one — **staging, which has every table** — and
+    for a job that deletes rows that is the worse of the two. A name is
+    the only thing that distinguishes two correctly-shaped databases, so
+    a deployment that knows which one it means can say so and this will
+    hold it to it.
+    """
+    if not names:
+        raise ValueError("assert_tables() with no table names asserts nothing")
+
+    # The name first: if it is wrong, a missing table is a symptom rather
+    # than the finding, and reporting the symptom sends the reader back
+    # to the schema — which is exactly the afternoon this file is about.
+    if expect_database:
+        who = identity(conn)
+        if who["database"] != expect_database:
+            raise WrongDatabase(
+                f"this is {who['database']} on {who['host']}:{who['port']} "
+                f"(as {who['user']}), and this job was told it is for "
+                f"{expect_database}. Refusing. Point DATABASE_URL at "
+                f"{expect_database}, or change EXPECTED_DATABASE if the "
+                "job has genuinely moved."
+            )
+
+    absent = missing_tables(conn, names)
+    if not absent:
+        return identity(conn)
+
+    who = identity(conn)
+    raise WrongDatabase(
+        f"{', '.join(absent)} not found in {who['database']} on "
+        f"{who['host']}:{who['port']} (connected as {who['user']}) — "
+        f"expected a database with: {', '.join(names)}. "
+        "Either this service is pointed at the wrong DATABASE_URL, or "
+        "the schema has not been created on this one. The message names "
+        "both so you do not have to guess which."
+    )

--- a/backend/tests/test_db_identity.py
+++ b/backend/tests/test_db_identity.py
@@ -1,0 +1,467 @@
+"""A job knows which database it is about to change, or it does not run.
+
+═══ THE AFTERNOON THIS COST ═══
+
+    relation "signing_participants" does not exist
+
+sent us hunting for a schema that had never run: a migration to re-check,
+a `create_tables` call to audit, two redeploys on an untested hypothesis.
+The schema was fine. The service was pointed at the wrong database.
+
+The message is technically true and useless, and the four values that
+would have ended the investigation in one run — database, host, port,
+user — are ones Postgres hands over for free.
+
+═══ WHAT THESE PINS PROTECT ═══
+
+ 1. THE ASSERTION COMES FIRST. Before a count, before a status report,
+    before anything that reads as progress. A purge that deletes contact
+    details in the wrong database is not recoverable by re-running it
+    somewhere else.
+
+ 2. EVERY WRITE-SIDE SCRIPT ASSERTS, OR IS EXEMPT WITH A STATED REASON.
+    The list is exact: a new script that connects and commits either
+    asserts its tables or gets written into the exemption list with an
+    argument. It cannot arrive silently, which is the whole difference
+    between a rule people must remember and a mechanism that remembers
+    for them.
+
+ 3. ONE IDENTITY IMPLEMENTATION, NOT THREE. `migrate_notary1_signings`
+    had its own two-line copy printing database and host. Standing rule:
+    when a new surface needs an existing judgement the answer is never a
+    second copy — this ticket ends with one fewer than it started with.
+
+ 4. THE CATALOG, NOT A PROBE. `to_regclass` answers "is it there";
+    `SELECT * FROM t LIMIT 0` answers "is it there AND may I read it",
+    and reports a permissions problem as a missing table. Two different
+    defects must not produce the same message — that is the whole
+    complaint of this file, applied to its own implementation.
+
+═══ THE ACCEPTANCE, RUN RATHER THAN DESCRIBED ═══
+
+The last test here runs the purge script as a subprocess against a real
+database that really lacks the table, and reads its real stderr. The
+thing being bought is a MESSAGE, and a message is the one kind of output
+that a unit test full of mocks can assert into existence without ever
+producing.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from services.db_identity import (WrongDatabase, assert_tables, describe,
+                                  expected_database, identity, missing_tables)
+from tests.source_text import code_only
+
+BACKEND = Path(__file__).resolve().parents[1]
+SCRIPTS = BACKEND / "scripts"
+
+dbonly = pytest.mark.skipif(not os.getenv("DATABASE_URL"),
+                            reason="needs a database")
+
+
+# ══════════════════════════════════════════════════════════════════════
+# 1. The identity block, without a database
+# ══════════════════════════════════════════════════════════════════════
+
+class _Cursor:
+    """Enough of a psycopg2 cursor to answer the two queries this module
+    asks: the identity SELECT, and one `to_regclass` probe per table."""
+
+    def __init__(self, row, present):
+        self._row = row
+        self._present = present
+        self._answer = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def execute(self, sql, params=None):
+        if "to_regclass" in sql:
+            self._answer = {"gone": not self._present}
+        else:
+            self._answer = self._row
+
+    def fetchone(self):
+        return self._answer
+
+
+class _Conn:
+    def __init__(self, row, present=True):
+        self._row = row
+        self._present = present
+
+    def cursor(self):
+        return _Cursor(self._row, self._present)
+
+
+DICT_ROW = {"db": "deedpro", "host": None, "port": 5432, "who": "deedpro_user",
+            "version": "PostgreSQL 16.3 on x86_64-pc-linux-gnu, compiled by gcc"}
+
+
+def test_a_unix_socket_is_reported_as_one_not_as_a_blank():
+    """`inet_server_addr()` is NULL over a local socket. That is not a
+    lookup that failed, and printing it as an empty string invites the
+    reader to go looking for a networking problem that is not there."""
+    who = identity(_Conn(DICT_ROW))
+    assert who["host"] == "local socket"
+    assert who["database"] == "deedpro"
+    assert who["user"] == "deedpro_user"
+
+
+def test_the_version_is_trimmed_to_the_part_a_human_reads():
+    """`version()` returns the compiler and the architecture too. The
+    identity line is meant to be read at a glance in a log."""
+    assert identity(_Conn(DICT_ROW))["version"] == "PostgreSQL 16.3"
+
+
+def test_a_plain_cursor_works_as_well_as_a_dict_one():
+    """This module is imported by scripts that configure either cursor
+    factory. A diagnostic that crashes on the cursor factory is a
+    diagnostic that fails exactly when it is needed — which is the same
+    complaint as the one it exists to fix."""
+    tup = ("deedpro", "10.26.62.147", 5432, "deedpro_user", "PostgreSQL 16.3 on x86")
+    who = identity(_Conn(tup))
+    assert who == {"database": "deedpro", "host": "10.26.62.147", "port": 5432,
+                   "user": "deedpro_user", "version": "PostgreSQL 16.3"}
+
+
+def test_describe_names_all_four_values_in_one_line():
+    line = describe(_Conn(DICT_ROW))
+    for fragment in ("deedpro", "local socket", "5432", "deedpro_user",
+                     "PostgreSQL 16.3"):
+        assert fragment in line
+
+
+def test_the_expected_database_is_unset_unless_a_deployment_says_so(monkeypatch):
+    """Optional on purpose: a local run and CI both legitimately point at
+    a database nobody named. Blank must therefore mean "do not check",
+    not "check against the empty string"."""
+    monkeypatch.delenv("EXPECTED_DATABASE", raising=False)
+    assert expected_database() == ""
+    monkeypatch.setenv("EXPECTED_DATABASE", "  deedpro  ")
+    assert expected_database() == "deedpro"
+
+
+def test_a_blank_expectation_does_not_silently_pass_everything():
+    """The failure mode of an optional check: `expect_database=""` must
+    skip the comparison rather than compare against nothing and refuse
+    every database, or accept every database while looking like it
+    checked."""
+    who = assert_tables(_Conn(DICT_ROW), "anything", expect_database="")
+    assert who["database"] == "deedpro"
+
+
+def test_the_wrong_named_database_names_both():
+    """The quiet wrong database — staging, with every table present.
+
+    Missing tables cannot catch it and this is the one job where being
+    wrong is unrecoverable, so the message names the database it is on
+    AND the one it was told it is for.
+    """
+    with pytest.raises(WrongDatabase) as raised:
+        assert_tables(_Conn(DICT_ROW), "signing_participants",
+                      expect_database="deedpro_staging")
+    message = str(raised.value)
+    assert "deedpro" in message              # where it is
+    assert "deedpro_staging" in message      # where it was told to be
+    assert "EXPECTED_DATABASE" in message    # and how to correct it
+
+
+def test_the_name_is_checked_before_the_tables():
+    """A name mismatch explains a missing table. Reporting the table
+    first sends the reader to the schema, which is the afternoon this
+    module exists to prevent."""
+    # A database that is BOTH wrongly named and missing the table: only
+    # one of the two facts is worth telling the reader first.
+    fake = _Conn(DICT_ROW, present=False)
+    with pytest.raises(WrongDatabase) as raised:
+        assert_tables(fake, "signing_participants", expect_database="somewhere_else")
+    assert "not found" not in str(raised.value)
+    assert "somewhere_else" in str(raised.value)
+
+
+def test_asserting_nothing_is_an_error_not_a_pass():
+    """`assert_tables(conn)` with no names would return successfully
+    having checked nothing — a green call that proves nothing, which is
+    the worst state a check can be in."""
+    with pytest.raises(ValueError):
+        assert_tables(_Conn(DICT_ROW))
+
+
+# ══════════════════════════════════════════════════════════════════════
+# 2. The mechanism, not the habit
+# ══════════════════════════════════════════════════════════════════════
+
+def _script_sources():
+    return {path.name: code_only(path) for path in sorted(SCRIPTS.glob("*.py"))}
+
+
+#: Scripts that connect AND commit, and are deliberately NOT asserting.
+#: Each carries the argument for its own exemption, because "it seemed
+#: fine" is how the list stops meaning anything.
+EXEMPT = {
+    "init_db.py":
+        "Creates the schema. Asserting that a table exists before the "
+        "run whose job is to create it is backwards.",
+    "add_pricing.py":
+        "CREATE TABLE IF NOT EXISTS, then seeds the rows. Its table is "
+        "its output, not its precondition — same reason as init_db.",
+    "add_property_cache.py":
+        "CREATE TABLE IF NOT EXISTS for the cache table. Its table is "
+        "its output, not its precondition — same reason as init_db.",
+    "s1_concurrency_proof.py":
+        "CI proof harness against a disposable database. The tables it "
+        "needs exist in production too, so asserting them would pass "
+        "there — the protection this one needs is a different one, and "
+        "it is ledgered rather than faked here.",
+    "s2_restore_drill.py":
+        "Same as s1 — and it dumps and restores, so the check it wants "
+        "is 'is this a throwaway database', which this module does not "
+        "answer.",
+}
+
+
+def test_every_write_side_script_names_its_database_or_argues_why_not():
+    """THE MECHANISM. A script that connects to DATABASE_URL and commits
+    is a script that changes data somewhere, and 'somewhere' is the word
+    doing the damage.
+
+    Exact-set equality on purpose: a new script cannot join the codebase
+    by being neither in the asserting set nor in the exemption list. It
+    has to be classified, and classifying it is one line either way.
+    """
+    writers = {name for name, src in _script_sources().items()
+               if "psycopg2.connect(" in src and ".commit()" in src}
+    asserting = {name for name, src in _script_sources().items()
+                 if "assert_tables(" in src}
+
+    unaccounted = sorted(writers - asserting - set(EXEMPT))
+    assert unaccounted == [], (
+        "these scripts connect to DATABASE_URL and commit, but never say "
+        "which database that is: " + ", ".join(unaccounted) +
+        " — call services.db_identity.assert_tables() with the tables "
+        "they need, or add them to EXEMPT with the reason.")
+
+    # And the exemption list does not outlive its entries: a script that
+    # is deleted or stops writing must not leave a standing excuse behind.
+    stale = sorted(set(EXEMPT) - writers)
+    assert stale == [], (
+        "exempted but no longer a write-side script: " + ", ".join(stale))
+
+
+@pytest.mark.parametrize("name,reason", sorted(EXEMPT.items()))
+def test_each_exemption_carries_an_argument(name, reason):
+    assert len(reason) > 60, f"{name}'s exemption is an assertion, not a reason"
+
+
+def test_the_purge_asserts_before_it_does_anything():
+    """Ordering is the point, not presence.
+
+    An assertion placed after the status report is an assertion that runs
+    second — and the purge is the one job here where being wrong deletes
+    something. `--status` reads, `--dry-run` counts, and the real run
+    destroys contact details; all three must be behind the check.
+    """
+    src = code_only(SCRIPTS / "purge_signer_contact.py")
+    first = src.index("assert_tables(")
+    for later in ("purge_status(conn)", "purge_signer_contact(conn)",
+                  "if status_only", "if verify_only"):
+        assert first < src.index(later), (
+            f"the database assertion runs after {later!r}")
+
+
+def test_there_is_one_identity_query_in_the_codebase():
+    """`migrate_notary1_signings` used to carry its own copy — database
+    and host, no port, no user, and no assertion that the tables were
+    there at all. Standing rule: the ticket ends with one fewer copy than
+    it started with."""
+    copies = []
+    for path in BACKEND.rglob("*.py"):
+        if {"tests", "__pycache__", "venv", ".venv"} & set(path.parts):
+            continue
+        if path.name == "db_identity.py":
+            continue
+        if "inet_server_addr" in code_only(path):
+            copies.append(str(path.relative_to(BACKEND)))
+    assert copies == [], (
+        "a second identity query lives in: " + ", ".join(copies) +
+        " — import services.db_identity.describe instead")
+
+
+def test_absence_is_asked_of_the_catalog_not_of_the_table():
+    """A probe SELECT conflates 'the table is not there' with 'you may
+    not read it', and this whole module exists because one message was
+    made to stand for two different defects."""
+    src = code_only(BACKEND / "services" / "db_identity.py")
+    assert "to_regclass" in src
+    assert "information_schema" not in src, (
+        "information_schema.tables answers a different question — it "
+        "omits views and is filtered by privilege")
+
+
+# ══════════════════════════════════════════════════════════════════════
+# 3. Against a real database
+# ══════════════════════════════════════════════════════════════════════
+
+@pytest.fixture
+def conn():
+    import psycopg2
+    from database import create_tables
+    from db_rows import ROW_FACTORY
+    create_tables()
+    c = psycopg2.connect(os.environ["DATABASE_URL"], cursor_factory=ROW_FACTORY)
+    yield c
+    c.rollback()
+    c.close()
+
+
+@dbonly
+def test_the_right_database_is_silent(conn):
+    who = assert_tables(conn, "signing_participants", "signing_requests")
+    assert who["database"]
+    assert who["user"]
+
+
+@dbonly
+def test_a_table_that_is_there_is_not_reported_missing(conn):
+    assert missing_tables(conn, ["signing_participants"]) == []
+
+
+@dbonly
+def test_the_wrong_database_says_which_one_it_looked_in(conn):
+    """The half the original message was missing.
+
+    Every value here is one a reader needs to decide between 'the schema
+    was never created' and 'this service is pointed somewhere else', and
+    the original error contained none of them.
+    """
+    with pytest.raises(WrongDatabase) as raised:
+        assert_tables(conn, "signing_participants", "a_table_that_never_existed")
+    message = str(raised.value)
+
+    who = identity(conn)
+    assert who["database"] in message
+    assert str(who["host"]) in message
+    assert str(who["port"]) in message
+    assert who["user"] in message
+    # The one that is missing, and the whole set that was expected.
+    assert "a_table_that_never_existed" in message
+    assert "signing_participants" in message
+    # And it names the two candidate causes rather than implying one.
+    assert "DATABASE_URL" in message
+
+
+# ══════════════════════════════════════════════════════════════════════
+# 4. The acceptance — the script itself, against a database that lacks
+#    the table
+# ══════════════════════════════════════════════════════════════════════
+
+def _sibling_url(url: str, database: str) -> str:
+    """The same server, a different database.
+
+    `postgres` is the maintenance database every Postgres install has and
+    none of this product's schema is in — a genuine wrong-database, on
+    the machine the test is already talking to, with no DDL and nothing
+    to clean up afterwards.
+    """
+    return re.sub(r"/[^/?]+(\?|$)", "/" + database + r"\1", url, count=1)
+
+
+def _run_purge(url: str, *args, expected: str = ""):
+    env = dict(os.environ, DATABASE_URL=url)
+    env.pop("EXPECTED_DATABASE", None)
+    if expected:
+        env["EXPECTED_DATABASE"] = expected
+    return subprocess.run(
+        [sys.executable, "scripts/purge_signer_contact.py", *args],
+        cwd=BACKEND, env=env, capture_output=True, text=True, timeout=120)
+
+
+@dbonly
+def test_the_purge_refuses_a_database_that_lacks_the_table():
+    """THE ACCEPTANCE, RUN.
+
+    Not "assert_tables raises" — the script, invoked the way a cron job
+    would invoke it, pointed at a real database on the real server that
+    really does not have `signing_participants`.
+
+    What is being bought is the MESSAGE, so the message is what is read.
+    """
+    real = os.environ["DATABASE_URL"]
+    wrong = _sibling_url(real, "postgres")
+    if wrong == real:
+        pytest.skip("DATABASE_URL already points at the maintenance database")
+
+    done = _run_purge(wrong)
+    assert done.returncode == 1, (
+        "the purge did not refuse a database without its tables: "
+        + done.stdout + done.stderr)
+
+    said = done.stderr
+    assert "signing_participants" in said       # what it wanted
+    assert "postgres" in said                   # where it actually was
+    assert "DATABASE_URL" in said               # and what to go and check
+    # It refused BEFORE reporting anything that reads like work done.
+    assert "purged" not in done.stdout
+
+
+@dbonly
+def test_the_purge_refuses_a_correctly_shaped_database_it_was_not_meant_for():
+    """The ledger's acceptance in its literal form: **a message naming
+    both databases.**
+
+    This is the staging case, and it is the one the table assertion
+    cannot reach — every table is present, every query would succeed, and
+    the purge would delete real contact details out of the wrong copy and
+    report a cheerful count. Only the NAME separates them.
+    """
+    real = os.environ["DATABASE_URL"]
+    done = _run_purge(real, expected="deedpro_production_not_this_one")
+
+    assert done.returncode == 1, done.stdout + done.stderr
+    said = done.stderr
+    here = identity_of(real)["database"]
+    assert here in said                                  # the one it is on
+    assert "deedpro_production_not_this_one" in said     # the one it wants
+    assert "purged" not in done.stdout
+
+
+@dbonly
+def test_the_right_database_runs_and_says_where():
+    """The other half of the acceptance: correct is quiet, but not mute.
+
+    `--verify` answers 'which database is this job actually on' without a
+    psql session — the question that started the afternoon — and exits 0.
+    """
+    done = _run_purge(os.environ["DATABASE_URL"], "--verify")
+    assert done.returncode == 0, done.stderr
+    who = describe_from(os.environ["DATABASE_URL"])
+    assert who in done.stdout.strip()
+    assert done.stderr.strip() == ""
+
+
+def _with_connection(url: str, fn):
+    import psycopg2
+    c = psycopg2.connect(url)
+    try:
+        return fn(c)
+    finally:
+        c.close()
+
+
+def describe_from(url: str) -> str:
+    return _with_connection(url, describe)
+
+
+def identity_of(url: str) -> dict:
+    return _with_connection(url, identity)

--- a/docs/EXECUTION_POLICY.md
+++ b/docs/EXECUTION_POLICY.md
@@ -109,6 +109,36 @@ ruled.
 it is a product decision on its own merits and deserves to be ruled as
 one, rather than shipped under a bug ticket that no longer has a bug.
 
+## Standing practice — a job that writes says which database it is in
+
+Ruled 2026-08-12 (db-identity ticket). `relation "signing_participants"
+does not exist` cost an afternoon and two redeploys on an untested
+hypothesis: it sent us hunting for a schema that had never run, when the
+schema was fine and the service was pointed at the wrong database.
+
+**The rule:** any script that connects to `DATABASE_URL` and commits
+either calls `services.db_identity.assert_tables()` before it does
+anything, or appears in the exemption list in
+`backend/tests/test_db_identity.py` with the argument for its exemption.
+Exact-set equality — a new script cannot arrive unclassified.
+
+**Two different wrong databases, and only one of them is loud.**
+
+- *Missing tables* — the wrong database, empty. `assert_tables` names the
+  database, host, port, user and every table it wanted, so one run ends
+  the investigation instead of starting one.
+- *Staging* — every table present, every query succeeding, the job
+  deleting or rewriting real rows in the wrong copy and reporting a
+  cheerful count. Nothing about the connection distinguishes it; only the
+  name does. `EXPECTED_DATABASE` lets a deployment state which database a
+  job is FOR, and it is optional because a local run and CI both point
+  somewhere else legitimately.
+
+This is Invariant #4 — a failure surfaces with its reason — pointed at
+the failure itself: **an error that names its context is a different
+quality of error.** Both phrasings of the message above are true and only
+one is useful, and the difference is four values Postgres gives away.
+
 ## Verification invariants
 
 - Honest CI stays blocking. No `|| true`, ever again.
@@ -125,7 +155,13 @@ one, rather than shipped under a bug ticket that no longer has a bug.
   (`backend/scripts/six_flow_baseline.py`) must stay green. Neither is
   re-recorded to make a failure pass without an approved, documented reason
   in the PR that re-records it.
-- The frontend `tsc` error baseline (currently **114**) may only go down.
+- The frontend `tsc` error baseline (currently **94**) may only go down.
+  Enforced by `TSC_BASELINE` in `.github/workflows/test.yml`, which is
+  the authority; this line said **114** until 2026-08-12, long after the
+  machine had been holding 94. Nothing was let through — the gate was
+  always the stricter of the two — but a reader checking their work
+  against this page would have believed they had twenty errors of
+  headroom they did not have.
 
 ## Dead code and revived code
 

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -110,6 +110,27 @@ when their trigger arrives.
   `http://localhost:3000` and a paying customer lands nowhere. This is
   independent of any route rename; see `docs/DASH1_REQUESTS_MERGE.md`.
 
+  **PR #166 did not close this, and must not be read as having closed
+  it.** #166 is the CLASS fix: the environment is declared, the boot log
+  names anything missing, and `require()` makes a checkout refuse rather
+  than redirect to localhost. The INSTANCE — whether `FRONTEND_URL` is
+  actually set on the production API — is still this card, still
+  unanswered, and still the owner's. Making an absence visible is not
+  the same act as ending it, and after #166 the failure mode changed
+  rather than disappeared: a customer no longer lands on their own
+  laptop, they get a refused checkout. Better, and still a customer who
+  cannot pay.
+
+- **`EXPECTED_DATABASE` on the purge cron — set it when the cron exists**
+  (db-identity, 2026-08-12). Not urgent, and it has no effect until the
+  Render Cron Job is created (Tier 3, still not created). When it is:
+  set `EXPECTED_DATABASE=deedpro` alongside `DATABASE_URL`. The purge
+  asserts its tables, but **staging has those tables too** — the name is
+  the only thing that separates the production database from a copy of
+  it, and the purge is the one job here where being wrong deletes real
+  contact details. Unset, the job runs wherever `DATABASE_URL` points,
+  which is correct for local and CI and is why the check is optional.
+
 - **Junk seed cleanup** (test rows in production data).
 - **TitlePoint / SiteX credential rotations.**
 - **DTT city-rates review** (`frontend/src/lib/dttCalc.ts`) — owner's
@@ -742,7 +763,39 @@ header stands until then.
 Doing neither leaves a file that will be believed. Recommended: (2) now,
 (1) if deploy topology ever gets complicated enough to need review.
 
-## TICKET — services assert their tables and name the database (queued)
+## TICKET — services assert their tables and name the database (DONE)
+
+**Shipped 2026-08-12.** `backend/services/db_identity.py`, called by the
+purge, the NOTARY1 migration and the plan backfill; `--verify` on the
+purge; `backend/tests/test_db_identity.py` holds it. Two departures from
+the text below, both deliberate and both argued in the PR:
+
+1. **"Naming both databases" needed something to compare against.** The
+   example message below names an expected database, and nothing in the
+   repo declares one — the purge legitimately runs against `deedpro`,
+   `deedpro_test` and `deedpro_ci`, so a hardcoded name would be wrong
+   three ways. Delivered as an optional `EXPECTED_DATABASE` a deployment
+   sets; with it the message names both, without it the tables are still
+   asserted. See the owner card above.
+2. **Two callers were swept in beyond the purge**, because both were the
+   same defect: `migrate_notary1_signings.py` carried its own two-line
+   copy of the identity query (database and host, no assertion at all —
+   so a wrong database would have reported a confident "found: 0"), and
+   `backfill_plan_sync.py` rewrites `users.plan` from a Render shell with
+   no identity line whatsoever.
+
+**Found while doing it, NOT fixed — needs a ruling.** `s1_concurrency_proof`
+and `s2_restore_drill` write to `users` and `deeds` in whatever
+`DATABASE_URL` points at, and `s2` runs `pg_dump`/`pg_restore`. Pointed
+at production they would insert junk rows into real tables. `assert_tables`
+is the wrong tool — production HAS those tables, so the assertion would
+pass — and the check they actually want is "is this a throwaway
+database", which is a different mechanism (a refusal unless the database
+name is test-shaped, or an explicit `I_AM_A_SCRATCH_DATABASE`). They are
+exempted with that reason recorded in the test rather than given a check
+that would not have caught anything.
+
+## The original ticket text, for the record
 
 **Why it is a ticket rather than a note.** It cost an afternoon of the
 owner's time and two redeploys on an untested hypothesis. Invariant #4


### PR DESCRIPTION
## The afternoon this cost

```
relation "signing_participants" does not exist
```

That message sent us hunting for a schema that had never run — a migration to re-check, a `create_tables` call to audit, two redeploys on an untested hypothesis. The schema was fine. **The service was pointed at the wrong database.**

The same failure, phrased with its context:

```
signing_participants not found in postgres on 127.0.0.1:5433 (connected as postgres) —
expected a database with: signing_participants, signing_requests. Either this service
is pointed at the wrong DATABASE_URL, or the schema has not been created on this one.
The message names both so you do not have to guess which.
```

Both messages are technically true and only one of them ends the investigation. The difference is four values Postgres hands over for free. This is Invariant #4 — a failure surfaces with its reason — pointed at the failure itself.

## Two different wrong databases, and only one of them is loud

| | What it looks like | What catches it |
|---|---|---|
| **The empty one** | `relation does not exist`, everything stops | `assert_tables()` — names the database, host, port, user, and every table it wanted |
| **Staging** | every table present, every query succeeding, the purge deleting real contact details out of the wrong copy and reporting a cheerful count | **nothing, until now** — only the NAME separates two correctly-shaped databases |

The second is the worse one, and it is the one the ledger's acceptance text was actually describing ("a message naming both databases"). Delivered as an optional `EXPECTED_DATABASE` a deployment sets — see the deviation note below.

## What is in the PR

**`backend/services/db_identity.py`** — `identity()`, `describe()`, `missing_tables()`, `assert_tables(conn, *names, expect_database=...)`, `expected_database()`.

- `to_regclass`, not a probe `SELECT`: a permission error and an absent table are different problems, and this whole module exists because one message was made to stand for two defects.
- A NULL `inet_server_addr()` (unix socket) is reported as `local socket`, not as a blank that invites a hunt for a networking problem that is not there.
- Works with either cursor factory — a diagnostic that crashes on the cursor factory is a diagnostic that fails exactly when it is needed.

**Three callers, not one.**

| Script | Before | Now |
|---|---|---|
| `purge_signer_contact.py` | nothing | asserts `signing_participants`, `signing_requests` before `--status`, `--dry-run` or the real run; `--verify` prints the identity block and exits |
| `migrate_notary1_signings.py` | its own two-line copy printing database + host, **no assertion** — a wrong database reports a confident `found: 0` and looks like success | one shared module, plus the assertion it was missing |
| `backfill_plan_sync.py` | nothing at all, and it rewrites `users.plan` from a Render shell with `--apply` | asserts `users`, prints the identity line at the top of its report |

The standing rule applies: **when a new surface needs an existing judgement the answer is never a second copy.** The ticket ends with one fewer copy than it started with, and a pin keeps it that way.

**A mechanism rather than a habit.** A script that connects to `DATABASE_URL` and commits either asserts its tables or appears in an exemption list with the argument for its exemption — exact-set equality, both directions, so a new script cannot arrive unclassified and a stale excuse cannot outlive its script.

## The acceptance, run rather than described

The ledger asked for it to be *"tested by running it against a database that lacks the table"*, so it is:

```python
done = _run_purge(_sibling_url(real, "postgres"))     # same server, no schema
assert done.returncode == 1
assert "signing_participants" in done.stderr          # what it wanted
assert "postgres" in done.stderr                      # where it actually was
assert "purged" not in done.stdout                    # it refused before doing work
```

The subprocess is the point. What is being bought here is a **message**, and a message is the one kind of output a suite full of mocks can assert into existence without ever producing.

## Deviations, flagged

**1. "A message naming both databases" needed something to compare against.** The ledger's example names an expected database. Nothing in the repo declares one, and nothing could: the purge legitimately runs against `deedpro`, `deedpro_test` and `deedpro_ci`, so a hardcoded name would be wrong three ways.

Delivered as an optional `EXPECTED_DATABASE` that a deployment sets. With it, the message names both. Without it, the tables are still asserted. It is optional because local and CI runs point elsewhere legitimately — which is also the honest cost: **an optional check is not set until somebody sets it.** Owner card added; the purge's suggested cron block in its own docstring now carries the variable so it is in front of whoever creates that service.

**2. Two callers swept in beyond the purge**, because they were the same defect and one of them was the duplicate copy the standing rule forbids.

**3. Found while doing it, NOT fixed — needs a ruling.** `s1_concurrency_proof` and `s2_restore_drill` insert into `users` and `deeds` in whatever `DATABASE_URL` points at, and `s2` runs `pg_dump`/`pg_restore`. Pointed at production they would write junk rows into real tables. `assert_tables` is the wrong tool — production *has* those tables, so the check would pass — and what they want is "is this a throwaway database", which is a different mechanism. They are exempted with that reason recorded rather than given a check that would not have caught anything.

**4. Branch deviation, flagged as standing practice.** The session config names `claude/docs-archive-regenerate-ehj87q`, which carries unrelated commits; this is on a fresh branch off current `main`, as ruled.

## Corrected in passing

`docs/EXECUTION_POLICY.md` recorded the tsc baseline as **114**. `TSC_BASELINE` in CI has been **94** for weeks and is the authority, so nothing was ever let through — but a reader checking their work against the policy page would have believed they had twenty errors of headroom they did not have.

## Verification

Six pins were mutation-probed; all six failed on the break. One probe came back green and the reason was instructive — I had removed only the first of two occurrences of the expected database name in the message, so the pin still found the second. Re-run with both removed: caught.

| Gate | Result |
|---|---|
| pytest, with a database | **1081 passed** (was 1057) |
| pytest, no database | **903 passed**, 178 skipped (was 885) |
| jest | 715 passed, 48 suites |
| tsc | **94** — baseline holds |
| six-flow baseline | ✔ |
| API baseline | ✔ |
| banned-claims | clean, 14 rules over 218 files |

`next build` not run: no frontend source changed in this PR.

Also exercised by hand, both directions — the migration script refuses `postgres` with the named message and exit 1, and reports `database: deedpro_test on 127.0.0.1:5433 as postgres (PostgreSQL 16.13)` against the right one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_