### PR TITLE
The row knows a signing is already out, and the officer sets the clock

### DIFF
--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -440,6 +440,26 @@ we reach it.
   already returns the actor's email and every handler discards it, so
   actor threading is the first task, not the last.
 
+## Open — needs a ruling (found 2026-08-12, NOT fixed)
+
+- **Revoking a share tells the recipient nothing.** Found by the sweep
+  for other revoke-then-notify compositions (CANCEL1 item 2's class).
+  `POST /shared-deeds/{id}/revoke` flips the status and sends no email
+  and no in-app notice, so a reviewer keeps a link that has silently
+  stopped working and finds out by clicking it.
+
+  This is NOT the composition bug — there is no notify loop to be
+  silenced, because there is no notify loop at all. It is the same
+  PRODUCT question the owner already ruled for cancellation: an invited
+  person holds a link, the link is dead, and discovering that by clicking
+  is worse than being told. The ruling there was yes-if-invited; whether
+  it carries to review shares is a separate call, because a revoked
+  review is sometimes a deliberate un-invitation the officer may not want
+  to announce.
+
+  Cheap either way — the transport, the template shape and the two
+  registers all exist.
+
 ## Parked tickets (scoped, not scheduled)
 
 - **CANCEL1's three post-creation gaps** (audit finding, ledgered

--- a/frontend/src/__tests__/shareEntryPoints.test.ts
+++ b/frontend/src/__tests__/shareEntryPoints.test.ts
@@ -46,6 +46,7 @@ const REVIEW = read('features', 'signing', 'ShareForReviewModal.tsx');
  */
 const SIGNING = read('features', 'signing', 'RequestSigningModal.tsx');
 const PICKER = read('features', 'partners', 'PartnerRecipientPicker.tsx');
+import { signingRowAction } from '../lib/signingRowAction';
 
 describe('Part B — two distinct actions on the deed', () => {
   it('the deed offers "Share for review" and "Request signing", separately', () => {
@@ -60,9 +61,22 @@ describe('Part B — two distinct actions on the deed', () => {
     // So the assertion moved UP in strength, not sideways: visible text,
     // and the titles that used to carry it are gone rather than kept as
     // a second copy of the same words.
+    //
+    // CANCEL1 RETARGETED THE SECOND HALF, and flagged it here rather than
+    // in a commit message nobody re-reads. "Request signing" is no longer
+    // a literal in this file: a deed that ALREADY has a signing out must
+    // offer to open it instead of creating a second, so the label comes
+    // from `lib/signingRowAction` — which exists because a
+    // string-presence pin could not tell a reachable branch from a dead
+    // one and stayed green with the feature disabled.
+    //
+    // The property is unchanged and is still checked, one step across:
+    // two separately-named actions, in visible text, on the row. The
+    // review half is still a literal because it has no second state.
     const flat = PAGE.replace(/\s+/g, ' ');
     expect(flat).toContain('<span className="whitespace-nowrap">Share for review</span>');
-    expect(flat).toContain('<span className="whitespace-nowrap">Request signing</span>');
+    expect(signingRowAction(1, {}).label).toBe('Request signing');
+    expect(flat).toContain('{action.label}</span>');
     expect(PAGE).not.toContain('title="Share for review"');
     expect(PAGE).not.toContain('title="Request signing"');
     // The generic one is gone, not relabelled alongside them.

--- a/frontend/src/__tests__/signingReuse.test.ts
+++ b/frontend/src/__tests__/signingReuse.test.ts
@@ -1,0 +1,133 @@
+/**
+ * CANCEL1 items 4–5 — the row knows, and the officer sets the clock.
+ *
+ * ═══ ITEM 4: THE ROW OFFERED A SECOND REQUEST ═══
+ *
+ * Past Deeds showed "Request signing" on a deed that already had one
+ * pending, with nothing on screen saying so. The officer's only way to
+ * check was to create a second request and find out — which is three
+ * more emails, two notaries who each believe they have the appointment,
+ * and two sets of links to whichever signers were invited twice.
+ *
+ * ═══ ITEM 5: THE EXPIRY WAS IMPOSED SILENTLY ═══
+ *
+ * `expires_in_days` has been on the create payload since NOTARY2 and no
+ * screen ever sent one, so every request got the 21-day default and the
+ * officer read the date off the agenda afterwards. Reviews have had the
+ * control all along — this is the same field, in the same place, on the
+ * other modal.
+ *
+ * ═══ WHAT THIS FILE DOES NOT PIN ═══
+ *
+ * Which states count as "still out". That is `signing_loop.is_live` and
+ * it is pinned in Python, where it lives. This screen joins a verdict it
+ * is handed; if it ever starts deciding, the pin in
+ * `signingCancel.test.ts` fails.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
+import { signingRowAction } from '../lib/signingRowAction';
+
+const SRC = path.join(__dirname, '..');
+const PAST_DEEDS = codeOnly(fs.readFileSync(path.join(SRC, 'app', 'past-deeds', 'page.tsx'), 'utf8'));
+const SIGNING_MODAL = codeOnly(fs.readFileSync(
+  path.join(SRC, 'features', 'signing', 'RequestSigningModal.tsx'), 'utf8'));
+const REVIEW_MODAL = codeOnly(fs.readFileSync(
+  path.join(SRC, 'features', 'signing', 'ShareForReviewModal.tsx'), 'utf8'));
+
+describe('a deed with a signing already out says so', () => {
+  it('reads the verdict rather than deciding which states are over', () => {
+    expect(PAST_DEEDS).toContain('r.live');
+    // The judgement stays in Python. A list here would be the copy that
+    // gets missed the day a seventh state is added.
+    expect(PAST_DEEDS).not.toContain("'cancelled', 'expired'");
+  });
+
+  it('opens the existing request instead of offering a second', () => {
+    /**
+     * CALLED, not grepped. The first version of this test asserted the
+     * strings appeared in `page.tsx` — and stayed green when the whole
+     * branch was disabled with `{false ? (`, because both strings were
+     * still there, inside code that could never run.
+     *
+     * A string-presence pin cannot tell REACHABLE from PRESENT. The
+     * decision moved into a function so the test can call it.
+     */
+    const live = { 7: { id: 42, summary: 'Waiting on the notary' } };
+    expect(signingRowAction(7, live)).toEqual({
+      kind: 'open',
+      href: '/signings?focus=42',
+      label: 'Open signing request',
+      summary: 'Waiting on the notary',
+    });
+  });
+
+  it('still offers to create one on a deed that has none', () => {
+    expect(signingRowAction(9, { 7: { id: 42, summary: 'x' } }))
+      .toEqual({ kind: 'create', label: 'Request signing' });
+    expect(signingRowAction(9, {})).toEqual({ kind: 'create', label: 'Request signing' });
+  });
+
+  it('is what the row actually calls', () => {
+    /** The function is only the decision if the page uses it. */
+    expect(PAST_DEEDS).toContain('signingRowAction(deed.id, liveSignings)');
+    expect(PAST_DEEDS).not.toContain('/signings?focus=${liveSignings');
+  });
+
+  it('shows the state as text, never as a tooltip', () => {
+    /**
+     * FLOW1 item 1's ruling reaches status as much as controls: a tooltip
+     * is invisible until you already suspect you need it, and absent
+     * entirely on touch. The first draft of this row put the summary in a
+     * `title` — this asserts it is rendered and that no `title` carries
+     * it, which is the half that would have gone unnoticed.
+     */
+    expect(PAST_DEEDS).toContain('{liveSignings[deed.id].summary}');
+    expect(PAST_DEEDS).not.toContain('title={liveSignings');
+  });
+
+  it('does not compose its own sentence about the signing', () => {
+    /** §13 rule 3 — one place turns a scheduling state into English. */
+    expect(PAST_DEEDS).not.toMatch(/waiting on the notary/i);
+    expect(PAST_DEEDS).not.toMatch(/scheduled for/i);
+  });
+
+  it('degrades to the old behaviour if the lookup fails', () => {
+    /**
+     * A failed signings lookup must not blank a page full of real deeds.
+     * The cost of missing it is the pre-CANCEL1 row, which is a worse
+     * row and not a broken one.
+     */
+    expect(PAST_DEEDS).toContain('silent: true');
+  });
+});
+
+describe('the officer sets the expiry on a signing, as she does on a review', () => {
+  it('sends the field the API has always accepted', () => {
+    expect(SIGNING_MODAL).toContain('expires_in_days: expiresInDays');
+  });
+
+  it('offers the choice in the same place the review dialog does', () => {
+    expect(SIGNING_MODAL).toContain('Links expire after');
+    expect(REVIEW_MODAL).toContain('Link expires after');
+  });
+
+  it('measures a signing in days and a review in hours', () => {
+    /** Same control, units that match the thing: a review is read in an
+     * afternoon, a signing is arranged over weeks. */
+    expect(SIGNING_MODAL).toMatch(/days: 21/);
+    expect(REVIEW_MODAL).toMatch(/hours: 168/);
+  });
+
+  it('says what expiry does and what it is NOT', () => {
+    /**
+     * Expiring is not cancelling, and the difference matters: expiry is a
+     * clock running out and nobody is told, cancellation is a decision
+     * and everybody is. A control that blurred them would have the
+     * officer reaching for the wrong one.
+     */
+    expect(SIGNING_MODAL).toContain('The request is not cancelled — nobody is told.');
+  });
+});

--- a/frontend/src/app/past-deeds/page.tsx
+++ b/frontend/src/app/past-deeds/page.tsx
@@ -6,6 +6,7 @@ import { useRouter, useSearchParams } from "next/navigation"
 import Sidebar from "@/components/Sidebar"
 import { FileText, Download, Share2, Trash2, AlertCircle, CheckCircle, Clock, X, Plus, Loader2, Search, CalendarClock } from "lucide-react"
 import { RequestSigningModal } from "@/features/signing/RequestSigningModal"
+import { signingRowAction } from "@/lib/signingRowAction"
 import { ShareForReviewModal } from "@/features/signing/ShareForReviewModal"
 import { PartnersProvider } from "@/features/partners/PartnersContext"
 import { toast } from "sonner"
@@ -70,6 +71,13 @@ function PastDeedsList() {
   // actions; a single "which modal" enum would have been the toggle this
   // part exists to remove.
   const [reviewDeedId, setReviewDeedId] = useState<number | null>(null)
+  /* CANCEL1 item 4 — WHICH DEEDS ALREADY HAVE A SIGNING OUT.
+     The row offered "Request signing" on a deed that already had one
+     pending, with nothing on screen to say so — so the officer's way of
+     checking was to create a second request and find out. `live` is the
+     server's verdict (services/signing_loop.is_live); this screen only
+     joins it to the row. */
+  const [liveSignings, setLiveSignings] = useState<Record<number, { id: number; summary: string }>>({})
   const [deleteConfirm, setDeleteConfirm] = useState<{ isOpen: boolean; deedId: number | null; deed?: Deed }>({
     isOpen: false,
     deedId: null,
@@ -120,6 +128,27 @@ function PastDeedsList() {
 
       const data = await response.json()
       setDeeds(Array.isArray(data) ? data : data.deeds || [])
+
+      /* Best-effort and SILENT: a failed lookup here must not blank a
+         page full of real deeds. The cost of missing it is that the row
+         offers "Request signing" as it always did — the pre-CANCEL1
+         behaviour — rather than a broken page. */
+      try {
+        const sr = await apiFetch(`/signing-requests/v2`, {},
+                                  { label: "Loading signings", silent: true })
+        if (sr.ok) {
+          const rows = await sr.json()
+          const byDeed: Record<number, { id: number; summary: string }> = {}
+          for (const r of Array.isArray(rows) ? rows : []) {
+            // `live` is the server's verdict. This screen holds no list
+            // of which states are over — see signing_loop.is_live.
+            if (r.live && !byDeed[r.deed_id]) {
+              byDeed[r.deed_id] = { id: r.id, summary: r.summary }
+            }
+          }
+          setLiveSignings(byDeed)
+        }
+      } catch { /* the row keeps its old behaviour; the page is fine */ }
     } catch (err) {
       if (err instanceof SessionExpiredError) return
       console.error("Error fetching deeds:", err)
@@ -388,7 +417,17 @@ function PastDeedsList() {
                           ) : null}
                         </td>
                         <td className="py-4 px-6 text-slate-600">{deedTypeLabel(deed.deed_type)}</td>
-                        <td className="py-4 px-6">{getStatusBadge(deed.status)}</td>
+                        <td className="py-4 px-6">
+                          {getStatusBadge(deed.status)}
+                          {liveSignings[deed.id] && (
+                            /* The server's sentence, verbatim. This screen
+                               does not describe a scheduling state — one
+                               place turns state into English (§13 rule 3). */
+                            <p className="text-xs text-slate-500 mt-1 max-w-[16rem]">
+                              {liveSignings[deed.id].summary}
+                            </p>
+                          )}
+                        </td>
                         <td className="py-4 px-6 text-sm text-slate-600">{formatDate(deed.created_at)}</td>
                         <td className="py-4 px-6 text-sm text-slate-600">{formatDate(deed.updated_at)}</td>
                         <td className="py-4 px-6">
@@ -451,13 +490,40 @@ function PastDeedsList() {
                                   <Share2 className="w-4 h-4 shrink-0" />
                                   <span className="whitespace-nowrap">Share for review</span>
                                 </button>
-                                <button
-                                  onClick={() => setSigningDeedId(deed.id)}
-                                  className="inline-flex items-center gap-1.5 px-3 py-2 bg-slate-600 hover:bg-slate-700 text-white text-sm font-medium rounded-lg transition-colors"
-                                >
-                                  <CalendarClock className="w-4 h-4 shrink-0" />
-                                  <span className="whitespace-nowrap">Request signing</span>
-                                </button>
+                                {/* CANCEL1 item 4 — a deed with a signing
+                                    already out says so, and the action
+                                    OPENS it. Offering "Request signing"
+                                    on a request that exists is an
+                                    invitation to create a second one,
+                                    which is three more emails and two
+                                    notaries who each think they have it. */}
+                                {(() => {
+                                  /* The decision is `lib/signingRowAction`,
+                                     not this ternary — see that file for
+                                     why: a string-presence pin could not
+                                     tell a reachable branch from a dead
+                                     one, and stayed green with the whole
+                                     feature disabled. */
+                                  const action = signingRowAction(deed.id, liveSignings)
+                                  return action.kind === 'open' ? (
+                                    <button
+                                      onClick={() => router.push(action.href)}
+                                      aria-label={`Open the signing request for ${deed.property_address}`}
+                                      className="inline-flex items-center gap-1.5 px-3 py-2 border border-slate-300 text-slate-700 hover:bg-slate-50 text-sm font-medium rounded-lg transition-colors"
+                                    >
+                                      <CalendarClock className="w-4 h-4 shrink-0" />
+                                      <span className="whitespace-nowrap">{action.label}</span>
+                                    </button>
+                                  ) : (
+                                    <button
+                                      onClick={() => setSigningDeedId(deed.id)}
+                                      className="inline-flex items-center gap-1.5 px-3 py-2 bg-slate-600 hover:bg-slate-700 text-white text-sm font-medium rounded-lg transition-colors"
+                                    >
+                                      <CalendarClock className="w-4 h-4 shrink-0" />
+                                      <span className="whitespace-nowrap">{action.label}</span>
+                                    </button>
+                                  )
+                                })()}
                               </>
                             )}
                             {/* UX2 item 2 — THE DESTRUCTIVE ONE IS SET APART.

--- a/frontend/src/features/signing/RequestSigningModal.tsx
+++ b/frontend/src/features/signing/RequestSigningModal.tsx
@@ -45,6 +45,15 @@ const NOTARY_CATEGORY = 'notary';
 /** The zones a California title product actually needs. Not the full
  * IANA list — a dropdown of six hundred zones is a worse question than a
  * dropdown of five. */
+/** Days, because a signing is arranged over days and a review is read in
+ *  hours. Same control, same placement, units that match the thing. */
+const EXPIRY_CHOICES = [
+  { days: 7, label: '7 days' },
+  { days: 14, label: '14 days' },
+  { days: 21, label: '21 days' },
+  { days: 30, label: '30 days' },
+];
+
 const ZONES = [
   { id: 'America/Los_Angeles', label: 'Pacific' },
   { id: 'America/Denver', label: 'Mountain' },
@@ -100,6 +109,12 @@ export function RequestSigningModal({
   const [signersAgreed, setSignersAgreed] = useState(false);
   const [location, setLocation] = useState(propertyAddress || '');
   const [tz, setTz] = useState(ZONES[0].id);
+  /* CANCEL1 item 5 — the expiry was imposed silently. The API has taken
+     `expires_in_days` since NOTARY2 and no screen ever sent one, so every
+     request got the 21-day default and the officer read the date off the
+     agenda afterwards. Reviews have had this control all along; this is
+     the same field, in the same place, on the other modal. */
+  const [expiresInDays, setExpiresInDays] = useState(21);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [done, setDone] = useState<{ id: number; links: Array<{ role: string; name: string; link: string }> } | null>(null);
@@ -141,6 +156,7 @@ export function RequestSigningModal({
                            phone: s.phone.trim() || undefined })),
           location: location || undefined,
           tz_name: tz,
+          expires_in_days: expiresInDays,
           ...(mode === 'dispatch' && start && end
             ? {
                 // withOffset: a bare wall-clock time makes the server
@@ -398,6 +414,27 @@ export function RequestSigningModal({
                   </select>
                   <p className="text-xs text-slate-500 mt-1">
                     Everyone sees times in this zone — the one where the signing happens.
+                  </p>
+                </div>
+                <div>
+                  <label className="block text-sm font-medium text-slate-700 mb-1">
+                    Links expire after
+                  </label>
+                  <select value={expiresInDays}
+                          onChange={(e) => setExpiresInDays(Number(e.target.value))}
+                          className={input}>
+                    {EXPIRY_CHOICES.map((c) => (
+                      <option key={c.days} value={c.days}>{c.label}</option>
+                    ))}
+                  </select>
+                  <p className="text-xs text-slate-500 mt-1">
+                    {/* What expiry DOES, in the same terms the review
+                        dialog uses: the links stop working and the
+                        recipient sees a notice. The signing request
+                        itself is not cancelled — that is a different act,
+                        with different consequences and its own button. */}
+                    When the links expire they stop working and everyone sees a
+                    notice. The request is not cancelled — nobody is told.
                   </p>
                 </div>
               </div>

--- a/frontend/src/lib/signingRowAction.ts
+++ b/frontend/src/lib/signingRowAction.ts
@@ -1,0 +1,57 @@
+/**
+ * What a Past Deeds row offers about signing.
+ *
+ * ═══ WHY THIS IS A FUNCTION AND NOT A TERNARY IN THE PAGE ═══
+ *
+ * It was a ternary in the page first, and the pin written for it asserted
+ * that the strings "Open signing request" and "/signings?focus=" appeared
+ * in the source. Then the probe: `{liveSignings[deed.id] ? (` → `{false ? (`,
+ * disabling the feature entirely. **The pin stayed green.** Both strings
+ * were still in the file, inside a branch that could never run.
+ *
+ * That is the "green and meaningless" state this codebase keeps naming,
+ * arrived at from a new direction: a string-presence pin cannot tell
+ * REACHABLE from PRESENT. `sitexProperty.ts` says the same thing about
+ * its own extraction — a rule you can only test through a UI is a rule
+ * you do not test.
+ *
+ * So the decision lives here, where a test can call it with both inputs
+ * and read the answer.
+ *
+ * ═══ THE DECISION ITSELF ═══
+ *
+ * A deed with a live signing request must not offer to create a second
+ * one. Two requests on one deed is three more emails, two notaries who
+ * each believe they have the appointment, and two sets of links to
+ * whichever signers were invited twice.
+ *
+ * Which states count as "live" is NOT decided here. That is
+ * `services/signing_loop.is_live`, the payload carries the verdict, and
+ * this function is handed the already-filtered map.
+ */
+
+export interface LiveSigning {
+  id: number;
+  /** The server's sentence about this request. Rendered verbatim. */
+  summary: string;
+}
+
+export type SigningRowAction =
+  | { kind: 'open'; href: string; label: string; summary: string }
+  | { kind: 'create'; label: string };
+
+export function signingRowAction(
+  deedId: number,
+  live: Record<number, LiveSigning>,
+): SigningRowAction {
+  const existing = live[deedId];
+  if (existing) {
+    return {
+      kind: 'open',
+      href: `/signings?focus=${existing.id}`,
+      label: 'Open signing request',
+      summary: existing.summary,
+    };
+  }
+  return { kind: 'create', label: 'Request signing' };
+}


### PR DESCRIPTION
CANCEL1 items 4–6. Two of the three needed correcting first.

## Item 6 was already done — fourth premise correction this wave

Both dead ends are fixed, and by DASH1:

- The dashboard's "Waiting on a reply" rows each carry `onOpen`, under DASH1's own comment: *"EVERY ROW LINKS TO THE THING ITSELF. A queue that tells her something is stuck and then makes her go and find it is a list of chores, not a queue."*
- Shared Deeds' "Open in Signings" already links to `/signings?focus={id}` — the specific request, via the anchor the ticket asked for *"once it has an anchor"*. It has one.

Closed as satisfied. Nothing shipped for item 6.

## Item 4 — the row offered a second request

"Request signing" appeared on deeds that already had one pending, with nothing on screen saying so — so the officer's way of checking was to create a second and find out. That's three more emails, two notaries who each believe they have the appointment, and two sets of links to whichever signers were invited twice.

The row now renders the server's sentence and the action opens the existing request. **Which states count as "still out" is not decided on the screen** — the agenda carries `live` from `signing_loop.is_live`, and Past Deeds joins a verdict it's handed.

## Item 5 — the expiry was imposed silently

`expires_in_days` has been on the create payload since NOTARY2 and no screen ever sent one, so every request took the 21-day default and the officer read the date off the agenda afterwards. Same control, same placement as the review dialog — in **days** rather than hours, because a review is read in an afternoon and a signing is arranged over weeks.

The help text says what expiry is *not*: the links stop working and **nobody is told**, which is the opposite of cancelling. A control that blurred those two would have the officer reaching for the wrong one.

## Two probes came back green, and both were my pins

**The item-4 pin asserted that `"Open signing request"` and `"/signings?focus="` appeared in `page.tsx`.** Then the probe disabled the entire branch with `{false ? (` — and the pin stayed green, because both strings were still in the file, inside code that could never run.

**A string-presence pin cannot tell REACHABLE from PRESENT.** That's the "green and meaningless" state, arrived at from a direction I hadn't hit before. The decision moved into `lib/signingRowAction.ts`, where a test calls it with both inputs and reads the answer — the same reasoning `sitexProperty.ts` already records: *a rule you can only test through a UI is a rule you do not test.* Re-probed: caught.

The second was the summary rendered only into a `title`. FLOW1 item 1's ruling reaches status as much as controls — a tooltip is invisible until you already suspect you need it, and absent entirely on touch. It renders as text now, and the pin asserts no `title` carries it.

## Retargeted, and flagged where the next reader will find it

`shareEntryPoints.test.ts` asserted the literal `<span className="whitespace-nowrap">Request signing</span>`. That literal is gone — the label comes from the decision function now. The property is unchanged and still checked one step across: two separately-named actions, in visible text, on the row. The review half stays a literal because it has no second state. The justification sits in the test beside the assertion.

## The sweep — no second instance

Looked for other revoke-then-notify compositions, per the ruling. **There are none:** the three other revoke sites (`sharing.revoke_share`, the verification document revoke, the admin delete) send no notifications at all, so there's no loop for the flag to silence. The composition needs both halves and only `officer_cancel` had them.

It did turn up an adjacent finding, ledgered rather than fixed: **revoking a share tells the recipient nothing.** Not the composition bug — there's no notify loop to silence — but the same *product* question you already ruled for cancellation. It needs its own call, because a revoked review is sometimes a deliberate un-invitation the officer may not want to announce.

## Verification

Six probes across both halves; the two that came back green are described above and both were re-probed after the fix.

| Gate | Result |
|---|---|
| pytest, with a database | **1153 passed** |
| pytest, no database | **961 passed**, 192 skipped |
| jest | **755 passed**, 52 suites |
| `next build` | ✔ |
| tsc | **88** |
| banned-claims | clean |

**One flake to name rather than hide:** an intermediate full run showed `test_admin15_reconciliation.py::test_the_dashboard_serves_both_windows_and_the_label` failing. It passes in isolation, passes alongside the new CANCEL1 file, and passed in two subsequent full runs — and it sits either side of a local Postgres restart, which has interrupted this session repeatedly. I could not reproduce it, so I'm reporting it as an unreproduced local-database flake rather than calling the run clean. CI's `proof-harnesses` job runs the same suite against a fresh Postgres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_