### PR TITLE
Unit 2 inputs — three investigations reported before building

### DIFF
--- a/docs/DEEDDETAIL_DESIGN.md
+++ b/docs/DEEDDETAIL_DESIGN.md
@@ -237,3 +237,137 @@ overruled.
    deed, and the honest answer might be that the tracker's rows become
    links to the deed page — which would be a larger change than this
    ticket, and worth knowing before the layout is settled.
+
+---
+
+# UNIT 2 INPUTS — three investigations, reported before building
+
+## 1. The `/api/generate/{type}` proxy routes — REPORT, ruling needed
+
+Asked: confirm nothing external calls them, and whether the builder needs
+them under another name.
+
+**The builder does not need them.** It generates through
+`/api/deeds/generate`, a different Next route that maps the builder's
+payload to `DeedCreate` and forwards to backend `POST /deeds` — the path
+that stores. The six Next proxies at `app/api/generate/*` forward to
+backend `/api/generate/*`, and after DEEDPREVIEW-FIX **no source in the
+app calls any of them.**
+
+But they are not unreachable in the `/security` sense, and the difference
+matters:
+
+- `docs/API.md` documents both layers explicitly, as the frontend's
+  route handlers.
+- `middleware/qa_instrumentation.py` carries a latency budget for
+  `/api/generate/grant-deed-ca`.
+- **`admin_api_v2.py` tells an admin to use them.** When a deed has no
+  stored PDF it returns: *"PDF not available. Use
+  /api/generate/{deed_type} to regenerate."*
+
+**And that message is this ticket's defect one layer over.** The backend
+`/api/generate/*` handlers take a *render context* — not a deed id — and
+they **render and stream, storing nothing**. So an admin following that
+advice gets a fresh document that is not the instrument, and the deed
+still has no stored PDF afterwards. It is advice that cannot fix the
+problem it is offered for, and it produces exactly the "document that
+resembles the instrument" DEEDPREVIEW-FIX deleted.
+
+The correct advice is `/deeds/{id}/download`, which self-heals a
+completed deed and now refuses a draft.
+
+**My recommendation, not applied:** fix the admin message first — it is a
+live instruction pointing somewhere wrong. Hold the deletion question
+separately: removing the Next proxies would be cosmetic while the backend
+render endpoints they front stay documented and referenced, and those
+endpoints may be a deliberate capability (`grant-deed-ca-pixel` suggests
+a pixel-comparison path). Deleting a documented API because the app
+stopped calling it is a different decision from deleting `/security`,
+which had no caller *and* no documented contract.
+
+## 2. Invariants enforced only by conditional rendering — SWEPT
+
+Asked after the draft-finalisation catch. Method: every status-gated
+conditional in `app/` and `features/`, then the endpoint behind each.
+
+| gated action | UI condition | server |
+|---|---|---|
+| Download a deed | `status === "completed"` | **WAS UNGUARDED** — fixed in DEEDPREVIEW-FIX |
+| Approve/reject a share | already-decided message | guarded, 409 "already been {status}" |
+| Resend a share | — | guarded, 400 "Cannot resend - share is {status}" |
+| Revoke a verified document | `status === 'active'` | guarded, 400 "already revoked" |
+| Continue/edit a deed | `status === "draft"` | protected by §9 itself: regenerating different bytes raises `StoredPdfConflict` |
+| Delete a deed with a live signing | — | guarded, 409 naming the notary (CANCEL1) |
+
+**Result: the download case was the outlier, not the pattern.** The rest
+were already enforced below the UI.
+
+This is a SAMPLE, not an inventory — it covers status-gated conditionals,
+which is where the class was found, and not every action in the app. A
+pass that says "audited" stops the next person looking, so: what was
+checked is the table above.
+
+## 3. The activity element — WHAT EXISTS, honestly
+
+Ruled as load-bearing and new to both proposals: "the reviewer responded
+Tuesday, the notary accepted Wednesday." **There is no events table.** So
+the question is which timestamps are real recorded moments and which
+would be inferred.
+
+### Real, and usable today
+
+Each of these is a column written at the moment the thing happened.
+
+| event | source |
+|---|---|
+| deed started | `deeds.created_at` |
+| deed generated | `deeds.completed_at` (stamped by `store_deed_pdf`) |
+| deed superseded | `deeds.superseded_at`, `superseded_by` |
+| review sent | `deed_shares.created_at` |
+| reviewer opened it | `deed_shares.viewed_at` |
+| reviewer decided | `deed_shares.responded_at` — written on BOTH the approve and reject paths, and backfilled from `feedback_at` |
+| signing requested | `signing_requests.created_at` |
+| a party opened their link | `signing_participants.viewed_at` |
+| **a party answered a time** | `signing_responses.asserted_at` + `answer` + `participant_id` |
+| signing booked | `signing_requests.booked_at`, `booked_by` |
+| signing cancelled | `signing_requests.cancelled_at` |
+| document revoked | `document_authenticity.revoked_at` + reason |
+
+`signing_responses` is the best event data in the product: one row per
+answer, with who and when. It is already an event log.
+
+### What would be SYNTHESIZED, and must not be
+
+- **Status transitions other than the decision.** `status` is
+  current-state; only `responded_at` has a time. "Marked viewed at 3pm"
+  is available, "moved to expired at midnight" is not — expiry is
+  computed from `expires_at`, not recorded as an event.
+- **View counts as events.** `view_count` is a counter and `viewed_at`
+  is one timestamp. Rendering "opened 4 times" as four entries would
+  invent three moments.
+- **Reminders as a series.** `reminder_count` + `last_reminder_sent_at`
+  gives the LAST one only. Three reminders is one known time and two
+  fabrications.
+- **Anything from `updated_at`.** It moves for reasons that are not
+  events.
+
+### The gap worth naming
+
+`notifications` is close to an event log — type, title, message, link,
+created_at — but has **no `deed_id`**. The deed is encoded in the `link`
+URL. So "everything that happened on this deed" cannot be answered from
+it without parsing links, and it only holds events worth notifying
+about.
+
+### The smallest honest version
+
+A per-deed activity list assembled as a UNION of the columns in the first
+table, each rendered with the sentence its own subsystem already writes
+(§13 rule 3 — no screen composes an account of a scheduling state), and
+**nothing shown that is not one of those recorded moments.**
+
+It is never empty: `deeds.created_at` always exists, so the list has at
+least "started" and, for any generated deed, "generated".
+
+If that is too thin to be worth the section, the honest alternative is to
+record real events first — not to pad it.

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -533,6 +533,58 @@ we reach it.
   where it sits — that is where the button was — but it reaches nobody
   until this is resolved. Flagging so the fix is not read as live.
 
+- **CLOSED 2026-08-13 — the preview served a re-render, not the stored
+  instrument.** Fixed in DEEDPREVIEW-FIX (#181): the preview fetches
+  `/deeds/{id}/download`, the re-render path is deleted, and a tree-wide
+  sweep pins that nothing outside the builder generates.
+
+  **And the fix as specified had a trap in it, which is the part worth
+  keeping.** `store_deed_pdf` sets `status='completed'`, stamps
+  `completed_at`, and refuses replacement under §9 — so "let the download
+  endpoint render when nothing is stored" would have converted a
+  half-filled draft into an immutable, unamendable instrument on a page
+  view. Rendering is not a read; under §9 it is a write that cannot be
+  undone, so **"generate if missing" is never a safe fallback on a
+  surface that merely displays.**
+
+  The invariant that prevented it was living in a SCREEN — Past Deeds
+  renders Download only when `status === "completed"` — which is exactly
+  why it survived until a second screen wanted the same document. A rule
+  enforced by a component is a rule the next component does not have.
+  The rule is `services/deed_pdf.may_self_heal` now, and the pin asserts
+  the draft is still a draft afterwards: it tests the harm, not the
+  response.
+
+- **The admin "regenerate" message points somewhere that cannot help**
+  (found 2026-08-13 while investigating the generate proxies; NOT fixed).
+  When a deed has no stored PDF, `admin_api_v2` returns *"PDF not
+  available. Use /api/generate/{deed_type} to regenerate."*
+
+  Those handlers take a render CONTEXT rather than a deed id, and they
+  render and stream **storing nothing** — so an admin following the
+  advice gets a document that is not the instrument, and the deed still
+  has no stored PDF. It is the same defect DEEDPREVIEW-FIX just closed,
+  one layer over, on an admin surface. The correct advice is
+  `/deeds/{id}/download`.
+
+  Small and self-contained; held only because it was found mid-ticket.
+
+- **The `app/api/generate/{type}` Next proxies have no in-app caller**
+  (found 2026-08-13, NOT deleted — ruling wanted). The preview page was
+  the last one. They are NOT unreachable in the `/security` sense:
+  `docs/API.md` documents them, QA instrumentation budgets one of them,
+  and the admin message above points at the backend routes they front.
+  Deleting the proxies would be cosmetic while those backend endpoints
+  stay documented and referenced. Reported rather than assumed; see
+  `docs/DEEDDETAIL_DESIGN.md`.
+
+- **TRIGGER — promote the matter to the unit** (ruled 2026-08-13).
+  DEEDDETAIL builds the DEED page with matter context on it, because
+  there is no `matters` table, matters are virtual, and officers
+  navigate from lists of deeds. **If officers consistently use the deed
+  page as a doorway to the file rather than to the deed, that is the
+  evidence to promote the matter.** Earned rather than assumed.
+
 ## Parked tickets (scoped, not scheduled)
 
 - **Audit the string-presence pins whose subject is a BRANCH** (CANCEL1


### PR DESCRIPTION
**Docs only. No code.** The activity scope gates Unit 2, and the two sweeps were asked for after the draft-finalisation catch. Reporting before building, as ruled.

## 1. The generate proxies — report, ruling wanted

**The builder does not need them.** It generates through `/api/deeds/generate`, which maps the builder payload to `DeedCreate` and forwards to backend `POST /deeds` — the path that stores. After DEEDPREVIEW-FIX, no source in the app calls the six proxies at `app/api/generate/*`.

**But they are not unreachable in the `/security` sense**, and the difference is the whole ruling:

- `docs/API.md` documents both layers explicitly.
- `qa_instrumentation.py` carries a latency budget for one of them.
- `admin_api_v2` **tells an admin to use them**: *"PDF not available. Use /api/generate/{deed_type} to regenerate."*

**And that message is this ticket's defect one layer over.** Those handlers take a render *context*, not a deed id, and they render and stream **storing nothing**. An admin following the advice gets a document that is not the instrument, and the deed still has no stored PDF afterwards. It is advice that cannot fix the problem it is offered for, and it produces exactly the "document that resembles the instrument" DEEDPREVIEW-FIX deleted. The correct target is `/deeds/{id}/download`.

**Recommendation, not applied:** fix the admin message — it is a live instruction pointing somewhere wrong. Hold the deletion separately: removing the proxies is cosmetic while the backend render endpoints stay documented and referenced, and `grant-deed-ca-pixel` suggests a deliberate pixel-comparison capability. Deleting a documented API because the app stopped calling it is a different decision from deleting `/security`, which had no caller **and** no documented contract.

## 2. Invariants enforced only by conditional rendering — swept

Method: every status-gated conditional in `app/` and `features/`, then the endpoint behind each.

| gated action | UI condition | server |
|---|---|---|
| Download a deed | `status === "completed"` | **WAS UNGUARDED** — fixed in #181 |
| Approve/reject a share | already-decided message | guarded, 409 |
| Resend a share | — | guarded, 400 |
| Revoke a verified document | `status === 'active'` | guarded, 400 |
| Continue/edit a deed | `status === "draft"` | protected by §9 itself — `StoredPdfConflict` |
| Delete with a live signing | — | guarded, 409 naming the notary |

**The download case was the outlier, not the pattern.** Everything else was already enforced below the UI.

Recorded as a **sample, not an inventory** — it covers status-gated conditionals, which is where the class was found, not every action in the app. A pass that says "audited" stops the next person looking, so the table above is exactly what was checked.

## 3. The activity element — what exists vs. what would be invented

**There is no events table.** So the question is which timestamps are real recorded moments.

**Real and usable today:** deed `created_at` / `completed_at` / `superseded_at`; per share `created_at` / `viewed_at` / `responded_at` (written on *both* the approve and reject paths, and backfilled from `feedback_at`); per signing `created_at` / `booked_at` / `cancelled_at`; per participant `viewed_at`; and **`signing_responses`, which is already a real event log** — one row per answer, with who and when. That is the best event data in the product.

**What would be synthesized, and must not be:**
- Status transitions other than the decision. `status` is current-state; only `responded_at` carries a time. Expiry is *computed* from `expires_at`, never recorded.
- `view_count` as separate events — it is a counter beside a single `viewed_at`.
- Reminders as a series — `reminder_count` plus `last_reminder_sent_at` is one known time and N−1 fabrications.
- Anything ordered by `updated_at`, which moves for reasons that are not events.

**Named gap:** `notifications` is close to an event log — type, title, message, link, created_at — but has **no `deed_id`**. The deed is encoded in the link URL, so "everything that happened on this deed" cannot be answered from it without parsing links, and it only holds events worth notifying about.

**The smallest honest version** is a union of the real columns, each rendered with the sentence its own subsystem already writes (§13 rule 3). It is never empty — `created_at` always exists. If that is too thin to earn the section, the honest answer is to record real events first, not to pad it.

## Ledgered

The preview fix closed (with the "rendering is a write" lesson and the rule-living-in-a-screen lesson kept), the admin-message finding, the proxy question, and the ruled trigger for promoting the matter to the unit.

**Branch note, as standing practice:** fresh per-ticket branch off current main, not the stale branch named in session config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_