### PR TITLE
The officer can call a signing off, and everybody who was asked hears

### DIFF
--- a/backend/routers/deeds_crud.py
+++ b/backend/routers/deeds_crud.py
@@ -528,6 +528,46 @@ def delete_deed_endpoint(deed_id: int, user_id: int = Depends(get_current_user_i
                 raise HTTPException(status_code=404, detail="Deed not found")
             if row[0] != user_id:
                 raise HTTPException(status_code=403, detail="You don't have permission to delete this deed")
+            # ── CANCEL1 item 3 — TWO DESTRUCTIVE ACTS DO NOT RIDE ONE
+            #    BUTTON ──────────────────────────────────────────────
+            #
+            # This delete is SOFT: the row stays, `status` becomes
+            # 'deleted', and the deed is hidden from her lists. Which
+            # means a live signing token does not break — it keeps
+            # working perfectly, serving a document the officer believes
+            # she withdrew, to somebody she can no longer see.
+            #
+            # That is not an orphaned link. It is a withdrawn document
+            # still being served on request, and the only surface that
+            # knows is the stranger's.
+            #
+            # Refused rather than cascaded, per the ruling: cancelling a
+            # signing notifies three people and voids their links, and
+            # that is not a side effect anybody should discover after
+            # pressing "Delete deed". The message names the notary so
+            # the officer knows which conversation she is about to end.
+            cur.execute("""
+                SELECT sr.id,
+                       (SELECT display_name FROM signing_participants
+                         WHERE signing_request_id = sr.id
+                           AND party_role = 'notary'
+                         ORDER BY id LIMIT 1) AS notary_name
+                  FROM signing_requests sr
+                 WHERE sr.deed_id = %s
+                   AND sr.cancelled_at IS NULL
+                 ORDER BY sr.id LIMIT 1
+            """, (deed_id,))
+            pending = cur.fetchone()
+            if pending:
+                pending = dict(pending)
+                notary = pending.get("notary_name") or "a notary"
+                raise HTTPException(
+                    status_code=409,
+                    detail=(f"This deed has a signing request waiting on "
+                            f"{notary}. Cancel the signing first — that "
+                            "voids everyone's links and tells them why. "
+                            "Then the deed can be deleted."))
+
             cur.execute("""
                 UPDATE deeds SET status = 'deleted', updated_at = CURRENT_TIMESTAMP
                 WHERE id = %s

--- a/backend/routers/signing.py
+++ b/backend/routers/signing.py
@@ -390,6 +390,13 @@ def officer_agenda(user_id: int = Depends(get_current_user_id)):
                 "deed_type": row.get("deed_type"),
                 "notary_name": row.get("notary_name"),
                 "state": loop.request_state(row, windows, responses),
+                # CANCEL1 item 4: whether this one is still somebody's
+                # problem, decided HERE. Past Deeds needs it to know that
+                # a deed already has a signing out, and the alternative —
+                # the screen listing which states are over — is that
+                # judgement copied into TypeScript, where it will be
+                # missed the day a state is added.
+                "live": loop.is_live(loop.request_state(row, windows, responses)),
                 # The server's sentence, rendered verbatim by every
                 # surface — §13 rule 3.
                 "summary": loop.state_label(row, windows, responses, participants),
@@ -554,7 +561,28 @@ def officer_remind(request_id: int, user_id: int = Depends(get_current_user_id))
 
 @router.post("/signing-requests/v2/{request_id}/cancel")
 def officer_cancel(request_id: int, user_id: int = Depends(get_current_user_id)):
+    """Call it off. Allowed in every state, INCLUDING booked.
+
+    Owner-ruled (CANCEL1): a booked signing is the one most likely to
+    need cancelling — the deal falls out, the closing moves, the buyer
+    reschedules — so a state guard forbidding it would refuse the officer
+    at the exact moment she needs it. Cancelling a booked signing is not
+    a different capability; it is a heavier moment, and the weight
+    belongs in the confirmation copy rather than in a rule that says no.
+
+    The request is never deleted. `cancelled_at` is its own column for
+    T-5's reason: a cancelled request that HAD a booked time still had
+    one, and folding cancellation into a status would make that
+    unsayable.
+    """
     _owned_request(request_id, user_id)
+
+    # BEFORE the update. Every participant is about to be revoked, and
+    # the notice loop skips revoked participants — read afterwards, this
+    # cancellation would be announced to nobody.
+    world = _load(request_id)
+    already = bool(world["request"].get("cancelled_at"))
+
     with db.conn.cursor() as cur:
         cur.execute("UPDATE signing_requests SET cancelled_at = now(), "
                     "updated_at = now() WHERE id = %s AND cancelled_at IS NULL",
@@ -563,6 +591,12 @@ def officer_cancel(request_id: int, user_id: int = Depends(get_current_user_id))
                     "updated_at = now() WHERE signing_request_id = %s "
                     "AND revoked_at IS NULL", (request_id,))
     db.conn.commit()
+
+    # Idempotent: cancelling twice is one cancellation and one round of
+    # notices. A second "this is cancelled" email is a second alarm about
+    # a fire that is already out.
+    if not already:
+        _tell_everyone_cancelled(world)
     return _officer_payload(_load(request_id))
 
 
@@ -1189,6 +1223,59 @@ def _tell_everyone_booked(request_id: int) -> None:
                 attachments=files)
     except Exception as e:
         print(f"[NOTARY2] ⚠️ booking notices failed (non-blocking): {e}")
+
+
+def _tell_everyone_cancelled(world: Dict[str, Any]) -> None:
+    """CANCEL1 — everybody who was ASKED is told it is off.
+
+    ═══ WHO, AND THE ONE THAT NEEDED A RULING ═══
+
+    The notary blocked out an afternoon. A signer who answered arranged
+    their day. Both obviously need telling. The question was the signer
+    who was invited and never answered, on a request where nothing was
+    ever booked — and the ruling is YES: they hold a link, the link is
+    now dead, and discovering that by clicking it is worse than being
+    told. Being invited is what earns the notice, not having replied.
+
+    ═══ THE WORLD IS READ BEFORE THE CANCEL, NOT AFTER ═══
+
+    `officer_cancel` revokes every participant row, and this loop skips
+    revoked participants everywhere else in this file for good reason —
+    a participant the officer removed should not keep receiving mail. So
+    the caller hands us the world as it was BEFORE the update, or this
+    notice would go to nobody at all. That is a real bug avoided by
+    ordering, and it is why this function takes a world instead of an id.
+
+    Best-effort, like every other notice here: a transport failure must
+    not un-cancel anything.
+    """
+    try:
+        from utils.notifications import send_signing_cancelled
+
+        req, deed = world["request"], world["deed"]
+        officer_name, _c = _officer_bits(world)
+        full_address = deed.get("property_address") or ""
+        street = full_address.split(",")[0].strip()
+
+        when = req.get("booked_at")
+        window = next((w for w in world["windows"]
+                       if w.get("starts_at") == when), None)
+        when_text = (loop.window_label(window, req.get("tz_name"))
+                     if window else "")
+
+        for p in world["participants"]:
+            if p.get("revoked_at") or not p.get("email"):
+                continue
+            consumer = p["party_role"] == loop.ROLE_SIGNER
+            send_signing_cancelled(
+                recipient_email=p["email"],
+                recipient_name=p.get("display_name") or "",
+                property_text=street if consumer else full_address,
+                when_text=when_text,
+                officer_name=officer_name,
+                is_consumer=consumer)
+    except Exception as e:
+        print(f"[CANCEL1] ⚠️ cancellation notices failed (non-blocking): {e}")
 
 
 def signing_ics(window: Dict[str, Any], address: str, officer_name: str) -> bytes:

--- a/backend/services/signing_loop.py
+++ b/backend/services/signing_loop.py
@@ -132,6 +132,22 @@ STATE_CANCELLED = "cancelled"
 STATE_EXPIRED = "expired"
 
 
+#: The states in which a request is still somebody's problem. Cancelled
+#: and expired are over; everything else is waiting on a human.
+#:
+#: CANCEL1 item 4 needs this and it is deliberately NOT a list the screen
+#: keeps: "is this signing still live" is a judgement about the state
+#: vocabulary, and the vocabulary lives here. A client-side
+#: `!['cancelled','expired'].includes(state)` is that judgement copied,
+#: and it is the copy that will be missed when a state is added.
+TERMINAL_STATES = (STATE_CANCELLED, STATE_EXPIRED)
+
+
+def is_live(state: str) -> bool:
+    """Is this request still waiting on somebody."""
+    return state not in TERMINAL_STATES
+
+
 def request_state(request: Dict[str, Any], windows: Sequence[Dict[str, Any]],
                   responses: Sequence[Dict[str, Any]],
                   now: Optional[datetime] = None) -> str:

--- a/backend/tests/test_admin3_email_outcomes.py
+++ b/backend/tests/test_admin3_email_outcomes.py
@@ -92,13 +92,11 @@ def test_every_template_routes_through_send():
         f"declared TEMPLATES and actual _send labels disagree: "
         f"only-declared={set(TEMPLATES) - named}, only-used={named - set(TEMPLATES)}"
     )
-    # The trip-wire, fired DOWNWARD again: 19 → 18 as NOTARY1's
-    # `signing_time_recorded` lost the only handler that sent it (the
-    # notary tapping one of the officer's proposed windows — a thing that
-    # can no longer happen). The same pin caught `share_signing_request`
-    # leaving in #162. A count that only ever goes up is a count that
-    # never notices a feature departing.
-    assert len(TEMPLATES) == 18
+    # The trip-wire. It has moved in both directions now: DOWN to 18 when
+    # NOTARY1's `signing_time_recorded` lost the only handler that sent
+    # it, and back UP to 19 with CANCEL1's `signing_cancelled`. The value
+    # of the number is that neither direction is silent.
+    assert len(TEMPLATES) == 19
 
 
 # ── The recorder's two constraints ───────────────────────────────────

--- a/backend/tests/test_cancel1_signing_cancellation.py
+++ b/backend/tests/test_cancel1_signing_cancellation.py
@@ -1,0 +1,327 @@
+"""The officer can call a signing off, and everybody who was asked hears.
+
+═══ WHAT WAS ACTUALLY MISSING ═══
+
+An external audit reported that the officer could not cancel a signing
+request in any state. Checked before building, and the truth was narrower
+and more useful: **the whole system was already there.**
+`POST /signing-requests/v2/{id}/cancel` sets `cancelled_at` and revokes
+every participant token; `request_state` derives `cancelled`;
+`state_label` says "Signing request cancelled"; and the token page has
+always rendered "This link has been withdrawn." on the 403 that a revoked
+participant produces.
+
+What did not exist was any way to reach it. The expanded signing panel
+was read-only — zero interactive elements — so a state the product could
+describe, and a recipient screen built to display it, could be produced
+by nothing an officer could press.
+
+Building an endpoint would have duplicated a working one.
+
+═══ WHAT THIS TICKET ADDED ═══
+
+ 1. The control, the confirmation, and the decision that a cancelled
+    request stays visible rather than disappearing.
+ 2. The notices. The endpoint told nobody, and a notary who blocked out
+    Thursday afternoon is exactly who needs telling.
+ 3. The refusal on the delete-deed path, which turned out to matter more
+    than "orphan" suggested — see below.
+
+═══ THE ONE THAT IS NOT A TIDINESS PROBLEM ═══
+
+`DELETE /deeds/{id}` is a SOFT delete: `status = 'deleted'`, the row
+stays. So a live signing token did not break when the officer deleted the
+deed — **it kept working perfectly**, serving a document she believed she
+had withdrawn, to somebody she could no longer see.
+
+That is not an orphaned link. It is a withdrawn document still being
+served on request, and the only surface that knew was the stranger's.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from services import signing_loop as loop
+from tests.source_text import code_only
+
+BACKEND = Path(__file__).resolve().parents[1]
+
+dbonly = pytest.mark.skipif(not os.getenv("DATABASE_URL"),
+                            reason="needs a database")
+
+
+# ══════════════════════════════════════════════════════════════════════
+# 1. The state vocabulary knows what is over
+# ══════════════════════════════════════════════════════════════════════
+
+def test_only_cancelled_and_expired_are_over():
+    """`is_live` exists so the SCREEN does not hold this list.
+
+    `['cancelled', 'expired']` lived in TypeScript on the Signings page —
+    the same disease as the deleted `STUCK_AFTER_DAYS`, one layer up. A
+    list of terminal states in another language is the copy that gets
+    missed the day a seventh state is added.
+    """
+    assert loop.is_live(loop.STATE_REQUESTED)
+    assert loop.is_live(loop.STATE_WINDOWS_POSTED)
+    assert loop.is_live(loop.STATE_PARTIALLY_AGREED)
+    assert loop.is_live(loop.STATE_BOOKED), (
+        "a booked signing is still live — it is the one most likely to "
+        "need cancelling")
+    assert not loop.is_live(loop.STATE_CANCELLED)
+    assert not loop.is_live(loop.STATE_EXPIRED)
+
+
+def test_the_agenda_sends_the_verdict_so_no_screen_has_to_decide():
+    """The server half of the one-copy rule.
+
+    THE OTHER HALF IS IN JEST, and the split is deliberate — the
+    sixteenth comment-trip in this codebase was this very test, written
+    to read `signings/page.tsx` through `code_only`, which parses PYTHON.
+    It matched the comment explaining the removal.
+
+    #15 already ruled on this shape: a TypeScript comment stripper on the
+    Python side would be a third opinion about what a comment is. So the
+    Python suite pins that the SERVER decides, and
+    `frontend/src/__tests__/signingCancel.test.ts` pins that the screen
+    holds no list of its own, using the stripper that speaks its language.
+    """
+    src = code_only(BACKEND / "routers" / "signing.py")
+    assert '"live": loop.is_live(' in src, (
+        "the agenda no longer sends the verdict, so every screen that "
+        "needs it will decide for itself")
+
+
+def test_no_state_guard_forbids_cancelling_a_booked_request():
+    """Owner-ruled. The deal falls out, the closing moves, the buyer
+    reschedules — refusing to cancel a booked signing would fail the
+    officer at the exact moment she needs the product most. The weight
+    goes in the confirmation copy, never in a rule that says no."""
+    src = code_only(BACKEND / "routers" / "signing.py")
+    handler = src[src.index("def officer_cancel("):]
+    handler = handler[:handler.index("def ", 10)]
+    for forbidden in ("booked_at IS NULL", "STATE_BOOKED", "cannot cancel"):
+        assert forbidden not in handler, (
+            f"a guard on {forbidden!r} would refuse the most important case")
+
+
+# ══════════════════════════════════════════════════════════════════════
+# 2. Against a real database
+# ══════════════════════════════════════════════════════════════════════
+
+@pytest.fixture
+def world():
+    import psycopg2
+    from database import create_tables
+    from db_rows import ROW_FACTORY
+    create_tables()
+    conn = psycopg2.connect(os.environ["DATABASE_URL"], cursor_factory=ROW_FACTORY)
+    conn.autocommit = True
+    tag = uuid.uuid4().hex[:8]
+    made = {"tag": tag}
+    with conn.cursor() as cur:
+        cur.execute("INSERT INTO users (email, password_hash, full_name, role) "
+                    "VALUES (%s, 'x', 'Olivia Officer', 'user') RETURNING id",
+                    (f"officer-{tag}@cancel1.test",))
+        made["officer"] = cur.fetchone()["id"]
+        cur.execute("""INSERT INTO deeds (user_id, deed_type, property_address,
+                                          county, status)
+                       VALUES (%s, 'grant_deed', '1358 5th Street, Coronado, CA',
+                               'San Diego', 'completed') RETURNING id""",
+                    (made["officer"],))
+        made["deed"] = cur.fetchone()["id"]
+        cur.execute("""INSERT INTO signing_requests (deed_id, officer_user_id,
+                                                     tz_name, expires_at)
+                       VALUES (%s, %s, 'America/Los_Angeles', %s) RETURNING id""",
+                    (made["deed"], made["officer"],
+                     datetime.now(timezone.utc) + timedelta(days=14)))
+        made["request"] = cur.fetchone()["id"]
+        for role, name in ((loop.ROLE_NOTARY, "Nora Notary"),
+                           (loop.ROLE_SIGNER, "Sam Signer")):
+            cur.execute(
+                """INSERT INTO signing_participants (signing_request_id, party_role,
+                        display_name, email, token, expires_at)
+                   VALUES (%s, %s, %s, %s, %s, %s) RETURNING id, token""",
+                (made["request"], role, name, f"{role}-{tag}@cancel1.test",
+                 str(uuid.uuid4()),
+                 datetime.now(timezone.utc) + timedelta(days=14)))
+            row = cur.fetchone()
+            made[f"{role}_token"] = row["token"]
+            made[f"{role}_id"] = row["id"]
+    made["conn"] = conn
+    yield made
+    conn.close()
+
+
+def _client_for(user_id: int):
+    from fastapi.testclient import TestClient
+    from auth import create_access_token
+    from main import app
+    client = TestClient(app)
+    client.headers.update({
+        "Authorization": f"Bearer {create_access_token({'sub': str(user_id), 'email': 'x@cancel1.test'})}"})
+    return client
+
+
+def _public():
+    from fastapi.testclient import TestClient
+    from main import app
+    return TestClient(app)
+
+
+@dbonly
+def test_cancelling_voids_every_link_and_the_recipient_screen_says_why(world):
+    """END TO END, across the seam the audit found.
+
+    The officer presses cancel; the notary's link answers 403; and the
+    token page renders "This link has been withdrawn." on exactly that
+    status. The recipient side was always built — this test is the proof
+    that the officer side now reaches it.
+    """
+    public = _public()
+    assert public.get(f"/signing/{world['notary_token']}").status_code == 200
+
+    done = _client_for(world["officer"]).post(
+        f"/signing-requests/v2/{world['request']}/cancel")
+    assert done.status_code == 200, done.text
+    assert done.json()["state"] == "cancelled"
+    assert done.json()["cancelled_at"]
+
+    for role in (loop.ROLE_NOTARY, loop.ROLE_SIGNER):
+        assert public.get(f"/signing/{world[f'{role}_token']}").status_code == 403
+
+
+@dbonly
+def test_the_request_is_never_deleted(world):
+    """T-5, third application. A cancelled request that HAD a booked time
+    still had one; folding cancellation into a status column would make
+    that unsayable, and deleting the row would make it unaskable."""
+    _client_for(world["officer"]).post(
+        f"/signing-requests/v2/{world['request']}/cancel")
+    with world["conn"].cursor() as cur:
+        cur.execute("SELECT cancelled_at FROM signing_requests WHERE id = %s",
+                    (world["request"],))
+        row = cur.fetchone()
+    assert row is not None, "the request was deleted rather than cancelled"
+    assert row["cancelled_at"] is not None
+
+    agenda = _client_for(world["officer"]).get("/signing-requests/v2").json()
+    mine = next(r for r in agenda if r["id"] == world["request"])
+    assert mine["live"] is False
+    assert "cancelled" in mine["summary"].lower(), (
+        "it stays visible and says what happened")
+
+
+@dbonly
+def test_everybody_invited_is_told_including_a_signer_who_never_answered(world):
+    """THE RULING THAT NEEDED MAKING. Nothing was ever booked here and the
+    signer never replied — and they are still told, because they hold a
+    link that is now dead and finding that out by clicking it is worse.
+
+    Being INVITED is what earns the notice, not having answered.
+    """
+    with patch("utils.notifications.send_signing_cancelled") as sender:
+        _client_for(world["officer"]).post(
+            f"/signing-requests/v2/{world['request']}/cancel")
+
+    told = {c.kwargs["recipient_email"] for c in sender.call_args_list}
+    assert told == {f"notary-{world['tag']}@cancel1.test",
+                    f"signer-{world['tag']}@cancel1.test"}
+
+    by_email = {c.kwargs["recipient_email"]: c.kwargs for c in sender.call_args_list}
+    signer = by_email[f"signer-{world['tag']}@cancel1.test"]
+    notary = by_email[f"notary-{world['tag']}@cancel1.test"]
+    # The two registers, same as every other notice in this feature: the
+    # signer gets the street line, the professional gets the address.
+    assert signer["is_consumer"] is True
+    assert signer["property_text"] == "1358 5th Street"
+    assert notary["is_consumer"] is False
+    assert notary["property_text"] == "1358 5th Street, Coronado, CA"
+    assert notary["officer_name"]
+
+
+@dbonly
+def test_the_notices_are_sent_from_the_world_before_the_revocation(world):
+    """THE BUG THIS ORDERING AVOIDS, pinned because it is invisible.
+
+    Cancelling revokes every participant row, and the notice loop skips
+    revoked participants — as every loop in that file does, so a
+    participant the officer removed stops receiving mail. Read the world
+    AFTER the update and this cancellation is announced to precisely
+    nobody, silently, with the endpoint returning 200.
+    """
+    with patch("utils.notifications.send_signing_cancelled") as sender:
+        _client_for(world["officer"]).post(
+            f"/signing-requests/v2/{world['request']}/cancel")
+    assert sender.call_count == 2, (
+        "the notices went to nobody — the world was read after the "
+        "participants were revoked")
+
+
+@dbonly
+def test_cancelling_twice_is_one_cancellation_and_one_round_of_notices(world):
+    """A second "this is cancelled" email is a second alarm about a fire
+    that is already out."""
+    officer = _client_for(world["officer"])
+    with patch("utils.notifications.send_signing_cancelled") as sender:
+        officer.post(f"/signing-requests/v2/{world['request']}/cancel")
+        again = officer.post(f"/signing-requests/v2/{world['request']}/cancel")
+    assert again.status_code == 200
+    assert sender.call_count == 2, "the second cancel sent a second round"
+
+
+@dbonly
+def test_a_stranger_cannot_cancel_somebody_elses_signing(world):
+    with world["conn"].cursor() as cur:
+        cur.execute("INSERT INTO users (email, password_hash, full_name, role) "
+                    "VALUES (%s, 'x', 'Stranger', 'user') RETURNING id",
+                    (f"stranger-{world['tag']}@cancel1.test",))
+        stranger = cur.fetchone()["id"]
+    r = _client_for(stranger).post(f"/signing-requests/v2/{world['request']}/cancel")
+    assert r.status_code == 404, r.text
+
+
+# ══════════════════════════════════════════════════════════════════════
+# 3. Two destructive acts do not ride one button
+# ══════════════════════════════════════════════════════════════════════
+
+@dbonly
+def test_deleting_a_deed_with_a_live_signing_is_refused_and_names_the_notary(world):
+    """The soft-delete finding. `status = 'deleted'` leaves the row, so
+    the signing token does not break — it keeps serving a document the
+    officer believes she withdrew, to somebody she can no longer see."""
+    r = _client_for(world["officer"]).delete(f"/deeds/{world['deed']}")
+    assert r.status_code == 409, r.text
+    assert "Nora Notary" in r.text, "the refusal must name who is waiting"
+    assert "Cancel the signing first" in r.text
+
+    with world["conn"].cursor() as cur:
+        cur.execute("SELECT status FROM deeds WHERE id = %s", (world["deed"],))
+        assert cur.fetchone()["status"] != "deleted"
+
+
+@dbonly
+def test_once_the_signing_is_cancelled_the_deed_can_be_deleted(world):
+    """The refusal is a sequencing rule, not a lock. Cancel, then delete —
+    two deliberate acts, in the order that tells three people why."""
+    officer = _client_for(world["officer"])
+    officer.post(f"/signing-requests/v2/{world['request']}/cancel")
+    r = officer.delete(f"/deeds/{world['deed']}")
+    assert r.status_code == 200, r.text
+
+
+@dbonly
+def test_a_deed_with_no_signing_deletes_as_before(world):
+    """The guard must not become a tax on every deletion."""
+    with world["conn"].cursor() as cur:
+        cur.execute("""INSERT INTO deeds (user_id, deed_type, property_address, status)
+                       VALUES (%s, 'grant_deed', '9 Nowhere Rd', 'completed')
+                       RETURNING id""", (world["officer"],))
+        lonely = cur.fetchone()["id"]
+    assert _client_for(world["officer"]).delete(f"/deeds/{lonely}").status_code == 200

--- a/backend/utils/email_templates.py
+++ b/backend/utils/email_templates.py
@@ -579,6 +579,47 @@ def signing_proposal_received(notary_name, signer_name, officer_name,
     return subject, _base("A signer suggested a different time", content, True), text
 
 
+def signing_cancelled(recipient_name, property_text, when_text, officer_name,
+                      is_consumer: bool) -> Rendered:
+    """CANCEL1 — the request is off, and everybody who was asked is told.
+
+    WHO GETS THIS AND WHY. A notary who blocked out Thursday afternoon
+    and a signer who picked a time both arranged their day around an
+    appointment that is no longer happening. Owner-ruled: an invited
+    signer is told even when nothing was ever booked — they hold a link,
+    the link is now dead, and finding that out by clicking it is worse
+    than being told.
+
+    NO REASON FIELD, deliberately. The product does not know why she
+    cancelled and will not invent one; "cancelled by {officer}" is the
+    whole of what it can say. A blank line inviting an explanation would
+    be a place for one to be guessed at later.
+
+    SAME TWO REGISTERS AS `signing_booked`, for the same reason: the
+    signer gets the street line, the professionals get the full address.
+    An email is not a loophole in the surface allowlist.
+    """
+    subject = f"Signing cancelled — {property_text}"
+    body = (
+        _p(f"Hi {_esc(recipient_name) or 'there'},")
+        + _p(f"{_esc(officer_name)} has cancelled this signing request. "
+             "Any link you were sent for it no longer works.")
+        + _facts([("Property", property_text),
+                  ("Time that was agreed", when_text)])
+        + _p('<span style="font-size:13px;color:#8a94a0;">'
+             f"There is nothing to do. If you were expecting this signing, "
+             f"contact {_esc(officer_name)}.</span>")
+    )
+    text = (
+        f"{officer_name} has cancelled this signing request. Any link you "
+        "were sent for it no longer works.\n\n"
+        f"Property: {property_text}\n"
+        + (f"Time that was agreed: {when_text}\n" if when_text else "")
+        + f"\nIf you were expecting this signing, contact {officer_name}.\n"
+    )
+    return subject, _base(subject, body, is_consumer), text
+
+
 def signing_booked(recipient_name, when_text, property_text, notary_name,
                    officer_name, is_consumer: bool, link) -> Rendered:
     """NOTARY2 — everybody, on convergence. Carries the .ics.

--- a/backend/utils/notifications.py
+++ b/backend/utils/notifications.py
@@ -39,6 +39,11 @@ TEMPLATES = (
     # "the signing happened," because nothing in this product knows that.
     "notary_invited", "signing_windows_posted",
     "signing_proposal_received", "signing_booked", "signing_reminder",
+    # CANCEL1 — the officer calls it off. Everybody who was ASKED is
+    # told, including a signer who was invited and never answered: they
+    # hold a link, the link is dead, and discovering that by clicking it
+    # is worse than being told.
+    "signing_cancelled",
 )
 
 
@@ -285,6 +290,19 @@ def send_signing_booked(recipient_email: str, recipient_name: str, when_text: st
         is_consumer, link),
         user_id=user_id, context={"party": "signer" if is_consumer else "professional"},
         attachments=attachments)
+
+
+def send_signing_cancelled(recipient_email: str, recipient_name: str,
+                           property_text: str, when_text: Optional[str],
+                           officer_name: str, is_consumer: bool,
+                           user_id: Optional[int] = None) -> SendResult:
+    """CANCEL1 — everybody who was asked, when the officer calls it off."""
+    return _send("signing_cancelled", recipient_email,
+                 email_templates.signing_cancelled(
+                     recipient_name, property_text, when_text or "",
+                     officer_name, is_consumer),
+                 user_id=user_id,
+                 context={"party": "signer" if is_consumer else "professional"})
 
 
 def send_welcome_with_reason(user_email: str, full_name: str) -> SendResult:

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -442,6 +442,25 @@ we reach it.
 
 ## Parked tickets (scoped, not scheduled)
 
+- **CANCEL1's three post-creation gaps** (audit finding, ledgered
+  2026-08-12 with the ticket that made them survivable). Every field on a
+  signing request is create-only: the notary cannot be reassigned, the
+  time/location/signers cannot be edited, and an invitation cannot be
+  resent. All three are real.
+
+  **They wait because cancel-and-recreate is a working path for all
+  three, and cancellation is its precondition** — which now exists, with
+  notices, so the clumsy path is at least an honest one: everybody is
+  told the old arrangement is off before the new one arrives.
+
+  **TRIGGER: an officer doing it twice.** Cancel-and-recreate costs three
+  emails and retyping the signers. That is tolerable once and grating on
+  repetition, and the repetition is the signal that the shortcut is worth
+  its own state. Reassign-notary is the likeliest first: a notary
+  declining is a normal outcome, not an error.
+
+
+
 - **Retire NOTARY1's read-side routes — DONE 2026-08-12.** All four
   removed (the ledger said three; `GET /approve/{token}/pcor.pdf` was
   not in the count), with `_signing_share_by_token`,

--- a/frontend/src/__tests__/signingCancel.test.ts
+++ b/frontend/src/__tests__/signingCancel.test.ts
@@ -1,0 +1,119 @@
+/**
+ * CANCEL1 — the screen half.
+ *
+ * ═══ WHY THIS FILE EXISTS SEPARATELY FROM THE PYTHON SUITE ═══
+ *
+ * The Python suite pins that the SERVER decides which states are over
+ * (`signing_loop.is_live`) and that the agenda sends the verdict. This
+ * file pins the other half: the screen holds no list of its own.
+ *
+ * The split is not tidiness. The first draft of that pin lived in Python
+ * and read `signings/page.tsx` through `code_only`, which parses PYTHON —
+ * so it matched the comment explaining the removal and became the
+ * sixteenth comment-trip in this codebase. #15 already ruled the shape:
+ * a TypeScript comment stripper on the Python side would be a third
+ * opinion about what a comment is. Each language's pin uses the stripper
+ * that speaks it.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
+import { cancelWarning } from '../lib/signingCopy';
+
+const SIGNINGS = codeOnly(
+  fs.readFileSync(path.join(__dirname, '..', 'app', 'signings', 'page.tsx'), 'utf8'));
+
+describe('which states are over is the server’s judgement', () => {
+  it('the screen holds no terminal-state list', () => {
+    /**
+     * `['cancelled', 'expired'].includes(r.state)` lived here — the same
+     * disease as the deleted `STUCK_AFTER_DAYS`, one layer up. A list of
+     * terminal states in TypeScript is the copy that gets missed the day
+     * a seventh state is added to the Python vocabulary.
+     */
+    expect(SIGNINGS).not.toContain("'cancelled', 'expired'");
+    expect(SIGNINGS).not.toContain("'expired', 'cancelled'");
+  });
+
+  it('renders the verdict the payload carries', () => {
+    expect(SIGNINGS).toContain('!r.live');
+  });
+});
+
+describe('the cancel confirmation names what is being cancelled', () => {
+  const unbooked = {
+    state: 'windows_posted',
+    summary: 'Waiting on signers',
+    property_address: '1358 5th Street, Coronado, CA',
+  };
+  const booked = {
+    state: 'booked',
+    summary: 'Nora and both signers agreed on Thursday, September 3, 2026, 2:00 PM.',
+    property_address: '1358 5th Street, Coronado, CA',
+  };
+
+  it('names the property on an ordinary request', () => {
+    const text = cancelWarning(unbooked, []);
+    expect(text).toContain('1358 5th Street, Coronado, CA');
+    expect(text).toContain('stops working');
+  });
+
+  it('carries the booking’s weight when a time is agreed', () => {
+    /**
+     * Owner-ruled: cancelling a booked signing is ALLOWED — the deal
+     * falls out, the closing moves, the buyer reschedules, and refusing
+     * there would fail the officer at the exact moment she needs the
+     * product. So the weight lands in the sentence instead: who agreed,
+     * to what, and what cancelling costs them.
+     */
+    const text = cancelWarning(booked, ['Nora Notary', 'Sam Signer']);
+    expect(text).toContain('Nora Notary and Sam Signer');
+    expect(text).toContain('voids their links');
+    expect(text).toContain('1358 5th Street, Coronado, CA');
+  });
+
+  it('reads differently for a booked request than an unbooked one', () => {
+    /**
+     * THE WHOLE POINT, and the same rule as the Past Deeds delete
+     * confirm: a sentence that reads identically every time is the one
+     * that gets read past. If these two ever converge, the heavier case
+     * has stopped being heavier.
+     */
+    expect(cancelWarning(booked, ['Nora Notary']))
+      .not.toEqual(cancelWarning(unbooked, ['Nora Notary']));
+  });
+
+  it('takes the booked sentence from the server verbatim', () => {
+    /** §13 rule 3: one place turns a scheduling state into English, and
+     * it is not a screen. This file formats no signing time. */
+    expect(cancelWarning(booked, [])).toContain(booked.summary);
+    const copy = fs.readFileSync(
+      path.join(__dirname, '..', 'lib', 'signingCopy.ts'), 'utf8');
+    expect(codeOnly(copy)).not.toMatch(/toLocaleString|toLocaleTimeString|Intl\./);
+  });
+
+  it('degrades to a name rather than a blank when the address is missing', () => {
+    expect(cancelWarning({ ...unbooked, property_address: null }, []))
+      .toContain('this deed');
+  });
+});
+
+describe('the panel that had no controls', () => {
+  it('offers the cancel, behind a confirmation', () => {
+    expect(SIGNINGS).toContain('Cancel this signing request');
+    expect(SIGNINGS).toContain('cancelWarning');
+    expect(SIGNINGS).toContain('Keep it');
+  });
+
+  it('does not compose its own scheduling sentence', () => {
+    expect(SIGNINGS).not.toMatch(/scheduled for/i);
+    expect(SIGNINGS).not.toMatch(/will (happen|take place)/i);
+  });
+
+  it('shows a cancelled request rather than hiding it', () => {
+    /** T-5: a cancelled request that HAD a booked time still had one.
+     * The row moves to the closed list and keeps saying what happened. */
+    expect(SIGNINGS).toContain('detail.cancelled_at');
+  });
+});

--- a/frontend/src/app/signings/page.tsx
+++ b/frontend/src/app/signings/page.tsx
@@ -23,11 +23,12 @@
  * label, rendered in the REQUEST's timezone.
  */
 
-import { Suspense, useEffect, useMemo, useState } from 'react';
+import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import Sidebar from '@/components/Sidebar';
 import { AlertCircle, CalendarClock, CheckCircle2, Clock, Loader2 } from 'lucide-react';
 import { SessionExpiredError, apiFetch } from '@/lib/apiClient';
+import { cancelWarning } from '@/lib/signingCopy';
 
 type Row = {
   id: number;
@@ -48,10 +49,18 @@ type Row = {
   stale: boolean;
   expires_at: string | null;
   signers: number;
+  /** CANCEL1: is this one still waiting on somebody. The server decides
+   * — see the note on the deleted terminal-state list below. */
+  live: boolean;
 };
 
 /** What `GET /signing-requests/v2/{id}` returns for one signing. */
 type Detail = {
+  state: string;
+  summary: string;
+  property_address: string | null;
+  booked_at: string | null;
+  cancelled_at: string | null;
   participants: Array<{
     id: number;
     party_role: string;
@@ -148,6 +157,13 @@ function SigningsAgenda() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
+  const reload = useCallback(async () => {
+    try {
+      const r = await apiFetch('/signing-requests/v2', {}, { label: 'Loading signings', silent: true });
+      if (r.ok) setRows(await r.json());
+    } catch { /* the panel already reported it; the list keeps what it has */ }
+  }, []);
+
   useEffect(() => {
     (async () => {
       // The auth guard. Caught by routeGuards.test.ts, which is the pin
@@ -208,12 +224,18 @@ function SigningsAgenda() {
     [rows]);
   const arranging = useMemo(
     () => rows
-      .filter((r) => !['booked', 'cancelled', 'expired'].includes(r.state))
+      .filter((r) => r.live && r.state !== 'booked')
       // Oldest first: longest-waiting is the one worth chasing.
       .sort((a, b) => (a.created_at || '').localeCompare(b.created_at || '')),
     [rows]);
   const closed = useMemo(
-    () => rows.filter((r) => ['cancelled', 'expired'].includes(r.state)), [rows]);
+    /* CANCEL1 — `['cancelled', 'expired']` USED TO LIVE HERE.
+       It is the same disease as the deleted STUCK_AFTER_DAYS above, one
+       layer up: which states are OVER is a fact about the state
+       vocabulary, and the vocabulary is `services/signing_loop.py`. A
+       list here is that judgement copied, and the copy is what gets
+       missed the day a seventh state is added. The server sends `live`. */
+    () => rows.filter((r) => !r.live), [rows]);
 
   return (
     <div className="flex min-h-screen bg-slate-50">
@@ -285,7 +307,8 @@ function SigningsAgenda() {
               <div className="space-y-3">
                 {bookedRows.map((r) => (
                   <SigningRow key={r.id} row={r} open={focus === r.id}
-                              onToggle={() => setFocus(focus === r.id ? null : r.id)} />
+                              onToggle={() => setFocus(focus === r.id ? null : r.id)}
+                              onCancelled={reload} />
                 ))}
               </div>
             </>
@@ -299,7 +322,8 @@ function SigningsAgenda() {
               <div className="space-y-3">
                 {arranging.map((r) => (
                   <SigningRow key={r.id} row={r} open={focus === r.id}
-                              onToggle={() => setFocus(focus === r.id ? null : r.id)} />
+                              onToggle={() => setFocus(focus === r.id ? null : r.id)}
+                              onCancelled={reload} />
                 ))}
               </div>
             </>
@@ -313,7 +337,8 @@ function SigningsAgenda() {
               <div className="space-y-3 opacity-70">
                 {closed.map((r) => (
                   <SigningRow key={r.id} row={r} open={focus === r.id}
-                              onToggle={() => setFocus(focus === r.id ? null : r.id)} />
+                              onToggle={() => setFocus(focus === r.id ? null : r.id)}
+                              onCancelled={reload} />
                 ))}
               </div>
             </>
@@ -342,10 +367,14 @@ function SigningsAgenda() {
  * `?focus=<id>` makes it linkable, so a notification can point at the
  * signing it is about rather than at the list.
  */
-function SigningRow({ row, open, onToggle }: {
+function SigningRow({ row, open, onToggle, onCancelled }: {
   row: Row;
   open: boolean;
   onToggle: () => void;
+  /* A cancelled request moves from the agenda to the closed list, and
+     the grouping is the server's — so the list is re-read rather than
+     patched here. Same reason the summary is never composed locally. */
+  onCancelled: () => void;
 }) {
   const stuck = isStuck(row);
   const booked = row.state === 'booked';
@@ -399,17 +428,44 @@ function SigningRow({ row, open, onToggle }: {
           </span>
         </div>
       </button>
-      {open && <SigningDetail requestId={row.id} />}
+      {open && <SigningDetail requestId={row.id} onCancelled={onCancelled} />}
     </div>
   );
 }
 
 /** The detail, fetched when she opens it. Read-only: this ticket links
  * the card to its signing; it does not move the officer's actions here. */
-function SigningDetail({ requestId }: { requestId: number }) {
+function SigningDetail({ requestId, onCancelled }: {
+  requestId: number;
+  onCancelled: () => void;
+}) {
   const [detail, setDetail] = useState<Detail | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+  const [confirming, setConfirming] = useState(false);
+  const [cancelling, setCancelling] = useState(false);
+
+  const cancel = async () => {
+    setCancelling(true);
+    setError(null);
+    try {
+      const r = await apiFetch(`/signing-requests/v2/${requestId}/cancel`, { method: 'POST' },
+                               { label: 'Cancelling this signing' });
+      if (!r.ok) {
+        throw new Error((await r.json().catch(() => ({}))).detail || `Failed (${r.status})`);
+      }
+      setDetail(await r.json());
+      setConfirming(false);
+      onCancelled();
+    } catch (err) {
+      if (err instanceof SessionExpiredError) return;
+      // §4: a cancellation that did not happen must not look like one
+      // that did. The panel says so and the request stays live.
+      setError(err instanceof Error ? err.message : 'Could not cancel this signing');
+    } finally {
+      setCancelling(false);
+    }
+  };
 
   useEffect(() => {
     (async () => {
@@ -489,6 +545,54 @@ function SigningDetail({ requestId }: { requestId: number }) {
               </ul>
             )}
           </div>
+
+          {/* CANCEL1 item 1 — the panel was read-only, with zero
+              interactive elements, on a feature whose recipient side has
+              always rendered "This link has been withdrawn." The state
+              existed, the endpoint existed, and no officer surface could
+              produce either. */}
+          {detail.cancelled_at ? (
+            <p className="text-sm text-slate-500 border-t border-slate-100 pt-4">
+              {/* Never deleted — a cancelled request that HAD a booked
+                  time still had one (T-5). It stays visible, and says so. */}
+              {detail.summary}
+            </p>
+          ) : (
+            <div className="border-t border-slate-100 pt-4">
+              {!confirming ? (
+                <button
+                  onClick={() => setConfirming(true)}
+                  className="text-sm font-medium text-red-700 hover:text-red-900 hover:underline"
+                >
+                  Cancel this signing request
+                </button>
+              ) : (
+                <div className="space-y-3 rounded-lg border border-red-200 bg-red-50 p-3">
+                  <p className="text-sm text-red-900">
+                    {cancelWarning(detail, detail.participants
+                      .filter((p) => !p.revoked)
+                      .map((p) => p.name || p.party_role))}
+                  </p>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={cancel}
+                      disabled={cancelling}
+                      className="px-3 py-2 text-sm font-medium rounded-lg bg-red-600 text-white hover:bg-red-700 disabled:opacity-60"
+                    >
+                      {cancelling ? 'Cancelling…' : 'Cancel the signing'}
+                    </button>
+                    <button
+                      onClick={() => setConfirming(false)}
+                      disabled={cancelling}
+                      className="px-3 py-2 text-sm font-medium rounded-lg border border-slate-300 text-slate-700 hover:bg-white disabled:opacity-60"
+                    >
+                      Keep it
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/frontend/src/lib/signingCopy.ts
+++ b/frontend/src/lib/signingCopy.ts
@@ -1,0 +1,49 @@
+/**
+ * The sentence the officer reads before she cancels a signing.
+ *
+ * IT LIVES HERE SO IT CAN BE PINNED, and because a `page.tsx` may export
+ * only its default — Next's own type check rejects anything else, which
+ * is how this function's first home failed the build.
+ *
+ * ═══ WHY THE COPY CARRIES THE WEIGHT ═══
+ *
+ * Cancelling a BOOKED signing is allowed, deliberately and without a
+ * state guard (owner-ruled, CANCEL1). A booked signing is the one most
+ * likely to need cancelling — the deal falls out, the closing moves, the
+ * buyer reschedules — so refusing there would fail the officer at the
+ * exact moment she needs the product most.
+ *
+ * Cancelling a booked signing is not a different capability. It is a
+ * heavier moment, and the weight belongs in this sentence rather than in
+ * a rule that says no.
+ *
+ * ═══ AND IT NAMES ITS OBJECT ═══
+ *
+ * The same rule as the delete confirmation on Past Deeds: a confirm that
+ * reads identically every time is the one that gets read past. It
+ * confirms that SOMETHING is being cancelled without ever confirming
+ * WHICH. So this one names the property, and when a time is agreed it
+ * names who agreed and what it costs them.
+ *
+ * The booked sentence itself comes from the SERVER (`state_label`) and is
+ * interpolated verbatim. This file formats no signing time — §13 rule 3:
+ * one place turns a scheduling state into English, and it is not a
+ * screen.
+ */
+
+export interface CancelSubject {
+  state: string;
+  /** The server's sentence about this request's state. Rendered as-is. */
+  summary: string;
+  property_address: string | null;
+}
+
+export function cancelWarning(subject: CancelSubject, agreed: string[]): string {
+  const where = subject.property_address || 'this deed';
+  if (subject.state === 'booked') {
+    const who = agreed.length ? agreed.join(' and ') : 'everyone involved';
+    return `${subject.summary} Cancelling notifies ${who} and voids their links. ${where}.`;
+  }
+  return `Cancel the signing request for ${where}? Everyone invited is told, `
+       + 'and every link they were sent stops working.';
+}


### PR DESCRIPTION
CANCEL1 items 1–3. Items 4–6 follow in their own PR — this one is complete end-to-end, with a client for every endpoint it touches.

## Item 1 — a control, not an endpoint

The audit said the officer couldn't cancel in any state. Checked first, and the truth was narrower and more useful: **the whole system was already there.** The endpoint sets `cancelled_at` and revokes every token, `request_state` derives `cancelled`, `state_label` says so, and the token page has always rendered *"This link has been withdrawn."* on the 403 a revoked participant produces.

What didn't exist was any way to reach it. The expanded panel was read-only — **zero interactive elements** — so a state the product could describe, and a recipient screen built to display it, could be produced by nothing an officer could press.

**Cancelling a booked request is allowed, without a state guard**, and a pin forbids one appearing. The weight lands in the sentence instead:

> *"Nora and both signers agreed on Thursday, September 3, 2:00 PM. Cancelling notifies Nora Notary and Sam Signer and voids their links. 1358 5th Street, Coronado, CA."*

versus the unbooked case, which names the property and says every link stops working. A test asserts the two **never converge** — if they do, the heavier case has stopped being heavier. Same ruling as the Past Deeds delete confirm, one ticket later.

The booked sentence comes from `state_label` verbatim; a pin checks `signingCopy.ts` formats no time itself.

## Item 2 — the notices

The endpoint told nobody. Your ruling on the hard case is the one the test is named after: **an invited signer who never answered is told too**, because they hold a link that's now dead and finding that out by clicking it is worse. Being invited earns the notice, not having answered.

**The ordering is load-bearing and pinned.** Cancelling revokes every participant, and the notice loop skips revoked participants — as every loop in that file does, so a removed participant stops getting mail. Read the world *after* the update and the cancellation is announced to **precisely nobody**, silently, with the endpoint returning 200. `_load` runs before the UPDATE, and a test asserts two notices go out.

Cancelling twice sends one round — a second "this is cancelled" email is a second alarm about a fire that's already out.

## Item 3 — the refusal, and it's worse than "orphan"

`DELETE /deeds/{id}` is a **soft** delete. The row stays, `status` becomes `'deleted'`. So a live signing token didn't break — **it kept working perfectly**, serving a document the officer believed she'd withdrawn, to somebody she could no longer see. The only surface that knew was the stranger's.

```
409: This deed has a signing request waiting on Nora Notary. Cancel the
     signing first — that voids everyone's links and tells them why.
     Then the deed can be deleted.
```

A sequencing rule, not a lock: cancel, then delete. Both paths tested, plus a deed with no signing deleting exactly as before.

## One fewer copy

`['cancelled', 'expired'].includes(r.state)` lived in TypeScript on the Signings page — the terminal-state judgement, in the wrong language, and the same disease as the deleted `STUCK_AFTER_DAYS` one layer up. `signing_loop.is_live` decides, the agenda sends `live`, the list is gone.

## Comment-trip sixteen, and it was this ticket's own pin

I wrote the "screen holds no terminal list" pin in **Python**, reading `signings/page.tsx` through `code_only` — which parses Python. It matched the comment explaining the removal.

#15 already ruled this shape: a TypeScript comment stripper on the Python side would be a third opinion about what a comment is. So the job splits — Python pins that the **server decides**, jest pins that the **screen holds no list**, each using the stripper that speaks its language. Both halves carry the reason.

## Verification

Five mutation probes, five caught — including deleting the notice call, and moving `_load` to after the revocation (the silent-nobody bug).

| Gate | Result |
|---|---|
| pytest, with a database | **1153 passed** |
| pytest, no database | **961 passed**, 192 skipped |
| jest | **744 passed**, 51 suites |
| `next build` | ✔ |
| tsc | **88** — baseline holds |
| six-flow / API baselines | ✔ |
| banned-claims | clean |

Template trip-wire 18 → 19 for `signing_cancelled`; it has now moved in both directions, which is the point of counting.

One in-passing fix: `cancelWarning` first lived in `page.tsx`, and Next's page-type check rejects any export but the default — so it moved to `lib/signingCopy.ts`, which is where a pinnable pure function belonged anyway.

## Ledgered

The three post-creation gaps — reassign notary, edit time/location/signers, resend invitation — with **cancel-and-recreate named as the interim path** and the trigger being an officer doing it twice. Reassign-notary is the likeliest first: a notary declining is a normal outcome, not an error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_