### PR TITLE
UX2 item 1: the parcel the officer chose is the parcel she gets

### DIFF
--- a/backend/api/property_endpoints.py
+++ b/backend/api/property_endpoints.py
@@ -11,6 +11,7 @@ import psycopg2
 from db_rows import ROW_FACTORY
 
 from auth import get_current_user_id
+from services import address_match
 
 logger = logging.getLogger(__name__)
 
@@ -139,6 +140,89 @@ class PropertyResolveMatchRequest(BaseModel):
     apn: str = Field(..., min_length=1)
 
 
+SELECTED_EXACT = "exact_address_match"
+SELECTED_ONLY_MATCH = "only_county_match"
+SELECTED_OFFICER = "officer_choice"
+
+
+def _decorate(matches):
+    """Every candidate says why a field of it is blank.
+
+    Invariant #4 in a data field: the screen used to print "Owner
+    unavailable" for a parcel the county simply has no owner name for,
+    which reads as a failure and is not one.
+    """
+    decorated = []
+    for match in matches:
+        row = dict(match)
+        row["owner_status"] = address_match.owner_status(row)
+        row["owner_reason"] = address_match.OWNER_REASONS.get(row["owner_status"], "")
+        decorated.append(row)
+    return decorated
+
+
+async def _resolve_multi_match(request, result, user_id: str) -> Dict:
+    """The county returned several parcels for one chosen address.
+
+    ═══ WHY THIS RUNS ON THE SERVER ═══
+
+    The officer chose a specific address from the autocomplete. Standing
+    rule: move the judgement server-side and send the answer, rather than
+    teaching a second surface how to compare addresses. The screen
+    renders what it is told, and there is one implementation of "is this
+    the same address" instead of one per client.
+
+    ═══ WHY IT CAN DECLINE ═══
+
+    Exactly one unambiguous match selects. Zero or several do not, and
+    then all of them go to the officer, nearest first, with nothing
+    chosen on their behalf. A multi-unit building is the common case of
+    "several", and picking a unit for somebody is how a deed ends up
+    describing the neighbour's home.
+    """
+    matches = _decorate([m.dict() for m in (result.matches or [])])
+    wanted = address_match.Address(
+        street=request.address, city=request.city, zip_code=request.zip_code)
+    selected, ranked = address_match.select(wanted, matches)
+
+    logger.info(
+        f"SiteX search-v2 multi_match: {len(matches)} candidates, "
+        f"exact selection={'yes' if selected else 'no'}")
+
+    if selected:
+        from services.sitex_service import sitex_service
+        resolved = await sitex_service.search_by_fips_apn(
+            fips=selected.get("fips", ""), apn=selected.get("apn", ""),
+            client_ref=f"user:{user_id}")
+        if resolved.status == "success" and resolved.data:
+            alternatives = [m for m in ranked if m is not selected]
+            payload = resolved.dict()
+            payload["selection"] = {
+                "basis": SELECTED_EXACT,
+                "matched_address": selected.get("address", ""),
+                "alternative_count": len(alternatives),
+            }
+            payload["alternatives"] = alternatives
+            return payload
+
+        # The exact parcel would not load. That is not a reason to pick a
+        # different one, and it is not a reason to say nothing happened —
+        # the officer gets the full list and the reason it is still a list.
+        logger.warning(
+            "SiteX resolve of the exact match failed (%s); falling back to "
+            "the candidate list", resolved.status)
+
+    return {
+        "status": "multi_match",
+        "message": "Multiple properties found. Please select one.",
+        "data": None,
+        "matches": ranked,
+        "match_count": len(ranked),
+        "selection": {"basis": SELECTED_OFFICER, "matched_address": "",
+                      "alternative_count": len(ranked)},
+    }
+
+
 @router.post("/search-v2")
 async def property_search_v2(
     request: PropertySearchRequestV2,
@@ -184,16 +268,7 @@ async def property_search_v2(
         print(f"⏱️  Property search v2 took {elapsed:.2f}s - status: {result.status}")
 
         if result.status == "multi_match":
-            match_count = len(result.matches or [])
-            response_payload = {
-                "status": "multi_match",
-                "message": "Multiple properties found. Please select one.",
-                "data": None,
-                "matches": [match.dict() for match in (result.matches or [])],
-                "match_count": match_count,
-            }
-            logger.info(f"SiteX search-v2 multi_match returned {match_count} matches")
-
+            response_payload = await _resolve_multi_match(request, result, user_id)
             background_tasks.add_task(
                 log_api_usage,
                 user_id,
@@ -202,9 +277,23 @@ async def property_search_v2(
                 request.dict(),
                 response_payload
             )
-
             return response_payload
-        
+
+        if result.status == "success":
+            payload = result.dict()
+            # §13.2 — who asserted this answer. One county match is not a
+            # choice anybody made; saying so is cheaper than leaving the
+            # reader to work out that no selection happened.
+            payload["selection"] = {
+                "basis": SELECTED_ONLY_MATCH,
+                "matched_address": (result.data.address if result.data else ""),
+                "alternative_count": 0,
+            }
+            background_tasks.add_task(
+                log_api_usage, user_id, "sitex_v2", "property_search",
+                request.dict(), payload)
+            return payload
+
         # Non-blocking logging
         background_tasks.add_task(
             log_api_usage, 
@@ -258,17 +347,27 @@ async def resolve_property_match(
             client_ref=f"user:{user_id}"
         )
         
+        payload = result.dict()
+        # §13.2 — who asserted the answer. This route exists BECAUSE a
+        # human picked a row, and the record should be able to tell that
+        # apart from a parcel the server matched.
+        payload["selection"] = {
+            "basis": SELECTED_OFFICER,
+            "matched_address": (result.data.address if result.data else ""),
+            "alternative_count": 0,
+        }
+
         # Non-blocking logging
         background_tasks.add_task(
-            log_api_usage, 
-            user_id, 
-            "sitex_v2", 
-            "resolve_match", 
+            log_api_usage,
+            user_id,
+            "sitex_v2",
+            "resolve_match",
             request.dict(),
-            result.dict() if result else None
+            payload
         )
-        
-        return result.dict()
+
+        return payload
         
     except Exception as e:
         return {

--- a/backend/services/address_match.py
+++ b/backend/services/address_match.py
@@ -1,0 +1,321 @@
+"""Did the county return the parcel the officer actually chose?
+
+═══ THE DEFECT ═══
+
+The officer picks `1358 5th Street, Coronado, CA` from the autocomplete —
+a specific address, chosen deliberately from a list. The county search
+comes back with 76 candidates, the chosen address is not first, and the
+screen's advice is "refine search for fewer results". There is nothing
+left to refine: the search WAS the address.
+
+Then the officer picks a row, and every downstream field — APN, legal
+description, vested owner — comes from that parcel. A wrong row does not
+produce an error. It produces a complete, plausible, confidently wrong
+deed, sourced from a real county record, with the officer's confirmation
+on every field.
+
+That is the one failure the confirmation model cannot catch. Confirming a
+value proves the officer read it; it does not prove the value belongs to
+the property they meant.
+
+═══ WHAT THIS MODULE DOES, AND WHAT IT REFUSES TO DO ═══
+
+It compares the address the officer chose against each candidate's
+address, and it answers ONE question: **is there exactly one candidate
+that is unambiguously the same address?** If yes, that parcel is the
+selection and the rest become alternatives. If no, every candidate goes
+in front of the officer, ordered by how close it is, and nothing is
+chosen on their behalf.
+
+It does NOT do fuzzy matching, spelling correction, or nearest-neighbour
+guessing. `1358` and `1356` are different properties, and a module that
+treats them as nearly-the-same is a module that eventually picks one.
+Every comparison here is an equality test on a normalised string; the
+normalisation is about SPELLING (`5th Street` vs `5TH ST`), never about
+identity.
+
+═══ WHY "EXACTLY ONE" IS THE WHOLE RULE ═══
+
+Two candidates that normalise to the same address are not a tie to be
+broken — they are a genuine ambiguity that only the officer can resolve,
+usually a multi-unit building where the unit is the deciding fact. The
+moment this module breaks such a tie by any rule at all (first returned,
+highest assessed value, closest ZIP) it has invented an answer, and it
+will be right often enough that nobody checks it.
+
+So: one exact match selects, zero or several do not. There is no third
+branch, and there is no confidence score — a number between 0 and 1
+invites a threshold, and a threshold is where invented answers come from.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+# ── Spelling, not identity ───────────────────────────────────────────
+#
+# Google returns "5th Street"; the county returns "5TH ST". Same place,
+# two spellings. Everything in these tables is a way of WRITING a word —
+# nothing here changes which parcel a string refers to.
+
+SUFFIXES: Dict[str, str] = {
+    "STREET": "ST", "ST": "ST",
+    "AVENUE": "AVE", "AVE": "AVE", "AV": "AVE",
+    "BOULEVARD": "BLVD", "BLVD": "BLVD",
+    "ROAD": "RD", "RD": "RD",
+    "DRIVE": "DR", "DR": "DR",
+    "LANE": "LN", "LN": "LN",
+    "COURT": "CT", "CT": "CT",
+    "PLACE": "PL", "PL": "PL",
+    "TERRACE": "TER", "TER": "TER",
+    "CIRCLE": "CIR", "CIR": "CIR",
+    "TRAIL": "TRL", "TRL": "TRL",
+    "PARKWAY": "PKWY", "PKWY": "PKWY",
+    "HIGHWAY": "HWY", "HWY": "HWY",
+    "WAY": "WAY",
+    "SQUARE": "SQ", "SQ": "SQ",
+    "LOOP": "LOOP",
+    "ALLEY": "ALY", "ALY": "ALY",
+    "PLAZA": "PLZ", "PLZ": "PLZ",
+}
+
+DIRECTIONALS: Dict[str, str] = {
+    "NORTH": "N", "N": "N",
+    "SOUTH": "S", "S": "S",
+    "EAST": "E", "E": "E",
+    "WEST": "W", "W": "W",
+    "NORTHEAST": "NE", "NE": "NE",
+    "NORTHWEST": "NW", "NW": "NW",
+    "SOUTHEAST": "SE", "SE": "SE",
+    "SOUTHWEST": "SW", "SW": "SW",
+}
+
+#: Words that introduce a unit. The DESIGNATOR is normalised away and the
+#: unit VALUE is kept, because "APT 3" and "UNIT 3" are the same unit
+#: written twice, while "UNIT 3" and "UNIT 4" are two different homes.
+UNIT_WORDS = {
+    "UNIT", "APT", "APARTMENT", "STE", "SUITE", "#", "NO", "RM", "ROOM",
+    "SPC", "SPACE", "TRLR", "LOT", "BLDG", "FL", "FLOOR", "PH",
+}
+
+_PUNCTUATION = re.compile(r"[.,;:]+")
+_WHITESPACE = re.compile(r"\s+")
+
+
+def _tokens(text: Optional[str]) -> List[str]:
+    if not text:
+        return []
+    cleaned = _PUNCTUATION.sub(" ", str(text).upper())
+    cleaned = cleaned.replace("#", " # ")
+    return [t for t in _WHITESPACE.split(cleaned) if t]
+
+
+def split_unit(text: Optional[str]) -> Tuple[List[str], str]:
+    """Separate the street part from the unit part.
+
+    `1358 5TH ST UNIT 3B` → (`[1358, 5TH, ST]`, `3B`).
+
+    A trailing bare `#3` counts; a bare trailing number does NOT. `1358
+    5TH ST 3` is more likely a mangled address than a unit, and inventing
+    a unit is exactly the kind of guess this module refuses to make.
+    """
+    tokens = _tokens(text)
+    for index, token in enumerate(tokens):
+        if token in UNIT_WORDS:
+            unit = "".join(tokens[index + 1:])
+            return tokens[:index], unit
+    return tokens, ""
+
+
+def normalize_street(text: Optional[str]) -> str:
+    """The street part, spelled one way.
+
+    Only ONE token is treated as the street type, and it is found by
+    position: `WAY` is the type in `Ocean Way` and part of the name in
+    `Broadway Ave`. The type is the last token, or the second-to-last
+    when a trailing directional follows it (`5th Street West`).
+    """
+    tokens, _ = split_unit(text)
+    if not tokens:
+        return ""
+
+    last = len(tokens) - 1
+    suffix_at = last
+    if last > 0 and tokens[last] in DIRECTIONALS:
+        suffix_at = last - 1
+
+    out: List[str] = []
+    for index, token in enumerate(tokens):
+        if index == suffix_at and index > 0 and token in SUFFIXES:
+            out.append(SUFFIXES[token])
+        elif index != suffix_at and token in DIRECTIONALS:
+            # Anywhere but the street-type slot: `742 North Beacon Blvd`,
+            # `55 5th St West`. Two directionals never collapse into each
+            # other — N and S map to different tokens — so this can make
+            # one address readable two ways, never two addresses one.
+            out.append(DIRECTIONALS[token])
+        else:
+            out.append(token)
+    return " ".join(out)
+
+
+def unit_value(text: Optional[str]) -> str:
+    """A unit given on its own — `3B`, `UNIT 3B`, `#3B` all mean 3B.
+
+    The designator is dropped and the value kept: `APT 3` and `UNIT 3`
+    are one home written twice, while `UNIT 3` and `UNIT 4` are two.
+    """
+    tokens = _tokens(text)
+    while tokens and tokens[0] in UNIT_WORDS:
+        tokens = tokens[1:]
+    return "".join(tokens)
+
+
+def normalize_unit(text: Optional[str]) -> str:
+    """A unit written inside a street line — `1358 5TH ST UNIT 3B` → `3B`."""
+    _, unit = split_unit(text)
+    return unit
+
+
+def normalize_city(text: Optional[str]) -> str:
+    return " ".join(_tokens(text))
+
+
+def normalize_zip(text: Optional[str]) -> str:
+    """Five digits, or nothing.
+
+    A ZIP+4 and its five-digit form are the same place; a blank and a ZIP
+    are not a mismatch, they are one side not knowing — which is why
+    comparisons below only run when BOTH sides have one.
+    """
+    digits = re.sub(r"\D", "", str(text or ""))
+    return digits[:5] if len(digits) >= 5 else ""
+
+
+class Address:
+    """One address, normalised, with the parts kept separate.
+
+    Kept separate on purpose: `1358 5TH ST` in Coronado and `1358 5TH ST`
+    in San Diego are different properties, and a single flattened string
+    makes that difference disappear at exactly the moment it matters.
+    """
+
+    __slots__ = ("street", "unit", "city", "zip_code")
+
+    def __init__(self, street=None, unit=None, city=None, zip_code=None):
+        self.street = normalize_street(street)
+        # The county puts the unit in either place — its own `UnitNumber`
+        # field, or welded into the address line. A separately-supplied
+        # unit wins, because it is the one somebody stated on purpose.
+        self.unit = unit_value(unit) or normalize_unit(street)
+        self.city = normalize_city(city)
+        self.zip_code = normalize_zip(zip_code)
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging aid
+        return (f"Address(street={self.street!r}, unit={self.unit!r}, "
+                f"city={self.city!r}, zip={self.zip_code!r})")
+
+
+def same_address(wanted: Address, candidate: Address) -> bool:
+    """Unambiguously the same address — every part that BOTH sides know.
+
+    The asymmetry matters. A missing ZIP on one side is silence, not
+    disagreement, so it cannot make a match; a DIFFERENT ZIP is
+    disagreement and disqualifies. Treating silence as agreement is how a
+    module like this matches the right street in the wrong town.
+    """
+    if not wanted.street or wanted.street != candidate.street:
+        return False
+    if wanted.unit != candidate.unit:
+        return False
+    if wanted.city and candidate.city and wanted.city != candidate.city:
+        return False
+    if wanted.zip_code and candidate.zip_code and wanted.zip_code != candidate.zip_code:
+        return False
+    return True
+
+
+def _closeness(wanted: Address, candidate: Address) -> Tuple[int, int, int, int]:
+    """How near a candidate is — for ORDERING only, never for choosing.
+
+    Higher sorts first. This decides what the officer reads first; it
+    never decides what the officer gets.
+    """
+    return (
+        1 if wanted.street and wanted.street == candidate.street else 0,
+        1 if wanted.unit == candidate.unit else 0,
+        1 if wanted.city and wanted.city == candidate.city else 0,
+        1 if wanted.zip_code and wanted.zip_code == candidate.zip_code else 0,
+    )
+
+
+def _candidate_address(match: Dict[str, Any]) -> Address:
+    return Address(
+        street=match.get("address"),
+        unit=match.get("unit_number"),
+        city=match.get("city"),
+        zip_code=match.get("zip_code") or match.get("zip"),
+    )
+
+
+def rank(wanted: Address, matches: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """The candidates, nearest first, all of them.
+
+    ALL of them. The screen used to render the first 25 of 76 and advise
+    "refine search" — so a parcel ranked 40th by the county's own ordering
+    was not on the page at all, and the advice could not reach it because
+    the search was already the exact address.
+    """
+    decorated = [(_closeness(wanted, _candidate_address(m)), i, m)
+                 for i, m in enumerate(matches)]
+    decorated.sort(key=lambda row: (tuple(-v for v in row[0]), row[1]))
+    return [row[2] for row in decorated]
+
+
+def select(wanted: Address,
+           matches: Sequence[Dict[str, Any]]) -> Tuple[Optional[Dict[str, Any]],
+                                                       List[Dict[str, Any]]]:
+    """(the one exact match, everything ranked) — or (None, everything ranked).
+
+    Returns the ranked list in BOTH cases so the caller can offer
+    "not this one?" without a second pass. The selection is never removed
+    from the caller's view of the alternatives by this function; deciding
+    what to show is the caller's job, and this one only answers the
+    question it was asked.
+    """
+    exact = [m for m in matches if same_address(wanted, _candidate_address(m))]
+    ranked = rank(wanted, matches)
+    if len(exact) == 1:
+        return exact[0], ranked
+    return None, ranked
+
+
+# ── Why a field is blank ─────────────────────────────────────────────
+
+OWNER_PRESENT = "present"
+OWNER_ABSENT_FROM_RECORD = "absent_from_record"
+
+#: Invariant #4 in a data field. "Owner unavailable" is three different
+#: situations wearing one label, and only one of them is the officer's to
+#: act on:
+#:
+#:   - the county returned this parcel but no owner name for it — a gap in
+#:     the record, nothing to do, and NOT a reason to distrust the parcel;
+#:   - the parcel was never matched — there is no record to be missing
+#:     from, which is a different screen entirely;
+#:   - the county service is down or unconfigured — a system problem, and
+#:     the officer's next action is to wait or enter details by hand.
+#:
+#: The third never reaches this list: a failed search returns an error
+#: status and no candidates. So the only distinction this module can draw
+#: honestly is the first, and it draws it by name rather than leaving a
+#: blank for the reader to interpret.
+OWNER_REASONS = {
+    OWNER_ABSENT_FROM_RECORD:
+        "No owner name in the county record for this parcel",
+}
+
+
+def owner_status(match: Dict[str, Any]) -> str:
+    name = (match.get("owner") or match.get("owner_name") or "").strip()
+    return OWNER_PRESENT if name else OWNER_ABSENT_FROM_RECORD

--- a/backend/tests/test_ux2_property_exact_match.py
+++ b/backend/tests/test_ux2_property_exact_match.py
@@ -1,0 +1,359 @@
+"""The parcel the officer chose is the parcel they get — or nobody chooses.
+
+═══ THE DEFECT ═══
+
+An exact autocomplete selection — `1358 5th Street, Coronado, CA` — came
+back as 76 candidates with the chosen address not first, neighbouring
+parcels above it, and the screen's only advice: "refine search for fewer
+results". There was nothing left to refine. The search WAS the address.
+
+APN, legal description and vested owner all come from whichever row gets
+clicked. A wrong row does not error — it produces a complete, plausible,
+confidently wrong deed from a real county record, with the officer's
+confirmation on every field. **Confirming a value proves the officer read
+it; it does not prove the value belongs to the property they meant.**
+That is the one failure the confirmation model cannot catch, which is why
+it is worth this much test.
+
+═══ WHAT THESE PINS PROTECT ═══
+
+ 1. AN EXACT MATCH IS SELECTED OUTRIGHT. One candidate that is
+    unambiguously the chosen address wins, and the rest become
+    alternatives behind "not this one?".
+
+ 2. AN AMBIGUOUS ONE IS NEVER BROKEN. Two candidates on the same address
+    is a genuine ambiguity — usually a multi-unit building — and the
+    moment any rule breaks that tie, the system has invented an answer it
+    will be right about often enough that nobody checks it.
+
+ 3. NOTHING IS SILENTLY DROPPED. The list used to render the first 25 of
+    76, so a parcel the county ranked 40th was not on the page at all —
+    and the advice to refine could not reach it.
+
+ 4. SPELLING IS NORMALISED, IDENTITY IS NOT. `5th Street` and `5TH ST`
+    are one address written twice. `1358` and `1356` are two properties,
+    and nothing here is allowed to bring them closer together.
+
+ 5. A BLANK FIELD SAYS WHY. "Owner unavailable" was three situations
+    wearing one label; only one of them is the officer's to act on.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from auth import get_current_user_id
+from main import app
+from models.property_data import PropertyData, PropertyMatch, PropertySearchResult
+from services import address_match as am
+from services.sitex_service import sitex_service
+from tests.source_text import code_only
+
+from pathlib import Path
+
+BACKEND = Path(__file__).resolve().parents[1]
+
+
+# ══════════════════════════════════════════════════════════════════════
+# 1. Spelling is normalised; identity is not
+# ══════════════════════════════════════════════════════════════════════
+
+@pytest.mark.parametrize("google,county", [
+    ("1358 5th Street", "1358 5TH ST"),
+    ("1358 Fifth Avenue", "1358 FIFTH AVE"),
+    ("742 North Beacon Boulevard", "742 N BEACON BLVD"),
+    ("12 Ocean Way", "12 OCEAN WAY"),
+    ("9 Broadway Avenue", "9 BROADWAY AVE"),
+    ("100 Sunset Drive.", "100 SUNSET DR"),
+    ("55 5th Street West", "55 5TH ST W"),
+])
+def test_one_address_written_two_ways_is_one_address(google, county):
+    assert am.normalize_street(google) == am.normalize_street(county)
+
+
+@pytest.mark.parametrize("one,other", [
+    ("1358 5th Street", "1356 5th Street"),      # a neighbour
+    ("1358 5th Street", "1358 6th Street"),      # a parallel street
+    ("1358 5th Street", "1358 5th Avenue"),      # a different street type
+    ("742 N Beacon Blvd", "742 S Beacon Blvd"),  # the other side of town
+])
+def test_two_properties_are_never_normalised_into_one(one, other):
+    """THE PIN THAT MATTERS MOST HERE.
+
+    Every fuzzy-matching temptation in this module ends at this test. A
+    normaliser that made any of these pairs equal would silently swap one
+    property for another on a recorded legal document.
+    """
+    assert am.normalize_street(one) != am.normalize_street(other)
+
+
+@pytest.mark.parametrize("written,unit", [
+    ("1358 5TH ST UNIT 3B", "3B"),
+    ("1358 5TH ST APT 3B", "3B"),
+    ("1358 5TH ST #3B", "3B"),
+    ("1358 5TH ST STE 200", "200"),
+])
+def test_the_unit_designator_is_spelling_and_the_unit_is_not(written, unit):
+    assert am.normalize_unit(written) == unit
+    assert am.normalize_street(written) == "1358 5TH ST"
+
+
+def test_a_bare_trailing_number_is_not_assumed_to_be_a_unit():
+    """`1358 5TH ST 3` is more likely a mangled address than unit 3, and
+    inventing a unit is the same class of guess as inventing a parcel."""
+    assert am.normalize_unit("1358 5TH ST 3") == ""
+
+
+def test_a_missing_zip_is_silence_and_a_different_zip_is_disagreement():
+    """Treating silence as agreement is how a matcher finds the right
+    street in the wrong town."""
+    wanted = am.Address(street="1358 5th Street", city="Coronado", zip_code="92118")
+    no_zip = am.Address(street="1358 5TH ST", city="Coronado")
+    wrong_zip = am.Address(street="1358 5TH ST", city="Coronado", zip_code="92101")
+
+    assert am.same_address(wanted, no_zip) is True
+    assert am.same_address(wanted, wrong_zip) is False
+
+
+def test_the_same_street_in_two_cities_is_two_properties():
+    wanted = am.Address(street="1358 5th Street", city="Coronado")
+    elsewhere = am.Address(street="1358 5TH ST", city="San Diego")
+    assert am.same_address(wanted, elsewhere) is False
+
+
+# ══════════════════════════════════════════════════════════════════════
+# 2. Exactly one selects; anything else does not
+# ══════════════════════════════════════════════════════════════════════
+
+def candidate(address, apn, *, city="Coronado", zip_code="92118",
+              unit=None, owner="SMITH, JANE"):
+    return {"address": address, "city": city, "state": "CA",
+            "zip_code": zip_code, "zip": zip_code, "apn": apn,
+            "fips": "06073", "owner": owner, "owner_name": owner,
+            "unit_number": unit, "unit_type": "UNIT" if unit else None,
+            "use_code_description": "Single Family"}
+
+
+CORONADO = am.Address(street="1358 5th Street", city="Coronado", zip_code="92118")
+
+
+def test_the_chosen_address_is_selected_out_of_a_crowd():
+    matches = [
+        candidate("1356 5TH ST", "537-101-01"),
+        candidate("1360 5TH ST", "537-101-03"),
+        candidate("1358 5TH ST", "537-101-02"),   # the one, and not first
+        candidate("1358 6TH ST", "537-102-02"),
+    ]
+    selected, ranked = am.select(CORONADO, matches)
+    assert selected is not None
+    assert selected["apn"] == "537-101-02"
+    # And the alternatives survive, all of them, nearest first.
+    assert len(ranked) == 4
+    assert ranked[0]["apn"] == "537-101-02"
+
+
+def test_a_multi_unit_building_is_never_resolved_for_the_officer():
+    """The 76-candidate case. Every unit in the building is the same
+    street address; the unit is the deciding fact and the officer has not
+    stated one. Picking here would be inventing an answer."""
+    matches = [candidate("1358 5TH ST", f"537-101-{n:02d}", unit=str(n))
+               for n in range(1, 20)]
+    selected, ranked = am.select(CORONADO, matches)
+    assert selected is None
+    assert len(ranked) == 19
+
+
+def test_two_parcels_on_one_address_are_a_tie_that_is_not_broken():
+    matches = [
+        candidate("1358 5TH ST", "537-101-02"),
+        candidate("1358 5TH ST", "537-101-99"),
+    ]
+    selected, _ = am.select(CORONADO, matches)
+    assert selected is None, (
+        "two candidates on one address is a genuine ambiguity — breaking "
+        "it by any rule is how a deed ends up describing the wrong parcel")
+
+
+def test_no_candidate_matching_selects_nothing():
+    matches = [candidate("1356 5TH ST", "537-101-01"),
+               candidate("1360 5TH ST", "537-101-03")]
+    selected, ranked = am.select(CORONADO, matches)
+    assert selected is None
+    assert len(ranked) == 2
+
+
+def test_a_stated_unit_selects_its_own_parcel():
+    wanted = am.Address(street="1358 5th Street", unit="3",
+                        city="Coronado", zip_code="92118")
+    matches = [candidate("1358 5TH ST", f"537-101-{n:02d}", unit=str(n))
+               for n in range(1, 6)]
+    selected, _ = am.select(wanted, matches)
+    assert selected is not None and selected["apn"] == "537-101-03"
+
+
+def test_ranking_never_drops_a_candidate():
+    """The screen rendered 25 of 76 and advised 'refine search'. A parcel
+    ranked 40th by the county's ordering was not on the page, and no
+    amount of refining could reach it — the search was already exact."""
+    matches = [candidate(f"{1300 + n} 5TH ST", f"537-101-{n:02d}")
+               for n in range(0, 76)]
+    _, ranked = am.select(CORONADO, matches)
+    assert len(ranked) == 76
+    assert {m["apn"] for m in ranked} == {m["apn"] for m in matches}
+
+
+def test_ranking_is_stable_for_equally_distant_candidates():
+    """An order that shuffles between identical searches is an order the
+    officer cannot learn to trust."""
+    matches = [candidate(f"{1300 + n} 5TH ST", f"a{n}") for n in range(5)]
+    first = [m["apn"] for m in am.select(CORONADO, matches)[1]]
+    second = [m["apn"] for m in am.select(CORONADO, matches)[1]]
+    assert first == second == [m["apn"] for m in matches]
+
+
+# ══════════════════════════════════════════════════════════════════════
+# 3. A blank field says why
+# ══════════════════════════════════════════════════════════════════════
+
+def test_a_parcel_with_no_owner_name_says_which_kind_of_nothing_that_is():
+    assert am.owner_status(candidate("1358 5TH ST", "x", owner="")) == \
+        am.OWNER_ABSENT_FROM_RECORD
+    assert am.owner_status(candidate("1358 5TH ST", "x")) == am.OWNER_PRESENT
+    reason = am.OWNER_REASONS[am.OWNER_ABSENT_FROM_RECORD]
+    assert "county record" in reason
+    assert "unavailable" not in reason.lower(), (
+        "'unavailable' is the word that made three situations look like "
+        "one — a record gap, an unmatched parcel and a dead service")
+
+
+def test_no_confidence_score_is_exposed():
+    """A number between 0 and 1 invites a threshold, and a threshold is
+    where invented answers come from. The answer is a parcel or nothing."""
+    src = code_only(BACKEND / "services" / "address_match.py")
+    assert "confidence" not in src.lower()
+
+
+# ══════════════════════════════════════════════════════════════════════
+# 4. Through the endpoint
+# ══════════════════════════════════════════════════════════════════════
+
+@pytest.fixture(autouse=True)
+def _auth_override():
+    app.dependency_overrides[get_current_user_id] = lambda: "1"
+    yield
+    app.dependency_overrides.pop(get_current_user_id, None)
+
+
+client = TestClient(app)
+
+
+def multi(matches):
+    return PropertySearchResult(
+        status="multi_match",
+        matches=[PropertyMatch(**{k: v for k, v in m.items()
+                                  if k in PropertyMatch.model_fields})
+                 for m in matches],
+        message="Multiple properties found", match_count=len(matches))
+
+
+def resolved(apn="537-101-02", address="1358 5TH ST"):
+    return PropertySearchResult(
+        status="success",
+        data=PropertyData(address=address, city="Coronado", state="CA",
+                          zip_code="92118", apn=apn, county="SAN DIEGO",
+                          legal_description="LOT 2", owner_name="SMITH, JANE"),
+        message="ok", match_count=1)
+
+
+def search(matches, resolve=None):
+    return patch.multiple(
+        sitex_service,
+        is_configured=lambda: True,
+        search_property=AsyncMock(return_value=multi(matches)),
+        search_by_fips_apn=AsyncMock(return_value=resolve or resolved()),
+    )
+
+
+def ask(street="1358 5th Street", city="Coronado", zip_code="92118"):
+    return client.post("/api/property/search-v2", json={
+        "address": street, "city": city, "state": "CA", "zip": zip_code})
+
+
+def test_the_endpoint_returns_the_exact_parcel_and_keeps_the_alternatives():
+    """END TO END: the officer's exact pick, 76 county candidates, one
+    property back — with the other 75 still reachable."""
+    # 76 neighbours on the same street, none of them 1358 — then the one
+    # the officer actually chose, arriving last as it did in the field.
+    matches = [candidate(f"{1400 + n} 5TH ST", f"537-101-{n:02d}")
+               for n in range(0, 76)]
+    matches.append(candidate("1358 5TH ST", "537-101-02"))
+
+    with search(matches):
+        body = ask().json()
+
+    assert body["status"] == "success"
+    assert body["data"]["apn"] == "537-101-02"
+    assert body["selection"]["basis"] == "exact_address_match"
+    assert body["selection"]["alternative_count"] == 76
+    assert len(body["alternatives"]) == 76
+
+
+def test_the_endpoint_hands_an_ambiguous_building_to_the_officer():
+    matches = [candidate("1358 5TH ST", f"537-101-{n:02d}", unit=str(n))
+               for n in range(1, 40)]
+    with search(matches):
+        body = ask().json()
+
+    assert body["status"] == "multi_match"
+    assert body["match_count"] == 39
+    assert len(body["matches"]) == 39, "every candidate reaches the officer"
+    assert body["selection"]["basis"] == "officer_choice"
+
+
+def test_a_failed_resolve_falls_back_to_the_list_rather_than_to_a_guess():
+    """The exact parcel would not load. That is not a reason to pick a
+    different one, and not a reason to report nothing happened."""
+    matches = [candidate("1358 5TH ST", "537-101-02"),
+               candidate("1360 5TH ST", "537-101-03")]
+    failed = PropertySearchResult(status="error", message="SiteX down",
+                                  match_count=0)
+    with search(matches, resolve=failed):
+        body = ask().json()
+
+    assert body["status"] == "multi_match"
+    assert body["match_count"] == 2
+    assert body["data"] is None
+
+
+def test_every_candidate_carries_the_reason_its_owner_is_blank():
+    matches = [candidate("1356 5TH ST", "537-101-01", owner=""),
+               candidate("1360 5TH ST", "537-101-03")]
+    with search(matches):
+        body = ask().json()
+
+    by_apn = {m["apn"]: m for m in body["matches"]}
+    assert by_apn["537-101-01"]["owner_status"] == "absent_from_record"
+    assert "county record" in by_apn["537-101-01"]["owner_reason"]
+    assert by_apn["537-101-03"]["owner_status"] == "present"
+    assert by_apn["537-101-03"]["owner_reason"] == ""
+
+
+def test_a_single_county_match_says_nobody_chose_it():
+    single = PropertySearchResult(
+        status="success", data=resolved().data, message="ok", match_count=1)
+    with patch.multiple(sitex_service, is_configured=lambda: True,
+                        search_property=AsyncMock(return_value=single)):
+        body = ask().json()
+    assert body["selection"]["basis"] == "only_county_match"
+
+
+def test_the_officers_own_pick_is_recorded_as_hers_to_own():
+    """§13.2 — who asserted the answer. A parcel the server matched and a
+    parcel a human clicked must not look the same in the record."""
+    with patch.multiple(sitex_service, is_configured=lambda: True,
+                        search_by_fips_apn=AsyncMock(return_value=resolved())):
+        body = client.post("/api/property/resolve-match",
+                           json={"fips": "06073", "apn": "537-101-02"}).json()
+    assert body["selection"]["basis"] == "officer_choice"

--- a/docs/DOCTRINE_CONFORMANCE.md
+++ b/docs/DOCTRINE_CONFORMANCE.md
@@ -928,12 +928,61 @@ declined dispatch returns to `requested` and the loop resumes; no signer
 is emailed before acceptance; an officer window is not attributed to the
 notary.
 
+### §13.3 — Who chose the record the facts came from (UX2 item 1, 2026-08-12)
+
+**Statement.** Every county-record field on a deed — APN, legal
+description, vested owner — descends from ONE row of a candidate list.
+The record says whether the officer picked that row or the system matched
+it, because **confirming a value proves the officer read it; it does not
+prove the value belongs to the property she meant.**
+
+**Why this is §13.2 and not a new idea.** §13.2 kept an officer-asserted
+answer from being recorded as the signer's. This is the same rule one
+level further out: the parcel is the source every other assertion is
+drawn from, and a parcel chosen by the system must not be indistinguishable
+from a parcel chosen by a human. `ParcelSelection.basis` is
+`exact_address_match` (the server matched it), `officer_choice` (she
+clicked it), or `only_county_match` (nobody chose — there was one).
+
+**The failure it exists to prevent.** An exact autocomplete selection
+returned 76 candidates with the chosen address not first and neighbouring
+parcels above it. A wrong click does not error. It produces a complete,
+plausible, confidently wrong deed out of a real county record with the
+officer's confirmation on every field — the one failure the confirmation
+model structurally cannot catch, because the confirmation is genuine and
+the source is genuine and only the correspondence between them is wrong.
+
+**Why the automatic selection is narrow to the point of stubbornness.**
+`services/address_match.py` selects only when EXACTLY ONE candidate is
+unambiguously the address chosen. Zero or several and it declines, every
+candidate goes to the officer, and nothing is chosen on her behalf. Two
+candidates on one address is not a tie to be broken — it is usually a
+multi-unit building where the unit is the deciding fact, and any rule
+that breaks such a tie invents an answer it will be right about often
+enough that nobody checks it. There is deliberately **no confidence
+score**: a number between 0 and 1 invites a threshold, and a threshold is
+where invented answers come from.
+
+Normalisation is about SPELLING (`5th Street` / `5TH ST`), never about
+identity. `1358` and `1356` are different properties and a pin holds them
+apart.
+
+**And it is visible.** When the server matched the parcel, the screen
+says so in the same place the officer is about to start confirming
+fields, with "not this one?" next to it and every alternative behind it.
+A selection recorded but not shown would satisfy the letter of §13.2 and
+miss the point of it.
+
+**Enforced by.** `backend/tests/test_ux2_property_exact_match.py` and
+`frontend/src/__tests__/propertyExactMatch.test.ts`.
+
 ---
 
 ## Change log
 
 | Date | Change |
 |---|---|
+| 2026-08-12 | §13.3 added (UX2 item 1) — who chose the record the facts came from. An exact autocomplete pick returned 76 county candidates with the chosen address not ranked first; APN, legal description and vested owner all descend from whichever row is clicked, so a wrong row produces a confidently wrong deed out of a real source with a genuine confirmation on every field. `services/address_match.py` selects a parcel only when EXACTLY ONE candidate is unambiguously the chosen address, declines otherwise, and exposes no confidence score. Also recorded: the audit's proposed root cause — "we re-search by address string instead of passing the autocomplete's identifier" — was checked and is not fixable as framed. Google's `place_id` is not a SiteX key; SiteX takes an address or a FIPS+APN, and the FIPS+APN only exists once SiteX has answered. The defect was real and the diagnosis was not, which is a distinct outcome from DASH1's route rename, where neither was. |
 | 2026-08-11 | §13.2 added (FLOW1 item 7, DISPATCH) — `signing_responses.asserted_by`. See the section for the full reasoning; the short version is that convergence had to be able to count an officer-asserted signer answer without any surface being able to call it the signer's. Also: the §11.1 sweep was WIDENED after it missed two live habitats it should have caught — `services/signing_loop.state_label()` (the one function that turns a scheduling state into a sentence for every surface) and the `.ics` description that lands in the officer's own diary. Both said "she" about a notary. `services/vesting_split.py` exempted with a cited reason: it MATCHES recorded vesting language rather than writing prose about anybody. |
 | 2026-08-11 | §11.1 added (FLOW1 items 3–4) — the product never infers a fact about a PERSON from their name or role. A live email told a notary that the officer "confirms the appointment with the signers herself", asserting an escrow officer's pronouns to her own professional contact on no information; the screen did the same about the notary. Ruled the same family as the "filed as" constraint, which forbids reading a partner's category as a statement about their authority — one direction infers what someone IS, the other what they MAY DO, and both put a claim in the record nobody made. Swept fail-closed across every template. Two habitats exempted with cited reasons and their own liveness test: the Civil Code §1189 all-purpose acknowledgement (prescribed certificate wording, names no party) and vesting terms of art. Also item 4: the Signings agenda's stuck age was reconstructed as `expires_at − 21 days`, duplicating `default_expiry()`'s constant into TypeScript as a bare number — the server sends `created_at` now. And its "soonest first" claim covered rows sorted by `COALESCE(booked_at, expires_at)`, two orthogonal facts under one sort key (T-5 one layer up); booked and being-arranged are now separated and each sorted by the fact it has. |
 | 2026-08-11 | §4 — FLOW1 item 0. Shared Deeds reported as showing fabricated rows; verdict recorded as NOT fabricated — a real fetch read through eight wrong key names, so `undefined` rendered as blank cells and Invalid Date. Recorded under §4 rather than invariant #4 because nothing was invented and the screen still asserted what it could not support ("Not viewed" under a badge reading "Viewed"). Three absent facts given columns: `recipient_name` (accepted, greeted with, never stored), `responded_at` (`updated_at` was not that fact — a revoke bumps it too), and a real `expires_at` (previously spent on a display string nothing rendered). Contract now pinned from both sides against one corpus; absence crosses the wire as `null`, never `""`. The feedback modal's fallback to a field the list endpoint never sent — a failed fetch reading as "the reviewer left no comments" — removed. |

--- a/docs/skills/sitex-integration.md
+++ b/docs/skills/sitex-integration.md
@@ -234,6 +234,36 @@ SiteX coordinates become canonical after lookup. Google coordinates are fallback
 
 Frontend should render a picker of `Locations[]`, send selected `{fips, apn}` to a resolve endpoint, and let the backend call `search_by_fips_apn`.
 
+### 7.1 There is no precise identifier to pass through (UX2, 2026-08-12)
+
+SiteX's search takes **an address, or a FIPS + APN**. Google's `place_id`
+is not a SiteX key and has no equivalent input — §6 above maps
+`street_number + route` into `addr` precisely because that is the only
+route in. The FIPS + APN that WOULD be precise does not exist on our side
+until SiteX has already answered with it.
+
+So "pass the autocomplete's identifier instead of re-searching by address
+string" is not an available fix. Re-searching by the address string is
+the interface, and a multi-match is a normal outcome of it — including
+for an address the officer selected exactly.
+
+### 7.2 Exactly one unambiguous candidate is selected server-side
+
+`backend/services/address_match.py` compares the chosen address against
+every `Locations[]` entry. **Exactly one** unambiguous match is resolved
+by FIPS + APN and returned as `status: "success"` with a `selection`
+block and the rest as `alternatives`. Zero or several returns
+`multi_match` with every candidate, ranked nearest-first.
+
+Two candidates on one address is a genuine ambiguity — normally a
+multi-unit building — and is never resolved automatically. Send
+`unit_type` / `unit_number` to the screen: in that case it is the only
+field distinguishing the candidates.
+
+`selection.basis` is `exact_address_match`, `officer_choice` or
+`only_county_match`. See doctrine §13.3 — a parcel the server matched
+must not be indistinguishable from one a human clicked.
+
 Reference DeedPro's working pattern:
 
 | File | Pattern |

--- a/frontend/src/__tests__/propertyExactMatch.test.ts
+++ b/frontend/src/__tests__/propertyExactMatch.test.ts
@@ -1,0 +1,143 @@
+/**
+ * UX2 item 1 — the screen renders the verdict, it does not reach one.
+ *
+ * ═══ THE DEFECT ═══
+ *
+ * An exact autocomplete pick — "1358 5th Street, Coronado, CA" — came
+ * back as 76 candidates, the chosen address not first, and the only
+ * advice on screen was "refine search for fewer results". There was
+ * nothing left to refine: the search WAS the address.
+ *
+ * APN, legal description and vested owner all descend from whichever row
+ * gets clicked, so a wrong row produces a complete, plausible,
+ * confidently wrong deed out of a real county record — with the
+ * officer's confirmation on every field.
+ *
+ * ═══ WHAT THIS FILE PINS, AND WHAT IT DELIBERATELY DOES NOT ═══
+ *
+ * The comparison "is this the same address" lives in ONE place —
+ * `backend/services/address_match.py` — and the tests that hold it are in
+ * Python, where it runs. Standing rule: when a new surface needs an
+ * existing judgement, the answer is never a second copy.
+ *
+ * So this file pins the SCREEN's half: it renders what it is told, it
+ * says who chose the parcel, it drops nothing, and it holds no opinion
+ * about street suffixes. The last of those is a pin, not an omission —
+ * see `it holds no address-matching logic of its own`.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
+import { mapSiteXResponse, readSelection } from '../lib/sitexProperty';
+import { ownerLine, unitLabel } from '../components/builder/sections/PropertySection';
+
+const SECTION = path.join(__dirname, '..', 'components', 'builder', 'sections', 'PropertySection.tsx');
+const source = () => codeOnly(fs.readFileSync(SECTION, 'utf8'));
+
+describe('who chose the parcel', () => {
+  it('carries the server’s basis through to the deed record', () => {
+    const property = mapSiteXResponse(
+      { address: '1358 5TH ST', apn: '537-101-02' },
+      '1358 5th Street',
+      { basis: 'exact_address_match', matched_address: '1358 5TH ST', alternative_count: 75 },
+    );
+    expect(property.parcelSelection).toEqual({
+      basis: 'exact_address_match',
+      matchedAddress: '1358 5TH ST',
+      alternativeCount: 75,
+    });
+  });
+
+  it('keeps a server match and an officer’s pick apart', () => {
+    expect(readSelection({ basis: 'officer_choice' })?.basis).toBe('officer_choice');
+    expect(readSelection({ basis: 'only_county_match' })?.basis).toBe('only_county_match');
+  });
+
+  it('drops a basis it does not recognise instead of defaulting', () => {
+    /**
+     * Both available defaults are lies: calling a server match an
+     * officer's choice launders it, and calling an officer's choice a
+     * server match slanders it. Doctrine §13.2 exists to keep those two
+     * apart, so an unreadable answer becomes no answer.
+     */
+    expect(readSelection({ basis: 'best_guess' })).toBeUndefined();
+    expect(readSelection({})).toBeUndefined();
+    expect(readSelection(undefined)).toBeUndefined();
+  });
+
+  it('records nothing when the server said nothing', () => {
+    const property = mapSiteXResponse({ address: '1358 5TH ST' }, 'fallback');
+    expect(property.parcelSelection).toBeUndefined();
+  });
+});
+
+describe('a candidate row shows what tells it apart', () => {
+  it('renders the unit, which is the only difference in a building', () => {
+    expect(unitLabel({ unit_type: 'UNIT', unit_number: '3B' })).toBe('UNIT 3B');
+    expect(unitLabel({ unit_number: '12' })).toBe('Unit 12');
+  });
+
+  it('renders nothing rather than an empty designator', () => {
+    expect(unitLabel({ unit_type: 'UNIT', unit_number: '' })).toBe('');
+    expect(unitLabel({})).toBe('');
+  });
+
+  it('says WHY an owner line is blank, using the server’s reason', () => {
+    expect(ownerLine({
+      address: 'x', apn: 'a', fips: 'f',
+      owner_status: 'absent_from_record',
+      owner_reason: 'No owner name in the county record for this parcel',
+    })).toContain('county record');
+  });
+
+  it('never calls a record gap "unavailable"', () => {
+    /**
+     * Invariant #4 in a data field. "Owner unavailable" was three
+     * situations wearing one label — a gap in the county record, a parcel
+     * that never matched, and a county service that is down — and only
+     * one of them is the officer's to act on.
+     */
+    const blank = ownerLine({ address: 'x', apn: 'a', fips: 'f' });
+    expect(blank.toLowerCase()).not.toContain('unavailable');
+    expect(blank.length).toBeGreaterThan(0);
+
+    expect(source()).not.toContain('Owner unavailable');
+    expect(source()).not.toContain('Property type unavailable');
+  });
+
+  it('prefers the owner name when there is one', () => {
+    expect(ownerLine({
+      address: 'x', apn: 'a', fips: 'f', owner: 'SMITH, JANE',
+      owner_reason: 'should not be used',
+    })).toBe('SMITH, JANE');
+  });
+});
+
+describe('the list drops nothing', () => {
+  it('renders every candidate it was given', () => {
+    /**
+     * The old list rendered `matches.slice(0, 25)` of 76 and advised
+     * "refine search" — so a parcel the county ranked 40th was not on the
+     * page at all, and no amount of refining could reach it because the
+     * search was already the exact address.
+     */
+    const src = source();
+    expect(src).not.toMatch(/\.slice\(0,\s*25\)/);
+    expect(src).not.toContain('refine search');
+  });
+
+  it('holds no address-matching logic of its own', () => {
+    /**
+     * THE ONE-COPY PIN. The server decides whether a candidate is the
+     * address the officer chose; the screen renders the answer. A street
+     * suffix table over here would be a second opinion about which
+     * property a deed describes — and the two copies would drift, as four
+     * copies of the partner categories already did.
+     */
+    const src = source();
+    for (const token of ['BOULEVARD', 'AVENUE', 'normalizeStreet', 'sameAddress']) {
+      expect(src).not.toContain(token);
+    }
+  });
+});

--- a/frontend/src/components/builder/sections/PropertySection.tsx
+++ b/frontend/src/components/builder/sections/PropertySection.tsx
@@ -2,12 +2,12 @@
 
 import { useState, useEffect, useRef, useCallback } from "react"
 import { MapPin, Search, Loader2, AlertCircle, Building2, ChevronRight } from "lucide-react"
-import type { PropertyData, PropertyProvenance, Sourced } from "@/types/builder"
+import type { ParcelSelection, PropertyData, PropertyProvenance, Sourced } from "@/types/builder"
 import { useAIAssist } from "@/contexts/AIAssistContext"
 import { AISuggestion } from "../AISuggestion"
 import { ConfirmableField } from "../ConfirmableField"
 import { propertyCandidatesRemaining } from "@/lib/provenance"
-import { mapSiteXResponse } from "@/lib/sitexProperty"
+import { mapSiteXResponse, readSelection } from "@/lib/sitexProperty"
 import { formatSuggestionSecondary } from "@/lib/addressLabels"
 
 interface PropertySectionProps {
@@ -56,6 +56,39 @@ interface PropertyMatchCandidate {
   owner_name?: string
   use_code_description?: string
   property_type?: string
+  /** Why the owner line is blank, decided server-side. See services/address_match.py. */
+  owner_status?: string
+  owner_reason?: string
+}
+
+/**
+ * The unit, when the county gave us one.
+ *
+ * UX2: in a multi-unit building every candidate carries the SAME street
+ * address and the unit is the only thing telling them apart — and it was
+ * being dropped from the render. Seventy-six identical-looking rows is
+ * not a choice, it is a coin toss with a scrollbar.
+ */
+export function unitLabel(match: Pick<PropertyMatchCandidate, 'unit_type' | 'unit_number'>): string {
+  const number = (match.unit_number || '').trim()
+  if (!number) return ''
+  const type = (match.unit_type || 'Unit').trim()
+  return `${type} ${number}`
+}
+
+/**
+ * The owner line, or the reason there isn't one.
+ *
+ * Invariant #4 in a data field. "Owner unavailable" covered three
+ * different situations — a gap in the county record, a parcel that never
+ * matched, and a county service that is down — and only one of them is
+ * the officer's to act on. The reason comes from the server; this
+ * function does not invent one when none was sent.
+ */
+export function ownerLine(match: PropertyMatchCandidate): string {
+  const name = (match.owner || match.owner_name || '').trim()
+  if (name) return name
+  return match.owner_reason || 'No owner name returned for this parcel'
 }
 
 interface PropertyMatchListProps {
@@ -63,28 +96,34 @@ interface PropertyMatchListProps {
   totalCount: number
   onSelect: (match: PropertyMatchCandidate) => void
   buildingAddress: string
+  heading?: string
+  subheading?: string
 }
 
-function PropertyMatchList({ matches, totalCount, onSelect, buildingAddress }: PropertyMatchListProps) {
-  const visibleMatches = matches.slice(0, 25)
-
+function PropertyMatchList({
+  matches, totalCount, onSelect, buildingAddress, heading, subheading,
+}: PropertyMatchListProps) {
   return (
     <div className="p-4 bg-emerald-50 border border-emerald-200 rounded-lg space-y-3">
       <div className="flex items-center justify-between">
         <div>
-          <p className="text-sm font-medium text-emerald-700">✨ Multiple properties found</p>
+          <p className="text-sm font-medium text-emerald-700">
+            {heading ?? `${totalCount} properties returned for this address`}
+          </p>
           <p className="font-medium text-gray-900">{buildingAddress}</p>
-          {totalCount > 25 && (
-            <p className="text-sm text-emerald-700">
-              Showing 25 of {totalCount} — refine search for fewer results
-            </p>
-          )}
+          <p className="text-sm text-emerald-700">
+            {/* UX2: the old line read "Showing 25 of 76 — refine search for
+                fewer results", which was wrong twice. The other 51 were not
+                on the page at all, and there was nothing left to refine —
+                the search WAS the address the officer picked. */}
+            {subheading ?? 'The county returned more than one parcel for it. Pick the one you mean.'}
+          </p>
         </div>
       </div>
 
       <div className="border border-emerald-200 rounded-lg overflow-hidden bg-white">
         <div className="max-h-80 overflow-y-auto">
-          {visibleMatches.map((match, index) => (
+          {matches.map((match, index) => (
             <button
               key={`${match.fips}-${match.apn}-${index}`}
               onClick={() => onSelect(match)}
@@ -93,12 +132,17 @@ function PropertyMatchList({ matches, totalCount, onSelect, buildingAddress }: P
               <div className="flex items-center gap-3">
                 <Building2 className="w-5 h-5 text-gray-400" />
                 <div className="text-left">
-                  <p className="font-medium text-gray-900">{match.address}</p>
-                  <p className="text-sm text-gray-600">
-                    {match.owner || match.owner_name || "Owner unavailable"}
+                  <p className="font-medium text-gray-900">
+                    {match.address}
+                    {unitLabel(match) && (
+                      <span className="ml-2 text-emerald-700">{unitLabel(match)}</span>
+                    )}
+                  </p>
+                  <p className={`text-sm ${match.owner || match.owner_name ? 'text-gray-600' : 'text-gray-500 italic'}`}>
+                    {ownerLine(match)}
                   </p>
                   <p className="text-sm text-gray-500">
-                    APN: {match.apn} · {match.use_code_description || match.property_type || "Property type unavailable"}
+                    APN: {match.apn} · {match.use_code_description || match.property_type || "Property type not in county record"}
                   </p>
                 </div>
               </div>
@@ -192,6 +236,12 @@ export function PropertySection({ value, onChange, onComplete }: PropertySection
   const [showSuggestions, setShowSuggestions] = useState(false)
   const [propertyMatches, setPropertyMatches] = useState<PropertyMatchCandidate[] | null>(null)
   const [propertyMatchCount, setPropertyMatchCount] = useState(0)
+  // UX2 — how this parcel came to be the parcel, and what else was on
+  // offer. The server decides (see services/address_match.py); this holds
+  // the answer so the screen can say it out loud and offer the way back.
+  const [parcelSelection, setParcelSelection] = useState<ParcelSelection | null>(null)
+  const [alternatives, setAlternatives] = useState<PropertyMatchCandidate[]>([])
+  const [showAlternatives, setShowAlternatives] = useState(false)
   const [selectedBuildingAddress, setSelectedBuildingAddress] = useState("")
   const [isGoogleLoaded, setIsGoogleLoaded] = useState(false)
   
@@ -411,14 +461,25 @@ export function PropertySection({ value, onChange, onComplete }: PropertySection
         // "surprise gates at the finish line" (the officer never saw the
         // inline cards before the gate modal re-asked). The accordion
         // advances when the last present field is confirmed below.
-        const propertyData = mapSiteXResponse(result.data, searchQuery)
+        //
+        // UX2: this branch now also covers "the county returned 76 and
+        // exactly one of them was the address she picked". The server made
+        // that call and says so in `selection`; the strip on the card
+        // below repeats it, because a parcel chosen FOR the officer must
+        // not look like one chosen BY her.
+        const propertyData = mapSiteXResponse(result.data, searchQuery, result.selection)
+        setParcelSelection(readSelection(result.selection) ?? null)
+        setAlternatives(result.alternatives ?? [])
+        setShowAlternatives(false)
         onChange(propertyData)
         if (propertyCandidatesRemaining(propertyData).length === 0) onComplete()
 
       } else if (result.status === 'multi_match' && result.matches?.length > 0) {
         setPropertyMatches(result.matches)
         setPropertyMatchCount(result.match_count || result.matches.length)
-        
+        setAlternatives(result.matches)
+        setParcelSelection(null)
+
       } else if (result.status === 'not_found') {
         setError("Property not found in county records. Please verify the address.")
       } else {
@@ -462,7 +523,10 @@ export function PropertySection({ value, onChange, onComplete }: PropertySection
       if (result.status === 'success' && result.data) {
         // U2.1: same rule as the single-match path — the accordion holds
         // until the county-record fields are confirmed inline.
-        const propertyData = mapSiteXResponse(result.data, match.address || selectedBuildingAddress)
+        const propertyData = mapSiteXResponse(
+          result.data, match.address || selectedBuildingAddress, result.selection)
+        setParcelSelection(readSelection(result.selection) ?? null)
+        setShowAlternatives(false)
         onChange(propertyData)
         if (propertyCandidatesRemaining(propertyData).length === 0) onComplete()
       } else {
@@ -484,6 +548,9 @@ export function PropertySection({ value, onChange, onComplete }: PropertySection
     setError(null)
     setAddressSelected(false)
     setSelectedParsedAddress(null)
+    setParcelSelection(null)
+    setAlternatives([])
+    setShowAlternatives(false)
     onChange(null as unknown as PropertyData)
     inputRef.current?.focus()
   }
@@ -496,6 +563,9 @@ export function PropertySection({ value, onChange, onComplete }: PropertySection
     setSelectedParsedAddress(null)
     setPropertyMatches(null)
     setPropertyMatchCount(0)
+    setParcelSelection(null)
+    setAlternatives([])
+    setShowAlternatives(false)
     setError(null)
   }
 
@@ -578,6 +648,49 @@ export function PropertySection({ value, onChange, onComplete }: PropertySection
             Change
           </button>
         </div>
+
+        {/* UX2 — WHO CHOSE THIS PARCEL.
+            Every field below comes from it: APN, legal description, vested
+            owner. The officer confirms each of those, and confirming a
+            value proves she read it — not that it belongs to the property
+            she meant. So when the server matched the parcel rather than
+            the officer picking it, the screen says so, in the same place
+            she is about to start confirming, with the way back next to it. */}
+        {parcelSelection?.basis === 'exact_address_match' && (
+          <div className="p-3 bg-blue-50 border border-blue-200 rounded-lg">
+            <div className="flex items-start justify-between gap-3">
+              <p className="text-sm text-blue-900">
+                Matched to the address you selected
+                {parcelSelection.alternativeCount > 0 && (
+                  <>
+                    {' '}— the county returned {parcelSelection.alternativeCount}{' '}
+                    other {parcelSelection.alternativeCount === 1 ? 'parcel' : 'parcels'} nearby
+                  </>
+                )}
+                .
+              </p>
+              {alternatives.length > 0 && (
+                <button
+                  onClick={() => setShowAlternatives((open) => !open)}
+                  className="text-sm font-medium text-blue-700 hover:text-blue-900 underline flex-shrink-0"
+                >
+                  {showAlternatives ? 'Hide the others' : 'Not this one?'}
+                </button>
+              )}
+            </div>
+          </div>
+        )}
+
+        {showAlternatives && alternatives.length > 0 && (
+          <PropertyMatchList
+            matches={alternatives}
+            totalCount={alternatives.length}
+            onSelect={handleSelectMatch}
+            buildingAddress={selectedBuildingAddress || value.address}
+            heading="Everything the county returned for this address"
+            subheading="Picking one here replaces the property above, and its APN, legal description and owner with it."
+          />
+        )}
 
         <div className="space-y-3">
           {hasValue('apn') && (

--- a/frontend/src/lib/sitexProperty.ts
+++ b/frontend/src/lib/sitexProperty.ts
@@ -9,8 +9,37 @@
  *
  * A rule you can only test through a UI is a rule you do not test.
  */
-import type { PropertyData, Sourced } from '@/types/builder';
+import type { ParcelSelection, PropertyData, Sourced } from '@/types/builder';
 import { ownerCandidates } from './vestingSplit';
+
+/** The server's answer to "who chose this parcel", as it arrives on the wire. */
+export interface SiteXSelection {
+  basis?: string;
+  matched_address?: string;
+  alternative_count?: number;
+}
+
+const SELECTION_BASES: ParcelSelection['basis'][] = [
+  'exact_address_match', 'officer_choice', 'only_county_match',
+];
+
+/**
+ * Carry the selection basis through, or carry nothing.
+ *
+ * An unrecognised basis becomes ABSENT rather than a default, because the
+ * defaults available here are both lies: calling a server match an
+ * officer's choice launders it, and calling an officer's choice a server
+ * match slanders it. Doctrine §13.2 is about not confusing those two.
+ */
+export function readSelection(raw?: SiteXSelection): ParcelSelection | undefined {
+  const basis = raw?.basis as ParcelSelection['basis'] | undefined;
+  if (!basis || !SELECTION_BASES.includes(basis)) return undefined;
+  return {
+    basis,
+    matchedAddress: raw?.matched_address || '',
+    alternativeCount: raw?.alternative_count ?? 0,
+  };
+}
 
 export interface SiteXProperty {
   address?: string;
@@ -44,7 +73,11 @@ export function formatOwnerName(
   return names.join(' AND ') || '';
 }
 
-export function mapSiteXResponse(data: SiteXProperty, fallbackAddress: string): PropertyData {
+export function mapSiteXResponse(
+  data: SiteXProperty,
+  fallbackAddress: string,
+  selection?: SiteXSelection,
+): PropertyData {
   const apn = data.apn || '';
   const legalDescription = data.legal_description || '';
   const ownerRaw = data.owner_name || formatOwnerName(data.primary_owner, data.secondary_owner);
@@ -87,6 +120,9 @@ export function mapSiteXResponse(data: SiteXProperty, fallbackAddress: string): 
       legalDescription: candidate(legalDescription),
       owner: candidate(owner),
     },
+    ...(readSelection(selection)
+      ? { parcelSelection: readSelection(selection) }
+      : {}),
     ...(split
       ? {
           ownerSplit: {

--- a/frontend/src/types/builder.ts
+++ b/frontend/src/types/builder.ts
@@ -84,6 +84,23 @@ export interface PropertyProvenance {
   owner?: Sourced<string>;
 }
 
+/**
+ * How this parcel came to be the parcel — doctrine §13.2, who asserted
+ * the answer.
+ *
+ * Every county-record field on a deed descends from one row of a
+ * candidate list. The officer confirms those fields, and her confirmation
+ * proves she read them; it does not prove the row was the property she
+ * meant. So the record keeps the two apart: a parcel the SERVER matched
+ * to her chosen address, a parcel SHE picked from a list, and the case
+ * where the county only ever returned one.
+ */
+export interface ParcelSelection {
+  basis: 'exact_address_match' | 'officer_choice' | 'only_county_match';
+  matchedAddress: string;
+  alternativeCount: number;
+}
+
 export interface PropertyData {
   address: string;
   city: string;
@@ -105,6 +122,8 @@ export interface PropertyData {
    * deed only through the officer's acceptance.
    */
   ownerSplit?: OwnerSplit;
+  /** UX2 — who chose this parcel. See ParcelSelection above. */
+  parcelSelection?: ParcelSelection;
 }
 
 export interface DTTData {


### PR DESCRIPTION
## The defect, and why it is the worst one on the board

An exact autocomplete selection — `1358 5th Street, Coronado, CA` — returned 76 county candidates, the chosen address not first, neighbouring parcels above it, and one piece of advice on screen: **"refine search for fewer results."** There was nothing left to refine. The search *was* the address.

APN, legal description and vested owner all descend from whichever row gets clicked. A wrong row does not error. It produces a complete, plausible, confidently wrong deed out of a real county record, with the officer's confirmation on every field.

**Confirming a value proves the officer read it. It does not prove the value belongs to the property she meant.** That correspondence is the one thing the confirmation model structurally cannot check — the confirmation is genuine, the source is genuine, and only the relationship between them is wrong.

## The root-cause hypothesis: checked, and it is not the cause

The ticket asked whether we pass the autocomplete's precise identifier to SiteX or re-search by address string, and said the latter would be the root cause.

**It is the latter, and it is not fixable as framed.** Per `docs/skills/sitex-integration.md` — the repo's own SiteX reference — the search endpoint takes `addr` + `lastLine`, **or** `fips` + `apn`. Google's `place_id` is not a SiteX key and has no equivalent input; §6 of that doc maps `street_number + route` into `addr` precisely because that is the only route in. The FIPS + APN that *would* be precise does not exist on our side until SiteX has already answered with it.

Re-searching by address string is the interface, not a shortcut somebody took. A multi-match is a normal outcome of it, including for an address chosen exactly.

So the defect is real and entirely ours — it is just one step later than the diagnosis put it. We had the officer's exact address, we had 76 candidates each carrying an address, and **we did nothing with that**: no comparison, no ranking, and `matches.slice(0, 25)` on the way to the screen.

*(Scope note: this is our SiteX client and our SiteX reference doc. If ICE's wider API exposes a precise key we have never integrated, that is not visible from here.)*

## The fix

`backend/services/address_match.py` answers exactly one question: **is there exactly one candidate that is unambiguously the address the officer chose?**

- **Yes** → that parcel is resolved by FIPS + APN and returned as the property, with the rest as `alternatives` behind a "not this one?" affordance.
- **No** → every candidate goes to the officer, nearest first, and nothing is chosen on her behalf.

**Zero or several never selects, and that is the whole rule.** Two candidates on one address is not a tie to be broken — it is usually a multi-unit building where the unit is the deciding fact. Any rule that breaks such a tie (first returned, closest ZIP, highest value) has invented an answer, and it will be right often enough that nobody checks it.

There is deliberately **no confidence score**. A number between 0 and 1 invites a threshold, and a threshold is where invented answers come from. The answer is a parcel or nothing.

Normalisation is about **spelling**, never identity:

| One address, two spellings | Two properties, never merged |
|---|---|
| `5th Street` ≡ `5TH ST` | `1358` ≠ `1356` |
| `742 North Beacon Boulevard` ≡ `742 N BEACON BLVD` | `5th Street` ≠ `6th Street` |
| `UNIT 3B` ≡ `APT 3B` ≡ `#3B` | `5th Street` ≠ `5th Avenue` |
| ZIP+4 ≡ its 5-digit form | `742 N Beacon` ≠ `742 S Beacon` |

A missing ZIP on one side is **silence, not agreement** — it cannot make a match, while a *different* ZIP disqualifies. Treating silence as agreement is how a matcher finds the right street in the wrong town.

## Three more things the screen was doing wrong

1. **`matches.slice(0, 25)` of 76.** A parcel the county ranked 40th was not on the page at all — and the advice to refine could not reach it, because the search was already the exact address. Now every candidate renders, ranked.

2. **`unit_type` / `unit_number` were dropped from the row.** In a multi-unit building that is the *only* field distinguishing the candidates. Seventy-six identical-looking rows is a coin toss with a scrollbar.

3. **"Owner unavailable" was three situations wearing one label** — a gap in the county record, a parcel that never matched, and a county service that is down. Only one of them is the officer's to act on. The server now says which, by name; the screen renders the reason and never invents one. Invariant #4 in a data field.

## Doctrine §13.3 — who chose the record the facts came from

Added, as §13.2 one level further out. A parcel the *server* matched must not be indistinguishable from one a *human* clicked — `selection.basis` is `exact_address_match`, `officer_choice`, or `only_county_match`, and it rides through to `PropertyData.parcelSelection`.

An unrecognised basis becomes **absent** rather than a default, because both available defaults are lies: calling a server match an officer's choice launders it, calling an officer's choice a server match slanders it.

**And it is visible, not just recorded.** When the server matched the parcel, the card says so in the same place she is about to start confirming fields, with "not this one?" beside it and every alternative behind that. A selection recorded but not shown would satisfy the letter of §13.2 and miss the point of it.

## One copy of the judgement

The comparison runs server-side; the screen renders the verdict. A pin fails if a street-suffix table, `normalizeStreet`, or `sameAddress` appears in the frontend — a second opinion about which property a deed describes is exactly the shape that gave us four divergent copies of the partner categories.

## Verification

Eleven pins mutation-probed across both languages, all eleven failed on the break — including the two that matter most: selecting on a tie, and truncating the ranked list.

One test failure during the build was the code being right and the test being wrong: my 76-neighbour fixture generated `1300+n`, which included 1358, so there were genuinely two candidates on the chosen address and the matcher correctly declined to pick. Fixture fixed, behaviour untouched.

| Gate | Result |
|---|---|
| pytest, with a database | **1090 passed** (was 1081) |
| pytest, no database | **918 passed**, 172 skipped (was 903) |
| jest | **726 passed**, 49 suites (was 715/48) |
| `next build` | ✔ — frontend PR, so it ran |
| tsc | **94** — baseline holds |
| six-flow baseline | ✔ |
| API baseline | ✔ |
| banned-claims | clean |

## Held

**#167 (db-identity) is still awaiting your ruling** and is not merged. This branch is cut fresh from `main`, so the two are independent — no stacking. Branch deviation flagged as standing practice: the session config still names `claude/docs-archive-regenerate-ehj87q`.

UX2 items 2–9 not started — item 1 rides alone, as ruled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_