### PR TITLE
Unit 2 step 1 — the activity feed, and it names its own epistemics

### DIFF
--- a/backend/routers/deeds_crud.py
+++ b/backend/routers/deeds_crud.py
@@ -683,6 +683,53 @@ def supersede_endpoint(deed_id: int, body: SupersedeRequest,
     }
 
 
+@router.get("/deeds/{deed_id}/activity")
+def activity_endpoint(deed_id: int, user_id: int = Depends(get_current_user_id)):
+    """What happened on this deed, from what was actually recorded.
+
+    There is no events table, so this is a UNION of columns that exist
+    for other reasons — which is precisely the shape in which a
+    fabricated history gets built. `services/deed_activity` is where the
+    epistemics live: every entry carries the column it came from and
+    whether it is an EVENT (an act with a surviving record) or a DERIVED
+    timestamp (a column that merely carries a time).
+
+    The distinction is in the payload rather than in a comment because a
+    consumer cannot recover it. If the API cannot tell them apart,
+    neither can a screen, and the first person to add "expired" will do
+    it because everything already looked like an event.
+
+    This handler assembles NOTHING. It fetches rows and hands them over.
+    """
+    from services import deed_activity
+
+    deed = _pcor_deed_row(deed_id, user_id)
+    with db.conn.cursor() as cur:
+        cur.execute("""SELECT id, recipient_name, recipient_email, status,
+                              created_at, viewed_at, responded_at
+                         FROM deed_shares WHERE deed_id = %s""", (deed_id,))
+        shares = [dict(r) for r in (cur.fetchall() or [])]
+        cur.execute("""SELECT id, created_at, booked_asserted_at, booked_by,
+                              cancelled_at
+                         FROM signing_requests WHERE deed_id = %s""", (deed_id,))
+        signings = [dict(r) for r in (cur.fetchall() or [])]
+        # The one real event log in the product: a row per answer, with
+        # who and when. Joined to its participant for the name only —
+        # §13.1, no contact detail crosses into this payload.
+        cur.execute("""SELECT r.answer, r.asserted_at,
+                              p.name, p.party_role
+                         FROM signing_responses r
+                         JOIN signing_participants p ON p.id = r.participant_id
+                         JOIN signing_requests s ON s.id = p.signing_request_id
+                        WHERE s.deed_id = %s""", (deed_id,))
+        responses = [dict(r) for r in (cur.fetchall() or [])]
+
+    return {"deed_id": deed_id,
+            "entries": deed_activity.activity(dict(deed), shares=shares,
+                                              signings=signings,
+                                              responses=responses)}
+
+
 @router.get("/deeds/{deed_id}/lineage")
 def lineage_endpoint(deed_id: int, user_id: int = Depends(get_current_user_id)):
     """The correction chain, forwards and backwards, all of it readable.

--- a/backend/services/deed_activity.py
+++ b/backend/services/deed_activity.py
@@ -1,0 +1,233 @@
+"""What happened on this deed — assembled only from what was recorded.
+
+═══ WHY THIS MODULE IS SUSPICIOUS OF ITSELF ═══
+
+There is NO events table. Every entry below is reconstructed from
+columns that exist for other reasons, which is exactly the shape in
+which a fabricated history gets built: the timestamps are right there,
+they sort, and the result looks like a log.
+
+A synthesized activity feed is worse than none. It is a page asserting
+that things happened at times, in a product whose whole doctrine is that
+the system never asserts what somebody else must.
+
+So this module names its own epistemics in the DATA, not in comments:
+
+  KIND_EVENT    — somebody performed an act and the record of that act
+                  survives. Write-once, or its own row.
+  KIND_DERIVED  — a column that merely carries a time. It tells you a
+                  state, and the time is when the state last changed.
+
+The distinction is structural because a consumer cannot recover it. If
+the API cannot tell them apart, no screen can, and the first person to
+add "expired" to the feed will do it because everything already looked
+like an event. `expired` is COMPUTED from `expires_at` — nobody recorded
+it, nobody was there — and the type system is what says so.
+
+═══ THE DISCRIMINATOR, AND HOW EACH COLUMN WAS CLASSIFIED ═══
+
+Not by intuition: by reading the statement that writes it. Does the
+write PRESERVE the moment, or does it hold the latest value?
+
+Two findings from doing that, both of which would have produced a wrong
+feed:
+
+ 1. `deed_shares.viewed_at` and `signing_participants.last_viewed_at`
+    are one word apart and have OPPOSITE semantics. The first is guarded
+    (`if status == 'sent' and not viewed_at`) — it is the FIRST view and
+    it survives. The second is `SET last_viewed_at = now()`,
+    unconditional, and is named for what it is. So the first is an event
+    and the second is a state field, and no amount of squinting at the
+    column names would tell you which.
+
+ 2. `booked_at` IS NOT WHEN THE BOOKING HAPPENED. It is the signing's
+    time — a future appointment. A feed keyed on it would place "booked"
+    at next month's date and sort it into the future. The moment is
+    `booked_asserted_at`, written `now()` on BOTH the convergence and
+    override paths, with `booked_by` naming who asserted it.
+
+    That is §13.2 arriving in the timeline: the event is the ASSERTION,
+    never the thing asserted.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+#: Somebody did this, and the record of their doing it survives.
+KIND_EVENT = "event"
+#: A column carrying a time. It reports a state, not an act.
+KIND_DERIVED = "derived"
+
+
+class FabricatedActivity(Exception):
+    """Raised when something asks this module to invent an entry."""
+
+
+#: Sources that must NEVER become entries, with the reason attached so a
+#: refusal explains itself. Owner-ruled; each one is a specific way to
+#: turn a number into a history nobody recorded.
+FORBIDDEN: Dict[str, str] = {
+    "expired": (
+        "expiry is COMPUTED from expires_at — no row records it, nobody "
+        "was present, and rendering it as an event asserts a moment that "
+        "was never observed"
+    ),
+    "expires_at": (
+        "a deadline is not something that happened; it is a fact about "
+        "the future that may still not happen"
+    ),
+    "view_count": (
+        "a counter is not a series. Four views is ONE recorded time "
+        "(viewed_at) and three moments nobody kept"
+    ),
+    "reminder_count": (
+        "only last_reminder_sent_at is kept, so N reminders is one known "
+        "time and N-1 fabrications"
+    ),
+    "updated_at": (
+        "it moves for reasons that are not events, so ordering by it "
+        "narrates writes rather than acts"
+    ),
+    "last_viewed_at": (
+        "overwritten on every view, so it is the latest state and not a "
+        "moment — see deed_shares.viewed_at, which is the opposite"
+    ),
+    "booked_at": (
+        "the signing's TIME, not when it was booked. Keying on it puts "
+        "the entry in the future; booked_asserted_at is the moment"
+    ),
+}
+
+
+def refuse(source: str) -> None:
+    """Name the reason, loudly, if a caller reaches for a forbidden source.
+
+    A rule that is only a comment gets read past. This is callable, so a
+    test can ask it and a future author gets an exception rather than a
+    plausible-looking feed.
+    """
+    if source in FORBIDDEN:
+        raise FabricatedActivity(f"{source}: {FORBIDDEN[source]}")
+
+
+def _iso(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return str(value)
+
+
+def entry(at: Any, kind: str, what: str, sentence: str, source: str) -> Optional[Dict[str, Any]]:
+    """One line of the record, or nothing if the moment is not there.
+
+    `sentence` is the words a screen renders. It is composed HERE and
+    nowhere else — §13 rule 3, the same reason no screen writes its own
+    account of a scheduling state.
+
+    `source` names the column this came from, and it is part of the
+    payload rather than a debugging aid: an entry that cannot say where
+    it came from is one nobody can check.
+    """
+    refuse(source.split(".")[-1])
+    when = _iso(at)
+    if when is None:
+        return None
+    if kind not in (KIND_EVENT, KIND_DERIVED):
+        raise FabricatedActivity(f"{kind!r} is not a kind of entry")
+    return {"at": when, "kind": kind, "what": what, "sentence": sentence,
+            "source": source}
+
+
+def _name(row: Mapping[str, Any]) -> str:
+    """Who, by the name we were given, or by the role. Never a pronoun."""
+    return ((row.get("recipient_name") or "").strip()
+            or (row.get("name") or "").strip()
+            or (row.get("recipient_email") or "").strip()
+            or (row.get("party_role") or "Someone"))
+
+
+def activity(
+    deed: Mapping[str, Any],
+    *,
+    shares: Iterable[Mapping[str, Any]] = (),
+    signings: Iterable[Mapping[str, Any]] = (),
+    responses: Iterable[Mapping[str, Any]] = (),
+) -> List[Dict[str, Any]]:
+    """Everything recorded about this deed, newest first.
+
+    Only the sources the owner permitted. Anything absent from a row is
+    simply not an entry — there is no filling in.
+    """
+    out: List[Optional[Dict[str, Any]]] = []
+
+    # ── The deed itself ───────────────────────────────────────────────
+    #
+    # `created_at` is DERIVED: it is the row's birth, and while starting
+    # a draft is an act, the column exists to age the row rather than to
+    # record that anybody did anything.
+    out.append(entry(deed.get("created_at"), KIND_DERIVED, "deed.started",
+                     "Draft started.", "deeds.created_at"))
+    # `completed_at` is an EVENT: stamped once by store_deed_pdf, under
+    # COALESCE so it never moves, at the moment the instrument came into
+    # existence. That is an act with a record.
+    out.append(entry(deed.get("completed_at"), KIND_EVENT, "deed.generated",
+                     "Deed generated — the instrument was recorded.",
+                     "deeds.completed_at"))
+    out.append(entry(deed.get("superseded_at"), KIND_EVENT, "deed.superseded",
+                     "Corrected and replaced by a later deed.",
+                     "deeds.superseded_at"))
+
+    # ── Reviews ───────────────────────────────────────────────────────
+    for share in shares:
+        who = _name(share)
+        out.append(entry(share.get("created_at"), KIND_DERIVED, "review.sent",
+                         f"Sent to {who} for review.", "deed_shares.created_at"))
+        # EVENT, and this is the classification that needed the code read:
+        # the write is guarded on `status = 'sent' AND NOT viewed_at`, so
+        # it is the FIRST view and it survives every later one.
+        out.append(entry(share.get("viewed_at"), KIND_EVENT, "review.viewed",
+                         f"{who} opened it.", "deed_shares.viewed_at"))
+        # EVENT: written at the decision, on BOTH the approve and reject
+        # paths, and a decided share cannot be decided again (409).
+        decision = (share.get("status") or "").strip().lower()
+        said = {"approved": "approved it", "rejected": "asked for changes"}.get(
+            decision, "responded")
+        out.append(entry(share.get("responded_at"), KIND_EVENT, f"review.{decision or 'responded'}",
+                         f"{who} {said}.", "deed_shares.responded_at"))
+
+    # ── Signings ──────────────────────────────────────────────────────
+    for signing in signings:
+        out.append(entry(signing.get("created_at"), KIND_DERIVED, "signing.requested",
+                         "Signing requested.", "signing_requests.created_at"))
+        # EVENT — and NOT `booked_at`, which is the appointment's time.
+        # `booked_asserted_at` is when somebody said so, and `booked_by`
+        # is who: §13.2, the assertion rather than the thing asserted.
+        by = (signing.get("booked_by") or "").strip()
+        out.append(entry(signing.get("booked_asserted_at"), KIND_EVENT, "signing.booked",
+                         "A time was agreed by everyone." if by == "convergence"
+                         else "The officer recorded the time.",
+                         "signing_requests.booked_asserted_at"))
+        out.append(entry(signing.get("cancelled_at"), KIND_EVENT, "signing.cancelled",
+                         "Signing cancelled — every link was voided.",
+                         "signing_requests.cancelled_at"))
+
+    # ── The real event log ────────────────────────────────────────────
+    #
+    # One row per answer, with who and when. This is the only source here
+    # that was built to be an event, and it shows: nothing is inferred,
+    # nothing is overwritten, and a second answer is a second row.
+    for response in responses:
+        answered = (response.get("answer") or "").strip().lower()
+        out.append(entry(
+            response.get("asserted_at"), KIND_EVENT, f"signing.{answered or 'answered'}",
+            f"{_name(response)} said "
+            + ("that time works." if answered == "available" else "that time does not work."),
+            "signing_responses.asserted_at"))
+
+    kept = [e for e in out if e is not None]
+    # Newest first: the question the page exists for is "what changed
+    # since I was last here", and the answer is at the top.
+    kept.sort(key=lambda e: e["at"], reverse=True)
+    return kept

--- a/backend/tests/snapshots/openapi_routes.json
+++ b/backend/tests/snapshots/openapi_routes.json
@@ -185,6 +185,10 @@
  ],
  [
   "GET",
+  "/deeds/{deed_id}/activity"
+ ],
+ [
+  "GET",
   "/deeds/{deed_id}/death-statement"
  ],
  [

--- a/backend/tests/test_deed_activity.py
+++ b/backend/tests/test_deed_activity.py
@@ -1,0 +1,268 @@
+"""The activity feed reports what was recorded, and says which is which.
+
+═══ THE RISK THIS FILE EXISTS FOR ═══
+
+There is no events table. Every entry is reconstructed from columns that
+exist for other reasons — the exact shape in which a fabricated history
+gets built, because the timestamps are already there, they sort, and the
+result looks like a log.
+
+A synthesized activity feed is worse than none, in a product whose
+doctrine is that the system never asserts what somebody else must.
+
+So two things are pinned: WHAT MAY BE A SOURCE, and — structurally, in
+the payload rather than in prose — WHETHER AN ENTRY IS AN ACT SOMEBODY
+PERFORMED or a column that merely carries a time. A consumer cannot
+recover that distinction, so if the API loses it, every screen loses it.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from services.deed_activity import (
+    FORBIDDEN, KIND_DERIVED, KIND_EVENT, FabricatedActivity, activity, entry, refuse,
+)
+
+T = lambda d: datetime(2026, 8, d, 12, 0, tzinfo=timezone.utc)  # noqa: E731
+
+
+# ══════════════════════════════════════════════════════════════════════
+# 1. The kinds are structural, not editorial
+# ══════════════════════════════════════════════════════════════════════
+
+def test_the_two_kinds_are_actually_two():
+    """THIS PIN EXISTS BECAUSE A MUTATION PROBE CAUGHT ITS ABSENCE.
+
+    Every assertion below was written as `row["kind"] == KIND_EVENT` —
+    in terms of the constants. Setting `KIND_DERIVED = "event"` collapses
+    the distinction completely, and the whole file stayed GREEN: both
+    comparisons become the same comparison, and the membership check
+    `kind in (KIND_EVENT, KIND_DERIVED)` is satisfied by one value.
+
+    That is the "green and meaningless" state this codebase keeps
+    naming, arrived at from a new direction — a test written in the
+    vocabulary of the thing it is supposed to be checking cannot notice
+    that vocabulary collapsing.
+
+    So the values are asserted LITERALLY here, and the discriminating
+    cases below assert literals too. A pin for a distinction has to be
+    able to fail when the distinction stops existing.
+    """
+    assert KIND_EVENT == "event"
+    assert KIND_DERIVED == "derived"
+    assert KIND_EVENT != KIND_DERIVED
+
+
+def test_a_real_feed_contains_both_kinds_distinguishably():
+    """The end-to-end half of the same guard: a deed that was started
+    (derived) and generated (event) must produce two DIFFERENT values,
+    not two labels that happen to read differently in the source."""
+    rows = activity({"created_at": T(1), "completed_at": T(2)})
+    kinds = {r["what"]: r["kind"] for r in rows}
+    assert kinds["deed.started"] == "derived"
+    assert kinds["deed.generated"] == "event"
+    assert len(set(kinds.values())) == 2
+
+
+def test_every_entry_says_which_kind_it_is():
+    """The distinction has to survive the wire.
+
+    A feed of undifferentiated `{at, text}` is one where "expired" fits
+    perfectly, because nothing in the shape objects.
+    """
+    rows = activity(
+        {"created_at": T(1), "completed_at": T(2)},
+        shares=[{"created_at": T(3), "viewed_at": T(4), "responded_at": T(5),
+                 "status": "approved", "recipient_name": "Nora Vasquez"}],
+    )
+    assert rows, "the feed is empty for a deed that was generated and shared"
+    for row in rows:
+        assert row["kind"] in (KIND_EVENT, KIND_DERIVED)
+        assert row["source"], "an entry that cannot say where it came from"
+        assert row["sentence"]
+
+
+def test_an_act_somebody_performed_is_an_event():
+    """Generation, a reviewer opening it, a reviewer deciding, a
+    correction — each has a record that survives."""
+    rows = {r["what"]: r for r in activity(
+        {"created_at": T(1), "completed_at": T(2), "superseded_at": T(9)},
+        shares=[{"created_at": T(3), "viewed_at": T(4), "responded_at": T(5),
+                 "status": "approved", "recipient_name": "Nora"}],
+    )}
+    # Literal, not `KIND_EVENT` — see test_the_two_kinds_are_actually_two.
+    for what in ("deed.generated", "deed.superseded", "review.viewed",
+                 "review.approved"):
+        assert rows[what]["kind"] == "event", what
+
+
+def test_a_column_that_merely_carries_a_time_is_derived():
+    """`created_at` ages a row. Nobody recorded "the draft was started"
+    as an act; the column exists so the row can be sorted."""
+    rows = {r["what"]: r for r in activity(
+        {"created_at": T(1)},
+        shares=[{"created_at": T(3), "recipient_name": "Nora"}],
+        signings=[{"created_at": T(4)}],
+    )}
+    # Literal, not `KIND_DERIVED` — see test_the_two_kinds_are_actually_two.
+    for what in ("deed.started", "review.sent", "signing.requested"):
+        assert rows[what]["kind"] == "derived", what
+
+
+def test_the_two_viewed_columns_are_classified_by_HOW_THEY_ARE_WRITTEN():
+    """`deed_shares.viewed_at` and `signing_participants.last_viewed_at`
+    are one word apart and have OPPOSITE semantics.
+
+    The first is guarded — `if status == 'sent' and not viewed_at` — so
+    it is the FIRST view and it survives every later one. That is an act
+    with a surviving record.
+
+    The second is `SET last_viewed_at = now()`, unconditional. It is the
+    latest state, and it is named for what it is.
+
+    No amount of reading the column names tells you which is which. Only
+    the statement that writes them does.
+    """
+    rows = {r["what"]: r for r in activity(
+        {}, shares=[{"viewed_at": T(4), "recipient_name": "Nora"}])}
+    assert rows["review.viewed"]["kind"] == "event"
+    assert rows["review.viewed"]["source"] == "deed_shares.viewed_at"
+
+    with pytest.raises(FabricatedActivity):
+        refuse("last_viewed_at")
+
+
+def test_the_booking_event_is_the_ASSERTION_not_the_appointment():
+    """`booked_at` IS NOT WHEN THE BOOKING HAPPENED.
+
+    It is the signing's time — a future appointment. A feed keyed on it
+    would place "booked" at next month's date and sort it into the
+    future, above everything that has actually happened.
+
+    The moment is `booked_asserted_at`, written `now()` on BOTH the
+    convergence and override paths, with `booked_by` naming who asserted
+    it. §13.2 arriving in the timeline: the event is the assertion, never
+    the thing asserted.
+    """
+    rows = {r["what"]: r for r in activity(
+        {}, signings=[{"booked_at": datetime(2026, 12, 25, tzinfo=timezone.utc),
+                       "booked_asserted_at": T(6), "booked_by": "convergence"}])}
+    booked = rows["signing.booked"]
+    assert booked["source"] == "signing_requests.booked_asserted_at"
+    assert booked["at"].startswith("2026-08-06"), (
+        "the entry is dated by the appointment rather than by the moment "
+        "somebody recorded it")
+
+    with pytest.raises(FabricatedActivity):
+        refuse("booked_at")
+
+
+def test_who_asserted_the_booking_changes_the_sentence():
+    """Convergence and an officer override are different claims, and §13
+    rule 3 says one place turns that into English. This is that place."""
+    agreed = activity({}, signings=[{"booked_asserted_at": T(6),
+                                     "booked_by": "convergence"}])[0]
+    recorded = activity({}, signings=[{"booked_asserted_at": T(6),
+                                       "booked_by": "officer"}])[0]
+    assert agreed["sentence"] != recorded["sentence"]
+
+
+# ══════════════════════════════════════════════════════════════════════
+# 2. What may never become an entry
+# ══════════════════════════════════════════════════════════════════════
+
+@pytest.mark.parametrize("source", sorted(FORBIDDEN))
+def test_a_forbidden_source_refuses_and_says_why(source):
+    """A rule that is only a comment gets read past.
+
+    Callable, so the next author gets an exception rather than a
+    plausible-looking feed — and the exception names the reason, because
+    a refusal that does not explain itself gets worked around.
+    """
+    with pytest.raises(FabricatedActivity) as raised:
+        refuse(source)
+    assert len(str(raised.value)) > 40, "the refusal does not explain itself"
+
+
+def test_the_owner_ruled_exclusions_are_all_present():
+    """The list is the ruling, so it is asserted by NAME.
+
+    Dropping one silently is how "expired" gets into the feed a year from
+    now, on the reasoning that everything else already looked like an
+    event.
+    """
+    for source in ("expired", "expires_at", "view_count", "reminder_count",
+                   "updated_at", "last_viewed_at", "booked_at"):
+        assert source in FORBIDDEN, f"{source} stopped being forbidden"
+
+
+def test_an_entry_cannot_be_built_from_a_forbidden_source():
+    """The refusal is not advisory — it is on the constructor path, so
+    there is no way to add one without deleting the rule first."""
+    with pytest.raises(FabricatedActivity):
+        entry(T(1), KIND_EVENT, "share.expired", "The link expired.",
+              "deed_shares.expires_at")
+
+
+def test_an_unknown_kind_is_refused():
+    """`kind` is a closed vocabulary. A third value invented at a call
+    site is how the distinction stops meaning anything."""
+    with pytest.raises(FabricatedActivity):
+        entry(T(1), "probably", "deed.something", "Something.", "deeds.created_at")
+
+
+# ══════════════════════════════════════════════════════════════════════
+# 3. It reports absence as absence
+# ══════════════════════════════════════════════════════════════════════
+
+def test_a_missing_moment_is_not_an_entry():
+    """No filling in. A share that was never viewed contributes no view."""
+    rows = activity({"created_at": T(1)},
+                    shares=[{"created_at": T(2), "viewed_at": None,
+                             "responded_at": None, "recipient_name": "Nora"}])
+    assert not any(r["what"].startswith("review.viewed") for r in rows)
+    assert not any(r["what"].startswith("review.responded") for r in rows)
+
+
+def test_the_feed_is_never_empty_for_a_real_deed():
+    """`created_at` always exists, so the section always has something to
+    say. That was the argument for building it rather than deferring."""
+    assert activity({"created_at": T(1)})
+
+
+def test_newest_first():
+    """The question the page exists for is "what changed since I was last
+    here", and the answer belongs at the top."""
+    rows = activity({"created_at": T(1), "completed_at": T(5)})
+    assert [r["at"] for r in rows] == sorted((r["at"] for r in rows), reverse=True)
+
+
+def test_the_responses_log_is_read_as_itself():
+    """`signing_responses` is the only source here built to be an event
+    log — one row per answer, with who and when. A second answer is a
+    second row, and both survive."""
+    rows = activity({}, responses=[
+        {"answer": "available", "asserted_at": T(7), "name": "Dana Ruiz",
+         "party_role": "signer"},
+        {"answer": "unavailable", "asserted_at": T(8), "name": "Sam Okafor",
+         "party_role": "signer"},
+    ])
+    assert len(rows) == 2
+    assert all(r["kind"] == "event" for r in rows)
+    assert {r["what"] for r in rows} == {"signing.available", "signing.unavailable"}
+    assert "Dana Ruiz" in " ".join(r["sentence"] for r in rows)
+
+
+def test_no_contact_detail_reaches_the_feed():
+    """§13.1. The responses join reaches a participant for a NAME, and a
+    name is all it may carry across."""
+    rows = activity({}, responses=[
+        {"answer": "available", "asserted_at": T(7), "name": "Dana Ruiz",
+         "party_role": "signer", "email": "dana@example.test",
+         "phone": "+1-555-0100"},
+    ])
+    blob = " ".join(str(v) for r in rows for v in r.values())
+    assert "example.test" not in blob
+    assert "555" not in blob


### PR DESCRIPTION
Step 1 of Unit 2. Backend only — the page is step 2, split because this is where the fabrication risk concentrates and it deserves review on its own.

## What it is

`GET /deeds/{id}/activity`, assembled only from the permitted sources. There is no events table, so every entry is reconstructed from columns that exist for other reasons — **the exact shape in which a fabricated history gets built**, because the timestamps are already there, they sort, and the result looks like a log.

## The distinction is in the data, as ruled

`KIND_EVENT` — an act somebody performed whose record survives.
`KIND_DERIVED` — a column that merely carries a time.

Structural, not commented, because a consumer cannot recover it. If the API can't tell them apart no screen can, and the first person to add "expired" will do it because everything already looked like an event.

Every entry also carries the **column it came from** — part of the payload rather than a debug aid, because an entry that cannot say where it came from is one nobody can check.

## Two classifications that were only settleable by reading the writes

**`deed_shares.viewed_at` and `signing_participants.last_viewed_at` are one word apart and have opposite semantics.** The first is guarded on `status = 'sent' AND NOT viewed_at` — it is the *first* view and it survives every later one, so it is an act with a record. The second is an unconditional `SET last_viewed_at = now()` — the latest state, and named for what it is. Nothing in the column names tells you which is which.

**`booked_at` is not when the booking happened.** It is the appointment's time. A feed keyed on it dates "booked" at next month, sorting it above everything that has actually occurred. The moment is `booked_asserted_at`, written `now()` on *both* the convergence and override paths, with `booked_by` naming who asserted it. §13.2 arriving in the timeline: **the event is the assertion, never the thing asserted.** Both are now in `FORBIDDEN` with that reason attached.

## The exclusions are callable

`refuse()` sits on the constructor path, so an entry cannot be built from a forbidden source without deleting the rule first. Each refusal names its reason — one that doesn't explain itself gets worked around. All seven owner-ruled exclusions are asserted by name, because dropping one silently is how "expired" arrives a year from now.

## A probe caught my own pin green and meaningless

Every assertion was written as `row["kind"] == KIND_EVENT` — **in the vocabulary of the thing being checked**. Setting `KIND_DERIVED = "event"` collapses the distinction entirely, and all 21 tests passed: both comparisons become the same comparison, and the membership check is satisfied by one value.

A test written in the vocabulary of a distinction cannot notice that vocabulary collapsing. The values are asserted literally now, plus a pin that the two constants differ and that a real feed yields two distinct values. Re-running the probe: 3 failures where there were 0.

## Gates

| gate | result |
|---|---|
| pytest (with DB) | 1189 passed |
| six-flow | green |
| banned-claims | clean |
| OpenAPI snapshot | re-recorded — exactly one route added |
| mutation probes | 4 run, 3 caught, **1 came back green** and produced the fix above |

## Next

Step 2 is the page in the ruled order: lineage banner (disqualifying), state and next action, activity, matter, instrument as a named line. Participants split and pinned, panel collapsed to a link, orphan resolved with real navigation. The success page lean is confirmed against what it renders — it reads four deed endpoints and serves the stored instrument, so it stays as the post-generation moment and links to the deed page rather than becoming a second implementation of it.

**Branch note, as standing practice:** fresh per-ticket branch off current main, not the stale branch named in session config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_