### PR TITLE
Every link this product hands out is a link this product can serve

### DIFF
--- a/backend/tests/test_link_contract.py
+++ b/backend/tests/test_link_contract.py
@@ -1,0 +1,231 @@
+"""A link this product hands out is a link this product can serve.
+
+═══ THE DEFECT THIS GENERALISES ═══
+
+`notary_package` advertised `pcor_url` and `pdf_url` from the day NOTARY2
+shipped. The notary's screen rendered both as download buttons. **Neither
+handler existed.** Two live 404s, for a feature's entire lifetime, on a
+surface whose audience has no account and no way to tell a broken product
+from a broken link.
+
+Nothing caught it because nothing compared the two lists — the links a
+payload hands out, and the routes the app serves. That is the same shape
+as the eight drifted Shared Deeds row keys: two declarations, and no
+third thing checking them against each other.
+
+Owner-ruled 2026-08-12: **any payload that hands out links gets its
+advertised URLs checked against what actually resolves.** This file is
+that check, in both directions a link can point.
+
+═══ TWO KINDS OF LINK, TWO DIFFERENT AUTHORITIES ═══
+
+ 1. AN API PATH — `/signing/{token}/pcor`. Resolves against this app's
+    own route table, and a miss is a 404 from our own server.
+
+ 2. A FRONTEND PAGE — `{FRONTEND_URL}/approve/{token}`, built in Python
+    and posted into somebody's INBOX. Resolves against the Next.js app
+    router, in a different language, in a different deployment, on a
+    different host. A miss here is worse than a broken button: an email
+    is immutable, so the 404 is permanent and arrives at a customer.
+
+The second is the reason this file reaches across the repository
+boundary. Nothing else in either test suite does, and the justification
+is that nothing else has to: a link is the one artifact whose two halves
+are deployed separately and must still agree.
+
+═══ WHAT THE SWEEP FOUND ═══
+
+No second instance. Every frontend link the backend emits — the approval
+page, the signing token page, the share focus link, the password-reset
+and verify-email pages, the Stripe return URLs, the welcome email's
+builder link, the QR verification page — resolves to a real route today.
+
+That is the point at which a pin is worth most and feels least urgent.
+"No second instance" is not a property of the code; it is a snapshot of
+it, and the thing that changes it is a route rename nobody connects to an
+email template written eight months earlier.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from tests.source_text import code_only
+
+BACKEND = Path(__file__).resolve().parents[1]
+FRONTEND_APP = BACKEND.parent / "frontend" / "src" / "app"
+
+
+def _backend_sources():
+    for folder in ("services", "routers", "api", "utils"):
+        for path in (BACKEND / folder).rglob("*.py"):
+            if "__pycache__" in path.parts:
+                continue
+            yield path
+
+
+def _shape(path: str) -> str:
+    """One route, however its parameters are spelled.
+
+    `/signing/{token}/pcor`, `/signing/{tok}/pcor` and Next's
+    `/signing/[token]/pcor` are the same route. What is being compared is
+    the SHAPE — the literal segments and where the holes are — not the
+    name somebody gave a variable.
+    """
+    out = []
+    for segment in path.split("/"):
+        if not segment:
+            out.append(segment)
+        elif "{" in segment or segment.startswith("["):
+            out.append("{}")
+        else:
+            out.append(segment)
+    return "/".join(out)
+
+
+# ══════════════════════════════════════════════════════════════════════
+# 1. API paths a payload hands out
+# ══════════════════════════════════════════════════════════════════════
+
+#: Two shapes, because the first draft of this pin only had the first and
+#: missed three real links — including the PCOR download URL, which is
+#: PASSED as an argument rather than written into a dict:
+#:
+#:     "pcor_url": f"/signing/{token}/pcor"      keyed into a payload
+#:     pcor_offer.status(deed, f"/signing/{token}/pcor.pdf")   handed over
+#:
+#: The second pattern is any f-string that looks like an absolute API
+#: path. It also matches route decorators, which is harmless — a route
+#: trivially resolves to itself — and it produced no false positives over
+#: the whole backend, because nothing else in this codebase writes an
+#: f-string beginning with `/`.
+#:
+#: Only values starting with `/`: an absolute URL is somebody else's
+#: server and not ours to resolve.
+API_LINK = re.compile(
+    r'"[a-z_]*(?:url|link)":\s*f?"(/[^"]*)"'
+    r'|f"(/[A-Za-z0-9_\-/{}\[\].]*)"')
+
+
+def _app_routes():
+    import main
+    return {_shape(getattr(r, "path", "")) for r in main.app.routes}
+
+
+def test_every_api_path_a_payload_advertises_is_a_route_that_exists():
+    """THE PIN THAT WOULD HAVE CAUGHT THE PCOR BUTTON.
+
+    A payload advertising a link the app cannot serve is a promise made
+    by a surface that cannot keep it — and the surface that made it is
+    never the surface that discovers it.
+    """
+    routes = _app_routes()
+    offenders = []
+    for path in _backend_sources():
+        src = code_only(path)
+        for match in API_LINK.finditer(src):
+            url = (match.group(1) or match.group(2)).split("?")[0]
+            if _shape(url) not in routes:
+                line = src[: match.start()].count("\n") + 1
+                offenders.append(f"{path.relative_to(BACKEND)}:{line} → {url}")
+    assert offenders == [], (
+        "a payload hands out API links this app does not serve:\n  "
+        + "\n  ".join(offenders) +
+        "\nEither build the route or stop advertising it — a button that "
+        "404s is worse than one that is absent.")
+
+
+def test_the_pin_is_looking_at_something():
+    """A sweep that matches nothing passes forever.
+
+    The regex has to keep finding the links it was written for; if a
+    refactor changes how payloads spell them, this fails rather than
+    going quietly green.
+    """
+    found = sum(len(API_LINK.findall(code_only(p))) for p in _backend_sources())
+    assert found >= 6, (
+        f"the API-link sweep found only {found} links — the payload shape "
+        "has changed and this pin is no longer reading anything")
+
+
+# ══════════════════════════════════════════════════════════════════════
+# 2. Frontend pages the backend puts in emails
+# ══════════════════════════════════════════════════════════════════════
+
+#: The base-URL expressions this backend builds frontend links from. Named
+#: explicitly rather than matched loosely: a pattern broad enough to catch
+#: every f-string is a pattern that reports half the codebase.
+BASES = (r"APP_URL\(\)", r"app_url", r"base_url", r"url", r"app",
+         r"_FRONTEND_URL_\(\)", r"_verification_base_url\(\)",
+         r"os\.getenv\(['\"]FRONTEND_URL['\"][^)]*\)")
+
+FRONTEND_LINK = re.compile(
+    r"\{(?:" + "|".join(BASES) + r")\}(/[A-Za-z0-9_\-/{}\[\]]*)")
+
+
+def _frontend_routes():
+    """Every page the Next.js app router serves, as a shape."""
+    routes = set()
+    for page in FRONTEND_APP.rglob("page.tsx"):
+        rel = page.relative_to(FRONTEND_APP).parent
+        path = "/" + "/".join(rel.parts) if rel.parts else "/"
+        routes.add(_shape(path))
+    return routes
+
+
+def test_every_frontend_link_the_backend_emails_resolves_to_a_page():
+    """AN EMAIL IS IMMUTABLE, and that is the whole reason this exists.
+
+    A broken button gets fixed and the next click works. A broken link in
+    somebody's inbox stays broken for as long as they keep the message,
+    and the person who finds it is a customer rather than a developer.
+
+    This reaches into the frontend deliberately. The two halves of a link
+    are deployed separately and must still agree, and nothing else was
+    comparing them.
+    """
+    pages = _frontend_routes()
+    assert pages, "found no frontend pages — has the app directory moved?"
+
+    offenders = []
+    for path in _backend_sources():
+        src = code_only(path)
+        for match in FRONTEND_LINK.finditer(src):
+            url = (match.group(1) or match.group(2)).split("?")[0].rstrip("/")
+            if not url:
+                continue          # the bare host is always fine
+            if _shape(url) not in pages:
+                line = src[: match.start()].count("\n") + 1
+                offenders.append(f"{path.relative_to(BACKEND)}:{line} → {url}")
+    assert offenders == [], (
+        "the backend builds links to frontend pages that do not exist:\n  "
+        + "\n  ".join(offenders) +
+        "\nIf a route was renamed, the alias has to be permanent — an "
+        "email already sent cannot be edited (docs/DASH1_REQUESTS_MERGE.md).")
+
+
+def test_the_frontend_sweep_is_looking_at_something():
+    found = sum(len(FRONTEND_LINK.findall(code_only(p)))
+                for p in _backend_sources())
+    assert found >= 5, (
+        f"the frontend-link sweep found only {found} links — it is no "
+        "longer reading the emails it was written to guard")
+
+
+@pytest.mark.parametrize("known", [
+    "/approve/{token}",      # the review and signing link, in two emails
+    "/signing/{token}",      # NOTARY2's consumer surface
+    "/shared-deeds",         # the focus link, in two emails
+    "/account-settings",     # THE STRIPE RETURN URLS
+    "/verify/{code}",        # the QR code printed on nothing, read by anyone
+])
+def test_the_links_that_matter_most_are_among_the_ones_checked(known):
+    """A sweep is only as good as its reach, and these five are the ones
+    whose failure is least recoverable: two are in emails already sent,
+    one is where a paying customer lands after checkout, and one is
+    printed into a QR code."""
+    assert _shape(known) in _frontend_routes(), (
+        f"{known} is not a page any more — every link already sent to it "
+        "is now a 404 in somebody's inbox")

--- a/backend/tests/test_notary2_documents.py
+++ b/backend/tests/test_notary2_documents.py
@@ -82,28 +82,12 @@ def _shape(path: str) -> str:
 # 1. Every advertised URL resolves — the class fix
 # ══════════════════════════════════════════════════════════════════════
 
-def test_every_url_a_package_advertises_is_a_route_that_exists():
-    """THE PIN THAT WOULD HAVE CAUGHT THIS.
-
-    `pcor_url` and `pdf_url` sat in the notary's package for a whole
-    feature's lifetime, rendered as buttons, pointing at nothing. Nothing
-    compared the two lists, so nothing could notice.
-
-    Matched as a SHAPE across the whole surfaces module rather than as
-    two known keys, because the next advertised link will be written by
-    somebody who never read this file.
-    """
-    src = code_only(SURFACES)
-    advertised = re.findall(r'"[a-z_]*url":\s*f?"([^"]+)"', src)
-    assert advertised, "the URL pin found nothing to check — has the shape changed?"
-
-    known = {_shape(p) for _m, p in _routes()}
-    missing = [u for u in advertised if _shape(u) not in known]
-    assert missing == [], (
-        "a signing package advertises links the app cannot serve: "
-        + ", ".join(missing) +
-        " — either build the route or stop putting it in the package; a "
-        "button that 404s is worse than one that is absent")
+# The "every advertised URL resolves" pin was born here, scoped to this
+# one module. It was ruled a CLASS and moved to
+# `tests/test_link_contract.py`, which now sweeps every payload in the
+# backend and — the half this file never had — every frontend page the
+# backend puts in an email. Not duplicated here: one sweep, one place, and
+# a narrower copy would go stale the day somebody widened the other.
 
 
 def test_the_notary_documents_are_registered():


### PR DESCRIPTION
The `*_url` pin from #171, generalised as ruled — swept across every payload, and extended to a habitat the original never reached.

## Two directions a link can point

| | Resolves against | A miss is |
|---|---|---|
| **API path** — `/signing/{token}/pcor` | this app's own route table | a 404 from our own server |
| **Frontend page** — `{FRONTEND_URL}/approve/{token}` | the Next.js app router | **a permanent 404 in somebody's inbox** |

The second is new, and it's the one with teeth. Those links are built in Python, in a different deployment, on a different host, and posted into email — and **an email is immutable**, so a route rename makes every message already sent permanently broken. The person who finds it is a customer.

That's why this file reaches across the repository boundary, which nothing else in either suite does. The justification is that nothing else has to: a link is the one artifact whose two halves deploy separately and must still agree.

## What the sweep found

**No second instance.** All 6 API paths and all 14 frontend links resolve today — the approval page, the signing token page, the share focus link, password reset, verify email, the Stripe return URLs, the welcome email's builder link, the QR verification page.

That is exactly when a pin is worth most and feels least urgent. "No second instance" is a snapshot of the code, not a property of it, and the thing that changes it is a route rename nobody connects to an email template written eight months earlier. `docs/DASH1_REQUESTS_MERGE.md` already established that these aliases are permanent for that reason — this makes it checkable instead of remembered.

Five links get their own named test, because their failure is least recoverable: `/approve/{token}` and `/shared-deeds` are in emails already sent, `/account-settings` is where a paying customer lands after checkout, and `/verify/{code}` is printed into a QR code.

## The first draft was too narrow, which is worth recording

The pattern initially read only dict-literal keys — `"pcor_url": f"/..."` — and **missed three real links**, including the PCOR download URL, which is *passed as an argument* rather than written into a payload:

```python
pcor_offer.status(world["deed"], f"/signing/{token}/pcor.pdf")   # invisible to draft 1
```

Widened to any f-string that looks like an absolute path. It also matches route decorators, which is harmless — a route resolves to itself — and it produced **no false positives** over the whole backend, because nothing else here writes an f-string beginning with `/`.

## Two counters, because a regex that stops matching passes forever

`test_the_pin_is_looking_at_something` and its frontend twin assert the sweep still finds at least the links it was written for. Probed directly: replacing the pattern with one that matches nothing fails the suite. That's the specific way a source-scanning pin dies quietly, and it's the second time this engagement has needed the guard.

## One fewer copy

The narrow version in `test_notary2_documents.py` is deleted, not left beside this one — a narrower duplicate goes stale the day somebody widens the other. A comment there points here.

## Verification

Four mutation probes, four caught:

- an advertised API path renamed → caught
- an emailed frontend path renamed → caught
- **the `/approve` page directory moved out from under the email that links to it** → caught
- the sweep regex neutered → caught by the counter

One probe came back green and it was the probe's fault, not the pin's: I changed an f-string to a plain string, which the keyed alternative still matches — so the link was still found and still checked. Correct behaviour.

| Gate | Result |
|---|---|
| pytest, with a database | **1141 passed** |
| pytest, no database | **958 passed**, 183 skipped |
| six-flow / API baselines | ✔ |
| banned-claims | clean |

No frontend source changed, so no `next build` — the frontend is *read* by this suite, not modified.

Next: UX2 item 2, then CANCEL1 as ruled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_