### PR TITLE
DEEDPREVIEW-FIX — the preview serves the instrument, and a draft is not made one

### DIFF
--- a/backend/routers/deeds_crud.py
+++ b/backend/routers/deeds_crud.py
@@ -881,14 +881,25 @@ def download_deed_endpoint(deed_id: int, user_id: int = Depends(get_current_user
             cur.execute("SELECT pdf_data FROM deed_pdfs WHERE deed_id = %s", (deed_id,))
             stored = cur.fetchone()
 
+        from services.deed_pdf import (
+            DraftHasNoInstrument, may_self_heal, render_deed_pdf, store_deed_pdf,
+        )
+
         if stored and stored[0]:
             pdf_bytes = bytes(stored[0])
-        else:
+        elif may_self_heal(dict(deed)):
             # Legacy row saved before the stored-PDF pipeline: render now,
             # store, and serve — subsequent downloads hit the stored copy.
-            from services.deed_pdf import render_deed_pdf, store_deed_pdf
+            # It HAS an instrument; we merely failed to keep the bytes.
             pdf_bytes = render_deed_pdf(dict(deed))
             store_deed_pdf(db.conn, deed_id, pdf_bytes)
+        else:
+            # A DRAFT. Rendering here would not preview it — storing is
+            # INSERT-OR-REFUSE and stamps `completed`, so this call would
+            # finalise a half-entered deed permanently. Until now the only
+            # thing preventing that was Past Deeds hiding the button.
+            raise HTTPException(status_code=409,
+                                detail=str(DraftHasNoInstrument(deed_id)))
 
         return Response(
             content=pdf_bytes,

--- a/backend/services/deed_pdf.py
+++ b/backend/services/deed_pdf.py
@@ -368,3 +368,60 @@ def generate_and_store(conn, row) -> str:
     """Render the PDF for a deed row and persist it. Returns the sha256."""
     pdf_bytes = render_deed_pdf(row)
     return store_deed_pdf(conn, row["id"], pdf_bytes)
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Who may be rendered on demand
+# ══════════════════════════════════════════════════════════════════════
+
+class DraftHasNoInstrument(Exception):
+    """A draft was asked for its instrument, and it does not have one."""
+
+    def __init__(self, deed_id: int):
+        self.deed_id = deed_id
+        super().__init__(
+            f"Deed {deed_id} has not been generated yet, so there is no "
+            "document to serve. Finish it in the builder — generating is "
+            "what creates the instrument, and it is recorded once."
+        )
+
+
+def may_self_heal(row) -> bool:
+    """May this deed be rendered on demand and stored as its instrument?
+
+    ═══ WHY THIS IS A RULE AND NOT AN `if` IN THE HANDLER ═══
+
+    `GET /deeds/{id}/download` serves the stored artifact, and renders +
+    stores one when a deed has none. That self-heal exists for LEGACY
+    ROWS — deeds completed before the stored-PDF pipeline, which have a
+    finished document and simply never had it captured.
+
+    It cannot tell a legacy row from a DRAFT, and the difference is
+    severe. `store_deed_pdf` sets `status = 'completed'`, stamps
+    `completed_at`, and is INSERT-OR-REFUSE by design (§9): the first
+    artifact stored for a deed is the only one it will ever have. So
+    rendering a draft on demand does not preview it — **it finalises it,
+    permanently, with whatever half-entered fields it had at that
+    moment.**
+
+    Nothing in the API stopped that. What stopped it was a button:
+    Past Deeds renders Download only when `status === "completed"`. A
+    rule that lives in a screen is a rule the next screen does not have,
+    and this ticket adds a second surface that wants the same document.
+
+    ═══ WHAT IT DECIDES ═══
+
+    A deed that has already been completed may be rendered on demand —
+    it HAS an instrument, we merely failed to keep the bytes. A draft may
+    not: it has no instrument yet, and saying so is the honest answer.
+    Generation stays the act that creates one, in the builder, once.
+    """
+    status = (row.get("status") or "draft").strip().lower()
+    if status == "completed":
+        return True
+    # `completed_at` is stamped at store time and never cleared, so a row
+    # carrying one has been through generation whatever its status says.
+    # Checked second, and separately, because the two disagreeing is a
+    # real state — a deleted deed keeps its completion — and reading only
+    # `status` would refuse a legacy row that has a document.
+    return row.get("completed_at") is not None

--- a/backend/tests/test_stored_instrument.py
+++ b/backend/tests/test_stored_instrument.py
@@ -1,0 +1,185 @@
+"""DEEDPREVIEW-FIX — the instrument is served, and a draft is not made one.
+
+═══ THE DEFECT ═══
+
+Two officer surfaces displayed "the deed" and only one displayed the
+deed. `/deed-builder/{type}/success` fetched `/deeds/{id}/download`,
+which serves the bytes in `deed_pdfs`. `/deeds/{id}/preview` POSTed the
+deed's fields to the generate endpoint on every visit and displayed the
+result, handing that blob over as Download.
+
+`deed_pdfs` is one row per deed, INSERT-OR-REFUSE under §9, with a
+sha256 stamped on the deed row — immutable on purpose, because §3
+removed QR codes from recorded pages on the reasoning that
+"verification survives as data" and that hash is the data.
+
+The two agree until a template, the rate registry, or the deed's own
+fields change after generation. Nothing compared them, and the registry
+version is a known mover (RED-S4 is queued because it is not yet stamped
+at generation time).
+
+═══ AND THE TRAP IN THE OBVIOUS FIX ═══
+
+Pointing the preview at `/download` and letting it render when nothing
+is stored would have been worse than the defect it repaired.
+
+`store_deed_pdf` sets `status = 'completed'`, stamps `completed_at`, and
+is INSERT-OR-REFUSE. So rendering a draft on demand does not preview
+it — **it finalises it**, permanently, with whatever half-entered fields
+it had at that moment, and refuses every later correction.
+
+Nothing in the API prevented that. What prevented it was a BUTTON: Past
+Deeds renders Download only for `status === "completed"`. A rule that
+lives in a screen is a rule the next screen does not have — and this
+ticket adds a second screen that wants the same document.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+from services.deed_pdf import DraftHasNoInstrument, may_self_heal
+
+dbonly = pytest.mark.skipif(not os.getenv("DATABASE_URL"),
+                            reason="needs a database")
+
+
+# ══════════════════════════════════════════════════════════════════════
+# 1. Who may be rendered on demand
+# ══════════════════════════════════════════════════════════════════════
+
+def test_a_completed_deed_may_be_rendered_on_demand():
+    """It HAS an instrument; we merely failed to keep the bytes.
+
+    This is the legacy row the self-heal was written for — completed
+    before the stored-PDF pipeline existed.
+    """
+    assert may_self_heal({"status": "completed", "completed_at": None})
+
+
+def test_a_deed_stamped_completed_may_be_rendered_whatever_its_status_says():
+    """`completed_at` is stamped at store time and never cleared.
+
+    Read separately from `status` because the two disagreeing is a REAL
+    state — a deleted deed keeps its completion — and a row that has been
+    through generation has a document regardless of what its status
+    column now says.
+    """
+    assert may_self_heal({"status": "deleted", "completed_at": "2026-01-01T00:00:00Z"})
+
+
+def test_a_draft_may_not():
+    """THE PIN THIS FILE EXISTS FOR.
+
+    Rendering a draft on demand stamps `completed`, stores bytes that
+    can never be replaced, and turns a half-entered form into the
+    instrument of record. The honest answer is that it has none yet.
+    """
+    for row in ({"status": "draft", "completed_at": None},
+                {"status": None, "completed_at": None},
+                {"status": "", "completed_at": None},
+                {}):
+        assert not may_self_heal(row), (
+            f"{row!r} would be rendered and permanently finalised")
+
+
+def test_the_refusal_says_what_to_do_about_it():
+    """§4 read forwards: a refusal that does not name its remedy is an
+    error message the officer can only escalate."""
+    message = str(DraftHasNoInstrument(41))
+    assert "41" in message
+    assert "builder" in message.lower()
+    # And it says WHY it cannot simply be produced — generating is the
+    # act that creates an instrument, and it happens once.
+    assert "once" in message.lower()
+
+
+# ══════════════════════════════════════════════════════════════════════
+# 2. The rule is the one the endpoint uses
+# ══════════════════════════════════════════════════════════════════════
+
+def test_the_download_endpoint_asks_the_rule():
+    """A rule is only the rule if the handler calls it.
+
+    CALLED rather than grepped for a spelling would be better, and needs
+    a database; the end-to-end half is below under `dbonly`. This is the
+    cheap belt that fails loudly if the handler grows its own opinion.
+    """
+    from pathlib import Path
+
+    from tests.source_text import code_only
+
+    src = code_only(Path(__file__).resolve().parents[1] / "routers" / "deeds_crud.py")
+    handler = src[src.index("def download_deed_endpoint("):]
+    handler = handler[: handler.index("\n@router.")]
+    assert "may_self_heal(" in handler, (
+        "the download endpoint decides for itself whether to render, so "
+        "the draft-finalising path is open again")
+    # And it does not re-list the vocabulary beside the call.
+    assert "'completed'" not in handler and '"completed"' not in handler, (
+        "the endpoint names statuses itself; that judgement belongs to "
+        "may_self_heal and nowhere else")
+
+
+@pytest.fixture
+def world():
+    """One officer and one DRAFT deed — the row this ticket protects."""
+    import psycopg2
+    from database import create_tables
+    from db_rows import ROW_FACTORY
+    create_tables()
+    conn = psycopg2.connect(os.environ["DATABASE_URL"], cursor_factory=ROW_FACTORY)
+    conn.autocommit = True
+    tag = uuid.uuid4().hex[:8]
+    made = {"conn": conn}
+    with conn.cursor() as cur:
+        cur.execute("INSERT INTO users (email, password_hash, full_name, role) "
+                    "VALUES (%s, 'x', 'Olivia Officer', 'user') RETURNING id",
+                    (f"officer-{tag}@instrument.test",))
+        made["officer"] = cur.fetchone()["id"]
+        cur.execute("""INSERT INTO deeds (user_id, deed_type, property_address,
+                                          county, status)
+                       VALUES (%s, 'grant_deed', '1 Draft Way, Los Angeles, CA',
+                               'Los Angeles', 'draft') RETURNING id""",
+                    (made["officer"],))
+        made["draft"] = cur.fetchone()["id"]
+    return made
+
+
+def _client_for(user_id: int):
+    from fastapi.testclient import TestClient
+    from auth import create_access_token
+    from main import app
+    client = TestClient(app)
+    client.headers.update({
+        "Authorization": f"Bearer {create_access_token({'sub': str(user_id), 'email': 'x@instrument.test'})}"})
+    return client
+
+
+@dbonly
+def test_downloading_a_draft_is_refused_and_the_draft_stays_a_draft(world):
+    """The end-to-end half: the deed is NOT finalised by being asked for.
+
+    The assertion that matters is the second one. A 409 that had already
+    stamped `completed` on the way to refusing would satisfy a
+    status-code check and still have destroyed the thing it was
+    protecting.
+    """
+    deed_id = world["draft"]
+    response = _client_for(world["officer"]).get(f"/deeds/{deed_id}/download")
+    assert response.status_code == 409, response.text
+    assert "builder" in response.json()["detail"].lower()
+
+    with world["conn"].cursor() as cur:
+        cur.execute("SELECT status, completed_at FROM deeds WHERE id = %s", (deed_id,))
+        row = cur.fetchone()
+        cur.execute("SELECT 1 FROM deed_pdfs WHERE deed_id = %s", (deed_id,))
+        stored = cur.fetchone()
+
+    assert row["status"] == "draft", (
+        "asking a draft for its document finalised it — which is worse "
+        "than the divergence this ticket set out to fix")
+    assert row["completed_at"] is None
+    assert stored is None, "a draft was given a permanent instrument"

--- a/frontend/src/__tests__/storedInstrument.test.ts
+++ b/frontend/src/__tests__/storedInstrument.test.ts
@@ -1,0 +1,137 @@
+/**
+ * A surface showing a deed shows the RECORDED document, not a lookalike.
+ *
+ * ═══ THE DEFECT ═══
+ *
+ * Two pages displayed "the deed" and only one displayed the deed.
+ *
+ * `/deed-builder/{type}/success` fetched `/deeds/{id}/download`, which
+ * serves the bytes stored in `deed_pdfs`. `/deeds/{id}/preview` POSTed
+ * the deed's fields to `/api/generate/{type}` on every visit and showed
+ * the result — and its Download button handed over that blob.
+ *
+ * `deed_pdfs` is one row per deed, INSERT-OR-REFUSE under doctrine §9,
+ * with a sha256 stamped on the deed row. It is immutable on purpose:
+ * §3 removed QR codes from recorded pages on the reasoning that
+ * "verification survives as data", and that hash is the data. A
+ * re-render routes around every part of it.
+ *
+ * The two agree until a template, the rate registry or the deed's own
+ * fields change after generation. Nothing compared them, and the
+ * registry version is a KNOWN mover — RED-S4 is queued precisely
+ * because it is not yet stamped at generation time.
+ *
+ * "Probably the instrument" is the wrong phrase for the thing being
+ * signed and recorded.
+ *
+ * ═══ AND THE TRAP IN THE OBVIOUS FIX ═══
+ *
+ * "Call the download endpoint, let it render when nothing is stored"
+ * would have been worse than the defect. `store_deed_pdf` sets
+ * `status = 'completed'`, stamps `completed_at`, and refuses to be
+ * replaced. So rendering a draft on demand does not preview it — it
+ * FINALISES it, permanently, with whatever half-entered fields it had at
+ * that moment.
+ *
+ * Nothing in the API prevented that. What prevented it was a button:
+ * Past Deeds renders Download only when `status === "completed"`. The
+ * rule is `deed_pdf.may_self_heal` now, pinned in Python where it lives.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
+
+const SRC = path.join(__dirname, '..');
+const read = (...p: string[]) => fs.readFileSync(path.join(SRC, ...p), 'utf8');
+const PREVIEW = codeOnly(read('app', 'deeds', '[id]', 'preview', 'page.tsx'));
+
+/** Every .ts/.tsx under src, so a re-render cannot arrive in a file this
+ *  test did not think to name. */
+function allSources(dir: string = SRC): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === '__tests__') continue;
+      // `app/api/generate/*` are the proxy ROUTES themselves — the thing
+      // being called, not a caller. Excluding them is the difference
+      // between "nothing generates" and "the endpoint does not exist".
+      if (full.endsWith(path.join('app', 'api'))) continue;
+      out.push(...allSources(full));
+    } else if (/\.tsx?$/.test(entry.name)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('the preview shows the recorded instrument', () => {
+  it('fetches the stored document instead of making one', () => {
+    expect(PREVIEW).toContain('apiFetch(`/deeds/${deedId}/download`');
+    expect(PREVIEW).not.toContain('/api/generate/');
+    expect(PREVIEW).not.toContain('generateWithRetry');
+  });
+
+  it('downloads what it displayed, and what it displayed is the record', () => {
+    // The Download button hands over the same blob the viewer showed —
+    // and that blob now comes from storage. A second fetch here would be
+    // a second chance to diverge.
+    expect(PREVIEW).toContain('a.href = pdfUrl');
+  });
+
+  it('says a draft has no instrument rather than making it one', () => {
+    /**
+     * The 409 is a NORMAL state with an obvious next step, not a
+     * failure. Rendering here instead would stamp `completed` on a
+     * half-entered deed and refuse to be corrected.
+     */
+    expect(PREVIEW).toContain('res.status === 409');
+    expect(PREVIEW).toContain('setNotGenerated');
+    expect(PREVIEW).toContain('Continue in the builder');
+  });
+
+  it('reports a document it could not load rather than an empty frame', () => {
+    // §4: an empty viewer would read as a deed with nothing in it.
+    expect(PREVIEW).toMatch(/Could not load this deed/);
+  });
+
+  it('no longer holds its own opinion about completeness', () => {
+    // The pre-flight field check guarded a generation this page does not
+    // perform. A second opinion beside the builder's own.
+    expect(PREVIEW).not.toContain('validateDeedData');
+    expect(PREVIEW).not.toContain('validationErrors');
+  });
+});
+
+describe('tree-wide: nothing renders a deed that already has one', () => {
+  it('no surface outside the builder POSTs to a generate endpoint', () => {
+    /**
+     * The PROPERTY, swept rather than spot-checked. The preview page was
+     * the only caller when this was written — the builder generates
+     * through `/api/deeds/generate`, which stores what it made — and the
+     * point of a sweep is that the second caller fails here rather than
+     * shipping.
+     */
+    const offenders = allSources()
+      .filter((f) => /\/api\/generate\//.test(codeOnly(fs.readFileSync(f, 'utf8'))))
+      .map((f) => path.relative(SRC, f));
+    expect(offenders).toEqual([]);
+  });
+
+  it('the sweep is reading a plausible corpus', () => {
+    // A walker that finds nothing exempts everything. Same scanner-floor
+    // rule the guard and link sweeps carry.
+    expect(allSources().length).toBeGreaterThan(80);
+  });
+
+  it('the surfaces that show a deed all read it from storage', () => {
+    for (const segments of [
+      ['app', 'past-deeds', 'page.tsx'],
+      ['app', 'deeds', '[id]', 'preview', 'page.tsx'],
+      ['app', 'deed-builder', '[type]', 'success', 'success-content.tsx'],
+    ]) {
+      expect(codeOnly(read(...segments))).toMatch(/\/deeds\/\$\{[^}]+\}\/download/);
+    }
+  });
+});

--- a/frontend/src/app/deeds/[id]/preview/page.tsx
+++ b/frontend/src/app/deeds/[id]/preview/page.tsx
@@ -2,7 +2,6 @@
 
 import React, { useEffect, useState } from 'react';
 
-import { validateDeedCompleteness, generateWithRetry } from '@/lib/preview/guard';
 import { useParams, useSearchParams } from 'next/navigation';
 import { useRouter } from 'next/navigation';
 import { 
@@ -14,6 +13,7 @@ import {
   ArrowPathIcon 
 } from '@heroicons/react/24/solid';
 import Sidebar from '@/components/Sidebar';
+import { SessionExpiredError, apiFetch } from '@/lib/apiClient';
 import { PartnersProvider } from '@/features/partners/PartnersContext';
 import { ShareForReviewModal } from '@/features/signing/ShareForReviewModal';
 import { RequestSigningModal } from '@/features/signing/RequestSigningModal';
@@ -45,10 +45,12 @@ export default function DeedPreviewPage() {
   const [deed, setDeed] = useState<DeedData | null>(null);
   const [pdfUrl, setPdfUrl] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
-  const [generating, setGenerating] = useState(false);
+  const [loadingPdf, setLoadingPdf] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [retryCount, setRetryCount] = useState(0);
-  const [validationErrors, setValidationErrors] = useState<string[]>([]);
+  /** Set when the server says this deed has no instrument yet. Not an
+   *  error — a draft that has not been generated is a normal state, and
+   *  the honest answer is the builder rather than a broken frame. */
+  const [notGenerated, setNotGenerated] = useState<string | null>(null);
 
   // Format deed type for display
   const formatDeedType = (type: string) => {
@@ -58,25 +60,17 @@ export default function DeedPreviewPage() {
       .join(' ');
   };
 
-  // Validate deed data completeness before PDF generation
-  const validateDeedData = (deedData: DeedData): string[] => {
-    const errors: string[] = [];
-    
-    if (!deedData.grantor_name || deedData.grantor_name.trim() === '') {
-      errors.push('Grantor name is required');
-    }
-    if (!deedData.grantee_name || deedData.grantee_name.trim() === '') {
-      errors.push('Grantee name is required');
-    }
-    if (!deedData.property_address || deedData.property_address.trim() === '') {
-      errors.push('Property address is required');
-    }
-    if (!deedData.apn || deedData.apn.trim() === '') {
-      errors.push('APN is required');
-    }
-    
-    return errors;
-  };
+  /**
+   * `validateDeedData` USED TO LIVE HERE and is deleted with the
+   * re-render it guarded. It checked grantor / grantee / address / APN
+   * before POSTing to the generate endpoint — a pre-flight for a
+   * generation this page no longer performs, and a second opinion about
+   * completeness beside the builder's own.
+   *
+   * What replaced it is the server's answer: a deed with no stored
+   * instrument is a draft, and the builder is where its missing fields
+   * are named and filled.
+   */
 
   // Fetch deed details
   useEffect(() => {
@@ -106,110 +100,76 @@ export default function DeedPreviewPage() {
     }
   }, [deedId]);
 
-  // Generate PDF with validation and retry limiting
+  /**
+   * THE INSTRUMENT IS SERVED, NOT RE-MADE.
+   *
+   * ═══ WHAT THIS REPLACED ═══
+   *
+   * This page used to POST the deed's fields to `/api/generate/{type}`
+   * on every visit and display the result, and its Download button
+   * handed over that blob. Meanwhile the success page fetched
+   * `/deeds/{id}/download`, which serves the bytes stored in
+   * `deed_pdfs`.
+   *
+   * So two surfaces showed "the deed" and only one showed the deed.
+   * `deed_pdfs` is one row per deed, INSERT-OR-REFUSE under §9, with a
+   * sha256 stamped on the deed row — deliberately immutable, because
+   * verification survives as data and that hash is the substrate. A
+   * re-render routes around all of it.
+   *
+   * The two agree until a template, the rate registry, or the deed's own
+   * fields change after generation. Nothing checked that they agreed,
+   * and the registry version is a known mover (RED-S4). "Probably the
+   * instrument" is the wrong phrase for the thing being signed and
+   * recorded.
+   *
+   * ═══ AND WHY A DRAFT IS NOT RENDERED INSTEAD ═══
+   *
+   * The obvious repair — call the download endpoint, let it render when
+   * nothing is stored — has a trap in it. Storing stamps `completed`
+   * and refuses to be replaced, so rendering a draft on demand does not
+   * preview it, it FINALISES it, with whatever half-entered fields it
+   * had at that moment.
+   *
+   * So the server decides (`deed_pdf.may_self_heal`) and this page shows
+   * what it is told: a completed deed shows its instrument, a draft says
+   * it has not been generated and points at the builder. Generation
+   * stays the act that creates an instrument, in one place, once.
+   */
   useEffect(() => {
-    const generatePDF = async () => {
-      if (!deed) return;
-
-      // Step 1: Validate deed data completeness
-      const errors = validateDeedData(deed);
-      if (errors.length > 0) {
-        console.warn('[Preview] Deed data validation failed:', errors);
-        setValidationErrors(errors);
-        setError('Cannot generate PDF: deed data is incomplete');
-        return; // Stop here - don't attempt generation
-      }
-
-      // Step 2: Check retry limit (max 3 attempts)
-      if (retryCount >= 3) {
-        console.error('[Preview] Max retry attempts reached (3)');
-        setError('Failed to generate PDF after 3 attempts. Please try again later.');
-        return;
-      }
-
+    if (!deed || pdfUrl || loadingPdf) return;
+    let revoked = false;
+    let url: string | null = null;
+    (async () => {
+      setLoadingPdf(true);
+      setError(null);
       try {
-        setGenerating(true);
-        setError(null);
-        setValidationErrors([]);
-        const token = localStorage.getItem('token') || localStorage.getItem('access_token');
-        
-        // Map deed type to API endpoint
-        const deedTypeMap: Record<string, string> = {
-          'grant-deed': 'grant-deed-ca',
-          'quitclaim-deed': 'quitclaim-deed-ca',
-          'interspousal-transfer': 'interspousal-transfer-ca',
-          'warranty-deed': 'warranty-deed-ca',
-          'tax-deed': 'tax-deed-ca'
-        };
-
-        const endpoint = deedTypeMap[deed.deed_type] || 'grant-deed-ca';
-        
-        console.log(`[Preview] Attempting PDF generation (attempt ${retryCount + 1}/3)`);
-        // 🔧 FIX: Map database field names to PDF generation endpoint field names
-        const pdfPayload = {
-          // Property fields (same names)
-          property_address: deed.property_address,
-          apn: deed.apn,
-          county: deed.county,
-          // 🔧 FIX: Map grantor_name → grantors_text
-          grantors_text: deed.grantor_name,
-          // 🔧 FIX: Map grantee_name → grantees_text
-          grantees_text: deed.grantee_name,
-          // Add missing legal_description
-          legal_description: deed.legal_description,
-          vesting: deed.vesting,
-          // Phase 16: Add requested_by
-          requested_by: deed.requested_by
-        };
-        console.log('[Preview] PDF payload:', pdfPayload);
-        
-        const res = await generateWithRetry(`/api/generate/${endpoint}`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            ...(token ? { Authorization: `Bearer ${token}` } : {})
-          },
-          body: JSON.stringify(pdfPayload)
-        });
-
-        if (!res.ok) {
-          // Only retry on server errors (500+), not client errors (400)
-          if (res.status >= 500 && retryCount < 2) {
-            console.warn(`[Preview] Server error ${res.status}, will retry (${retryCount + 1}/3)`);
-            setRetryCount(prev => prev + 1);
-            throw new Error(`Server error (${res.status}). Retrying...`);
-          } else {
-            // Client error (400, 403, etc.) OR max retries reached - don't retry
-            const errorText = await res.text();
-            console.error(`[Preview] Error ${res.status}:`, errorText);
-            // Set retryCount to max to prevent further attempts
-            setRetryCount(3);
-            throw new Error(`Failed to generate PDF: ${errorText || res.statusText}`);
-          }
+        const res = await apiFetch(`/deeds/${deedId}/download`, {},
+                                   { label: 'Loading this deed' });
+        if (res.status === 409) {
+          // Not an error: a draft honestly has no instrument yet.
+          const body = await res.json().catch(() => ({}));
+          setNotGenerated(body.detail
+            || 'This deed has not been generated yet.');
+          return;
         }
-
-        const blob = await res.blob();
-        const url = window.URL.createObjectURL(blob);
-        setPdfUrl(url);
-        setRetryCount(0); // Reset retry count on success
-        console.log('[Preview] PDF generation successful');
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}));
+          throw new Error(body.detail || `Could not load the document (${res.status})`);
+        }
+        url = window.URL.createObjectURL(await res.blob());
+        if (!revoked) setPdfUrl(url);
       } catch (e: any) {
-        console.error('[Preview] PDF generation error:', e);
-        setError(e.message || 'Failed to generate PDF');
+        if (e instanceof SessionExpiredError) return;
+        // §4: a document we could not fetch says so. An empty frame
+        // would read as a deed with nothing in it.
+        setError(e?.message || 'Could not load this deed\u2019s document');
       } finally {
-        setGenerating(false);
+        setLoadingPdf(false);
       }
-    };
-
-    // Only attempt generation if:
-    // 1. Deed is loaded
-    // 2. No PDF URL yet
-    // 3. Not currently generating
-    // 4. Not exceeded retry limit
-    if (deed && !pdfUrl && !generating && retryCount < 3) {
-      generatePDF();
-    }
-  }, [deed, pdfUrl, generating, retryCount]);
+    })();
+    return () => { revoked = true; if (url) window.URL.revokeObjectURL(url); };
+  }, [deed, deedId, pdfUrl, loadingPdf]);
 
   // Download handler
   const handleDownload = () => {
@@ -295,8 +255,9 @@ export default function DeedPreviewPage() {
     );
   }
 
-  // Validation error state - deed loaded but has incomplete data
-  if (validationErrors.length > 0 && deed) {
+  // A draft has no instrument yet. Not an error — a normal state with
+  // an obvious next step, which is the builder.
+  if (notGenerated && deed) {
     return (
       <div style={{ display: 'flex' }}>
         <Sidebar />
@@ -304,21 +265,16 @@ export default function DeedPreviewPage() {
           <div className="wizard-container">
             <div className="preview-error">
               <div className="error-icon">📝</div>
-              <h2>Deed Data Incomplete</h2>
-              <p>This deed cannot be generated because some required information is missing:</p>
-              <ul style={{ textAlign: 'left', marginTop: '1rem', marginBottom: '1.5rem' }}>
-                {validationErrors.map((err, i) => (
-                  <li key={i} style={{ color: '#dc2626' }}>{err}</li>
-                ))}
-              </ul>
+              <h2>This deed has not been generated yet</h2>
+              <p>{notGenerated}</p>
               <div style={{ display: 'flex', gap: '1rem', justifyContent: 'center' }}>
                 <button onClick={handleEdit} className="btn-primary">
                   <PencilIcon style={{ width: 18, height: 18 }} />
-                  Edit Deed
+                  Continue in the builder
                 </button>
-                <button onClick={() => router.push('/dashboard')} className="btn-secondary">
+                <button onClick={() => router.push('/past-deeds')} className="btn-secondary">
                   <HomeIcon style={{ width: 18, height: 18 }} />
-                  Back to Dashboard
+                  Back to your deeds
                 </button>
               </div>
             </div>
@@ -374,11 +330,12 @@ export default function DeedPreviewPage() {
 
       {/* PDF Viewer */}
       <section className="preview-pdf-section">
-        {generating ? (
+        {loadingPdf ? (
           <div className="pdf-loading">
             <ArrowPathIcon className="animate-spin" style={{ width: 48, height: 48 }} />
-            <p>Generating your document...</p>
-            <small>This may take up to 30 seconds</small>
+            {/* Loading, not generating. This page no longer makes a
+                document — it fetches the one that was recorded. */}
+            <p>Loading the recorded document…</p>
           </div>
         ) : pdfUrl ? (
           <div className="pdf-viewer">


### PR DESCRIPTION
Unit 1 of the DEEDDETAIL ruling. Ships alone, before any layout work, as ruled. Branches off main — **not** stacked on #180, which carries the design conversation and is still open.

## The fix as ruled

`/deeds/{id}/preview` POSTed the deed's fields to `/api/generate/{type}` on every visit and handed that blob over as Download, while the success page fetched `/deeds/{id}/download`. Two surfaces showed "the deed" and one showed a document that *resembles* it — routing around `deed_pdfs`, INSERT-OR-REFUSE, and the sha256 §9 exists to protect. They agree until a template, the rate registry, or the deed's own fields change after generation; nothing compared them, and the registry version is a known mover (RED-S4).

The preview now fetches the stored artifact. The re-render is deleted, and so is the pre-flight field validation that guarded it — a second opinion about completeness sitting beside the builder's own.

## The trap in the obvious fix — the substantive half

**"Call the download endpoint, let it render when nothing is stored" would have been worse than the defect it repaired.**

`store_deed_pdf` sets `status = 'completed'`, stamps `completed_at`, and refuses replacement. So rendering a draft on demand does not preview it — **it finalises it**, permanently, with whatever half-entered fields it had at that moment, and refuses every later correction.

Nothing in the API prevented that. What prevented it was a **button**: Past Deeds renders Download only when `status === "completed"`. A rule living in a screen is a rule the next screen does not have — and this ticket adds a second screen that wants the same document.

The ruling anticipated the shape of this ("if a legitimate re-render case exists, it must be reachable only where no artifact exists, and say so"). The finding is the inverse hazard: where no artifact exists *and the deed is a draft*, rendering is not merely unnecessary, it is destructive.

So the rule moved to `services/deed_pdf.may_self_heal`:

- **A completed deed may be rendered on demand.** It HAS an instrument; the bytes were never captured. This is the legacy row the self-heal was written for.
- **A draft may not.** It gets a 409 naming the builder, and the preview shows that as a normal state with an obvious next step — not an error.

`completed_at` is read separately from `status`, because the two disagreeing is a real state: a deleted deed keeps its completion, and reading only `status` would refuse a legacy row that does have a document.

**The end-to-end pin asserts the draft is still a draft afterwards.** A 409 that had already stamped `completed` on the way to refusing would satisfy a status-code check and still have destroyed the thing it was protecting.

## Tree-wide property

No source outside the builder POSTs to a generate endpoint. Swept over every `.ts`/`.tsx` under `src`, with a scanner-floor assertion so a walker that finds nothing cannot exempt everything, and with `app/api/generate/*` excluded because those are the routes being called rather than callers. The builder generates through `/api/deeds/generate`, which stores what it made.

Probe 20 adds a brand-new file that generates and confirms the sweep fails on it.

## Gates

| gate | result |
|---|---|
| pytest (with DB) | 1164 passed |
| jest | 797 passed, 55 suites |
| tsc baseline | 88 (holds) |
| six-flow | green |
| banned-claims | clean |
| `next build` | clean |
| mutation probes | 5 run, 5 caught |

Probes: `may_self_heal` lets a draft through (**confirms the draft really is finalised** when the rule breaks); the endpoint grows its own opinion again; the preview re-renders again; a second surface starts generating; the draft state stops being handled.

## Notes

- **The ledger is untouched here on purpose.** #180 adds the two entries this closes the first of; editing the same file in both PRs would conflict. Mark it closed when #180 lands.
- **#178's Share fix is still pending-live, not live** — the preview page remains orphaned until Unit 2 gives it navigation.
- **Reported, not decided:** with the preview's re-render gone, the `app/api/generate/{type}` Next proxy routes have no callers in the app. Whether they should be deleted is the "/security" question again, and it is out of this unit's scope.

**Branch note, as standing practice:** fresh per-ticket branch off current main, not the stale branch named in session config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_