### PR TITLE
The admin PDF message names an endpoint that can actually fix the row

### DIFF
--- a/backend/routers/admin_api_v2.py
+++ b/backend/routers/admin_api_v2.py
@@ -442,16 +442,41 @@ def admin_delete_deed(deed_id: int, admin=Depends(get_current_admin)):
 
 @router.get("/deeds/{deed_id}/pdf")
 def admin_get_deed_pdf(deed_id: int, admin=Depends(get_current_admin)):
-    """Get the PDF for a deed - Phase 5B
-    
-    Returns the stored PDF URL or regenerates the PDF if needed.
+    """Where an admin can get this deed's document, if it has one.
+
+    ═══ THIS USED TO GIVE ADVICE THAT COULD NOT WORK ═══
+
+    When no PDF was stored it said: *"PDF not available. Use
+    /api/generate/{deed_type} to regenerate."*
+
+    Those handlers take a RENDER CONTEXT rather than a deed id, and they
+    render and stream **storing nothing**. So an admin who followed the
+    instruction got a document that is not the instrument, and the deed
+    still had no stored PDF afterwards — the advice could not fix the
+    problem it was offered for.
+
+    It is the same defect DEEDPREVIEW-FIX closed on the officer's side
+    (a re-render standing in for the recorded document), arriving as a
+    help string. §4 reaches messages: a refusal that names the wrong
+    remedy is worse than one that names none, because it spends
+    somebody's afternoon before failing.
+
+    The endpoint that actually repairs this is `/deeds/{id}/download`,
+    which self-heals a deed that HAS an instrument whose bytes were
+    never captured. Whether this deed is such a row is
+    `deed_pdf.may_self_heal` — the same rule the download endpoint asks,
+    not a second opinion about it.
     """
+    from services.deed_pdf import may_self_heal
+
     with db_connection() as conn, conn.cursor() as cur:
-        # Get deed with PDF info
+        # `completed_at` is read because may_self_heal needs it: a row
+        # stamped complete has been through generation whatever its
+        # status column now says.
         cur.execute("""
-            SELECT id, deed_type, status, pdf_url, property_address, 
-                   grantor_name, grantee_name, created_at
-            FROM deeds 
+            SELECT id, deed_type, status, pdf_url, property_address,
+                   grantor_name, grantee_name, created_at, completed_at
+            FROM deeds
             WHERE id = %s
         """, (deed_id,))
         row = cur.fetchone()
@@ -470,13 +495,34 @@ def admin_get_deed_pdf(deed_id: int, admin=Depends(get_current_admin)):
                 "message": "PDF available"
             }
         
-        # No PDF stored - return info for regeneration
+        # Nothing stored. Two different situations, and telling them
+        # apart is the whole point — one is recoverable and one is not a
+        # fault at all.
+        if may_self_heal(deed):
+            return {
+                "success": False,
+                "pdf_url": None,
+                "deed_type": deed['deed_type'],
+                "deed_id": deed_id,
+                "message": (
+                    f"No PDF stored for a completed deed. GET /deeds/{deed_id}/download "
+                    "serves it and stores the bytes on the way through, which repairs "
+                    "this row permanently."
+                ),
+            }
         return {
             "success": False,
             "pdf_url": None,
             "deed_type": deed['deed_type'],
             "deed_id": deed_id,
-            "message": "PDF not available. Use /api/generate/{deed_type} to regenerate."
+            # Neutral phrasing, and NOT a stylistic preference: the §11.1
+            # sweep caught "on her behalf" in this very string. Rendered
+            # copy names the role, never a pronoun for it.
+            "message": (
+                "This deed is a draft and has no document yet, which is not a "
+                "fault. Generating one is the officer's act, in the builder, and "
+                "it happens once — no admin tool should produce it for them."
+            ),
         }
 
 

--- a/backend/tests/test_stored_instrument.py
+++ b/backend/tests/test_stored_instrument.py
@@ -183,3 +183,53 @@ def test_downloading_a_draft_is_refused_and_the_draft_stays_a_draft(world):
         "than the divergence this ticket set out to fix")
     assert row["completed_at"] is None
     assert stored is None, "a draft was given a permanent instrument"
+
+
+# ══════════════════════════════════════════════════════════════════════
+# 3. The advice we give points somewhere that can help
+# ══════════════════════════════════════════════════════════════════════
+
+def test_the_admin_pdf_message_names_an_endpoint_that_can_fix_it():
+    """§4 REACHES HELP STRINGS.
+
+    This handler used to tell an admin: "PDF not available. Use
+    /api/generate/{deed_type} to regenerate." Those handlers take a
+    render CONTEXT rather than a deed id and store NOTHING — so the
+    admin got a document that is not the instrument, and the deed still
+    had no stored PDF. Advice that cannot fix the problem it is offered
+    for, which is worse than no advice: it spends an afternoon first.
+
+    The same defect DEEDPREVIEW-FIX closed on the officer's side,
+    arriving as a help string.
+    """
+    from pathlib import Path
+
+    from tests.source_text import code_only
+
+    src = code_only(Path(__file__).resolve().parents[1] / "routers" / "admin_api_v2.py")
+    handler = src[src.index("def admin_get_deed_pdf("):]
+    handler = handler[: handler.index("\n@router.")]
+
+    assert "/api/generate/" not in handler, (
+        "the admin is being sent to a render endpoint that stores nothing, "
+        "so following the advice leaves the deed exactly as it was")
+    assert "/download" in handler, (
+        "the message names no endpoint that repairs the row")
+    # And the recoverable case is told apart from the draft, using the
+    # SAME rule the download endpoint asks rather than a second opinion.
+    assert "may_self_heal(" in handler
+
+
+def test_the_admin_message_does_not_promise_to_generate_for_her():
+    """A draft with no document is not a fault, and an admin tool that
+    offered to produce one would be asserting an instrument on the
+    officer's behalf — the §9 write dressed as a convenience."""
+    from pathlib import Path
+
+    from tests.source_text import code_only
+
+    src = code_only(Path(__file__).resolve().parents[1] / "routers" / "admin_api_v2.py")
+    handler = src[src.index("def admin_get_deed_pdf("):]
+    handler = handler[: handler.index("\n@router.")]
+    assert "draft" in handler.lower()
+    assert "builder" in handler.lower()

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -555,8 +555,18 @@ we reach it.
   the draft is still a draft afterwards: it tests the harm, not the
   response.
 
-- **The admin "regenerate" message points somewhere that cannot help**
-  (found 2026-08-13 while investigating the generate proxies; NOT fixed).
+- **CLOSED 2026-08-13 — the admin "regenerate" message pointed somewhere
+  that could not help.** Fixed: `admin_get_deed_pdf` now tells the two
+  cases apart with `may_self_heal` (the same rule the download endpoint
+  asks) and names `/deeds/{id}/download`, which repairs the row on the
+  way through. A draft is told it is a draft, and no admin tool offers to
+  generate on the officer's behalf — that would be the §9 write dressed
+  as a convenience.
+
+  §4 REACHES HELP STRINGS. A refusal that names the wrong remedy is
+  worse than one that names none: it spends an afternoon before failing.
+
+  _Original finding:_
   When a deed has no stored PDF, `admin_api_v2` returns *"PDF not
   available. Use /api/generate/{deed_type} to regenerate."*
 
@@ -584,6 +594,29 @@ we reach it.
   navigate from lists of deeds. **If officers consistently use the deed
   page as a doorway to the file rather than to the deed, that is the
   evidence to promote the matter.** Earned rather than assumed.
+
+- **TRIGGER — retire the `/api/generate/{type}` render layer.** The six
+  Next proxies at `app/api/generate/*` have no in-app caller (owner-ruled
+  2026-08-13: hold the deletion). They are not the `/security` case —
+  that had no caller AND no contract; these have `docs/API.md`, a QA
+  budget line, and until today an admin-facing reference.
+
+  **FIRES WHEN** either: `docs/API.md` stops documenting the render
+  layer, or the render layer is deliberately retired as a public
+  contract. Deleting the proxies before then is cosmetic — the backend
+  render endpoints they front would remain documented and reachable.
+
+- **`notifications` has no `deed_id`** (found 2026-08-13 during the
+  activity-element scoping; NOT fixed, and correctly not this ticket).
+  The table is close to an event log — type, title, message, link,
+  created_at — but the deed it concerns is encoded only in the `link`
+  URL. So "everything that happened on this deed" cannot be answered
+  from it without parsing links, and it holds only events worth
+  notifying about.
+
+  Adding the column is the right eventual answer. Until then the deed
+  page's activity list is a UNION of real timestamp columns, which is
+  honest but is not the log this table nearly is.
 
 ## Parked tickets (scoped, not scheduled)
 


### PR DESCRIPTION
Ruled to ship immediately, separate from Unit 2. Branches off main.

## The defect

`admin_get_deed_pdf` told an admin: *"PDF not available. Use `/api/generate/{deed_type}` to regenerate."*

Those handlers take a render **context** rather than a deed id, and they render and stream **storing nothing**. So an admin following our own instruction got a document that is not the instrument, and the deed still had no stored PDF afterwards.

**Advice that cannot fix the problem it is offered for is worse than no advice** — it spends an afternoon before failing. §4 reaches help strings.

It is also DEEDPREVIEW-FIX's defect arriving as copy: a re-render standing in for the recorded document, one layer over, on an admin surface.

## The fix

The handler now tells the two situations apart using `may_self_heal` — **the same rule the download endpoint asks**, not a second opinion about it:

- **A completed deed whose bytes were never captured** → pointed at `GET /deeds/{id}/download`, which serves it *and stores it on the way through*, repairing the row permanently.
- **A draft** → told it is a draft. That is not a fault, and no admin tool offers to generate for the officer. That would be the §9 write dressed as a convenience — exactly the hazard #181 closed.

`completed_at` joins the SELECT because `may_self_heal` needs it: a row stamped complete has been through generation whatever its status column now says.

## Caught by the tree

The first draft of the draft-case message said *"on her behalf"*, and the §11.1 pronoun sweep failed on it. Rendered copy names the role, never a pronoun for it. Worth recording because the sweep caught new copy written by someone who had just read the doctrine and still did it.

## Ledgered

- **Render-layer retirement, with its own trigger** as ruled: fires when `docs/API.md` stops documenting the render layer, or the layer is deliberately retired as a public contract. Deleting the proxies before then is cosmetic — the backend endpoints they front would remain documented and reachable.
- **`notifications` has no `deed_id`** — the deed lives in a link URL. Adding the column is the right eventual answer and is not this ticket.
- The admin-message finding is marked closed, with the "§4 reaches help strings" reasoning kept.

## Gates

| gate | result |
|---|---|
| pytest (with DB) | 1166 passed |
| jest | 797 passed, 55 suites |
| six-flow | green |
| banned-claims | clean |
| mutation probes | 2 run, 2 caught |

Probes: the advice points back at the render endpoint; the two cases stop being told apart.

**Branch note, as standing practice:** fresh per-ticket branch off current main, not the stale branch named in session config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_