### PR TITLE
Doctrine §0: the argument underneath every heuristic this product declined

### DIFF
--- a/docs/DOCTRINE_CONFORMANCE.md
+++ b/docs/DOCTRINE_CONFORMANCE.md
@@ -17,6 +17,53 @@ each discovered *incidentally* by unrelated work.
 
 ---
 
+## §0 — Why this product keeps declining heuristics
+
+**Owner-ruled 2026-08-12 (UX2 item 1). Read this before arguing for the
+next one.** It is not a new rule; it is the argument underneath a dozen
+existing ones, written down once so each of them stops having to make it
+from scratch.
+
+> **A tie-breaking rule invents an answer that will be right often enough
+> that nobody checks it.**
+
+That is the whole objection, and the crucial word is *often*. **A
+heuristic that is wrong 5% of the time is more dangerous than one that is
+wrong 50% of the time**, because the 5% version earns trust it cannot
+sustain. The 50% version is discovered in an afternoon and removed. The
+5% version becomes the thing everybody relies on, and its failures arrive
+individually, months apart, on documents nobody is re-reading.
+
+**The same reasoning kills a confidence score.** A number between 0 and 1
+invites a threshold, and a threshold is where invented answers come from:
+somebody picks 0.8, nothing visibly breaks, and the product now asserts
+things it does not know at a rate nobody has measured. The answers this
+product gives are a value or nothing.
+
+Where this argument has already done the work:
+
+| Declined | What the heuristic would have invented |
+|---|---|
+| §1 | A vesting or DTT choice inferred from the facts on the deed. |
+| §11 | A field's kind guessed from its NAME rather than its content. |
+| §11.1 | A person's pronouns or licensure guessed from their name or role. |
+| §13.2 | An answer attributed to the signer that the officer gave. |
+| §13.3 | A parcel picked out of two candidates on one address. |
+| Doctrine A | A relationship read out of two owners sharing a surname. |
+
+Every row is the same shape: a rule that would be right most of the time,
+declined because *most* is not a standard a recorded legal document can
+be held to, and because the failures would be invisible in exactly the
+cases where they matter.
+
+**What is permitted instead.** Normalising SPELLING is not a heuristic —
+`5th Street` and `5TH ST` are one thing written twice, and no property
+changes hands over the difference. Deciding IDENTITY is. When the two are
+hard to tell apart, the test is: could this rule ever make two different
+real things into one? If yes, it is identity, and it is declined.
+
+---
+
 ## 1. Legal choices are never auto-applied
 
 **Statement.** A legal choice (documentary transfer tax declaration,

--- a/docs/EXECUTION_POLICY.md
+++ b/docs/EXECUTION_POLICY.md
@@ -109,6 +109,32 @@ ruled.
 it is a product decision on its own merits and deserves to be ruled as
 one, rather than shipped under a bug ticket that no longer has a bug.
 
+### A ruling can fail in two ways, and both need checking
+
+**Owner-ruled 2026-08-12 (UX2 item 1).** DASH1 was one failure mode. UX2
+item 1 was the other, and confusing them wastes the lesson.
+
+| | DASH1 route rename | UX2 item 1 property search |
+|---|---|---|
+| The defect | **did not exist** — both routes were already aliases | **was real**, and worse than described |
+| The diagnosis | — | **was wrong**: "we re-search by address string instead of passing the autocomplete's identifier" |
+| The right answer | ship nothing, report | ship the fix, at the place the defect actually is |
+
+UX2's hypothesis was framed from outside the constraint. SiteX takes
+`addr` + `lastLine` **or** `fips` + `apn`; Google's `place_id` is not a
+SiteX key, and the FIPS + APN that would be precise does not exist on our
+side until SiteX has already answered. Re-searching by address string is
+the interface, not a shortcut somebody took.
+
+The defect was one step later and entirely ours: we had the officer's
+exact address, we had 76 candidates each carrying an address, and we
+compared nothing.
+
+**The rule:** verify the DEFECT and verify the EXPLANATION. A ticket that
+names a cause is making two claims, and building against the wrong one
+produces a change that is real work, passes review, and leaves the defect
+where it was.
+
 ## Standing practice — a job that writes says which database it is in
 
 Ruled 2026-08-12 (db-identity ticket). `relation "signing_participants"


### PR DESCRIPTION
Documentation only. Two things you asked to have recorded from UX2 item 1, in the places the next reader will look.

## §0 — the general argument

> **A tie-breaking rule invents an answer that will be right often enough that nobody checks it.**

The crucial word is *often*. **A heuristic wrong 5% of the time is more dangerous than one wrong 50% of the time**, because the 5% version earns trust it cannot sustain — the 50% version is found in an afternoon and removed, while the 5% version becomes the thing everybody relies on, and its failures arrive individually, months apart, on documents nobody is re-reading.

Same reasoning kills a confidence score: a number between 0 and 1 invites a threshold, and a threshold is where invented answers come from.

It goes in as **§0**, before §1, because it is not a new rule — it is the argument beneath a dozen existing ones, written down once so each stops having to make it from scratch:

| Declined | What the heuristic would have invented |
|---|---|
| §1 | A vesting or DTT choice inferred from the facts on the deed |
| §11 | A field's kind guessed from its NAME rather than its content |
| §11.1 | A person's pronouns or licensure guessed from name or role |
| §13.2 | An answer attributed to the signer that the officer gave |
| §13.3 | A parcel picked out of two candidates on one address |
| Doctrine A | A relationship read out of two owners sharing a surname |

And the test for the hard cases, since "normalisation is spelling, never identity" needs a way to tell them apart in the moment: **could this rule ever make two different real things into one?** If yes, it is identity, and it is declined.

## A ruling can fail in two ways

Added to `EXECUTION_POLICY.md` beside the DASH1 lesson, because filing them together is what makes them useful:

| | DASH1 route rename | UX2 item 1 |
|---|---|---|
| The defect | **did not exist** | **was real**, and worse than described |
| The diagnosis | — | **was wrong** |
| The right answer | ship nothing, report | ship the fix, where the defect actually is |

A ticket that names a cause makes two claims. Building against the wrong one produces a change that is real work, passes review, and leaves the defect exactly where it was.

## Verification

`pytest` 936 passed / 178 skipped (no DB), banned-claims clean. No code changed — no frontend files, so no `next build`.

Also in this batch: #168 and #167 merged, in that order, both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_