### PR TITLE
Share on the deed preview opens the dialog instead of navigating away

### DIFF
--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -469,26 +469,27 @@ we reach it.
   inherits the naming rule — a revoke confirm that does not name the deed
   is the same defect the delete confirm had.
 
-- **The preview page's Share button lands nowhere in particular** (found
-  2026-08-12 during the Requests merge, NOT fixed — pre-existing).
-  `/deeds/{id}/preview` pushes `/requests?deed={id}` (was
-  `/shared-deeds?deed={id}`); nothing has ever read `?deed=`. So a button
-  labelled Share drops the officer on an unfiltered tracker with no
-  dialog open and no indication which deed it was about — she has to
-  find the deed again on a page she reached *from* that deed.
+- **The preview page's Share button lands nowhere in particular** —
+  RULED AND FIXED 2026-08-12 (found during the Requests merge; the
+  pre-existing behaviour was carried across unchanged by the rename, then
+  fixed in its own PR).
 
-  Same class as the `?focus=` defect DASH1 found from the other end: a
-  parameter built by one half and read by neither. The rename carried it
-  across unchanged rather than fixing it, because the merge PR should be
-  a rename and not a behaviour change.
+  `/deeds/{id}/preview` pushed `/requests?deed={id}` and nothing has ever
+  read `?deed=`, so a button labelled Share navigated away from the deed,
+  landed on an unfiltered tracker with no dialog open, and left her to
+  find the deed she had been looking at a moment earlier.
 
-  Two candidate answers and they are genuinely different products, which
-  is why this is ledgered rather than decided: either the button opens
-  the review modal on the preview page (it is the deed she is looking
-  at — no navigation at all), or `/requests` learns `?deed=` and opens
-  the modal on arrival. The first is better if Share means "send THIS";
-  the second is better if the tracker is meant to be where sharing
-  happens. Owner's read on what the button means decides it.
+  **Owner's ruling: open the share dialog in place.** She is looking at
+  the deed; routing her to a tracker to locate the deed she is already
+  looking at is a detour ending in a lookup. Teaching `/requests` the
+  parameter would have worked and optimises the wrong journey — the
+  tracker is for finding, and she has already found it. Same reasoning as
+  the dashboard queue's `onOpen`.
+
+  Built as ruled: the review modal opens on the deed, with FLOW1 item 1's
+  signing interrupt wired to its other half so the "did you mean a
+  signing?" question has somewhere to go. No chooser — `share_kind` stays
+  set by which button she pressed.
 
 ## Parked tickets (scoped, not scheduled)
 

--- a/frontend/src/__tests__/previewShare.test.ts
+++ b/frontend/src/__tests__/previewShare.test.ts
@@ -1,0 +1,88 @@
+/**
+ * The Share button on the deed preview opens the dialog, in place.
+ *
+ * ═══ THE DEFECT ═══
+ *
+ * It pushed `/shared-deeds?deed={id}` — later `/requests?deed={id}` when
+ * the tracker was renamed — and NOTHING HAS EVER READ `?deed=`. So the
+ * button navigated away from the deed, landed on an unfiltered tracker
+ * with no dialog open and no indication which deed it was about, and
+ * left her to find the deed she had been looking at a moment earlier.
+ *
+ * A parameter built by one half and read by neither: the same defect
+ * DASH1 found in `?focus=`, arriving from the other end. It survived the
+ * Requests merge because a rename PR should carry behaviour across
+ * unchanged, and was ledgered for a ruling rather than fixed in passing.
+ *
+ * ═══ THE RULING, AND WHY THIS ANSWER AND NOT THE OTHER ONE ═══
+ *
+ * Teaching `/requests` to read `?deed=` would also have worked. It
+ * optimises the wrong journey: the tracker is where she goes to FIND
+ * something, and she has already found it — she is looking at it. A
+ * surface that tells you about a thing and then makes you go locate it
+ * is a list of chores, which is the reasoning behind the dashboard
+ * queue's `onOpen` opening the row's subject rather than its list.
+ *
+ * ═══ AND THE KIND IS STILL NOT ASKED ═══
+ *
+ * PARTNER2/B: `share_kind` is set by WHICH BUTTON SHE PRESSED, never
+ * inferred and never offered as a selector. This button has always meant
+ * a review — it pointed at the reviews tracker. So it opens the review
+ * modal, and the signing path is reachable only through FLOW1 item 1's
+ * interrupt, which is a suggestion with a way to act on it rather than a
+ * chooser that makes her classify her own intent first.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
+
+const SRC = path.join(__dirname, '..');
+const PREVIEW = codeOnly(
+  fs.readFileSync(path.join(SRC, 'app', 'deeds', '[id]', 'preview', 'page.tsx'), 'utf8'));
+
+describe('Share opens the dialog rather than navigating to a list', () => {
+  it('does not send her to the tracker to find the deed she is on', () => {
+    expect(PREVIEW).not.toContain('/requests?deed=');
+    expect(PREVIEW).not.toContain('/shared-deeds?deed=');
+    // And not with any other parameter either — the point is that Share
+    // does not navigate, not that this particular query string is gone.
+    expect(PREVIEW).not.toMatch(/router\.push\(\s*[`'"]\/requests/);
+  });
+
+  it('opens the review modal on this deed', () => {
+    expect(PREVIEW).toContain('const handleShare = () => setReviewOpen(true)');
+    expect(PREVIEW).toContain('<ShareForReviewModal');
+    expect(PREVIEW).toContain('deedId={Number(deedId)}');
+  });
+
+  it('offers the signing switch rather than leaving the interrupt hanging', () => {
+    /**
+     * The modal notices when the recipient is filed as a notary and asks
+     * whether she meant a signing. On a surface with nowhere to switch
+     * to, that question is a scolding — it names a mistake and offers no
+     * way out of it. So this page wires the other half.
+     */
+    expect(PREVIEW).toContain('onSwitchToSigning');
+    expect(PREVIEW).toContain('<RequestSigningModal');
+  });
+
+  it('does not ask her which kind of share this is', () => {
+    // A chooser would make her classify her own intent for the
+    // database's benefit before she could act. One button, one kind.
+    expect(PREVIEW).not.toContain('share_kind');
+    expect(PREVIEW).not.toMatch(/Choose.{0,20}(share|kind)/i);
+  });
+
+  it('seeds signer NAMES and never a way to reach anybody', () => {
+    /** §13.1 — the deed holds names. It has never held a phone number or
+     *  an email for a party and does not start now; she types those. */
+    expect(PREVIEW).toContain('suggestedSigners');
+    expect(PREVIEW).not.toMatch(/suggestedSigners=\{[^}]*email/);
+    expect(PREVIEW).not.toMatch(/suggestedSigners=\{[^}]*phone/);
+  });
+
+  it('reuses the partner path rather than growing another creation form', () => {
+    expect(PREVIEW).toContain('<PartnersProvider>');
+  });
+});

--- a/frontend/src/app/deeds/[id]/preview/page.tsx
+++ b/frontend/src/app/deeds/[id]/preview/page.tsx
@@ -14,6 +14,9 @@ import {
   ArrowPathIcon 
 } from '@heroicons/react/24/solid';
 import Sidebar from '@/components/Sidebar';
+import { PartnersProvider } from '@/features/partners/PartnersContext';
+import { ShareForReviewModal } from '@/features/signing/ShareForReviewModal';
+import { RequestSigningModal } from '@/features/signing/RequestSigningModal';
 import '@/styles/dashboard.css';
 import './preview.css';
 
@@ -221,10 +224,31 @@ export default function DeedPreviewPage() {
     document.body.removeChild(a);
   };
 
-  // Share handler
-  const handleShare = () => {
-    router.push(`/requests?deed=${deedId}`);
-  };
+  /**
+   * SHARE OPENS THE DIALOG, ON THE DEED SHE IS LOOKING AT.
+   *
+   * It used to `router.push('/shared-deeds?deed={id}')` — and nothing
+   * has ever read `?deed=`. So a button labelled Share navigated away
+   * from the deed, landed on an unfiltered tracker with no dialog open,
+   * and left her to find the deed she had just been looking at. A
+   * parameter built by one half and read by neither, which is the same
+   * defect DASH1 found in `?focus=` from the other end.
+   *
+   * Teaching `/requests` to read `?deed=` would have worked and
+   * optimises the wrong journey (owner-ruled): the tracker is for
+   * FINDING things and she has already found it. A surface that tells
+   * you about a thing and then makes you go locate it is a list of
+   * chores — the same reasoning as the dashboard queue's `onOpen`.
+   *
+   * The kind is not asked. `share_kind` is set by which button she
+   * pressed, never inferred (PARTNER2/B), and this button has always
+   * meant a review — it pointed at the reviews tracker. The signing path
+   * is reachable only through the interrupt, which is FLOW1 item 1's
+   * other half rather than a chooser.
+   */
+  const [reviewOpen, setReviewOpen] = useState(false);
+  const [signingOpen, setSigningOpen] = useState(false);
+  const handleShare = () => setReviewOpen(true);
 
   // Edit handler
   const handleEdit = () => {
@@ -468,6 +492,41 @@ export default function DeedPreviewPage() {
           Back to Dashboard
         </button>
       </footer>
+
+      {/* Both modals sit under one PartnersProvider, as on Past Deeds:
+          the recipient picker and its inline "add a partner" reuse the
+          existing partner path rather than growing another creation
+          form. */}
+      {(reviewOpen || signingOpen) && (
+        <PartnersProvider>
+          {reviewOpen && (
+            <ShareForReviewModal
+              deedId={Number(deedId)}
+              onClose={() => setReviewOpen(false)}
+              /* FLOW1 item 1: the interrupt's other half. Asking "did you
+                 mean a signing?" and then making her close the modal and
+                 go find another button would be a scolding rather than a
+                 suggestion. */
+              onSwitchToSigning={() => {
+                setReviewOpen(false);
+                setSigningOpen(true);
+              }}
+            />
+          )}
+          {signingOpen && (
+            <RequestSigningModal
+              deedId={Number(deedId)}
+              propertyAddress={deed?.property_address}
+              /* Party NAMES only. The deed has never held a way to reach
+                 anybody (§13.1) and does not start now — she types the
+                 addresses. */
+              suggestedSigners={[deed?.grantor_name, deed?.grantee_name]
+                .filter((n): n is string => !!n && !!n.trim())}
+              onClose={() => setSigningOpen(false)}
+            />
+          )}
+        </PartnersProvider>
+      )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
The ledgered preview-Share item, built as ruled. Its own small PR rather than folded into step 2 — it is independently ruled and independently verifiable, and bundling a UX fix into a large structural move makes both harder to review.

## The defect

`/deeds/{id}/preview` pushed `/requests?deed={id}` — and `/shared-deeds?deed={id}` before the rename — and **nothing has ever read `?deed=`**. So a button labelled Share navigated away from the deed, landed on an unfiltered tracker with no dialog open and no indication which deed it was about, and left her to find the deed she had been looking at a moment earlier.

A parameter built by one half and read by neither: the same defect DASH1 found in `?focus=`, arriving from the other end. It survived the Requests merge because a rename PR should carry behaviour across unchanged.

## The ruling, and why this answer and not the other one

Teaching `/requests` to read `?deed=` would also have worked. It optimises the wrong journey — **the tracker is where she goes to find something, and she has already found it.** A surface that tells you about a thing and then makes you go locate it is a list of chores, which is the reasoning behind the dashboard queue's `onOpen` opening the row's subject rather than its list.

## The kind is still not asked

`share_kind` is set by which button she pressed, never inferred and never offered as a selector (PARTNER2/B). This button has always meant a review — it pointed at the reviews tracker. So it opens the review modal, and the signing path is reachable only through FLOW1 item 1's interrupt.

That interrupt is wired to its other half here. The modal notices when the recipient is filed as a notary and asks whether she meant a signing; on a surface with nowhere to switch to, that question names a mistake and offers no way out of it. Both modals sit under one `PartnersProvider`, as on Past Deeds, so the recipient picker reuses the existing partner path rather than growing another creation form.

Signer seeding is names only — the deed has never held a way to reach a party (§13.1) and does not start now.

## Gates

| gate | result |
|---|---|
| jest | 785 passed, 54 suites |
| tsc baseline | 88 (holds) |
| `next build` | clean |
| mutation probes | 2 run, 2 caught |

Probes: Share reverts to navigating; the interrupt is left without its switch.

**Branch note, as standing practice:** fresh per-ticket branch off current main, not the stale branch named in session config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_