### PR TITLE
The notary's documents exist, and a harness cannot destroy production

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,6 +76,16 @@ jobs:
         sudo apt-get install -y -qq postgresql-client-16
         pg_dump --version
 
+    # The proof harnesses below WRITE ROWS and, in S2's case, drop and
+    # restore a database. They refuse any database that does not carry
+    # the throwaway marker — so the CI database is marked here, once,
+    # explicitly. Production is never marked, which is the whole
+    # mechanism: a mis-pasted DATABASE_URL now fails closed instead of
+    # writing junk into real tables.
+    - name: Mark the CI database as disposable
+      working-directory: backend
+      run: python scripts/mark_scratch_database.py --yes-this-is-a-throwaway-database
+
     # The DB-backed tests, which the no-Postgres job silently skips.
     - name: Backend suite WITH a database
       working-directory: backend

--- a/backend/routers/deeds_crud.py
+++ b/backend/routers/deeds_crud.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field
 import db
 from auth import get_current_user_id
 from database import create_deed
+from services import pcor_offer
 
 router = APIRouter()
 
@@ -545,37 +546,12 @@ def pcor_status_endpoint(deed_id: int, user_id: int = Depends(get_current_user_i
     """Is a PCOR available for this deed's county, and what will it still
     need from the buyer?
 
-    T-3. The PCOR is the conveyance's legally required companion (R&T
-    §480.3 — a deed presented without one may be charged an extra $20 at
-    recording), and roughly the parts a deed already knows are the parts
-    an officer would otherwise retype.
-
-    This returns availability + the ASKS rather than a count or a
-    percentage. We fill nine text fields of sixty-five; "80% prefilled"
-    would be a claim we cannot support, and the standing rule is that
-    claims trace to something real.
+    T-3. The body is built by `services/pcor_offer.py` — the notary now
+    offers the same form from her signing link, and two surfaces offering
+    one document must offer the same shape of it.
     """
-    row = _pcor_deed_row(deed_id, user_id)
-    from services.county_forms import lookup_form
-    from services.boe_form_fill import values_from_deed
-
-    form = lookup_form(row.get("county") or "")
-    if form is None:
-        return {
-            "available": False,
-            "county": row.get("county"),
-            "reason": f"No PCOR on file for {row.get('county') or 'this county'}.",
-        }
-    _values, asks = values_from_deed(row)
-    return {
-        "available": True,
-        "county": form.county,
-        "form_code": form.form_code,
-        "revision": form.revision,
-        "county_revision": form.county_revision,
-        "url": f"/deeds/{deed_id}/pcor.pdf",
-        "still_needed": asks,
-    }
+    return pcor_offer.status(_pcor_deed_row(deed_id, user_id),
+                             f"/deeds/{deed_id}/pcor.pdf")
 
 
 @router.get("/deeds/{deed_id}/pcor.pdf")
@@ -587,20 +563,8 @@ def pcor_download_endpoint(deed_id: int, user_id: int = Depends(get_current_user
     somebody else must complete and sign would be the wrong kind of
     faithful.
     """
-    from services.boe_form_fill import PcorUnavailable, fill_pcor
-
-    row = _pcor_deed_row(deed_id, user_id)
-    try:
-        pdf_bytes, _asks = fill_pcor(row)
-    except PcorUnavailable as e:
-        raise HTTPException(status_code=404, detail=str(e))
-
-    return Response(
-        content=pdf_bytes,
-        media_type="application/pdf",
-        headers={"Content-Disposition":
-                 f'attachment; filename="PCOR-deed-{deed_id}.pdf"'},
-    )
+    return pcor_offer.download(_pcor_deed_row(deed_id, user_id),
+                               f"PCOR-deed-{deed_id}.pdf")
 
 
 def _pcor_deed_row(deed_id: int, user_id: int) -> dict:

--- a/backend/routers/signing.py
+++ b/backend/routers/signing.py
@@ -28,11 +28,12 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import Response
 from pydantic import BaseModel, Field
 
 import db
 from auth import get_current_user_id
-from services import officer_queue
+from services import officer_queue, pcor_offer
 from services import signing_loop as loop
 from services import signing_purge, signing_surfaces
 from utils.throttle import client_key, throttle
@@ -635,6 +636,105 @@ def token_view(token: str, http_request: Request):
         request=world["request"], me=me, participants=world["participants"],
         windows=world["windows"], responses=world["responses"],
         deed=world["deed"], officer=world["officer"])
+
+
+# ── The notary's documents ───────────────────────────────────────────
+#
+# THESE ROUTES WERE ADVERTISED BEFORE THEY EXISTED. `notary_package`
+# has sent `pcor_url` and `pdf_url` since NOTARY2 shipped, and the
+# notary's screen has rendered both as download links — against handlers
+# that were never written. Two live 404s on a consumer-facing surface,
+# found while retiring NOTARY1 (which had working equivalents behind its
+# own token) and ruled BUILD rather than remove: the capability is real,
+# the PCOR is filled from the deed's own data, and the notary handing it
+# to the buyer at the signing table is the workflow.
+#
+# THE TOKEN IS THE AUTHORITY, and it means exactly what it means
+# everywhere else: `_participant_by_token` has already refused a withdrawn
+# link (403) and an expired one (410) before either handler runs. "Which
+# URL did you ask" is not a property a permission may have — the same
+# ruling that governs the review link's deed, PDF and expiry.
+#
+# NOTARY-ONLY, ENFORCED HERE. `signer_package` does not carry these URLs,
+# but a package that omits a link is presentation; this is the rule. A
+# signer gets the street line and their times, and neither the instrument
+# nor the buyer's tax form.
+
+
+def _notary_or_404(me: Dict[str, Any]) -> None:
+    """404, not 403, for a signer asking after the notary's documents.
+
+    Same reasoning as `_owned_request`: "it exists but is not yours"
+    turns a probe into an inventory. A signer holding a valid link learns
+    nothing from asking.
+    """
+    if me.get("party_role") != loop.ROLE_NOTARY:
+        raise HTTPException(status_code=404, detail="This link is not valid")
+
+
+@router.get("/signing/{token}/pcor")
+def token_pcor_status(token: str, http_request: Request):
+    """Is there a PCOR for this deed's county, and what will it still need.
+
+    The body is `services/pcor_offer.status` — the same shape the officer
+    sees from her own deed, because two surfaces offering one document
+    must offer the same document.
+    """
+    me = _participant_by_token(token, http_request)
+    _notary_or_404(me)
+    world = _load(me["signing_request_id"])
+    return pcor_offer.status(world["deed"], f"/signing/{token}/pcor.pdf")
+
+
+@router.get("/signing/{token}/pcor.pdf")
+def token_pcor_download(token: str, http_request: Request):
+    """The filled PCOR, unflattened — the buyer still has to finish it.
+
+    Not stored and not hashed: doctrine §9 freezes the instrument because
+    the instrument is ours. This is the buyer's form.
+    """
+    me = _participant_by_token(token, http_request)
+    _notary_or_404(me)
+    world = _load(me["signing_request_id"])
+    return pcor_offer.download(
+        world["deed"], f"PCOR-deed-{world['deed'].get('id')}.pdf")
+
+
+@router.get("/signing/{token}/pdf")
+def token_deed_pdf(token: str, http_request: Request):
+    """The stored instrument, for the notary who has to notarise it.
+
+    Served from `deed_pdfs` — the stored bytes, not a re-render — because
+    the document she signs must be the document that was generated. A
+    deed with no stored PDF says so rather than returning an empty
+    response somebody would mistake for a blank form.
+    """
+    me = _participant_by_token(token, http_request)
+    _notary_or_404(me)
+    world = _load(me["signing_request_id"])
+    deed = world["deed"]
+
+    with db.conn.cursor() as cur:
+        # `deed_id` IS the primary key — one stored instrument per deed,
+        # never overwritten (§9). There is no "latest" to order by, and a
+        # query that asked for one would be describing a history this
+        # table deliberately does not keep.
+        cur.execute("SELECT pdf_data FROM deed_pdfs WHERE deed_id = %s",
+                    (deed.get("id"),))
+        stored = cur.fetchone()
+    pdf_data = (dict(stored).get("pdf_data") if stored else None)
+
+    if not pdf_data:
+        # §4: a missing document is a stated condition, not an empty body.
+        raise HTTPException(
+            status_code=404,
+            detail="The deed PDF has not been generated yet. The escrow "
+                   "officer can generate it from the DeedPro dashboard.")
+
+    address = (deed.get("property_address") or "deed").split(",")[0]
+    safe = f"{deed.get('deed_type') or 'deed'}_{address}".replace(" ", "_")[:50]
+    return Response(content=bytes(pdf_data), media_type="application/pdf",
+                    headers={"Content-Disposition": f'inline; filename="{safe}.pdf"'})
 
 
 @router.post("/signing/{token}/windows")

--- a/backend/scripts/mark_scratch_database.py
+++ b/backend/scripts/mark_scratch_database.py
@@ -1,0 +1,81 @@
+"""Declare a database disposable, so the destructive harnesses will run.
+
+`s1_concurrency_proof` and `s2_restore_drill` insert users and deeds, and
+`s2` runs `pg_dump` and `pg_restore`. They now refuse any database that
+does not carry the marker this script creates.
+
+    DATABASE_URL=postgresql://... python scripts/mark_scratch_database.py \
+        --yes-this-is-a-throwaway-database
+
+═══ WHY THE FLAG IS SPELLED LIKE THAT ═══
+
+Nothing here can stop somebody marking production — no code can. What it
+can do is make the two acts LOOK DIFFERENT. Mis-pasting a DATABASE_URL is
+easy and common; typing `--yes-this-is-a-throwaway-database` while
+looking at an identity line that reads `deedpro` is not something anybody
+does by accident.
+
+So the script prints WHICH database it is about to mark, before it marks
+it, and refuses without the flag. The safety is in the shape of the
+mistake, not in a promise that no mistake is possible — see
+`services/db_identity.assert_scratch` for the full reasoning, including
+what was rejected: an `ALLOW_DESTRUCTIVE_TESTS` variable somebody sets
+and forgets, and matching production by NAME, which fails the moment a
+second production-shaped database exists.
+
+Exit codes: 0 marked (or already marked), 1 refused.
+"""
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+FLAG = "--yes-this-is-a-throwaway-database"
+
+
+def main() -> int:
+    url = os.getenv("DATABASE_URL")
+    if not url:
+        print("DATABASE_URL is not set — refusing to guess at a database",
+              file=sys.stderr)
+        return 1
+
+    import psycopg2
+    from services.db_identity import (SCRATCH_MARKER, describe, is_scratch,
+                                      mark_scratch)
+
+    conn = psycopg2.connect(url)
+    try:
+        where = describe(conn)
+        if is_scratch(conn):
+            print(f"already marked: {where}")
+            return 0
+
+        # The identity line comes FIRST, and before the refusal, so that
+        # the operator who forgot the flag has already read which
+        # database they were pointed at.
+        print(f"about to mark as a THROWAWAY database: {where}")
+        print(f"  this creates the table `{SCRATCH_MARKER}` and allows the")
+        print("  destructive proof harnesses to write and drop data here.")
+
+        if FLAG not in sys.argv:
+            print(f"\nrefusing without {FLAG}", file=sys.stderr)
+            print("If the line above names production, that refusal is the "
+                  "point.", file=sys.stderr)
+            return 1
+
+        mark_scratch(conn)
+        conn.commit()
+        print(f"marked: {where}")
+        return 0
+    except Exception as e:
+        conn.rollback()
+        print(f"marking failed: {type(e).__name__}: {e}", file=sys.stderr)
+        return 1
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/s1_concurrency_proof.py
+++ b/backend/scripts/s1_concurrency_proof.py
@@ -42,6 +42,28 @@ DURATION_S = int(os.getenv("S1_DURATION", "10"))
 failures = []
 
 
+def _refuse_unless_disposable() -> None:
+    """This harness writes rows. It runs where that is harmless, or not
+    at all.
+
+    Marker-based rather than name-based: a blacklist of production names
+    fails the moment a second production-shaped database exists, and an
+    `ALLOW_DESTRUCTIVE_TESTS` variable is an opt-in somebody sets and
+    forgets. See `services/db_identity.assert_scratch`.
+    """
+    from services.db_identity import WrongDatabase, assert_scratch, describe
+    conn = psycopg2.connect(DB_URL, connect_timeout=10)
+    try:
+        try:
+            assert_scratch(conn)
+        except WrongDatabase as wrong:
+            print(str(wrong))
+            sys.exit(1)
+        print(f"  database: {describe(conn)}\n")
+    finally:
+        conn.close()
+
+
 def check(label, ok, detail=""):
     print(f"  {'PASS' if ok else 'FAIL'}  {label}{(' — ' + detail) if detail else ''}")
     if not ok:
@@ -285,6 +307,7 @@ def part3_burst(client):
 
 if __name__ == "__main__":
     print("RED-S1 concurrency proof")
+    _refuse_unless_disposable()
     part1_induced_failure()
     part2_load()
     print()

--- a/backend/scripts/s2_restore_drill.py
+++ b/backend/scripts/s2_restore_drill.py
@@ -64,6 +64,28 @@ RESTORE_DB = os.getenv("S2_RESTORE_DB", "deedpro_restore_drill")
 failures = []
 
 
+def _refuse_unless_disposable() -> None:
+    """This harness writes rows. It runs where that is harmless, or not
+    at all.
+
+    Marker-based rather than name-based: a blacklist of production names
+    fails the moment a second production-shaped database exists, and an
+    `ALLOW_DESTRUCTIVE_TESTS` variable is an opt-in somebody sets and
+    forgets. See `services/db_identity.assert_scratch`.
+    """
+    from services.db_identity import WrongDatabase, assert_scratch, describe
+    conn = psycopg2.connect(DB_URL, connect_timeout=10)
+    try:
+        try:
+            assert_scratch(conn)
+        except WrongDatabase as wrong:
+            print(str(wrong))
+            sys.exit(1)
+        print(f"  database: {describe(conn)}\n")
+    finally:
+        conn.close()
+
+
 def check(label, ok, detail=""):
     print(f"  {'PASS' if ok else 'FAIL'}  {label}{(' — ' + detail) if detail else ''}")
     if not ok:
@@ -85,6 +107,7 @@ def restore_url():
 
 def main():
     print("RED-S2 restore drill\n")
+    _refuse_unless_disposable()
 
     from services.artifact_store import artifact_key, get_store, reset_store
     reset_store()

--- a/backend/services/db_identity.py
+++ b/backend/services/db_identity.py
@@ -192,3 +192,83 @@ def assert_tables(conn, *names: str, expect_database: str = "") -> Dict[str, Any
         "the schema has not been created on this one. The message names "
         "both so you do not have to guess which."
     )
+
+
+# ── Is this a database I may destroy? ────────────────────────────────
+
+SCRATCH_MARKER = "deedpro_scratch_database"
+
+MARK_COMMAND = ("python scripts/mark_scratch_database.py "
+                "--yes-this-is-a-throwaway-database")
+
+
+def is_scratch(conn) -> bool:
+    """Does this database carry the throwaway marker."""
+    return not missing_tables(conn, [SCRATCH_MARKER])
+
+
+def assert_scratch(conn) -> Dict[str, Any]:
+    """Refuse to run a destructive harness against an unmarked database.
+
+    ═══ WHY A MARKER AND NOT A FLAG OR A NAME ═══
+
+    `s1_concurrency_proof` and `s2_restore_drill` insert users and deeds
+    into whatever `DATABASE_URL` points at, and `s2` runs `pg_dump` and
+    `pg_restore`. Pointed at production they would write junk rows into
+    real tables. Three mechanisms were considered and two were rejected:
+
+      - `ALLOW_DESTRUCTIVE_TESTS=1` — an opt-in somebody eventually sets
+        and forgets. A variable left set is indistinguishable from one
+        set on purpose, and the forgetting is silent.
+      - matching the production database NAME — fails the moment a second
+        production-shaped database exists, which is precisely the
+        situation this codebase just lived through.
+
+    Both of those BLACKLIST the dangerous thing. A marker table
+    WHITELISTS the safe one: throwaway databases carry it, production
+    never will, and the check is a positive fact rather than the absence
+    of a negative one. `EXPECTED_DATABASE` above is the same reasoning
+    pointed the other way — name the expected thing, never enumerate the
+    dangerous ones.
+
+    ═══ THE HONEST BOUND ═══
+
+    Creating the marker is itself a deliberate act, and nothing here can
+    stop somebody running the marking script against production. What
+    changes is the SHAPE of the mistake: "I pasted the wrong
+    DATABASE_URL" no longer destroys data, because a second, explicit,
+    differently-worded act is required first. Mis-pasting is common;
+    declaring production a throwaway database is not.
+    """
+    if is_scratch(conn):
+        return identity(conn)
+
+    who = identity(conn)
+    raise WrongDatabase(
+        f"{who['database']} on {who['host']}:{who['port']} is not marked as "
+        "a throwaway database, and this harness writes rows and drops "
+        "data. Refusing.\n\n"
+        f"If {who['database']} really is disposable, mark it once:\n"
+        f"    DATABASE_URL=... {MARK_COMMAND}\n\n"
+        "If it is not, this message is doing its job — check DATABASE_URL."
+    )
+
+
+def mark_scratch(conn) -> None:
+    """Declare this database disposable. Deliberate, never automatic.
+
+    Kept out of `create_tables` on purpose: the schema authority runs
+    against production on every boot, and a marker it created would mark
+    the one database that must never carry it.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            f"CREATE TABLE IF NOT EXISTS {SCRATCH_MARKER} ("
+            "  marked_at TIMESTAMPTZ NOT NULL DEFAULT now(),"
+            "  marked_by TEXT NOT NULL,"
+            "  note TEXT"
+            ")")
+        cur.execute(
+            f"INSERT INTO {SCRATCH_MARKER} (marked_by, note) VALUES (%s, %s)",
+            (identity(conn)["user"],
+             "Declared disposable. Destructive harnesses may run here."))

--- a/backend/services/environment.py
+++ b/backend/services/environment.py
@@ -129,10 +129,13 @@ MANIFEST: Tuple[EnvVar, ...] = (
            "than trusting them — the failure is closed, not silent. If "
            "that ever changes this becomes REQUIRED in the same diff."),
     EnvVar("PYTHON_VERSION", OPTIONAL,
-           "Read by Render at BUILD time, never by this process. Listed "
-           "because render.yaml declares it and the manifest is checked "
-           "against that file; classifying it required would make every "
-           "local run warn about a variable it has no use for."),
+           "Read by Render at BUILD time, never by this process — so "
+           "nothing in this module could ever see it, and this entry is "
+           "the record of that limit rather than a check. Confirmed the "
+           "hard way on 2026-08-12: it is declared in render.yaml and "
+           "still had to be set by hand in the dashboard. Declaring a "
+           "variable does not apply it; the boot report catches drift "
+           "only for REQUIRED variables the process reads at runtime."),
 )
 
 BY_KEY: Dict[str, EnvVar] = {v.key: v for v in MANIFEST}

--- a/backend/services/environment.py
+++ b/backend/services/environment.py
@@ -103,9 +103,30 @@ MANIFEST: Tuple[EnvVar, ...] = (
            "checkout failed at Stripe with an error about a price that "
            "was never real. Fail loudly with a named reason, never fall "
            "back to a placeholder."),
-    EnvVar("ALLOWED_ORIGINS", REQUIRED,
-           "CORS. Wrong or absent, the browser refuses every call and the "
-           "product looks broken with nothing in the server log."),
+    # ⚠️ THIS ENTRY WAS WRONG, AND THE CORRECTION MATTERS MORE THAN THE
+    # ENTRY. It said CORS breaks without this variable. **Nothing reads
+    # it.** `main.py` hardcodes its origin list, and a grep of the whole
+    # backend finds this name in exactly one place: here, declaring it
+    # required.
+    #
+    # The boot check named it missing on the first production deploy, the
+    # owner set it on the strength of that, and setting it changed
+    # nothing — because the claim it was acting on was mine and it was
+    # false. A manifest that is believed is a manifest that has to be
+    # right.
+    #
+    # Classified OPTIONAL because that is the truth about its ABSENCE:
+    # nothing changes. It is not deleted, because `render.yaml` declares
+    # it and the two files are checked against each other — and because
+    # the open question is whether `main.py` should read it, which is a
+    # production CORS change and the owner's to rule. See the ledger.
+    EnvVar("ALLOWED_ORIGINS", OPTIONAL,
+           "Read by NOTHING today. `main.py` hardcodes `allow_origins` "
+           "and never consults this name, so its absence changes no "
+           "behaviour and setting it changes none either. Declared here "
+           "and in render.yaml, which is how it came to be set on a "
+           "service that does not consume it. Pending an owner ruling on "
+           "whether CORS should be configured from it."),
     EnvVar("SENDGRID_API_KEY", OPTIONAL,
            "No email leaves the building. OPTIONAL and it is a close "
            "call: the product degrades honestly — every sender returns "

--- a/backend/services/pcor_offer.py
+++ b/backend/services/pcor_offer.py
@@ -1,0 +1,95 @@
+"""The PCOR offer — one shape, wherever it is offered from.
+
+═══ WHY THIS MODULE EXISTS ═══
+
+The PCOR is the conveyance's legally required companion (R&T §480.3 — a
+deed presented without one may be charged an extra $20 at recording), and
+roughly the parts a deed already knows are the parts somebody would
+otherwise retype.
+
+Three surfaces offer it, and they must offer the SAME THING:
+
+  - the officer, from her own deed        (`/deeds/{id}/pcor`)
+  - the notary, from her signing link     (`/signing/{token}/pcor`)
+  - and whatever asks next
+
+Before this module there were two copies of the availability body — one
+in `routers/deeds_crud.py`, one in the NOTARY1 route retired in #170 —
+and they had already drifted in their filename. Standing rule: when a new
+surface needs an existing judgement, the answer is never a second copy.
+This ticket adds a surface and ends with one fewer.
+
+═══ WHAT THE STATUS BODY SAYS, AND WHAT IT REFUSES TO SAY ═══
+
+Availability, the form's identity, and the **asks** — the fields the
+buyer must still complete. Not a count and not a percentage. We fill nine
+text fields of sixty-five; "80% prefilled" would be a claim we cannot
+support, and every claim this product makes has to trace to something
+real.
+
+═══ UNFLATTENED, NEVER STORED, NEVER HASHED ═══
+
+Doctrine §9 freezes the stored instrument because the instrument is ours.
+**The PCOR is not.** It is the buyer's form, they must complete and sign
+it, and freezing a document somebody else has to finish would be the
+wrong kind of faithful. So it is generated on demand, handed over
+editable, and no copy is kept.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from fastapi import HTTPException
+from fastapi.responses import Response
+
+
+def status(deed: Dict[str, Any], download_url: str) -> Dict[str, Any]:
+    """Is there a PCOR for this deed's county, and what will it still need.
+
+    `download_url` is the caller's, because the route that offers the
+    form is the route that should serve it — an officer's link and a
+    notary's link are scoped differently and must not be handed each
+    other's URL.
+    """
+    from services.boe_form_fill import values_from_deed
+    from services.county_forms import lookup_form
+
+    county = deed.get("county") or ""
+    form = lookup_form(county)
+    if form is None:
+        return {
+            "available": False,
+            "county": deed.get("county"),
+            "reason": f"No PCOR on file for {deed.get('county') or 'this county'}.",
+        }
+    _values, asks = values_from_deed(deed)
+    return {
+        "available": True,
+        "county": form.county,
+        "form_code": form.form_code,
+        "revision": form.revision,
+        "county_revision": form.county_revision,
+        "url": download_url,
+        "still_needed": asks,
+    }
+
+
+def download(deed: Dict[str, Any], filename: str) -> Response:
+    """The filled PCOR, unflattened, as an attachment.
+
+    A county with no form on file is a 404 with the reason attached
+    rather than an empty PDF — invariant #4: the caller learns which of
+    "we cannot" and "there is nothing" applies.
+    """
+    from services.boe_form_fill import PcorUnavailable, fill_pcor
+
+    try:
+        pdf_bytes, _asks = fill_pcor(deed)
+    except PcorUnavailable as e:
+        raise HTTPException(status_code=404, detail=str(e))
+
+    return Response(
+        content=pdf_bytes,
+        media_type="application/pdf",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/backend/tests/snapshots/openapi_routes.json
+++ b/backend/tests/snapshots/openapi_routes.json
@@ -293,6 +293,18 @@
  ],
  [
   "GET",
+  "/signing/{token}/pcor"
+ ],
+ [
+  "GET",
+  "/signing/{token}/pcor.pdf"
+ ],
+ [
+  "GET",
+  "/signing/{token}/pdf"
+ ],
+ [
+  "GET",
   "/usage/limit-check/user/{user_id}"
  ],
  [

--- a/backend/tests/test_db_identity.py
+++ b/backend/tests/test_db_identity.py
@@ -55,8 +55,9 @@ from pathlib import Path
 
 import pytest
 
-from services.db_identity import (WrongDatabase, assert_tables, describe,
-                                  expected_database, identity, missing_tables)
+from services.db_identity import (MARK_COMMAND, SCRATCH_MARKER, WrongDatabase, assert_scratch,
+                                  assert_tables, describe, expected_database,
+                                  identity, is_scratch, missing_tables)
 from tests.source_text import code_only
 
 BACKEND = Path(__file__).resolve().parents[1]
@@ -220,14 +221,17 @@ EXEMPT = {
         "CREATE TABLE IF NOT EXISTS for the cache table. Its table is "
         "its output, not its precondition — same reason as init_db.",
     "s1_concurrency_proof.py":
-        "CI proof harness against a disposable database. The tables it "
-        "needs exist in production too, so asserting them would pass "
-        "there — the protection this one needs is a different one, and "
-        "it is ledgered rather than faked here.",
+        "Asserts the SCRATCH MARKER instead. Its tables exist in "
+        "production too, so asserting them would pass there — the check "
+        "it needs is 'may I destroy this', and that is assert_scratch.",
     "s2_restore_drill.py":
-        "Same as s1 — and it dumps and restores, so the check it wants "
-        "is 'is this a throwaway database', which this module does not "
-        "answer.",
+        "Same as s1, and it dumps and restores, so the same answer: the "
+        "marker, not the tables.",
+    "mark_scratch_database.py":
+        "Creates the marker. Asserting the marker exists before the run "
+        "whose job is to create it is backwards — same shape as init_db, "
+        "and it demands an explicit flag and prints the identity line "
+        "first, which the others do not.",
 }
 
 
@@ -257,6 +261,106 @@ def test_every_write_side_script_names_its_database_or_argues_why_not():
     stale = sorted(set(EXEMPT) - writers)
     assert stale == [], (
         "exempted but no longer a write-side script: " + ", ".join(stale))
+
+
+def test_an_unmarked_database_is_refused_and_the_message_says_how_to_mark_it():
+    """The behaviour, not the source. An unmarked database gets a refusal
+    that names it and carries the exact command — invariant #4: the
+    failure states its own remedy, because the alternative is somebody
+    guessing and reaching for the blunt instrument."""
+    with pytest.raises(WrongDatabase) as raised:
+        assert_scratch(_Conn(DICT_ROW, present=False))
+    message = str(raised.value)
+    assert "deedpro" in message                          # which database
+    assert "not marked" in message
+    assert "mark_scratch_database.py" in message         # and how
+    assert "--yes-this-is-a-throwaway-database" in message
+
+
+def test_a_marked_database_is_silent():
+    assert is_scratch(_Conn(DICT_ROW, present=True)) is True
+    who = assert_scratch(_Conn(DICT_ROW, present=True))
+    assert who["database"] == "deedpro"
+
+
+def test_the_marker_is_a_positive_fact_not_the_absence_of_a_negative():
+    """The whole argument for this shape over the two rejected ones.
+
+    `ALLOW_DESTRUCTIVE_TESTS` is an opt-in somebody sets and forgets, and
+    a variable left set is indistinguishable from one set on purpose.
+    Name-matching production fails the moment a second production-shaped
+    database exists — which is the situation this codebase just lived
+    through. Both blacklist the dangerous thing; a marker whitelists the
+    safe one.
+    """
+    src = code_only(BACKEND / "services" / "db_identity.py")
+    assert "ALLOW_DESTRUCTIVE" not in src, (
+        "the guard grew an environment-variable opt-in")
+    assert SCRATCH_MARKER in src
+    # No production database is named anywhere in the mechanism.
+    assert "deedpro_prod" not in src
+
+    # AND THE MARKER IS NOT A TABLE THE SCHEMA CREATES. This is the one
+    # that makes the whole guard real: `create_tables` runs against
+    # production on every boot, so a marker it happened to create — or a
+    # marker that named an ordinary application table — would mark the
+    # one database that must never carry it.
+    schema = code_only(BACKEND / "database.py")
+    assert SCRATCH_MARKER not in schema, (
+        f"{SCRATCH_MARKER} is created by the schema authority, so every "
+        "database has it and the guard passes everywhere")
+
+
+def test_the_destructive_harnesses_refuse_an_unmarked_database():
+    """Exempt from `assert_tables` is not exempt from a guard.
+
+    These two write rows and, in S2's case, drop and restore a database.
+    `assert_tables` would pass against production — production HAS those
+    tables — so the check they need is the opposite one: a positive
+    marker only a throwaway database carries.
+
+    Rejected on the way here, and both for the same reason: an
+    `ALLOW_DESTRUCTIVE_TESTS` opt-in is a variable somebody sets and
+    forgets, and matching production by NAME fails the moment a second
+    production-shaped database exists. Both blacklist the dangerous
+    thing; the marker whitelists the safe one.
+    """
+    for name in ("s1_concurrency_proof.py", "s2_restore_drill.py"):
+        src = code_only(SCRIPTS / name)
+        assert "assert_scratch(" in src, (
+            f"{name} writes rows and no longer checks whether it may — "
+            "call services.db_identity.assert_scratch()")
+        assert "sys.exit(1)" in src, f"{name} does not stop on a refusal"
+
+
+def test_nothing_marks_a_database_disposable_by_accident():
+    """THE ONE THING THAT MUST NOT LEAK. `create_tables` runs against
+    production on every boot; a marker it created would mark the one
+    database that must never carry it."""
+    offenders = []
+    for path in BACKEND.rglob("*.py"):
+        if {"tests", "__pycache__", "venv", ".venv"} & set(path.parts):
+            continue
+        if path.name in ("db_identity.py", "mark_scratch_database.py"):
+            continue
+        if "mark_scratch" in code_only(path):
+            offenders.append(str(path.relative_to(BACKEND)))
+    assert offenders == [], (
+        "something other than the marking script marks a database "
+        "disposable: " + ", ".join(offenders))
+
+
+def test_marking_requires_an_explicit_flag():
+    """Nothing can stop somebody marking production. What this changes is
+    the SHAPE of the mistake: mis-pasting a DATABASE_URL is common,
+    typing `--yes-this-is-a-throwaway-database` under an identity line
+    reading `deedpro` is not."""
+    src = code_only(SCRIPTS / "mark_scratch_database.py")
+    assert 'FLAG = "--yes-this-is-a-throwaway-database"' in src
+    assert "if FLAG not in sys.argv:" in src
+    # And the identity line is printed BEFORE the refusal, so the person
+    # who forgot the flag has already read which database they were on.
+    assert src.index("about to mark") < src.index("refusing without")
 
 
 @pytest.mark.parametrize("name,reason", sorted(EXEMPT.items()))
@@ -385,6 +489,38 @@ def _run_purge(url: str, *args, expected: str = ""):
     return subprocess.run(
         [sys.executable, "scripts/purge_signer_contact.py", *args],
         cwd=BACKEND, env=env, capture_output=True, text=True, timeout=120)
+
+
+@dbonly
+def test_the_marker_is_read_from_the_database_not_from_a_stub():
+    """The stub above cannot tell one table name from another — it answers
+    "present" to everything — so the marker's identity is checked here,
+    against a real catalog.
+
+    The maintenance database is the control: same server, real connection,
+    and it will never carry the marker.
+    """
+    import psycopg2
+    real = os.environ["DATABASE_URL"]
+    marked = psycopg2.connect(real)
+    try:
+        assert is_scratch(marked) is True, (
+            "the test database is not marked — CI marks it in the "
+            f"proof-harnesses job; locally run: {MARK_COMMAND}")
+    finally:
+        marked.close()
+
+    sibling = _sibling_url(real, "postgres")
+    if sibling == real:
+        pytest.skip("DATABASE_URL already points at the maintenance database")
+    control = psycopg2.connect(sibling)
+    try:
+        assert is_scratch(control) is False
+        with pytest.raises(WrongDatabase) as raised:
+            assert_scratch(control)
+        assert "postgres" in str(raised.value)
+    finally:
+        control.close()
 
 
 @dbonly

--- a/backend/tests/test_notary2_documents.py
+++ b/backend/tests/test_notary2_documents.py
@@ -1,0 +1,329 @@
+"""The notary's documents exist, and a link nobody built cannot ship again.
+
+═══ THE DEFECT ═══
+
+`notary_package` has advertised `pcor_url` and `pdf_url` since NOTARY2
+shipped. The notary's screen has rendered both as download buttons. **The
+handlers were never written** — `routers/signing.py` had no PCOR route
+and no PDF route at all, so both buttons were live 404s on a surface
+whose audience has no account, no history and no way to tell a broken
+product from a broken link.
+
+NOTARY1 had working equivalents behind its own token. They were removed
+in #170, which is how this surfaced: retiring a feature turned up its
+replacement advertising a capability it had never built.
+
+Owner-ruled BUILD rather than remove: the PCOR is real, it is filled from
+the deed's own data, and the notary handing it to the buyer at the
+signing table is the workflow.
+
+═══ WHAT THESE PINS PROTECT ═══
+
+ 1. EVERY ADVERTISED URL RESOLVES. The class fix, and the one that would
+    have caught this on the day it was written. A package that hands out
+    a link the app cannot serve is a promise made by a surface that
+    cannot keep it.
+
+ 2. THE TOKEN MEANS THE SAME THING ON EVERY URL. Withdrawn is 403 and
+    expired is 410 on the deed, the PDF and the PCOR alike — "which URL
+    did you ask" is not a property a permission may have.
+
+ 3. NOTARY-ONLY, ENFORCED SERVER-SIDE. `signer_package` omits the links,
+    but a package that omits a link is presentation. A signer asking
+    directly gets 404 — not 403, because "it exists but is not yours"
+    turns a probe into an inventory.
+
+ 4. ONE DOCUMENT, TWO SURFACES, ONE SHAPE. The officer and the notary get
+    the same availability body from the same module. Two copies of it had
+    already drifted before this ticket.
+
+ 5. NOT STORED, NOT HASHED, NOT FLATTENED. Doctrine §9 freezes the
+    instrument because the instrument is ours. The PCOR is the buyer's,
+    they must sign it, and a frozen copy of somebody else's unfinished
+    form is the wrong kind of faithful.
+"""
+from __future__ import annotations
+
+import os
+import re
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+from tests.source_text import code_only
+
+BACKEND = Path(__file__).resolve().parents[1]
+SURFACES = BACKEND / "services" / "signing_surfaces.py"
+
+dbonly = pytest.mark.skipif(not os.getenv("DATABASE_URL"),
+                            reason="needs a database")
+
+
+def _routes():
+    import main
+    return {(m, getattr(r, "path", ""))
+            for r in main.app.routes
+            for m in (getattr(r, "methods", set()) or set())}
+
+
+def _shape(path: str) -> str:
+    """`/signing/{token}/pcor` and `/signing/{tok}/pcor` are one route.
+
+    Both sides are normalised so the pin compares SHAPES: the name a
+    package happens to give its f-string variable is not the property
+    being checked.
+    """
+    return re.sub(r"\{[^}]*\}", "{}", path)
+
+
+# ══════════════════════════════════════════════════════════════════════
+# 1. Every advertised URL resolves — the class fix
+# ══════════════════════════════════════════════════════════════════════
+
+def test_every_url_a_package_advertises_is_a_route_that_exists():
+    """THE PIN THAT WOULD HAVE CAUGHT THIS.
+
+    `pcor_url` and `pdf_url` sat in the notary's package for a whole
+    feature's lifetime, rendered as buttons, pointing at nothing. Nothing
+    compared the two lists, so nothing could notice.
+
+    Matched as a SHAPE across the whole surfaces module rather than as
+    two known keys, because the next advertised link will be written by
+    somebody who never read this file.
+    """
+    src = code_only(SURFACES)
+    advertised = re.findall(r'"[a-z_]*url":\s*f?"([^"]+)"', src)
+    assert advertised, "the URL pin found nothing to check — has the shape changed?"
+
+    known = {_shape(p) for _m, p in _routes()}
+    missing = [u for u in advertised if _shape(u) not in known]
+    assert missing == [], (
+        "a signing package advertises links the app cannot serve: "
+        + ", ".join(missing) +
+        " — either build the route or stop putting it in the package; a "
+        "button that 404s is worse than one that is absent")
+
+
+def test_the_notary_documents_are_registered():
+    routes = _routes()
+    for expected in (("GET", "/signing/{token}/pcor"),
+                     ("GET", "/signing/{token}/pcor.pdf"),
+                     ("GET", "/signing/{token}/pdf")):
+        assert expected in routes, f"{expected} is missing"
+
+
+# ══════════════════════════════════════════════════════════════════════
+# 2. One document, one shape
+# ══════════════════════════════════════════════════════════════════════
+
+def test_both_surfaces_build_the_status_body_from_one_module():
+    """Two copies of this body existed before this ticket — one in
+    `deeds_crud`, one in the NOTARY1 route retired in #170 — and they had
+    already drifted in their filename. The ticket that added a third
+    surface ends with one."""
+    crud = code_only(BACKEND / "routers" / "deeds_crud.py")
+    token = code_only(BACKEND / "routers" / "signing.py")
+    for src, name in ((crud, "deeds_crud"), (token, "signing")):
+        assert "pcor_offer.status(" in src, f"{name} builds its own body"
+        assert "pcor_offer.download(" in src, f"{name} builds its own download"
+    # And neither one reaches past the module to the form layer directly.
+    for src, name in ((crud, "deeds_crud"), (token, "signing")):
+        assert "values_from_deed" not in src, (
+            f"{name} assembles the availability body itself again")
+
+
+def test_the_pcor_is_never_stored_or_hashed():
+    """Doctrine §9 freezes the stored instrument because the instrument
+    is ours. The PCOR is the buyer's form — they must complete and sign
+    it — and a frozen copy of somebody else's unfinished document is the
+    wrong kind of faithful."""
+    src = code_only(BACKEND / "services" / "pcor_offer.py")
+    for forbidden in ("sha256", "INSERT INTO", "artifact", "store("):
+        assert forbidden not in src, (
+            f"the PCOR path grew a {forbidden!r} — it is generated on "
+            "demand, handed over editable, and no copy is kept")
+
+
+def test_a_county_with_no_form_says_so_rather_than_returning_a_blank():
+    from services import pcor_offer
+
+    body = pcor_offer.status({"county": "Nowhere"}, "/x")
+    assert body["available"] is False
+    assert "Nowhere" in body["reason"]
+    # Invariant #4: the reader learns WHICH of "we cannot" and "there is
+    # nothing" applies.
+    assert "still_needed" not in body
+
+
+def test_the_status_body_offers_asks_and_not_a_percentage():
+    """We fill nine text fields of sixty-five. "80% prefilled" would be a
+    claim nothing supports, and every claim this product makes has to
+    trace to something real."""
+    src = code_only(BACKEND / "services" / "pcor_offer.py")
+    assert "%" not in src.replace("%s", "")
+    assert "percent" not in src.lower()
+
+
+def test_the_caller_supplies_its_own_download_url():
+    """An officer's link and a notary's link are scoped differently and
+    must never be handed each other's URL."""
+    from services import pcor_offer
+
+    src = code_only(BACKEND / "services" / "pcor_offer.py")
+    assert "/deeds/" not in src and "/signing/" not in src, (
+        "the shared module hardcoded one caller's URL")
+
+
+# ══════════════════════════════════════════════════════════════════════
+# 3. Against a real database — the token means one thing
+# ══════════════════════════════════════════════════════════════════════
+
+@pytest.fixture
+def world():
+    import psycopg2
+    from database import create_tables
+    from db_rows import ROW_FACTORY
+    create_tables()
+    conn = psycopg2.connect(os.environ["DATABASE_URL"], cursor_factory=ROW_FACTORY)
+    conn.autocommit = True
+    tag = uuid.uuid4().hex[:8]
+    made = {}
+    with conn.cursor() as cur:
+        cur.execute("INSERT INTO users (email, password_hash, full_name, role) "
+                    "VALUES (%s, 'x', 'Officer', 'user') RETURNING id",
+                    (f"officer-{tag}@n2doc.test",))
+        made["officer"] = cur.fetchone()["id"]
+        cur.execute("""INSERT INTO deeds (user_id, deed_type, property_address,
+                                          apn, grantor_name, grantee_name,
+                                          county, status)
+                       VALUES (%s, 'grant_deed', '9 Private Way, Los Angeles, CA',
+                               '1234-567-890', 'A GRANTOR', 'A GRANTEE',
+                               'Los Angeles', 'completed') RETURNING id""",
+                    (made["officer"],))
+        made["deed"] = cur.fetchone()["id"]
+        cur.execute("""INSERT INTO signing_requests (deed_id, officer_user_id,
+                                                     tz_name, expires_at)
+                       VALUES (%s, %s, 'America/Los_Angeles', %s) RETURNING id""",
+                    (made["deed"], made["officer"],
+                     datetime.now(timezone.utc) + timedelta(days=14)))
+        made["request"] = cur.fetchone()["id"]
+        for role, name in (("notary", "Nora"), ("signer", "Sam")):
+            cur.execute(
+                """INSERT INTO signing_participants (signing_request_id, party_role,
+                        display_name, email, token, expires_at)
+                   VALUES (%s, %s, %s, %s, %s, %s) RETURNING id, token""",
+                (made["request"], role, name, f"{name.lower()}-{tag}@n2doc.test",
+                 str(uuid.uuid4()),
+                 datetime.now(timezone.utc) + timedelta(days=14)))
+            row = cur.fetchone()
+            made[f"{role}_token"] = row["token"]
+            made[f"{role}_id"] = row["id"]
+    made["conn"] = conn
+    yield made
+    conn.close()
+
+
+def _public():
+    from fastapi.testclient import TestClient
+    from main import app
+    return TestClient(app)
+
+
+@dbonly
+def test_the_notary_gets_the_form_the_officer_would_get(world):
+    """END TO END, and the point of the ticket: the button works."""
+    body = _public().get(f"/signing/{world['notary_token']}/pcor")
+    assert body.status_code == 200, body.text
+    offer = body.json()
+    assert offer["available"] is True
+    assert offer["county"]
+    # It points at its OWN download, not the officer's authenticated one.
+    assert offer["url"] == f"/signing/{world['notary_token']}/pcor.pdf"
+
+
+@dbonly
+def test_the_filled_form_comes_back_as_a_pdf(world):
+    got = _public().get(f"/signing/{world['notary_token']}/pcor.pdf")
+    assert got.status_code == 200, got.text
+    assert got.headers["content-type"] == "application/pdf"
+    assert got.content.startswith(b"%PDF")
+    # UNFLATTENED — the buyer still has to complete and sign it. A form
+    # with no AcroForm is a picture of a form.
+    assert b"/AcroForm" in got.content
+
+
+@dbonly
+def test_a_signer_cannot_reach_the_notarys_documents(world):
+    """404, not 403. "It exists but is not yours" turns a probe into an
+    inventory, and the signer's own link is perfectly valid."""
+    public = _public()
+    for url in (f"/signing/{world['signer_token']}/pcor",
+                f"/signing/{world['signer_token']}/pcor.pdf",
+                f"/signing/{world['signer_token']}/pdf"):
+        assert public.get(url).status_code == 404, url
+
+
+@dbonly
+def test_the_signer_package_does_not_advertise_them_either(world):
+    """The rule is enforced above; this is the presentation agreeing with
+    it. A button a signer cannot use is a button they will press."""
+    pkg = _public().get(f"/signing/{world['signer_token']}").json()
+    assert "pcor_url" not in pkg
+    assert "pdf_url" not in pkg
+
+
+@dbonly
+def test_a_withdrawn_link_stops_answering_on_every_url(world):
+    """Ruling 2 as a class, carried onto NOTARY2's token: revocation that
+    depends on which URL you ask is not revocation. #170 fixed exactly
+    this gap on the review link."""
+    with world["conn"].cursor() as cur:
+        cur.execute("UPDATE signing_participants SET revoked_at = now() "
+                    "WHERE id = %s", (world["notary_id"],))
+    public = _public()
+    token = world["notary_token"]
+    for url in (f"/signing/{token}", f"/signing/{token}/pcor",
+                f"/signing/{token}/pcor.pdf", f"/signing/{token}/pdf"):
+        assert public.get(url).status_code == 403, url
+
+
+@dbonly
+def test_an_expired_link_stops_answering_on_every_url(world):
+    with world["conn"].cursor() as cur:
+        cur.execute("UPDATE signing_participants SET expires_at = now() - "
+                    "INTERVAL '1 day' WHERE id = %s", (world["notary_id"],))
+    public = _public()
+    token = world["notary_token"]
+    for url in (f"/signing/{token}", f"/signing/{token}/pcor",
+                f"/signing/{token}/pcor.pdf", f"/signing/{token}/pdf"):
+        assert public.get(url).status_code == 410, url
+
+
+@dbonly
+def test_a_deed_with_no_stored_pdf_says_so(world):
+    """§4: a missing document is a stated condition, not an empty body
+    somebody would mistake for a blank form."""
+    got = _public().get(f"/signing/{world['notary_token']}/pdf")
+    assert got.status_code == 404
+    assert "not been generated" in got.text
+
+
+@dbonly
+def test_the_stored_bytes_are_what_the_notary_gets(world):
+    """The document she notarises must be the document that was
+    generated — not a re-render that could differ from it."""
+    marker = b"%PDF-1.4\n% stored-instrument-" + uuid.uuid4().hex.encode()
+    with world["conn"].cursor() as cur:
+        cur.execute("INSERT INTO deed_pdfs (deed_id, pdf_data, sha256) "
+                    "VALUES (%s, %s, %s)",
+                    (world["deed"], psycopg2_binary(marker), "x" * 64))
+    got = _public().get(f"/signing/{world['notary_token']}/pdf")
+    assert got.status_code == 200, got.text
+    assert got.content == marker
+
+
+def psycopg2_binary(data: bytes):
+    import psycopg2
+    return psycopg2.Binary(data)

--- a/backend/tests/test_render_environment_contract.py
+++ b/backend/tests/test_render_environment_contract.py
@@ -161,6 +161,38 @@ def test_every_variable_states_what_breaks(var):
         f"{var.key} describes its purpose rather than its absence")
 
 
+def test_every_required_variable_is_actually_read_by_something():
+    """THE PIN THIS FILE WAS MISSING, added because it was needed.
+
+    `ALLOWED_ORIGINS` sat here classified REQUIRED, with a consequence
+    describing a CORS failure, for the whole life of #166. **Nothing read
+    it.** `main.py` hardcodes its origin list and the name appeared in
+    exactly one place in the backend: the manifest declaring it required.
+
+    The cost was not theoretical. The boot check named it missing on the
+    first production deploy, and the owner set it on the strength of that
+    — an action taken on a claim this file made and could not support.
+
+    A manifest is a set of assertions about the running system. This is
+    the one that checks the assertions are about something.
+    """
+    sources = {}
+    for path in BACKEND.rglob("*.py"):
+        if {"tests", "__pycache__", "venv", ".venv"} & set(path.parts):
+            continue
+        if path.name == "environment.py":
+            continue        # the declaration is not a reading
+        sources[path] = code_only(path)
+
+    unread = [key for key in env.REQUIRED_KEYS
+              if not any(key in src for src in sources.values())]
+    assert unread == [], (
+        "declared REQUIRED and read by nothing: " + ", ".join(unread) +
+        " — either wire it up or reclassify it. A variable whose absence "
+        "changes no behaviour is not required, whatever the manifest says, "
+        "and somebody will act on this file believing otherwise.")
+
+
 def test_the_required_set_is_the_silent_ones():
     """The test is not importance — it is whether absence is SILENT and
     WRONG. A missing ADMIN_EMAIL loses a notification; a missing

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -121,15 +121,103 @@ when their trigger arrives.
   laptop, they get a refused checkout. Better, and still a customer who
   cannot pay.
 
-- **`EXPECTED_DATABASE` on the purge cron — set it when the cron exists**
-  (db-identity, 2026-08-12). Not urgent, and it has no effect until the
-  Render Cron Job is created (Tier 3, still not created). When it is:
-  set `EXPECTED_DATABASE=deedpro` alongside `DATABASE_URL`. The purge
-  asserts its tables, but **staging has those tables too** — the name is
-  the only thing that separates the production database from a copy of
-  it, and the purge is the one job here where being wrong deletes real
-  contact details. Unset, the job runs wherever `DATABASE_URL` points,
-  which is correct for local and CI and is why the check is optional.
+## Closed by the owner — 2026-08-12 production verification
+
+- **`EXPECTED_DATABASE=deedpro` is SET on the purge cron. The check is
+  live, not inert.** The populated-wrong-database case — staging, which
+  has every table the purge asserts — is now refused by name rather than
+  merely refusable. This was the last thing standing between the purge
+  and a mistake that deletes real contact details out of the wrong copy.
+
+  *Correction to this card as it was written:* it said the cron was "still
+  not created". It was — `signer_contact_purge`, 2026-08-11, recorded in
+  the `render.yaml` header the same day. The card inherited a staleness
+  from the ticket that wrote it.
+
+- **`PYTHON_VERSION=3.12.7` verified in production, on both services.**
+  `deedpro-main-api` and the purge cron both built clean, confirmed by
+  cp312 wheel tags (sqlalchemy, greenlet, watchfiles, yarl, zopfli) in
+  both build logs, both "Build successful." The nondeterminism the pin
+  existed to close — a service inheriting whatever Render's default was
+  on the day it built — is closed.
+
+  **And the caveat now has production evidence behind it:** the dashboard
+  is authoritative and the `render.yaml` pin alone never applied. That is
+  no longer an inference from one variable; it is the observed behaviour
+  of two services. See the note beside the value in `render.yaml`.
+
+- **`ALLOWED_ORIGINS` — SET, AND IT DOES NOTHING. My error, corrected.**
+  The boot check named it missing on the first production deploy, the
+  owner set it on the strength of that, and **setting it changed
+  nothing, because nothing reads it.** `main.py` hardcodes its CORS
+  origin list; a grep of the whole backend finds this name in exactly one
+  place — the manifest declaring it REQUIRED. The consequence text I
+  wrote for it ("the browser refuses every call") described a failure
+  that cannot happen.
+
+  Reclassified OPTIONAL with the truth in its entry, and a new pin now
+  fails the suite if any REQUIRED variable is read by nothing —
+  `test_every_required_variable_is_actually_read_by_something`. It
+  catches this exact error; probed against it.
+
+  **The mechanism's first catch is still real, and the honest version is
+  better than the flattering one:** the boot check surfaced a declared
+  variable that was genuinely unset, which nobody knew. Chasing what it
+  caught is what revealed the declaration itself was wrong. Both halves
+  are the system working.
+
+  **And it sharpens the STRICT_ENV argument rather than weakening it.**
+  #166 argued you cannot refuse to boot on a condition nobody has
+  verified, "because the refusal is then the incident". Had `STRICT_ENV=1`
+  been the default, the deploy that shipped #166 would have refused to
+  start — over a variable that changes no behaviour at all. Not an outage
+  caused by a real absence; an outage caused by a mis-classification.
+  STRICT_ENV stays off, and the ticket that turns it on is the ticket
+  that audits the manifest against the code, which the new pin now does
+  continuously.
+
+## Open — needs a ruling (found 2026-08-12, NOT fixed)
+
+- **CORS allows every origin, with credentials.** `backend/main.py:66-76`:
+
+  ```python
+  allow_origins=[
+      "http://localhost:3000",
+      "https://deedpro-frontend-new.vercel.app",
+      "https://deedpro-frontend-new-*.vercel.app",  # Preview deployments
+      "*"  # Fallback for development
+  ],
+  allow_credentials=True,
+  ```
+
+  Starlette sets `allow_all_origins = "*" in allow_origins`, so
+  `is_allowed_origin` returns True for everything and the four entries
+  above the wildcard are decorative. With `allow_credentials=True` it
+  echoes the requesting origin back instead of `*`, which is the form
+  browsers accept — so every site on the internet is an allowed origin.
+  A comment calls it a development fallback; it is in production.
+
+  **The bound, stated so nobody over- or under-reacts.** This API
+  authenticates with `Authorization: Bearer` read from `localStorage`,
+  not cookies. A malicious page cannot read another origin's
+  localStorage, so it cannot forge an authenticated request merely by
+  being allowed. What the wildcard removes is the browser-side barrier
+  that would otherwise contain a token obtained some other way, and it
+  makes any allowlist meaningless.
+
+  **Why it is not a quick fix, and why it needs you rather than me.**
+  Removing `"*"` today breaks every Vercel preview deployment.
+  `allow_origins` is EXACT-matched — the `deedpro-frontend-new-*.vercel.app`
+  entry has never matched anything, and previews work solely because of
+  the wildcard. Doing this properly means `allow_origin_regex` for the
+  preview pattern plus the production host, which is a production CORS
+  change with a real chance of taking the frontend down if the pattern is
+  wrong. Tier 3-adjacent, and the right shape is: build it, verify
+  against a preview URL and the production host, then ship.
+
+  It is also the obvious answer to the question above — this is what
+  `ALLOWED_ORIGINS` was presumably declared FOR, and wiring it is one
+  ticket with the regex work.
 
 - **Demo video: `homepageLinks.test.ts` has to be retargeted first.**
   The GTM plan says the 90-second video "fills the homepage's dead Watch

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -131,22 +131,14 @@ when their trigger arrives.
   contact details. Unset, the job runs wherever `DATABASE_URL` points,
   which is correct for local and CI and is why the check is optional.
 
-- **`/signing/{token}/pcor` does not exist — the NOTARY2 signer's PCOR
-  button is a live 404** (found 2026-08-12 while retiring NOTARY1's read
-  side). `services/signing_surfaces.py:192` puts
-  `pcor_url = "/signing/{token}/pcor"` in the signer package, and
-  `frontend/src/app/signing/[token]/page.tsx:355` renders a Download
-  PCOR link at `${pcor_url}.pdf`. **Neither route is registered** —
-  `routers/signing.py` has no PCOR handler at all. NOTARY1 had a working
-  pair; NOTARY2 advertises them and never built them.
-
-  NOT FIXED, because the two fixes are different products: build the
-  route (the signer gets the county's companion form) or stop
-  advertising it (the button goes). The first is a feature and the
-  second removes one, and `pcor_url` is inside `signing_surfaces`'
-  exact-key-set contract, so either way it is a deliberate change rather
-  than a repair. **Needs a ruling.** The audience is consumers with no
-  account, which is the argument for it being soon.
+- **Demo video: `homepageLinks.test.ts` has to be retargeted first.**
+  The GTM plan says the 90-second video "fills the homepage's dead Watch
+  Demo". There is no dead Watch Demo — HM1 removed it along with a
+  placeholder demo iframe (a rickroll), and the pin asserts BOTH that no
+  such button exists AND that `components/landing-v2/VideoPlayer.tsx`
+  does not exist on disk. Whoever adds a player retargets that pin in the
+  same commit, with the reason it is now allowed, or hits a confusing
+  red. Ten minutes; recorded so it is not discovered at 11pm.
 
 - **Junk seed cleanup** (test rows in production data).
 - **TitlePoint / SiteX credential rotations.**

--- a/render.yaml
+++ b/render.yaml
@@ -77,6 +77,13 @@ services:
   # dashboard. That is the proof behind the header's warning — the file
   # DECLARES, it does not APPLY.
   #
+  # VERIFIED IN PRODUCTION once it was set by hand: both
+  # `deedpro-main-api` and the purge cron built clean on 3.12.7, cp312
+  # wheel tags across sqlalchemy, greenlet, watchfiles, yarl and zopfli in
+  # both build logs. The nondeterminism this pin exists to close — a
+  # service inheriting whatever Render's default was the day it built —
+  # is closed on both services.
+  #
   # Nothing was going to catch it, either, and the reason is worth
   # keeping: the boot report in `services/environment.py` reads the REAL
   # environment on the REAL service, so it does catch dashboard drift —

--- a/render.yaml
+++ b/render.yaml
@@ -25,6 +25,12 @@
 # it did not. That is the defect class this whole engagement has been
 # closing: a fact the system depends on, that nothing checks.
 #
+# ⚠️ DECLARING A VARIABLE HERE DOES NOT APPLY IT. This file is read by
+#    the repo's tests, not by the running service; the dashboard is where
+#    values live. `services/environment.py` closes half the loop by
+#    reporting what the REAL service is missing at boot — see the note on
+#    PYTHON_VERSION below for the half it structurally cannot close.
+#
 # A variable whose value is a SECRET is declared here with `sync: false`
 # — the key is named, the value stays in the dashboard. Declaring the
 # name is the whole point; declaring the value would be the thing the
@@ -65,6 +71,22 @@ services:
   # Pinned, not inherited. See the header: this is a downgrade from the
   # 3.13 the service runs today, and the main API must be redeployed and
   # its build watched before this is considered settled.
+  #
+  # ⚠️ AND IT DID NOT TAKE. Confirmed 2026-08-12: this declaration is
+  # here, and the value still had to be set by hand in the Render
+  # dashboard. That is the proof behind the header's warning — the file
+  # DECLARES, it does not APPLY.
+  #
+  # Nothing was going to catch it, either, and the reason is worth
+  # keeping: the boot report in `services/environment.py` reads the REAL
+  # environment on the REAL service, so it does catch dashboard drift —
+  # for variables the PROCESS reads at RUNTIME, and only the ones the
+  # manifest marks REQUIRED. `PYTHON_VERSION` is neither. Render consumes
+  # it at BUILD time, before the process that would report it exists.
+  #
+  # That bounds the mechanism rather than refuting it. `FRONTEND_URL` is
+  # runtime and REQUIRED, which is exactly the case the boot check does
+  # see.
   - key: PYTHON_VERSION
     value: "3.12.7"
   - key: DATABASE_URL


### PR DESCRIPTION
Rulings 1 and 2, plus the accepted corrections. One PR because the second ruling is a guard on scripts the first one does not touch — say the word and I'll split it, but they share no code and both are small.

## Ruling 1 — the PCOR 404, built

**It was two 404s, not one.** `notary_package` has advertised `pcor_url` *and* `pdf_url` since NOTARY2 shipped, and the notary's screen rendered both as download buttons. Neither handler was ever written.

| Route | Serves |
|---|---|
| `GET /signing/{token}/pcor` | availability, the form's identity, and the asks |
| `GET /signing/{token}/pcor.pdf` | the filled form, **unflattened** |
| `GET /signing/{token}/pdf` | the stored instrument, from `deed_pdfs` |

**Token semantics are the deed's, exactly.** Withdrawn is 403 and expired is 410 on all three — `_participant_by_token` already enforced both before either handler runs. "Which URL did you ask" is not a property a permission may have.

**Notary-only is enforced in the handler**, not merely omitted from the signer's package: a package that omits a link is presentation, and this is the rule. 404 rather than 403, because "it exists but is not yours" turns a probe into an inventory — the signer's own link is perfectly valid.

**Unflattened is asserted, not asserted-about**: the download test checks the bytes carry `/AcroForm`. A form with no form fields is a picture of a form, and the buyer has to complete and sign it. Not stored, not hashed — §9 freezes the instrument because the instrument is ours; the PCOR is theirs.

### The class fix, which is the part worth keeping

```python
advertised = re.findall(r'"[a-z_]*url":\s*f?"([^"]+)"', code_only(SURFACES))
missing = [u for u in advertised if _shape(u) not in known_routes]
assert missing == []
```

A package advertising a link the app cannot serve is a promise made by a surface that cannot keep it. **Nothing compared those two lists**, so nothing could notice for a whole feature's lifetime. Matched as a shape across the module rather than as two known keys, because the next advertised link will be written by somebody who never read that file.

### One fewer copy

The availability body had two implementations — `deeds_crud` and the NOTARY1 route retired in #170 — which had already drifted in their filename. `services/pcor_offer.py` is now the one, and the officer's route uses it too. The caller supplies its own download URL, because an officer's link and a notary's link are scoped differently and must never be handed each other's.

## Ruling 2 — the destructive-test guard, marker-based

Rejected, both for the reason you gave: `ALLOW_DESTRUCTIVE_TESTS` is an opt-in somebody sets and forgets (a variable left set is indistinguishable from one set on purpose), and name-matching production fails the moment a second production-shaped database exists. **Both blacklist the dangerous thing.** `assert_scratch` whitelists the safe one.

```
$ DATABASE_URL=...deedpro_test python scripts/s1_concurrency_proof.py
RED-S1 concurrency proof
deedpro_test on 127.0.0.1:5433 is not marked as a throwaway database, and this
harness writes rows and drops data. Refusing.

If deedpro_test really is disposable, mark it once:
    DATABASE_URL=... python scripts/mark_scratch_database.py --yes-this-is-a-throwaway-database

If it is not, this message is doing its job — check DATABASE_URL.
```

The marking script prints **which database it is about to mark, before it marks it**, and refuses without the flag — so the person who forgot the flag has already read the identity line.

**The honest bound, stated in the code:** nothing can stop somebody marking production. What changes is the *shape* of the mistake — mis-pasting a `DATABASE_URL` no longer destroys data, because a second, explicit, differently-worded act is required first. Mis-pasting is common; declaring production a throwaway database is not.

**The load-bearing pin is not that the guard exists.** It is that the marker is absent from `create_tables`:

> `create_tables` runs against production on every boot, and a marker it created would mark the one database that must never carry it.

That pin is what caught my own weak test — see below.

CI marks its own database in one declared step in `proof-harnesses`, before the harnesses run.

## The corrections, recorded

**`PYTHON_VERSION`** — declared in `render.yaml` and it still had to be set by hand. That is proof the file *declares* and does not *apply*, and it **bounds** #166 rather than refuting it: the boot report reads the real environment on the real service, so it does catch dashboard drift — for variables the process reads at **runtime** that the manifest marks **REQUIRED**. `PYTHON_VERSION` is neither; Render consumes it before the process exists. `FRONTEND_URL` is both, which is exactly the case the check does see. In the header, beside the pin, and in the manifest entry.

*(The header caveat had to be trimmed and relocated: my first draft pushed the existing PYTHON_VERSION downgrade note past the 4000-character window `test_render_service_pins` reads, and the pin failed. The detail now sits beside the value it describes, which is the better place for it anyway.)*

**Demo video** — ledgered: whoever adds a player retargets `homepageLinks.test.ts` first, since it asserts both that no Watch Demo button exists and that `VideoPlayer.tsx` does not exist on disk.

## Verification

Nine pins mutation-probed. **Two came back green and both were my tests being weak, not the code:**

1. Renaming `SCRATCH_MARKER` to `users` passed, because my live control was the `postgres` maintenance database, which lacks *every* app table — so it could not distinguish "the marker" from "any table". Fixed by pinning the marker's absence from `database.py`, which is the property that actually matters. Re-probed: caught.
2. A stub-only assertion could not tell one table name from another, since the stub answers "present" to everything. Added a live test against a real catalog.

| Gate | Result |
|---|---|
| pytest, with a database | **1132 passed** |
| pytest, no database | **949 passed**, 183 skipped |
| jest | 726 passed, 49 suites |
| `next build` | ✔ |
| tsc | **94** |
| six-flow / API baselines | ✔ |
| banned-claims | clean |

Also exercised by hand: `s1_concurrency_proof` refused the unmarked database, was marked, and then passed all four checks.

**OpenAPI snapshot re-recorded** — exactly the three new routes, deliberately, per the invariant.

One in-passing fix: my first draft of the PDF handler ordered `deed_pdfs` by `id`, which does not exist — `deed_id` is the primary key, one stored instrument per deed, never overwritten (§9). There is no "latest" to order by, and asking for one would describe a history the table deliberately does not keep.

Next: UX2 item 2 through 9, then DEEDDETAIL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_