### PR TITLE
NOTARY1's read side retires, and a revoked link stops answering

### DIFF
--- a/backend/routers/sharing.py
+++ b/backend/routers/sharing.py
@@ -589,6 +589,23 @@ def view_shared_deed(approval_token: str):
                     db.conn.commit()
                 raise HTTPException(status_code=410, detail="This approval link has expired")
 
+            # ONE REVOCATION SEMANTIC PER LINK — the same argument as the
+            # expiry block above, and the half of it that was missing.
+            #
+            # FOUND WHILE RETIRING NOTARY1'S READ SIDE. This handler
+            # checked expiry and never checked revocation, so an officer
+            # who revoked a share went on serving the deed at this URL —
+            # deed type, property address, APN, county, grantor and
+            # grantee names — indefinitely. The PDF route next door 403s a
+            # revoked share, and `_signing_share_by_token` did too, which
+            # is why the gap survived: every test that exercised
+            # revocation went through one of those two.
+            #
+            # Revocation is a deliberate act, not a timer. Honouring it on
+            # some URLs and not others is not honouring it.
+            if status == 'revoked':
+                raise HTTPException(status_code=403, detail="Access has been revoked")
+
             # Track first view (only if status is still 'sent')
             if status == 'sent' and not viewed_at:
                 try:
@@ -643,25 +660,25 @@ def view_shared_deed(approval_token: str):
             }
 
             if is_signing:
-                scheduled_at = row_map.get("scheduled_at")
-                deed_data["signing"] = {
-                    # DERIVED (T-5). `status` above still says sent/viewed
-                    # and knows nothing about scheduling — the two facts
-                    # are orthogonal and never share a column.
-                    "state": signing.scheduling_state(row_map),
-                    "summary": signing.scheduling_label(row_map),
-                    "windows": [
-                        {"index": i, "start": w.get("start"), "end": w.get("end"),
-                         "label": signing.window_label(w)}
-                        for i, w in enumerate(signing.windows_of(row_map))
-                    ],
-                    "scheduled_at": scheduled_at.isoformat() if hasattr(scheduled_at, "isoformat") else scheduled_at,
-                    "scheduled_by": row_map.get("scheduled_by"),
-                    # A window may still be chosen after one already was —
-                    # a notary who mis-tapped can correct it while the link
-                    # lives. What she cannot do is say the signing happened.
-                    "can_choose_window": not is_expired and status != 'revoked',
-                    "pcor_url": f"/approve/{approval_token}/pcor",
+                # NOTARY1's read side is retired (see the note at the foot
+                # of this file). This link used to carry a window picker
+                # and a PCOR download; both are gone with the model.
+                #
+                # A LINK THAT DOES NOTHING MUST SAY WHY. Nothing can create
+                # such a row any more, so in production this branch is
+                # unreachable — but "unreachable" is a claim about one
+                # database, and the officer holding a link that opens onto
+                # a page with no actions and no explanation is exactly the
+                # empty-state-over-a-real-condition invariant #4 forbids.
+                # So the payload states the condition, and the page reads
+                # it out.
+                deed_data["retired"] = {
+                    "model": "notary1",
+                    "reason": "This link was created by an earlier scheduling "
+                              "flow that has been retired. It cannot be used "
+                              "to choose a time.",
+                    "what_to_do": "Ask the escrow officer to send a new "
+                                  "signing request.",
                 }
 
             print(f"[Sharing] ✅ Approval link accessed: share_id={share_id}, status={status}, can_approve={can_approve}")
@@ -1003,413 +1020,60 @@ def get_shared_deed_pdf(approval_token: str):
 
 
 # ══════════════════════════════════════════════════════════════════════
-# NOTARY1 — the signing handoff
+# NOTARY1 IS RETIRED — WRITE SIDE (#162) AND NOW READ SIDE
 #
-# The doctrine lives in services/signing.py; this file is the wiring.
-# Four rules govern everything below, and they are the reason the code
-# looks more careful than "store a datetime" would suggest:
+# NOTARY1 coordinated a signing as a `deed_shares` row: `share_kind =
+# 'signing_request'`, a JSONB list of windows the OFFICER had guessed at,
+# and a `scheduled_at` the notary or the officer wrote back. §13.1
+# reversed the model — the notary posts her own availability, the signers
+# answer, convergence books it — and NOTARY2 built that as one aggregate
+# across four tables in routers/signing.py.
 #
-#   1. No signer contact. The product coordinates officer↔notary and
-#      nothing else; no endpoint here accepts, stores or sends to a
-#      signer's address. Pinned fail-closed in test_notary1_signing.py.
-#   2. The scheduling state is DERIVED from `scheduled_at` and never
-#      written into `deed_shares.status` (T-5's ruling).
-#   3. The system never asserts a signing OCCURRED. Nothing below sets
-#      anything to completed, and no passed window changes any state.
-#   4. Whoever asserted a time is on the row beside it (RED-S4's shape).
+# #162 removed the write path on evidence: the owner ran
+# `migrate_notary1_signings.py --dry-run` against production and got
+# found: 0, migrated: 0, on database `deedpro` at 10.26.62.147, confirmed
+# by the script's own identity line. Four read-side routes stayed, flagged
+# rather than decided, because a second removal has its own blast radius.
+#
+# THIS IS THAT SECOND REMOVAL. Gone:
+#
+#   POST /approve/{token}/schedule          the notary taps a window
+#   POST /shared-deeds/{id}/schedule        the officer records a time
+#   GET  /approve/{token}/pcor              PCOR status behind a signing link
+#   GET  /approve/{token}/pcor.pdf          the filled PCOR
+#
+# — with `_signing_share_by_token`, `_pcor_deed_for_token`,
+# `_tell_the_officer`, `WindowChoice` and `OfficerSchedule`.
+#
+# WHY NOW AND NOT BEFORE. They were unreachable by construction rather
+# than by decision: nothing could create the row they load. Unreachable
+# code is not harmless — it is the state where a future change makes
+# something live again without anybody choosing that, and where a reader
+# cannot tell "deliberately kept" from "nobody looked".
+#
+# WHAT A ROW SOMEWHERE ELSE GETS INSTEAD, and this is the whole safety
+# argument: **the read side was never the recovery path — the migration
+# is.** `scripts/migrate_notary1_signings.py` still reads `deed_shares`
+# directly, still carries a NOTARY1 share into the NOTARY2 aggregate, and
+# now asserts which database it is in before it does. A row found in some
+# other database is migrated into the model the product believes in,
+# rather than served through one it does not.
+#
+# WHAT DELIBERATELY STAYS:
+#
+#   - THE COLUMNS. `share_kind`, `proposed_windows`, `scheduled_at`,
+#     `scheduled_by`, `scheduled_asserted_at`. A drop is irreversible and
+#     the migration must keep being able to read what it finds.
+#   - THE TWO FAIL-CLOSED REFUSALS above (`resend_share`,
+#     `submit_approval_response`). They are not features of NOTARY1; they
+#     are the rule that a signing share must never be answered as if it
+#     were a review request. §13: approving a signing request would write
+#     an approval into the record on behalf of somebody who was asked a
+#     different question. That rule outlives the model it was written for.
+#   - THE VOCABULARY. `signing.SHARE_KIND_SIGNING` is how the guards, the
+#     shared row contract and the migration RECOGNISE such a row.
+#     Removing the ability to make more is not the same act as removing
+#     the ability to read what exists.
+#
+# Pinned in tests/test_flow1_notary1_retired.py.
 # ══════════════════════════════════════════════════════════════════════
-
-
-class WindowChoice(BaseModel):
-    """The notary's answer: the INDEX of a window the officer offered.
-
-    Not a timestamp. Accepting a time from the request body would let
-    anyone holding the link assert an hour nobody proposed.
-    """
-    window_index: int
-
-
-class OfficerSchedule(BaseModel):
-    """Owner ruling 3: the officer may record a time she agreed out of
-    band. Either an offered window by index, or an explicit ISO time when
-    they settled on something that was never proposed."""
-    window_index: Optional[int] = None
-    scheduled_at: Optional[str] = None
-
-
-def _signing_share_by_token(approval_token: str, cur) -> dict:
-    """Load a signing share by token, with the link's OWN scoping.
-
-    Ruling 2, and it is a class rather than a special case: an expired or
-    revoked token is expired or revoked for everything it reaches. The
-    deed, the PDF and the PCOR answer identically, because "which URL did
-    you ask" is not a property a permission should have.
-    """
-    cur.execute("""
-        SELECT ds.id, ds.deed_id, ds.owner_user_id, ds.recipient_email,
-               ds.status, ds.expires_at, ds.share_kind, ds.proposed_windows,
-               ds.scheduled_at, ds.scheduled_by, ds.scheduled_asserted_at,
-               d.deed_type, d.property_address,
-               u.email AS owner_email, u.full_name AS owner_name
-        FROM deed_shares ds
-        JOIN deeds d ON d.id = ds.deed_id
-        LEFT JOIN users u ON u.id = ds.owner_user_id
-        WHERE ds.token = %s
-    """, (approval_token,))
-    row = cur.fetchone()
-    if not row:
-        raise HTTPException(status_code=404, detail="This link is invalid or does not exist")
-    row = dict(row)
-    if row.get("share_kind") != signing.SHARE_KIND_SIGNING:
-        raise HTTPException(status_code=404, detail="This link is not a signing request")
-    if row.get("status") == 'revoked':
-        raise HTTPException(status_code=403, detail="Access has been revoked")
-    expires_at = row.get("expires_at")
-    if expires_at and expires_at < datetime.now(_tz.utc):
-        raise HTTPException(status_code=410, detail="This link has expired")
-    return row
-
-
-# ══════════════════════════════════════════════════════════════════════
-# FLOW1 item 6 — NOTARY1'S WRITE PATH IS RETIRED
-#
-# `POST /signing-requests` used to create a signing as a `deed_shares`
-# row with `share_kind='signing_request'` and a JSONB list of windows the
-# OFFICER had guessed at. §13.1 reversed that model: the notary posts her
-# own availability, signers answer, convergence books it — one aggregate
-# across four tables, in routers/signing.py. The NOTARY2 create path is
-# `POST /signing-requests/v2`.
-#
-# The old route's UI was deleted when NOTARY2 shipped, and #156 migrated
-# its rows. What remained was a LIVE ENDPOINT WITH NO CLIENT — writable
-# by anybody holding a token, tested against no screen, producing rows in
-# a model the product had stopped believing in. Every migration run after
-# such a call would have carried it across, so nothing would have been
-# lost; the objection is not data loss, it is that two writable models
-# for one act is one model too many, and the one nobody can see is the
-# one that rots.
-#
-# RETIRED ON EVIDENCE, NOT ON SCHEDULE. The owner ran
-# `migrate_notary1_signings.py --dry-run` against production —
-# found: 0, migrated: 0, "no NOTARY1 signing requests remain to migrate",
-# on database `deedpro` at 10.26.62.147, confirmed by the script's own
-# identity line. The removal is safe because that number was checked,
-# not because enough time had passed.
-#
-# WHAT DELIBERATELY STAYS. The `deed_shares` columns (`share_kind`,
-# `proposed_windows`, `scheduled_at`, `scheduled_by`,
-# `scheduled_asserted_at`) are NOT dropped: a column drop is
-# irreversible, production is not the only database this schema runs on,
-# and the migration script must keep being able to read a row it might
-# find somewhere else. The READ-side routes below
-# (`/approve/{t}/schedule`, `/shared-deeds/{id}/schedule`,
-# `/approve/{t}/pcor`) also stay, and they are now unreachable by
-# construction — `_signing_share_by_token` 404s anything that is not a
-# signing share, and nothing can create one. That is flagged rather than
-# decided: retiring them is a second removal with its own blast radius
-# and its own doctrine tests, and it was not what this ticket ruled.
-#
-# Pinned in tests/test_flow1_notary1_retired.py — the route is absent
-# from the table, and no backend source writes SHARE_KIND_SIGNING.
-# ══════════════════════════════════════════════════════════════════════
-
-
-@router.post("/approve/{approval_token}/schedule")
-def notary_choose_window(approval_token: str, choice: WindowChoice):
-    """The notary taps a window. Public, token-scoped.
-
-    WHAT THIS RECORDS is availability — she is free then — and nothing
-    more. It is not an attestation that a notarial act was performed, it
-    does not complete anything, and no later moment turns it into one.
-    """
-    approval_token = _valid_token_or_404(approval_token)
-    if not db.conn:
-        raise HTTPException(status_code=500, detail="Database connection unavailable")
-
-    try:
-        with db.conn.cursor() as cur:
-            row = _signing_share_by_token(approval_token, cur)
-            window = signing.find_window(row, choice.window_index)
-            if window is None:
-                raise HTTPException(
-                    status_code=400,
-                    detail="That is not one of the proposed times")
-            try:
-                chosen = _dt.fromisoformat(window["start"])
-            except ValueError:
-                raise HTTPException(status_code=400, detail="That time could not be read")
-
-            cur.execute("""
-                UPDATE deed_shares
-                SET scheduled_at = %s,
-                    scheduled_by = %s,
-                    scheduled_asserted_at = NOW(),
-                    updated_at = NOW()
-                WHERE id = %s
-            """, (chosen, signing.ASSERTED_BY_NOTARY, row["id"]))
-            db.conn.commit()
-
-            fresh = dict(row)
-            fresh["scheduled_at"] = chosen
-            fresh["scheduled_by"] = signing.ASSERTED_BY_NOTARY
-
-        _tell_the_officer(row, window, signing.ASSERTED_BY_NOTARY)
-
-        return {
-            "success": True,
-            # The words come from one place so no surface can turn an
-            # arrangement into a promise (rule 3).
-            "message": signing.scheduling_label(fresh),
-            "state": signing.scheduling_state(fresh),
-            "scheduled_at": chosen.isoformat(),
-            "scheduled_by": signing.ASSERTED_BY_NOTARY,
-        }
-    except HTTPException:
-        raise
-    except Exception as e:
-        try:
-            db.conn.rollback()
-        except Exception:
-            pass
-        print(f"[NOTARY1] ❌ window selection error: {e}")
-        raise HTTPException(status_code=500, detail="Could not record that time")
-
-
-@router.post("/shared-deeds/{shared_deed_id}/schedule")
-def officer_record_schedule(shared_deed_id: int, payload: OfficerSchedule,
-                            user_id: int = Depends(get_current_user_id)):
-    """Owner ruling 3 — the officer records a time she agreed elsewhere.
-
-    Two people can settle a time on the phone in fifteen seconds, and a
-    product that then insists the notary tap a link is a product being
-    fussy about its own bookkeeping. So this path exists — and it writes
-    `scheduled_by = 'officer'`, because the record must not claim the
-    notary asserted something she said over the phone to one person.
-    """
-    if not db.conn:
-        raise HTTPException(status_code=500, detail="Database connection not available")
-
-    try:
-        with db.conn.cursor() as cur:
-            cur.execute("""
-                SELECT ds.id, ds.owner_user_id, ds.share_kind, ds.status,
-                       ds.proposed_windows, ds.recipient_email,
-                       d.deed_type, d.property_address
-                FROM deed_shares ds
-                JOIN deeds d ON d.id = ds.deed_id
-                WHERE ds.id = %s
-            """, (shared_deed_id,))
-            row = cur.fetchone()
-            if not row:
-                raise HTTPException(status_code=404, detail="Signing request not found")
-            row = dict(row)
-            if row["owner_user_id"] != user_id:
-                raise HTTPException(status_code=404, detail="Signing request not found")
-            if row.get("share_kind") != signing.SHARE_KIND_SIGNING:
-                raise HTTPException(
-                    status_code=400,
-                    detail="That share is a review request, which has no signing time")
-
-            if payload.window_index is not None:
-                window = signing.find_window(row, payload.window_index)
-                if window is None:
-                    raise HTTPException(status_code=400,
-                                        detail="That is not one of the proposed times")
-                raw = window["start"]
-            elif payload.scheduled_at:
-                raw = payload.scheduled_at
-            else:
-                raise HTTPException(
-                    status_code=400,
-                    detail="Give either a proposed window or a time")
-
-            try:
-                chosen = _dt.fromisoformat(str(raw).replace("Z", "+00:00"))
-            except ValueError:
-                raise HTTPException(status_code=400,
-                                    detail="scheduled_at must be an ISO-8601 date and time")
-
-            cur.execute("""
-                UPDATE deed_shares
-                SET scheduled_at = %s,
-                    scheduled_by = %s,
-                    scheduled_asserted_at = NOW(),
-                    updated_at = NOW()
-                WHERE id = %s
-            """, (chosen, signing.ASSERTED_BY_OFFICER, shared_deed_id))
-            db.conn.commit()
-
-        fresh = dict(row)
-        fresh["scheduled_at"] = chosen
-        fresh["scheduled_by"] = signing.ASSERTED_BY_OFFICER
-        return {
-            "success": True,
-            "message": signing.scheduling_label(fresh),
-            "state": signing.scheduling_state(fresh),
-            "scheduled_at": chosen.isoformat(),
-            "scheduled_by": signing.ASSERTED_BY_OFFICER,
-        }
-    except HTTPException:
-        raise
-    except Exception as e:
-        try:
-            db.conn.rollback()
-        except Exception:
-            pass
-        print(f"[NOTARY1] ❌ officer schedule error: {e}")
-        raise HTTPException(status_code=500, detail="Could not record that time")
-
-
-def _tell_the_officer(row: dict, window: dict, asserted_by: str) -> None:
-    """In-app record first, then the email. Best-effort, never fatal.
-
-    E1's ordering, for E1's reason: the in-app notification is the
-    unlosable copy. A notary's chosen time that existed only as an email
-    would vanish on a transport failure, and the officer would be waiting
-    on an answer that already arrived.
-    """
-    app_url = os.getenv('FRONTEND_URL', 'https://deedpro-frontend-new.vercel.app')
-    address = row.get("property_address") or "your deed"
-    when_text = signing.window_label(window)
-    notary = row.get("recipient_email") or "The notary"
-
-    try:
-        from utils.notifications import create_notification
-        create_notification(
-            db.conn,
-            user_id=row.get("owner_user_id"),
-            ntype="signing_scheduled",
-            title="Notary confirmed availability",
-            message=f"{notary} is available {when_text} for {address}",
-            link=f"/shared-deeds?focus={row.get('id')}",
-        )
-    except Exception as notif_error:
-        try:
-            db.conn.rollback()
-        except Exception:
-            pass
-        print(f"[NOTARY1] ⚠️ notification error (non-blocking): {notif_error}")
-
-    owner_email = row.get("owner_email")
-    if not owner_email:
-        return
-    ics = signing.window_to_ics(
-        window,
-        summary=f"Notary signing — {address}",
-        location=address or None,
-        # §11.1: a name is not a pronoun. This calendar file went into
-        # the officer's own diary asserting the notary's pronouns.
-        description=(f"{notary} said they are available at this time. "
-                     "DeedPro has not contacted the signers."),
-        uid=f"share-{row.get('id')}-scheduled@deedpro",
-    )
-    attachments = [_ics_attachment("signing.ics", ics, "text/calendar")] if ics else []
-    note = (f"{notary} chose a time for the signing."
-            if asserted_by == signing.ASSERTED_BY_NOTARY
-            else "A signing time was recorded.")
-    try:
-        from utils.notifications import send_signing_time_recorded_with_reason
-        ok, reason = send_signing_time_recorded_with_reason(
-            owner_email=owner_email,
-            owner_name=row.get("owner_name") or "there",
-            deed_type=row.get("deed_type") or "deed",
-            property_address=row.get("property_address"),
-            notary_email=notary,
-            when_text=when_text,
-            asserted_note=note,
-            view_link=f"{app_url}/shared-deeds?focus={row.get('id')}",
-            user_id=row.get("owner_user_id"),
-            attachments=attachments,
-        )
-        if not ok:
-            print(f"[NOTARY1] ⚠️ officer email not sent: {reason}")
-    except Exception as email_error:
-        print(f"[NOTARY1] ⚠️ officer email error (non-blocking): {email_error}")
-
-
-@router.get("/approve/{approval_token}/pcor")
-def signing_pcor_status(approval_token: str):
-    """Is there a PCOR for this deed's county, and what will it still need?
-
-    Token-scoped, signing links only. A review share asks somebody to
-    check the instrument; the PCOR is the companion form the signing
-    table needs, so it travels with the signing link and not with every
-    link we have ever issued.
-    """
-    approval_token = _valid_token_or_404(approval_token)
-    if not db.conn:
-        raise HTTPException(status_code=500, detail="Database connection unavailable")
-    from services.county_forms import lookup_form
-    from services.boe_form_fill import values_from_deed
-
-    row = _pcor_deed_for_token(approval_token)
-    form = lookup_form(row.get("county") or "")
-    if form is None:
-        return {
-            "available": False,
-            "county": row.get("county"),
-            "reason": f"No PCOR on file for {row.get('county') or 'this county'}.",
-        }
-    _values, asks = values_from_deed(row)
-    return {
-        "available": True,
-        "county": form.county,
-        "form_code": form.form_code,
-        "revision": form.revision,
-        "county_revision": form.county_revision,
-        "url": f"/approve/{approval_token}/pcor.pdf",
-        "still_needed": asks,
-    }
-
-
-@router.get("/approve/{approval_token}/pcor.pdf")
-def signing_pcor_download(approval_token: str):
-    """The filled PCOR, unflattened — the buyer still has to finish it.
-
-    Same posture as the authenticated route (§9: this is the buyer's
-    form, not our instrument, so it is neither stored nor hashed) and the
-    same expiry as the deed behind the same token (ruling 2).
-    """
-    approval_token = _valid_token_or_404(approval_token)
-    if not db.conn:
-        raise HTTPException(status_code=500, detail="Database connection unavailable")
-    from fastapi.responses import Response
-    from services.boe_form_fill import PcorUnavailable, fill_pcor
-
-    row = _pcor_deed_for_token(approval_token)
-    try:
-        pdf_bytes, _asks = fill_pcor(row)
-    except PcorUnavailable as e:
-        raise HTTPException(status_code=404, detail=str(e))
-    return Response(
-        content=pdf_bytes,
-        media_type="application/pdf",
-        headers={"Content-Disposition":
-                 f'attachment; filename="PCOR-{row.get("id")}.pdf"'},
-    )
-
-
-def _pcor_deed_for_token(approval_token: str) -> dict:
-    """The deed behind a live signing token — the link IS the authority.
-
-    Mirrors `_pcor_deed_row`'s shape (`d.*`, so boe_form_fill sees the
-    same row it sees for the owner) and replaces its owner check with the
-    token's own scoping: signing kind, not revoked, not expired.
-    """
-    try:
-        with db.conn.cursor() as cur:
-            share = _signing_share_by_token(approval_token, cur)
-            cur.execute("SELECT * FROM deeds WHERE id = %s", (share["deed_id"],))
-            deed = cur.fetchone()
-    except HTTPException:
-        raise
-    except Exception as e:
-        try:
-            db.conn.rollback()
-        except Exception:
-            pass
-        print(f"[NOTARY1] ❌ PCOR token lookup error: {e}")
-        raise HTTPException(status_code=500, detail="Could not load the form")
-    if not deed:
-        raise HTTPException(status_code=404, detail="Deed not found")
-    return dict(deed)

--- a/backend/services/signing.py
+++ b/backend/services/signing.py
@@ -1,68 +1,55 @@
-"""NOTARY1 — the signing handoff, and the line it must not cross.
+"""What survives NOTARY1: the vocabulary, one honest sentence, one .ics.
 
-═══ WHAT THIS IS ═══
+═══ WHAT THIS MODULE IS NOW ═══
 
-An officer picks a notary from her own partner list, sends a signing
-request with two or three proposed windows, and the notary taps one. She
-is told. That is the whole feature.
+NOTARY1 coordinated a signing as a `deed_shares` row — the officer
+proposed windows, the notary tapped one. §13.1 reversed that model,
+NOTARY2 rebuilt it as an aggregate across four tables
+(`services/signing_loop.py`), #162 removed NOTARY1's write path on
+evidence, and the read side went with it.
 
-What it removes is the leg she does not control. She already has her
-clients' numbers and already calls them; what she cannot do is stop
-playing phone tag with a notary. So the product coordinates
-officer↔notary and nothing else.
+What is left here is what OUTLIVED the feature, and each piece has a
+living caller:
 
-═══ NO SIGNER CONTACT. ANYWHERE. (owner-ruled) ═══
+  - THE VOCABULARY. `SHARE_KIND_REVIEW` / `SHARE_KIND_SIGNING` is how the
+    two fail-closed refusals in `routers/sharing.py`, the shared row
+    contract and the migration script RECOGNISE a NOTARY1 row. Removing
+    the ability to make more of them is not the same act as removing the
+    ability to read what exists.
+  - `windows_of` — the migration script's parser for `proposed_windows`.
+  - `scheduling_state` / `scheduling_label` — the officer's list still
+    renders a line for such a row (`services/shared_deed_row.py`).
+  - `build_ics` — NOTARY2 sends the same kind of calendar copy.
+  - `default_expiry` — every share, of either kind.
 
-Signers — grantors and grantees — are consumers. They have no account,
-never agreed to our terms, cannot see what we hold and cannot ask us to
-delete it. Storing their email or phone would make every deed row carry
-third-party contact data, which changes what a database dump IS, and it
-would do so to automate a message the officer is better placed to send.
+DELETED WITH THE FEATURE, and worth naming because they were a SECOND
+ANSWER to questions NOTARY2 answers for itself: `normalize_windows` and
+`MAX_WINDOWS = 3` (NOTARY2 validates its own posts, at five), `find_window`
+(index-into-officer-proposed-list, a shape that no longer exists),
+`window_label` and `window_labels` (`signing_loop.window_label` writes
+every window this product shows, and it takes a timezone, which this one
+never did), `window_to_ics`. Two divergent answers to "how many windows"
+lived in this repo, and only one of them was reachable.
 
-So the product captures no signer contact information, stores none, and
-messages no signer. `deeds` carries party NAMES because names print on
-the instrument; that is the whole of it, and it stays that way. Pinned
-fail-closed in `tests/test_notary1_signing.py` — a new
-`signer_email`-shaped field anywhere fails the suite rather than waiting
-to be noticed.
+═══ THE RULE THAT DID NOT RETIRE ═══
 
-═══ THE STATE IS DERIVED (T-5's ruling, transferred) ═══
+A scheduled time is an ARRANGEMENT, not a legal act, and "confirmed"
+must still mean somebody said so. `scheduling_label()` is why the words
+are written once: no surface may render `scheduled` as a claim that the
+signing WILL happen, and a label composed screen by screen is how that
+distinction erodes. It also refuses to attribute an arrangement to
+anybody it cannot name — an unrecognised asserter gets "Signing time
+recorded", not a person.
 
-`deed_shares.status` holds sent / viewed / approved / rejected / revoked
-/ expired. Scheduling is NOT one of those, and it must not become one.
+The same rule, in NOTARY2's vocabulary, is `signing_loop.state_label`.
 
-T-5 refused to add `superseded` to `deeds.status` because a superseded
-deed is still a completed deed — two orthogonal facts cannot share one
-column without one of them becoming unsayable. The same is true here: a
-signing request that has been viewed AND scheduled is the normal case,
-and folding `scheduled` into `status` makes it inexpressible.
+═══ NO SIGNER CONTACT ON THIS ROW ═══
 
-So `scheduled_at` is its own column and the scheduling state is computed
-from it. Nothing writes "scheduled" into `status`, ever.
-
-═══ THE DOCTRINE LINE ═══
-
-A scheduled time is an ARRANGEMENT, not a legal act. Nobody's rights
-change because a calendar says Tuesday, so this needs none of the violet
-machinery a vesting choice needs.
-
-But "confirmed" must still mean somebody said so, and this file mirrors
-RED-S4's recording shape exactly: `scheduled_by` + `scheduled_asserted_at`
-alongside the value, because the system's knowledge of a signing time is
-always somebody's statement and never its own inference.
-
-Three things follow, and all three are pinned:
-
-  1. THE SYSTEM NEVER ASSERTS A SIGNING OCCURRED. No auto-completion, no
-     timer, no inference from a window that has passed. A time that has
-     come and gone is not evidence that anybody met.
-  2. `completed` IS OFFICER-ONLY. The notary is not our user, has no
-     account, and a tap on a public token is not an attestation that a
-     notarial act was performed.
-  3. A NOTARY TAPPING A WINDOW ASSERTS AVAILABILITY, NOT ATTENDANCE. No
-     surface may render `scheduled` as a claim that the signing will
-     happen — `scheduling_label()` exists so that the words are written
-     once and cannot drift into a promise on some screen nobody rechecked.
+NOTARY1 stored none, deliberately, and that has not changed for
+`deed_shares`. §13.1 gave signers their own participation in NOTARY2 —
+on one purgeable row in `signing_participants`, with a purge job behind
+it — which is a different mechanism with its own retention rule, not a
+relaxation of this one.
 """
 from __future__ import annotations
 
@@ -84,52 +71,20 @@ ASSERTED_BY_NOTARY = "notary"
 ASSERTED_BY_OFFICER = "officer"
 ASSERTERS = (ASSERTED_BY_NOTARY, ASSERTED_BY_OFFICER)
 
-MAX_WINDOWS = 3
-MIN_WINDOWS = 1
-
-
-class SigningRequestError(ValueError):
-    """A signing request we will not create, with the reason."""
-
-
-def normalize_windows(raw: Any) -> List[Dict[str, str]]:
-    """Validate and normalise proposed windows.
-
-    Each window is `{start, end}` in ISO-8601 with an offset. Times are
-    stored as the officer entered them — a signing happens at a place, in
-    that place's time, and helpfully converting to UTC for display is how
-    somebody arrives an hour late.
-    """
-    if raw is None:
-        return []
-    if not isinstance(raw, list):
-        raise SigningRequestError("Proposed windows must be a list")
-    if len(raw) > MAX_WINDOWS:
-        raise SigningRequestError(
-            f"At most {MAX_WINDOWS} windows — more than three choices is a "
-            f"negotiation, and this is not one")
-
-    out: List[Dict[str, str]] = []
-    for i, window in enumerate(raw):
-        if not isinstance(window, dict):
-            raise SigningRequestError(f"Window {i + 1} is not an object")
-        start, end = window.get("start"), window.get("end")
-        if not start or not end:
-            raise SigningRequestError(f"Window {i + 1} needs a start and an end")
-        try:
-            s = datetime.fromisoformat(str(start))
-            e = datetime.fromisoformat(str(end))
-        except ValueError:
-            raise SigningRequestError(
-                f"Window {i + 1} is not a valid date/time") from None
-        if e <= s:
-            raise SigningRequestError(f"Window {i + 1} ends before it starts")
-        out.append({"start": str(start), "end": str(end)})
-    return out
-
-
 def windows_of(row: Dict[str, Any]) -> List[Dict[str, str]]:
-    """The stored windows, whatever shape the driver handed back."""
+    """The stored windows, whatever shape the driver handed back.
+
+    NON-DICT ENTRIES ARE DROPPED, and that is a widening of this function
+    rather than a quiet tightening: `signing_migration` carried its own
+    private copy that filtered them, this one did not, and the two have
+    now converged HERE — on the filtering behaviour, because every caller
+    goes on to read `w["start"]` and a bare string in the list is a
+    crash rather than a window.
+
+    Flagged because a narrowing and a widening look identical in a diff.
+    The migration's behaviour is unchanged; this function's is, and only
+    in the direction of not raising on data it cannot use.
+    """
     raw = row.get("proposed_windows")
     if raw is None:
         return []
@@ -138,54 +93,9 @@ def windows_of(row: Dict[str, Any]) -> List[Dict[str, str]]:
             raw = json.loads(raw)
         except ValueError:
             return []
-    return raw if isinstance(raw, list) else []
-
-
-def _fmt_time(dt: datetime) -> str:
-    return dt.strftime("%I:%M %p").lstrip("0")
-
-
-def window_label(window: Dict[str, str]) -> str:
-    """One window, in words. THE ONLY PLACE a window becomes English.
-
-    Every surface — the notary's email, the token page, the officer's
-    status line — calls this, for the same reason `scheduling_label` is
-    single-sourced: a second formatter is a second chance to print the
-    wrong hour, and the wrong hour is somebody driving to an empty
-    office.
-    """
-    try:
-        start = datetime.fromisoformat(str(window.get("start")))
-        end = datetime.fromisoformat(str(window.get("end")))
-    except (TypeError, ValueError):
-        return f"{window.get('start', '?')} – {window.get('end', '?')}"
-    day = start.strftime("%A, %B ") + str(start.day) + start.strftime(", %Y")
-    if end.date() == start.date():
-        return f"{day}, {_fmt_time(start)} – {_fmt_time(end)}"
-    end_day = end.strftime("%B ") + str(end.day)
-    return f"{day}, {_fmt_time(start)} – {end_day}, {_fmt_time(end)}"
-
-
-def window_labels(row: Dict[str, Any]) -> List[str]:
-    return [window_label(w) for w in windows_of(row)]
-
-
-def find_window(row: Dict[str, Any], index: Any) -> Optional[Dict[str, str]]:
-    """The window a notary tapped, by its position in the stored list.
-
-    Position, not a client-supplied time: accepting a time from the
-    request body would let a link holder assert any hour they liked,
-    including one the officer never offered.
-    """
-    windows = windows_of(row)
-    try:
-        i = int(index)
-    except (TypeError, ValueError):
-        return None
-    if i < 0 or i >= len(windows):
-        return None
-    w = windows[i]
-    return w if isinstance(w, dict) else None
+    if not isinstance(raw, list):
+        return []
+    return [w for w in raw if isinstance(w, dict)]
 
 
 def scheduling_state(row: Dict[str, Any]) -> Optional[str]:
@@ -270,24 +180,6 @@ def build_ics(*, summary: str, start: datetime, end: datetime,
         lines.append(f"LOCATION:{esc(location)}")
     lines += ["END:VEVENT", "END:VCALENDAR"]
     return ("\r\n".join(lines) + "\r\n").encode("utf-8")
-
-
-def window_to_ics(window: Dict[str, str], *, summary: str,
-                  location: Optional[str], description: str,
-                  uid: str) -> Optional[bytes]:
-    try:
-        start = datetime.fromisoformat(window["start"])
-        end = datetime.fromisoformat(window["end"])
-    except (KeyError, ValueError):
-        return None
-    if start.tzinfo is None:
-        # A naive time is ambiguous, and guessing a zone is how a
-        # calendar entry lands an hour out. Assume UTC only so the file
-        # is VALID, and say so in the description rather than silently.
-        start = start.replace(tzinfo=timezone.utc)
-        end = end.replace(tzinfo=timezone.utc)
-    return build_ics(summary=summary, start=start, end=end,
-                     location=location, description=description, uid=uid)
 
 
 def default_expiry(days: int = 14) -> datetime:

--- a/backend/services/signing_migration.py
+++ b/backend/services/signing_migration.py
@@ -41,6 +41,7 @@ import json
 import uuid
 from typing import Any, Dict, List
 
+from services import signing
 from services import signing_loop as loop
 
 SOURCE_SQL = """
@@ -55,16 +56,13 @@ SOURCE_SQL = """
 """
 
 
-def _windows_of(row: Dict[str, Any]) -> List[Dict[str, str]]:
-    raw = row.get("proposed_windows")
-    if raw is None:
-        return []
-    if isinstance(raw, str):
-        try:
-            raw = json.loads(raw)
-        except ValueError:
-            return []
-    return [w for w in (raw or []) if isinstance(w, dict)]
+# The `proposed_windows` parser lives in `services/signing.py` — this
+# file used to carry a second copy of it. Standing rule: when a new
+# surface needs an existing judgement the answer is never a second copy,
+# and with NOTARY1's read side retired this is now the ONLY caller, which
+# makes keeping two parsers for one column indefensible rather than
+# merely untidy.
+_windows_of = signing.windows_of
 
 
 def migrate(conn, *, dry_run: bool = False) -> Dict[str, Any]:

--- a/backend/tests/snapshots/openapi_routes.json
+++ b/backend/tests/snapshots/openapi_routes.json
@@ -153,14 +153,6 @@
  ],
  [
   "GET",
-  "/approve/{approval_token}/pcor"
- ],
- [
-  "GET",
-  "/approve/{approval_token}/pcor.pdf"
- ],
- [
-  "GET",
   "/approve/{approval_token}/pdf"
  ],
  [
@@ -413,10 +405,6 @@
  ],
  [
   "POST",
-  "/approve/{approval_token}/schedule"
- ],
- [
-  "POST",
   "/deeds"
  ],
  [
@@ -470,10 +458,6 @@
  [
   "POST",
   "/shared-deeds/{shared_deed_id}/revoke"
- ],
- [
-  "POST",
-  "/shared-deeds/{shared_deed_id}/schedule"
  ],
  [
   "POST",

--- a/backend/tests/test_admin3_email_outcomes.py
+++ b/backend/tests/test_admin3_email_outcomes.py
@@ -92,7 +92,13 @@ def test_every_template_routes_through_send():
         f"declared TEMPLATES and actual _send labels disagree: "
         f"only-declared={set(TEMPLATES) - named}, only-used={named - set(TEMPLATES)}"
     )
-    assert len(TEMPLATES) == 19
+    # The trip-wire, fired DOWNWARD again: 19 → 18 as NOTARY1's
+    # `signing_time_recorded` lost the only handler that sent it (the
+    # notary tapping one of the officer's proposed windows — a thing that
+    # can no longer happen). The same pin caught `share_signing_request`
+    # leaving in #162. A count that only ever goes up is a count that
+    # never notices a feature departing.
+    assert len(TEMPLATES) == 18
 
 
 # ── The recorder's two constraints ───────────────────────────────────

--- a/backend/tests/test_flow1_notary1_retired.py
+++ b/backend/tests/test_flow1_notary1_retired.py
@@ -27,16 +27,28 @@ checked, not because enough time had passed.
 ═══ WHAT THIS PIN DOES AND DOES NOT CLAIM ═══
 
 It forbids the ROUTE and the WRITE. It does not claim NOTARY1 data
-cannot exist: the `deed_shares` columns stay (a column drop is
+cannot exist: the `deed_shares` columns stay, because a column drop is
 irreversible, production is not the only database this schema runs on,
 and the migration script must keep being able to read a row it might
-find elsewhere), and the read-side routes stay and are now unreachable
-by construction — `_signing_share_by_token` 404s anything that is not a
-signing share, and nothing can create one.
+find elsewhere.
 
-Those three residual routes are FLAGGED, not removed. Retiring them is a
-second deletion with its own blast radius and its own doctrine tests,
-and it is not what this ticket ruled.
+═══ AND NOW THE READ SIDE (2026-08-12) ═══
+
+#162 left four read-side routes in place, flagged rather than decided,
+because a second removal has its own blast radius. This file now pins
+that second removal too: `/approve/{t}/schedule`,
+`/shared-deeds/{id}/schedule`, `/approve/{t}/pcor` and
+`/approve/{t}/pcor.pdf` are gone.
+
+The safety argument is one sentence and it is pinned below: **the read
+side was never the recovery path — the migration is.** A row found in
+another database is carried into NOTARY2's aggregate, not served through
+a model the product stopped believing in.
+
+Three things deliberately survive, and each has its own pin: the
+columns, the two fail-closed refusals (which are §13's rule, not
+NOTARY1's feature), and the vocabulary that lets the guards, the shared
+row contract and the migration RECOGNISE such a row.
 """
 from __future__ import annotations
 
@@ -159,22 +171,70 @@ def test_the_dead_modal_is_deleted():
         "exists")
 
 
-def test_the_residual_read_routes_are_flagged_not_forgotten():
-    """The three NOTARY1 routes that remain are unreachable by
-    construction, and this asserts somebody said so in the source rather
-    than leaving a reader to work it out.
+def test_the_read_side_is_retired_too():
+    """#162 removed the write path and FLAGGED four read-side routes.
+    This is the second removal, and the flag is now a fact.
 
-    They are not removed because that was not ruled. They are recorded
-    because an endpoint that cannot fire, with nothing saying why, is
-    indistinguishable from one nobody has looked at.
+    They were unreachable by construction rather than by decision —
+    nothing could create the row they load. That is not the same as
+    harmless: unreachable code is where a future change makes something
+    live again without anybody choosing it, and where a reader cannot
+    tell "deliberately kept" from "nobody looked".
     """
     routes = _routes()
-    for residual in (("POST", "/approve/{approval_token}/schedule"),
-                     ("POST", "/shared-deeds/{shared_deed_id}/schedule"),
-                     ("GET", "/approve/{approval_token}/pcor")):
-        assert residual in routes, (
-            f"{residual} was removed — that is a second deletion this "
-            "ticket did not rule; if it is now intended, say so here")
-    src = (BACKEND / "routers" / "sharing.py").read_text(encoding="utf-8")
-    assert "unreachable by\n# construction" in src, (
-        "the note explaining why the residual routes cannot fire is gone")
+    for gone in (("POST", "/approve/{approval_token}/schedule"),
+                 ("POST", "/shared-deeds/{shared_deed_id}/schedule"),
+                 ("GET", "/approve/{approval_token}/pcor"),
+                 ("GET", "/approve/{approval_token}/pcor.pdf")):
+        assert gone not in routes, (
+            f"{gone} is back — NOTARY1's read side is retired; the model "
+            "is NOTARY2's aggregate in routers/signing.py")
+
+
+def test_a_row_found_elsewhere_still_has_a_way_forward():
+    """THE SAFETY ARGUMENT, pinned rather than asserted in prose.
+
+    Retiring the read side does not strand a NOTARY1 row in some other
+    database, because the read side was never the recovery path — the
+    MIGRATION is. It still reads `deed_shares` directly, still carries a
+    share into the NOTARY2 aggregate, and now names the database it is
+    in before it starts.
+    """
+    from services import signing, signing_migration
+
+    src = code_only(BACKEND / "services" / "signing_migration.py")
+    assert "deed_shares" in src
+    assert "share_kind" in src, (
+        "the migration lost its ability to recognise a NOTARY1 row")
+    # It reads the windows through the one parser, not a private copy.
+    assert signing_migration._windows_of is signing.windows_of
+
+    script = code_only(BACKEND / "scripts" / "migrate_notary1_signings.py")
+    assert "assert_tables(" in script, (
+        "the migration no longer says which database it is in — the "
+        "db-identity ticket exists because a confident `found: 0` "
+        "against the wrong database looks exactly like success")
+
+
+def test_the_two_fail_closed_refusals_outlive_the_model():
+    """These are not features of NOTARY1 and do not retire with it.
+
+    A signing share must never be answered as if it were a review
+    request: §13 — approving one would write an approval into the record
+    on behalf of somebody who was asked a different question — and the
+    review reminder asks a notary the wrong question twice.
+    """
+    src = code_only(BACKEND / "routers" / "sharing.py")
+    assert src.count("signing.SHARE_KIND_SIGNING") >= 3, (
+        "a guard that recognises a NOTARY1 row has gone missing")
+    assert "not a review request" in src
+    assert "wrong question" in src
+
+
+def test_a_retired_link_says_so_rather_than_going_quiet():
+    """Invariant #4 wearing an empty state. A link that opens onto a page
+    with no actions and no explanation leaves the reader unable to tell
+    "retired" from "broken", and only one of those is theirs to solve."""
+    src = code_only(BACKEND / "routers" / "sharing.py")
+    assert '"retired"' in src or "'retired'" in src
+    assert "what_to_do" in src

--- a/backend/tests/test_notary1_signing.py
+++ b/backend/tests/test_notary1_signing.py
@@ -134,13 +134,26 @@ def test_scheduling_is_never_written_into_status():
     orthogonal facts cannot share one column without one of them becoming
     unsayable. A signing request that has been VIEWED and SCHEDULED is
     the normal case; folding `scheduled` into `status` makes it
-    inexpressible."""
-    src = code_only(SHARING)
-    bad = re.findall(r"status\s*=\s*'(scheduled|proposed|completed)'", src)
-    assert bad == [], f"scheduling leaked into deed_shares.status: {bad}"
+    inexpressible.
 
-    for statement in ("SET scheduled_at", "scheduled_by"):
-        assert statement in src, f"{statement} should be its own column"
+    RETARGETED, and flagged. The second half used to assert that
+    `SET scheduled_at` and `scheduled_by` APPEAR in the router — a
+    positive check that the columns were written separately. Nothing in
+    the router writes them any more, so that half would now fail for the
+    right reason, which makes it the wrong assertion to keep.
+
+    What survives is the half that is still a rule: scheduling must never
+    be written into `status`, and it is now pinned across every backend
+    source rather than one file, because the writer that could reintroduce
+    it need not be this one.
+    """
+    for path in BACKEND.rglob("*.py"):
+        if {"tests", "__pycache__", "venv", ".venv"} & set(path.parts):
+            continue
+        bad = re.findall(r"status\s*=\s*'(scheduled|proposed)'", code_only(path))
+        assert bad == [], (
+            f"scheduling leaked into a status column in {path.name}: {bad} — "
+            "T-5's rule: two orthogonal facts never share one column")
 
 
 def test_scheduling_state_is_computed_not_stored():
@@ -250,7 +263,16 @@ def test_every_surface_takes_its_words_from_one_place():
     """
     sources = [code_only(SHARING), code_only(ROW_BUILDER)]
     calls = sum(s.count("signing.scheduling_label(") for s in sources)
-    assert calls >= 4, f"only {calls} surfaces take their words from one place"
+
+    # RETARGETED from `>= 4`, and flagged because a loosened threshold and
+    # a broken pin look identical in a diff. The four callers were the
+    # router's window picker, its status payload, the officer's list and
+    # the row builder; three of them retired with NOTARY1's read side.
+    # ONE surface remains, so "four" now measures history rather than the
+    # property. The property was never the number — it is that no surface
+    # writes its own scheduling sentence, and THAT half is unchanged and
+    # is where the teeth always were.
+    assert calls >= 1, "nothing takes its words from the one place any more"
     for src in sources:
         assert not re.search(r'f?"[^"]*[Ss]cheduled for', src), (
             "a surface is writing its own scheduling sentence")
@@ -259,36 +281,6 @@ def test_every_surface_takes_its_words_from_one_place():
 # ══════════════════════════════════════════════════════════════════════
 # Windows
 # ══════════════════════════════════════════════════════════════════════
-
-def test_at_most_three_windows():
-    four = [{"start": f"2026-09-0{i}T10:00:00-07:00",
-             "end": f"2026-09-0{i}T11:00:00-07:00"} for i in range(1, 5)]
-    with pytest.raises(signing.SigningRequestError):
-        signing.normalize_windows(four)
-
-
-def test_a_window_that_ends_before_it_starts_is_refused():
-    with pytest.raises(signing.SigningRequestError):
-        signing.normalize_windows([{"start": "2026-09-01T11:00:00-07:00",
-                                    "end": "2026-09-01T10:00:00-07:00"}])
-
-
-def test_the_officers_offset_survives_storage():
-    """Times are stored as entered. A signing happens at a place, in that
-    place's time, and helpfully normalising to UTC for display is how
-    somebody arrives an hour late."""
-    stored = signing.normalize_windows(
-        [{"start": "2026-09-01T10:00:00-07:00", "end": "2026-09-01T11:00:00-07:00"}])
-    assert stored[0]["start"].endswith("-07:00")
-
-
-def test_a_notary_can_only_choose_a_window_that_was_offered():
-    row = {"proposed_windows": [{"start": "2026-09-01T10:00:00-07:00",
-                                 "end": "2026-09-01T11:00:00-07:00"}]}
-    assert signing.find_window(row, 0) is not None
-    for bad in (1, -1, 99, "x", None):
-        assert signing.find_window(row, bad) is None
-
 
 def test_the_ics_is_a_copy_not_an_invitation():
     """METHOD:PUBLISH, not REQUEST. REQUEST makes it an invitation with
@@ -546,137 +538,94 @@ def test_a_stranger_cannot_share_a_deed_they_do_not_own(world):
 
 
 @dbonly
-def test_the_whole_handoff(world):
-    """Officer asks → notary sees windows and no approve buttons → notary
-    taps one → the record says who said so and when."""
+def test_a_notary1_link_says_it_is_retired_rather_than_going_quiet(world):
+    """What became of the handoff.
+
+    The window picker, the PCOR download and both scheduling routes went
+    with NOTARY1's read side. What must NOT happen is the other failure:
+    a link that opens onto a page with no actions and no explanation.
+    That is invariant #4 wearing an empty state — the officer cannot tell
+    "retired" from "broken", and one of those is her problem to solve.
+
+    So the payload states the condition, and the approval refusal is
+    still a RULE rather than a hidden button (§13: answering "approved"
+    on a signing request writes an approval into the record on behalf of
+    somebody who was asked a different question).
+    """
     from fastapi.testclient import TestClient
     from main import app
 
-    officer = world["users"][0]
     token = _make_notary1_share(world, notary_email="notary@notary1.test")["token"]
-
     public = TestClient(app)
+
     view = public.get(f"/approve/{token}")
     assert view.status_code == 200, view.text
     package = view.json()
     assert package["share_kind"] == "signing_request"
     assert package["can_approve"] is False, "a signing request has no approval"
-    assert package["signing"]["state"] == "proposed"
-    assert len(package["signing"]["windows"]) == 2
 
-    # The approval route refuses it as a RULE, not as a hidden button.
+    # The retired model says so, by name, with what to do next.
+    assert package["retired"]["model"] == "notary1"
+    assert "retired" in package["retired"]["reason"].lower()
+    assert package["retired"]["what_to_do"]
+    # And it does not still advertise what it can no longer do.
+    assert "signing" not in package, "the window picker payload survived"
+
     refused = public.post(f"/approve/{token}", json={"approved": True})
     assert refused.status_code == 409, refused.text
 
-    # High-water marks BEFORE the tap. `email_log` and `notifications`
-    # are append-only and survive between runs, so "a row with this
-    # template exists" is satisfied by yesterday's row — the first draft
-    # of the assertion below passed with the send deliberately broken,
-    # which is the whole reason a green result gets probed.
-    with world["conn"].cursor() as cur:
-        cur.execute("SELECT COALESCE(MAX(id), 0) AS m FROM email_log")
-        email_mark = cur.fetchone()["m"]
-        cur.execute("SELECT COALESCE(MAX(id), 0) AS m FROM notifications")
-        note_mark = cur.fetchone()["m"]
-
-    chosen = public.post(f"/approve/{token}/schedule", json={"window_index": 1})
-    assert chosen.status_code == 200, chosen.text
-    assert chosen.json()["scheduled_by"] == "notary"
-
-    after = public.get(f"/approve/{token}").json()
-    assert after["signing"]["state"] == "scheduled"
-    assert "availability" in after["signing"]["summary"].lower()
-
-    # RED-S4's shape, on the row: the value, who asserted it, and when.
-    with world["conn"].cursor() as cur:
-        cur.execute("SELECT status, share_kind, scheduled_at, scheduled_by, "
-                    "scheduled_asserted_at FROM deed_shares WHERE token = %s",
-                    (token,))
-        row = cur.fetchone()
-    assert row["share_kind"] == "signing_request"
-    assert row["scheduled_by"] == "notary"
-    assert row["scheduled_at"] is not None
-    assert row["scheduled_asserted_at"] is not None
-    # T-5: the two facts never share a column.
-    assert row["status"] in ("sent", "viewed")
-
-    # The officer was told, and the ATTEMPT is on the ledger whether or
-    # not a transport is configured (ADMIN3). This is also the only thing
-    # that proves the .ics was built and handed to the sender — the
-    # attachment path runs before the transport reports its outcome, so a
-    # row here means the whole chain executed rather than raising into
-    # the best-effort catch.
-    with world["conn"].cursor() as cur:
-        cur.execute("SELECT template, recipient FROM email_log "
-                    "WHERE template = 'signing_time_recorded' AND id > %s "
-                    "ORDER BY id DESC LIMIT 1", (email_mark,))
-        logged = cur.fetchone()
-        cur.execute("SELECT type, message FROM notifications "
-                    "WHERE type = 'signing_scheduled' AND id > %s "
-                    "ORDER BY id DESC LIMIT 1", (note_mark,))
-        note = cur.fetchone()
-    assert logged is not None, "the officer's email was never attempted"
-    assert note is not None, "the in-app record is missing — E1's unlosable copy"
-    for promise in ("will happen", "confirmed for"):
-        assert promise not in note["message"].lower()
-
 
 @dbonly
-def test_a_notary_cannot_assert_a_time_nobody_proposed(world):
-    from fastapi.testclient import TestClient
-    from main import app
-    officer = world["users"][0]
-    token = _make_notary1_share(world)["token"]
-    r = TestClient(app).post(f"/approve/{token}/schedule", json={"window_index": 7})
-    assert r.status_code == 400
+def test_the_retired_routes_are_gone_from_the_app(world):
+    """Not 404-by-guard — absent from the routing table.
+
+    A guard that 404s is a door with a lock on it; these are doors that
+    are not there. The distinction matters because a guard can be edited
+    out in one line by somebody who does not know why it exists.
+    """
+    import main
+    paths = {(m, getattr(r, "path", ""))
+             for r in main.app.routes
+             for m in (getattr(r, "methods", set()) or set())}
+    for gone in (("POST", "/approve/{approval_token}/schedule"),
+                 ("POST", "/shared-deeds/{shared_deed_id}/schedule"),
+                 ("GET", "/approve/{approval_token}/pcor"),
+                 ("GET", "/approve/{approval_token}/pcor.pdf")):
+        assert gone not in paths, f"{gone} came back"
+
+    # NOTARY2's equivalents are present, so this cannot pass by the whole
+    # signing feature having been deleted.
+    assert ("POST", "/signing-requests/v2") in paths
+    assert ("GET", "/signing/{token}") in paths
 
 
-@dbonly
-def test_the_officer_may_record_a_time_agreed_out_of_band(world):
-    """Owner ruling 3 — and the record keeps the two assertions apart."""
-    officer = world["users"][0]
-    client = _client_for(officer)
-    made = _make_notary1_share(world)
-    r = client.post(f"/shared-deeds/{made['share_id']}/schedule",
-                    json={"scheduled_at": "2026-09-15T10:00:00-07:00"})
-    assert r.status_code == 200, r.text
-    assert r.json()["scheduled_by"] == "officer"
-    assert "you recorded" in r.json()["message"].lower()
-
-    with world["conn"].cursor() as cur:
-        cur.execute("SELECT scheduled_by, scheduled_asserted_at FROM deed_shares "
-                    "WHERE id = %s", (made["share_id"],))
-        row = cur.fetchone()
-    assert row["scheduled_by"] == "officer"
-    assert row["scheduled_asserted_at"] is not None
-
-
-@dbonly
-def test_a_stranger_cannot_record_a_time_on_someone_elses_request(world):
-    officer, stranger = world["users"]
-    made = _make_notary1_share(world)
-    r = _client_for(stranger).post(f"/shared-deeds/{made['share_id']}/schedule",
-                                   json={"window_index": 0})
-    assert r.status_code == 404, r.text
+def _review_share(world, owner_index: int = 0) -> dict:
+    made = _client_for(world["users"][owner_index]).post("/shared-deeds", json={
+        "deed_id": world["deeds"][0], "recipient_email": "r@notary1.test",
+        "recipient_role": "Other"}).json()
+    return made["shared_deed"]
 
 
 @dbonly
 def test_one_expiry_semantic_per_link(world):
-    """Ruling 2, applied as a class. An expired token answers the deed,
-    the PDF and the PCOR the same way — 410 — because "which URL did you
-    ask" is not a property a permission may have.
+    """Ruling 2, applied as a class: an expired token answers the deed
+    and the PDF the same way — 410 — because "which URL did you ask" is
+    not a property a permission may have.
 
-    This also covers the second defect the ticket found: the deed view
-    used to 410 only when the status was still 'sent', so a link that had
-    been OPENED once kept serving the deed after expiry forever.
+    RETARGETED, and flagged as such. It used to run against a NOTARY1
+    signing share and cover four URLs including the two PCOR routes;
+    those routes are retired, so it runs against a REVIEW share, which is
+    the live kind, over the two URLs that remain. The rule is unchanged
+    and the surface it is pinned to shrank with the product.
+
+    It also still covers the second defect the original ticket found: the
+    deed view used to 410 only while the status was 'sent', so a link
+    somebody had OPENED kept serving the deed after expiry forever.
     """
     from fastapi.testclient import TestClient
     from main import app
 
-    officer = world["users"][0]
-    made = _make_notary1_share(world)
-    token = made["token"]
-
+    token = _review_share(world)["approval_token"]
     public = TestClient(app)
     assert public.get(f"/approve/{token}").status_code == 200  # marks it viewed
 
@@ -684,54 +633,29 @@ def test_one_expiry_semantic_per_link(world):
         cur.execute("UPDATE deed_shares SET expires_at = NOW() - INTERVAL '1 day' "
                     "WHERE token = %s", (token,))
 
-    for url in (f"/approve/{token}", f"/approve/{token}/pdf",
-                f"/approve/{token}/pcor", f"/approve/{token}/pcor.pdf"):
+    for url in (f"/approve/{token}", f"/approve/{token}/pdf"):
         assert public.get(url).status_code == 410, f"{url} still answers an expired link"
-    assert public.post(f"/approve/{token}/schedule",
-                       json={"window_index": 0}).status_code == 410
 
 
 @dbonly
 def test_a_revoked_link_stops_answering(world):
+    """Same retarget — and it found a live defect on the way.
+
+    Retargeting this onto a REVIEW share is what exposed it: the deed
+    view checked expiry and never checked revocation, so an officer who
+    revoked a share kept serving the address, APN, county and both party
+    names at that URL forever. Every existing revocation test went
+    through the PDF route or `_signing_share_by_token`, both of which
+    did check — which is exactly how a gap survives a suite.
+    """
     from fastapi.testclient import TestClient
     from main import app
-    officer = world["users"][0]
-    client = _client_for(officer)
-    made = _make_notary1_share(world)
-    assert client.post(f"/shared-deeds/{made['share_id']}/revoke").status_code == 200
+    share = _review_share(world)
+    client = _client_for(world["users"][0])
+    assert client.post(f"/shared-deeds/{share['id']}/revoke").status_code == 200
     public = TestClient(app)
-    assert public.get(f"/approve/{made['token']}/pcor").status_code == 403
-    assert public.post(f"/approve/{made['token']}/schedule",
-                       json={"window_index": 0}).status_code == 403
-
-
-@dbonly
-def test_a_review_token_does_not_open_the_pcor_route(world):
-    """The PCOR travels with the signing link, not with every link we
-    have ever issued."""
-    from fastapi.testclient import TestClient
-    from main import app
-    officer = world["users"][0]
-    made = _client_for(officer).post("/shared-deeds", json={
-        "deed_id": world["deeds"][0], "recipient_email": "r@notary1.test",
-        "recipient_role": "Other"}).json()
-    token = made["shared_deed"]["approval_token"]
-    assert TestClient(app).get(f"/approve/{token}/pcor").status_code == 404
-
-
-@dbonly
-def test_a_signing_request_is_stored_before_anybody_is_emailed(world):
-    """§4 applied to the create path: a notary holding a link to a row
-    that does not exist is worse than an officer who knows her request
-    did not go out."""
-    officer = world["users"][0]
-    made = _make_notary1_share(world)
-    with world["conn"].cursor() as cur:
-        cur.execute("SELECT proposed_windows FROM deed_shares WHERE id = %s",
-                    (made["share_id"],))
-        stored = cur.fetchone()["proposed_windows"]
-    stored = json.loads(stored) if isinstance(stored, str) else stored
-    assert len(stored) == 2
+    assert public.get(f"/approve/{share['approval_token']}").status_code == 403
+    assert public.get(f"/approve/{share['approval_token']}/pdf").status_code == 403
 
 
 @dbonly

--- a/backend/utils/email_templates.py
+++ b/backend/utils/email_templates.py
@@ -361,39 +361,6 @@ def admin_api_key_request(company_name, contact_email, business_type,
 # test_admin3_email_outcomes.py is what caught it.
 
 
-def signing_time_recorded(owner_name, deed_type, property_address, notary_email,
-                          when_text, asserted_note, view_link) -> Rendered:
-    """NOTARY1 — to the officer: a time is on the record.
-
-    The subject and body say RECORDED, never "confirmed for" or "your
-    signing is set". A time in this system is an arrangement two people
-    made; the product knows the arrangement was made and knows nothing
-    about whether anybody keeps it. `asserted_note` carries who said so,
-    because per RED-S4 the system's knowledge is always somebody's
-    statement.
-    """
-    addr = _short_addr(property_address)
-    subject = f"Signing time recorded — {addr}" if addr else "Signing time recorded"
-    content = (
-        _p(f"Hi {_esc(owner_name)},")
-        + _p(_esc(asserted_note))
-        + _facts([("Time", when_text), ("Notary", notary_email),
-                  ("Document", deed_type), ("Property", addr)])
-        + _button(view_link, "Open in DeedPro")
-        + _p('<span style="font-size:13px;color:#8a94a0;">The signers have not been '
-             "contacted — DeedPro does not message them. A calendar file for this time "
-             "is attached.</span>")
-    )
-    text = (
-        f"{asserted_note}\n\n"
-        f"Time: {when_text}\nNotary: {notary_email}\n"
-        f"Document: {deed_type}\nProperty: {addr}\n\n"
-        f"Open: {view_link}\n\n"
-        "The signers have not been contacted — DeedPro does not message them."
-    )
-    return subject, _base(f"Signing time recorded — {addr}", content, True), text
-
-
 def notary_invited(notary_name, officer_name, officer_company, deed_type,
                    property_address, county, link, expires_at) -> Rendered:
     """NOTARY2 — officer → notary: post the times you are free.

--- a/backend/utils/notifications.py
+++ b/backend/utils/notifications.py
@@ -25,10 +25,13 @@ TEMPLATES = (
     "welcome", "admin_api_key_request", "admin_new_user",
     # TRIAL1 — renewal failure. The event dunning actually runs on.
     "payment_failed",
-    # NOTARY1 — the two ends of the signing handoff. Officer→notary asks
-    # about availability; notary→officer (or officer→herself) records a
-    # time. There is deliberately no third: no signer is ever emailed.
-    "signing_time_recorded", "notary_dispatched",
+    # NOTARY1 — what is left of the signing handoff. `notary_dispatched`
+    # is NOTARY2's, named for the older flow and still sent.
+    # `signing_time_recorded` went with NOTARY1's read side: its only
+    # caller told the officer that a notary had tapped one of her
+    # proposed windows, and nothing can propose windows that way any
+    # more. The orphan pin below is what caught it, downward, again.
+    "notary_dispatched",
     # NOTARY2 — the coordination loop. Five, and the count is the point:
     # ask the notary, ask the signers, tell the signers when there is
     # something to answer, tell the notary when a signer proposes, and
@@ -199,22 +202,6 @@ def send_payment_failed_with_reason(user_email: str, full_name: str,
     return _send("payment_failed", user_email,
                  email_templates.payment_failed(full_name, amount_text, billing_url),
                  user_id=user_id)
-
-
-def send_signing_time_recorded_with_reason(owner_email: str, owner_name: str,
-                                           deed_type: str, property_address: Optional[str],
-                                           notary_email: str, when_text: str,
-                                           asserted_note: str, view_link: str,
-                                           user_id: Optional[int] = None,
-                                           attachments: Optional[list] = None) -> SendResult:
-    """NOTARY1 — a time is on the record; tell the officer who said so."""
-    return _send("signing_time_recorded", owner_email,
-                 email_templates.signing_time_recorded(
-                     owner_name, deed_type, property_address, notary_email,
-                     when_text, asserted_note, view_link),
-                 user_id=user_id,
-                 context={"deed_type": deed_type, "notary": notary_email},
-                 attachments=attachments)
 
 
 def send_notary_invited(recipient_email: str, notary_name: str, officer_name: str,

--- a/docs/DOCTRINE_CONFORMANCE.md
+++ b/docs/DOCTRINE_CONFORMANCE.md
@@ -230,6 +230,28 @@ guard functions** to reject trivial `return True` implementations (the
 class-killer for stubbed guards). Six-flow baseline exercises real JWT
 issuance and authenticated flows against live Postgres.
 
+**Findings (2026-08-12, NOTARY1 read-side retirement). A revoked share
+link kept serving the deed.** `GET /approve/{token}` checked expiry and
+never checked `status = 'revoked'`, so after an officer revoked a share
+that URL went on returning the deed type, property address, APN, county
+and both party names — indefinitely, to anybody holding the link. The
+PDF route next door 403s a revoked share, and the retired
+`_signing_share_by_token` did too.
+
+**How it survived a suite that tests revocation:** every existing
+revocation test went through one of those two paths. The gap was found
+by RETARGETING a NOTARY1 test onto a review share — the live kind — when
+its original subject was removed. A pin that only ever exercises the
+strict door does not discover the unlocked one beside it.
+
+The rule is the one the same handler already states about expiry, and
+this is the half that was missing: **honouring a revocation on some URLs
+and not others is not honouring it.** Revocation is a deliberate act by
+the officer, not a timer.
+
+Fixed and pinned in
+`backend/tests/test_notary1_signing.py::test_a_revoked_link_stops_answering`.
+
 ---
 
 ## 7. Flagged items and owner rulings (2026-07-28)

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -131,6 +131,23 @@ when their trigger arrives.
   contact details. Unset, the job runs wherever `DATABASE_URL` points,
   which is correct for local and CI and is why the check is optional.
 
+- **`/signing/{token}/pcor` does not exist — the NOTARY2 signer's PCOR
+  button is a live 404** (found 2026-08-12 while retiring NOTARY1's read
+  side). `services/signing_surfaces.py:192` puts
+  `pcor_url = "/signing/{token}/pcor"` in the signer package, and
+  `frontend/src/app/signing/[token]/page.tsx:355` renders a Download
+  PCOR link at `${pcor_url}.pdf`. **Neither route is registered** —
+  `routers/signing.py` has no PCOR handler at all. NOTARY1 had a working
+  pair; NOTARY2 advertises them and never built them.
+
+  NOT FIXED, because the two fixes are different products: build the
+  route (the signer gets the county's companion form) or stop
+  advertising it (the button goes). The first is a feature and the
+  second removes one, and `pcor_url` is inside `signing_surfaces`'
+  exact-key-set contract, so either way it is a deliberate change rather
+  than a repair. **Needs a ruling.** The audience is consumers with no
+  account, which is the argument for it being soon.
+
 - **Junk seed cleanup** (test rows in production data).
 - **TitlePoint / SiteX credential rotations.**
 - **DTT city-rates review** (`frontend/src/lib/dttCalc.ts`) — owner's
@@ -345,20 +362,28 @@ we reach it.
 
 ## Parked tickets (scoped, not scheduled)
 
-- **Retire NOTARY1's read-side routes** (FLOW1 item 6 follow-up,
-  owner-ruled 2026-08-11: leave them for now). Three routes survive the
-  write path's retirement and are now unreachable by construction —
-  `POST /approve/{token}/schedule`, `POST /shared-deeds/{id}/schedule`,
-  `GET /approve/{token}/pcor(.pdf)`. `_signing_share_by_token` 404s
-  anything that is not a signing share, and nothing can create one.
-  **Trigger:** the confirmed zero-row count (already had — production
-  `deedpro` at 10.26.62.147, found 0) PLUS a decision that no other
-  database holds NOTARY1 shares. Until then a pin asserts the source
-  note explaining why they cannot fire is still present, because an
-  endpoint that cannot fire with nothing saying why is
-  indistinguishable from one nobody has looked at. The `deed_shares`
-  columns stay regardless — a column drop is irreversible and the
-  migration script must keep being able to read a row it might find.
+- **Retire NOTARY1's read-side routes — DONE 2026-08-12.** All four
+  removed (the ledger said three; `GET /approve/{token}/pcor.pdf` was
+  not in the count), with `_signing_share_by_token`,
+  `_pcor_deed_for_token`, `_tell_the_officer`, the `WindowChoice` /
+  `OfficerSchedule` models, the dead half of `services/signing.py`, the
+  orphaned `signing_time_recorded` email, and the approve page's window
+  picker.
+
+  **The trigger's second half was answered by argument rather than by a
+  survey**, and that is worth stating plainly: nobody enumerated every
+  database that runs this schema. The reason it did not need to is that
+  **the read side was never the recovery path — the migration is.**
+  `migrate_notary1_signings.py` still reads `deed_shares` directly,
+  still carries a share into the NOTARY2 aggregate, and now names the
+  database it is in first. A row found anywhere is migrated into the
+  model the product believes in rather than served through one it does
+  not. Pinned.
+
+  A link held by somebody from that era now says what happened and what
+  to do, rather than opening onto a page with no actions — invariant #4
+  wearing an empty state. The `deed_shares` columns stay; a column drop
+  is irreversible and was not ruled.
 
 - **Sweep for pins reading files nothing imports** (FLOW1 item 6
   finding, owner-ruled as its own category). `shareEntryPoints.test.ts`

--- a/frontend/src/__tests__/signingHandoff.test.ts
+++ b/frontend/src/__tests__/signingHandoff.test.ts
@@ -92,8 +92,18 @@ describe('NOTARY1 — no signer contact, anywhere', () => {
 });
 
 describe('NOTARY1 — the words come from one place', () => {
-  it('the token page renders the summary the server wrote', () => {
-    expect(APPROVE).toContain('deed.signing.summary');
+  it('the token page takes the retired notice from the server too', () => {
+    /**
+     * RETARGETED with NOTARY1's read side. The page used to render
+     * `deed.signing.summary` — the server's scheduling sentence — and
+     * there is no longer a scheduling sentence for it to render, because
+     * the routes behind the window picker are gone.
+     *
+     * The property is unchanged: the CONDITION is known on the server and
+     * the page renders what it is told. What changed is which condition.
+     */
+    expect(APPROVE).toContain('deed?.retired?.reason');
+    expect(APPROVE).toContain('deed?.retired?.what_to_do');
   });
 
   it('the token page never composes its own scheduling sentence', () => {
@@ -119,8 +129,19 @@ describe('NOTARY1 — a signing request is not an approval request', () => {
     expect(APPROVE).toContain('deed?.can_approve && !showRejectForm');
   });
 
-  it('the notary is told what tapping a time means', () => {
-    expect(flat(APPROVE)).toContain('you are available then');
+  it('a retired link says what happened rather than going quiet', () => {
+    /**
+     * The picker is gone; the visitor holding an old link is not. A page
+     * with no actions and no explanation is invariant #4 wearing an empty
+     * state — the reader cannot tell "retired" from "broken", and only
+     * one of those is theirs to solve.
+     */
+    const flatCode = flat(APPROVE);
+    expect(flatCode).toContain('This scheduling link has been retired');
+    expect(flatCode).toContain('Ask the escrow officer to send a new signing request');
+    // And it no longer offers what it cannot do.
+    expect(codeOnly(APPROVE)).not.toContain('chooseWindow');
+    expect(codeOnly(APPROVE)).not.toContain('pcor_url');
   });
 
   it('a notary is never sent the review reminder', () => {

--- a/frontend/src/app/approve/[token]/page.tsx
+++ b/frontend/src/app/approve/[token]/page.tsx
@@ -21,35 +21,28 @@ import {
 } from 'lucide-react';
 
 /**
- * NOTARY1 — this page now serves two kinds of link.
+ * This page serves two kinds of link, and one of them is retired.
  *
- * A REVIEW share asks somebody to approve or request changes. A SIGNING
- * REQUEST asks a notary one question: are you free at one of these
- * times? It has no approve and no reject — the server refuses both for a
- * signing link, so hiding the buttons here is presentation of a rule
- * rather than the rule itself.
+ * A REVIEW share asks somebody to approve or request changes. That is
+ * the live kind and everything below is about it.
  *
- * `summary` is written by the backend and rendered VERBATIM. There is
- * exactly one place in this product that turns a scheduling state into a
- * sentence, and it is not this file: "scheduled" must never grow into
- * "the signing will happen", and it cannot drift here if the words never
- * originate here.
+ * A SIGNING REQUEST was NOTARY1: the officer proposed times and a notary
+ * tapped one. §13.1 reversed the model, NOTARY2 rebuilt it, and the
+ * routes behind this page's window picker are gone. Nothing can create
+ * such a link any more, so a visitor holding one is holding something
+ * from another era.
+ *
+ * WHAT THAT MEANS FOR THIS FILE: the picker is deleted, and in its place
+ * the page says what happened and what to do. A link that opens onto a
+ * page with no actions and no explanation is invariant #4 wearing an
+ * empty state — the reader cannot tell "retired" from "broken", and only
+ * one of those is theirs to solve. The words come from the server, which
+ * is where the condition is known.
  */
-interface SigningWindow {
-  index: number;
-  start: string;
-  end: string;
-  label: string;
-}
-
-interface SigningDetails {
-  state: 'proposed' | 'scheduled' | null;
-  summary: string | null;
-  windows: SigningWindow[];
-  scheduled_at: string | null;
-  scheduled_by: string | null;
-  can_choose_window: boolean;
-  pcor_url: string;
+interface RetiredNotice {
+  model: string;
+  reason: string;
+  what_to_do: string;
 }
 
 interface DeedDetails {
@@ -65,7 +58,7 @@ interface DeedDetails {
   can_approve: boolean;
   pdf_url?: string;
   share_kind?: string;
-  signing?: SigningDetails;
+  retired?: RetiredNotice;
 }
 
 // Common issues for structured feedback
@@ -94,39 +87,8 @@ export default function ApproveDeedPage() {
   const [showRejectForm, setShowRejectForm] = useState(false);
   const [rejectComments, setRejectComments] = useState('');
   const [selectedIssues, setSelectedIssues] = useState<string[]>([]);
-  const [choosing, setChoosing] = useState<number | null>(null);
 
   const isSigning = deed?.share_kind === 'signing_request';
-
-  const chooseWindow = async (windowIndex: number) => {
-    setChoosing(windowIndex);
-    setError(null);
-    try {
-      const api = process.env.NEXT_PUBLIC_API_URL || 'https://deedpro-main-api.onrender.com';
-      const response = await fetch(`${api}/approve/${token}/schedule`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ window_index: windowIndex }),
-      });
-      const data = await response.json();
-      if (!response.ok) {
-        setError(data.detail || 'That time could not be recorded.');
-        return;
-      }
-      // Re-read rather than patching local state: the summary sentence
-      // is the server's to write, and a locally-composed one is exactly
-      // the drift this design exists to prevent.
-      await fetchDeedDetails();
-    } catch (err) {
-      setError('Unable to connect to server.');
-    } finally {
-      setChoosing(null);
-    }
-  };
-
-  useEffect(() => {
-    fetchDeedDetails();
-  }, [token]);
 
   const fetchDeedDetails = async () => {
     try {
@@ -478,60 +440,23 @@ export default function ApproveDeedPage() {
               </div>
             )}
 
-            {/* NOTARY1 — the signing card. No approve, no reject: the
-                question is availability, and the answer is a time. */}
-            {isSigning && deed?.signing && (
+            {/* NOTARY1's window picker retired with its routes. What is
+                left is the one thing a dead link owes its visitor: what
+                happened, and who can fix it. */}
+            {isSigning && (
               <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6">
                 <h2 className="font-bold text-slate-800 mb-1 flex items-center gap-2">
-                  <CalendarClock className="w-5 h-5 text-[#7C4DFF]" />
-                  Are you available?
+                  <CalendarClock className="w-5 h-5 text-slate-400" />
+                  This scheduling link has been retired
                 </h2>
-                <p className="text-sm text-slate-500 mb-4">
-                  {deed.owner_name} proposed these times. Choosing one tells them you
-                  are available then — they confirm the appointment with the signers.
+                <p className="text-sm text-slate-600 mt-2">
+                  {deed?.retired?.reason ||
+                    'This link was created by an earlier scheduling flow that has been retired. It cannot be used to choose a time.'}
                 </p>
-
-                <div className="space-y-2">
-                  {deed.signing.windows.map((w) => {
-                    const chosen = deed.signing?.scheduled_at === w.start;
-                    return (
-                      <button
-                        key={w.index}
-                        onClick={() => chooseWindow(w.index)}
-                        disabled={choosing !== null || !deed.signing?.can_choose_window}
-                        className={`w-full flex items-center justify-between gap-3 px-4 py-3 rounded-lg border text-left font-medium transition-colors disabled:opacity-60 disabled:cursor-not-allowed ${
-                          chosen
-                            ? 'border-[#7C4DFF] bg-purple-50 text-slate-800'
-                            : 'border-slate-300 text-slate-700 hover:bg-slate-50'
-                        }`}
-                      >
-                        <span className="text-sm">{w.label}</span>
-                        {choosing === w.index ? (
-                          <Loader2 className="w-4 h-4 animate-spin shrink-0" />
-                        ) : chosen ? (
-                          <CheckCircle className="w-4 h-4 text-[#7C4DFF] shrink-0" />
-                        ) : null}
-                      </button>
-                    );
-                  })}
-                </div>
-
-                {/* The server's sentence, verbatim. */}
-                {deed.signing.summary && (
-                  <p className="text-sm text-slate-600 mt-4 pt-4 border-t border-slate-200">
-                    {deed.signing.summary}
-                  </p>
-                )}
-
-                <a
-                  href={`${process.env.NEXT_PUBLIC_API_URL || 'https://deedpro-main-api.onrender.com'}${deed.signing.pcor_url}.pdf`}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="mt-4 inline-flex items-center gap-2 text-sm text-[#7C4DFF] hover:underline"
-                >
-                  <Download className="w-4 h-4" />
-                  Preliminary Change of Ownership Report
-                </a>
+                <p className="text-sm text-slate-600 mt-2">
+                  {deed?.retired?.what_to_do ||
+                    'Ask the escrow officer to send a new signing request.'}
+                </p>
               </div>
             )}
 


### PR DESCRIPTION
Ticket 3. #162 removed NOTARY1's write path on evidence and left four read-side routes **flagged rather than decided**, because a second removal has its own blast radius. This is that second removal — and it turned up a live access-control defect on the way.

## What is gone

| Route | Was |
|---|---|
| `POST /approve/{t}/schedule` | the notary taps one of the officer's windows |
| `POST /shared-deeds/{id}/schedule` | the officer records a time agreed by phone |
| `GET /approve/{t}/pcor` | PCOR status behind a signing link |
| `GET /approve/{t}/pcor.pdf` | the filled PCOR |

**The ledger said three.** `GET /approve/{t}/pcor.pdf` was never in the count.

With them: `_signing_share_by_token`, `_pcor_deed_for_token`, `_tell_the_officer`, the `WindowChoice` / `OfficerSchedule` models, the approve page's window picker, the dead half of `services/signing.py`, and the orphaned `signing_time_recorded` email — which **the email orphan pin caught by itself**, firing downward again, 19 templates to 18.

They were unreachable *by construction* rather than by decision: nothing could create the row they load. That is not the same as harmless. Unreachable code is where a future change makes something live again without anybody choosing it, and where a reader cannot tell "deliberately kept" from "nobody looked".

## The safety argument, and why the trigger's second half needed no survey

Your trigger was the confirmed zero-row count **plus a decision that no other database holds NOTARY1 shares**. Nobody enumerated every database that runs this schema, and it did not need doing, because:

> **The read side was never the recovery path — the migration is.**

`migrate_notary1_signings.py` still reads `deed_shares` directly, still carries a share into the NOTARY2 aggregate, and now names the database it is in before it starts (#167). A row found anywhere is *migrated into the model the product believes in*, not served through one it does not. That is pinned, not asserted in prose.

## Found while doing it, and fixed: a revoked link kept serving the deed

`GET /approve/{token}` checked expiry and **never checked `status = 'revoked'`**. After an officer revoked a share, that URL went on returning deed type, property address, APN, county and both party names — indefinitely, to anybody holding the link.

The PDF route beside it 403s a revoked share. So did `_signing_share_by_token`. **Every existing revocation test went through one of those two** — which is precisely how the gap survived a suite that tests revocation. It surfaced because retargeting a NOTARY1 test onto a *review* share, when its original subject was removed, pointed a revocation assertion at the door nobody had tried.

The rule is the one this handler already states about expiry, and this is the missing half: **honouring a revocation on some URLs and not others is not honouring it.** Revocation is a deliberate act by the officer, not a timer. Recorded under doctrine §6.

## A link from another era says so

Nothing can create such a row, so in production the branch is unreachable — but "unreachable" is a claim about one database, and a visitor holding an old link opening onto a page with no actions and no explanation is **invariant #4 wearing an empty state**: they cannot tell "retired" from "broken", and only one of those is theirs to solve. The server states the condition; the page reads it out.

## Three retargeted pins, each carrying its own justification

A loosened pin and a broken one look identical in a diff, so:

1. **scheduling-never-in-`status`** — the half asserting `SET scheduled_at` *appears* in the router is dropped (nothing writes it now, so it would fail for the right reason). The surviving half now sweeps **every backend source** instead of one file.
2. **"every surface takes its words from one place"** — `>= 4` callers becomes `>= 1`. Three retired. The number was never the property; "no surface composes its own scheduling sentence" is, and that half is untouched.
3. **expiry and revocation as class-rules** — retargeted from a NOTARY1 signing share onto a review share, the live kind.

## Deliberately kept

- **The columns.** A drop is irreversible and was not ruled.
- **The two fail-closed refusals.** They are §13's rule, not NOTARY1's feature: a signing share must never be answered as if it were a review request, because approving one writes an approval into the record on behalf of somebody asked a different question.
- **The vocabulary.** `SHARE_KIND_SIGNING` is how the guards, the shared row contract and the migration *recognise* such a row.

## One fewer copy

`signing_migration` carried its own private `_windows_of`; `services/signing.py` had `windows_of`. They differed — the private one filtered non-dict entries. Converged **onto the filtering behaviour**, flagged in the docstring: the migration's behaviour is unchanged, `windows_of`'s is, and only in the direction of not crashing on data it cannot use.

Also deleted as a *second answer* to a question NOTARY2 answers itself: `normalize_windows` + `MAX_WINDOWS = 3` (NOTARY2 validates its own posts, at five), `find_window`, `window_label` / `window_labels` (`signing_loop.window_label` takes a timezone; this one never did), `window_to_ics`. Two divergent answers to "how many windows" lived here and only one was reachable.

## Discovery — NOT fixed, needs a ruling

**`/signing/{token}/pcor` does not exist. The NOTARY2 signer's PCOR button is a live 404.**

```
services/signing_surfaces.py:192          "pcor_url": f"/signing/{token}/pcor"
frontend/.../signing/[token]/page.tsx:355 href={`${API()}${pkg.pcor_url}.pdf`}
routers/signing.py                        no PCOR handler at all
```

NOTARY1 had a working pair; NOTARY2 advertises them and never built them. Not fixed because the two fixes are different products — build the route (the signer gets the county's companion form) or stop advertising it (the button goes) — and `pcor_url` sits inside `signing_surfaces`' exact-key-set contract, so either way it is a deliberate change, not a repair. The audience is consumers with no account, which is the argument for ruling it soon.

## Verification

Seven pins mutation-probed, all seven caught — including re-adding a retired route, deleting the revocation guard, and breaking the migration's parser identity.

| Gate | Result |
|---|---|
| pytest, with a database | **1109 passed** |
| pytest, no database | **935 passed**, 174 skipped |
| jest | 726 passed, 49 suites |
| `next build` | ✔ |
| tsc | **94** — baseline holds |
| six-flow / API baselines | ✔ |
| banned-claims | clean |

**OpenAPI snapshot re-recorded**, deliberately, per the invariant: the diff is exactly the four removed routes and nothing else (16 lines, all deletions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_