### PR TITLE
LEGAL1 — stop collecting a consent we cannot honour; stop the browser filling a password nobody chose

### DIFF
--- a/backend/routers/users_auth.py
+++ b/backend/routers/users_auth.py
@@ -36,7 +36,36 @@ class UserRegister(BaseModel):
     phone: Optional[str] = None
     state: str
     agree_terms: bool
-    subscribe: bool = False
+    # ── LEGAL1: `subscribe` IS NO LONGER ACCEPTED ─────────────────────
+    #
+    # It was captured here and written to the users table, and then
+    # appeared NOWHERE ELSE in 119 endpoints: not in any response, not on
+    # /users/profile, not in admin search or export. `ProfilePatch` takes
+    # only default_county and onboarding_completed. There is no
+    # unsubscribe endpoint and no email-preferences endpoint, while
+    # /admin/emails and /admin/emails/stats both exist.
+    #
+    # So the consent was unreadable, unmodifiable by the person who gave
+    # it, unproducible by support, and had no opt-out path. Mailing a
+    # list whose consent cannot be produced and which offers no way out
+    # is a CAN-SPAM problem, not a UX gap.
+    #
+    # OWNER-RULED: stop collecting it. Collecting consent we cannot
+    # honour is worse than not collecting it — it manufactures a record
+    # that looks like permission and cannot function as one.
+    #
+    # The COLUMN stays and existing rows are untouched: dropping a column
+    # is a data operation, and those values are evidence of what was
+    # collected even though they are unusable as permission.
+    #
+    # The lifecycle gets built when there is an actual reason to mail
+    # anyone — stored, readable on the profile, patchable by the user, a
+    # real unsubscribe path, and a List-Unsubscribe header on any
+    # non-transactional send. All of it, or none of it.
+    #
+    # Pydantic's `extra = "ignore"` is NOT relied on here: the field is
+    # absent from the model, so a client still sending it is ignored
+    # rather than silently honoured.
 
 class UserLogin(BaseModel):
     email: str
@@ -104,8 +133,8 @@ async def register_user(user: UserRegister = Body(...)):
         with conn.cursor() as cur:
             cur.execute("""
                 INSERT INTO users (email, password_hash, full_name, role, company_name,
-                                 company_type, phone, state, subscribe, plan)
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                                 company_type, phone, state, plan)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
                 RETURNING id
             """, (
                 # Profile-hygiene: name/company/phone print on deed faces
@@ -114,7 +143,7 @@ async def register_user(user: UserRegister = Body(...)):
                 clean_profile_text(user.full_name), user.role,
                 clean_profile_text(user.company_name), user.company_type,
                 clean_profile_text(user.phone), user.state.upper(),
-                user.subscribe, 'free'
+                'free'
             ))
             result = cur.fetchone()
             if result:

--- a/backend/tests/test_stored_instrument.py
+++ b/backend/tests/test_stored_instrument.py
@@ -377,3 +377,51 @@ def test_the_sweep_is_reading_a_plausible_corpus():
     assert found >= 3, (
         f"only {found} writes to `users` found — the sweep is no longer "
         "reading the statements it was written to guard")
+
+
+# ══════════════════════════════════════════════════════════════════════
+# 6. LEGAL1 — no consent is collected that cannot be honoured
+# ══════════════════════════════════════════════════════════════════════
+
+def test_registration_does_not_accept_a_marketing_consent():
+    """`subscribe` was accepted here and written to `users`, then appeared
+    NOWHERE ELSE in 119 endpoints — no response, no profile field, no
+    patch path, no unsubscribe endpoint, while /admin/emails exists.
+
+    Unreadable, unmodifiable by the person who gave it, unproducible by
+    support, unhonourable. Mailing a list whose consent cannot be
+    produced and which offers no way out is a CAN-SPAM problem.
+
+    OWNER-RULED: stop collecting it. Collecting consent we cannot honour
+    is worse than not collecting it — it manufactures a record that
+    looks like permission and cannot function as one.
+
+    THE COLUMN STAYS and existing rows are untouched: dropping a column
+    is a data operation, and those values are evidence of what was
+    collected even though they are unusable as permission.
+
+    This pin is what stops HALF the lifecycle reappearing. If collection
+    comes back, it comes back with a read path, a patch path, an
+    unsubscribe endpoint and a List-Unsubscribe header — or not at all.
+    """
+    from pathlib import Path
+
+    from tests.source_text import code_only
+
+    backend = Path(__file__).resolve().parents[1]
+    src = code_only(backend / "routers" / "users_auth.py")
+
+    model = src[src.index("class UserRegister"):]
+    model = model[: model.index("class UserLogin")]
+    assert "subscribe" not in model, (
+        "registration accepts a marketing consent again — it must arrive "
+        "with a read path, a patch path and an unsubscribe endpoint, or "
+        "not at all")
+
+    # And it is not written on the way past either. The checkbox going
+    # while the write stayed would be the worst of both: still collected,
+    # no longer even asked for.
+    handler = src[src.index("INSERT INTO users"):]
+    handler = handler[:600]
+    assert "subscribe" not in handler, (
+        "the registration INSERT still writes a consent nothing can read")

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -120,8 +120,9 @@ when their trigger arrives.
      on our side is **sent and rejected with a 400 (signature)** — and
      the handler now says which of the two 400s it is.
 
-  2. **Report `SELECT count(*) FROM users WHERE subscribe = true`** when
-     LEGAL1 is built. `subscribe` IS a real column — the consent value is
+  2. **Report `SELECT count(*) FROM users WHERE subscribe = true`.**
+     LEGAL1 has shipped the stop-collecting half; this count is the only
+     part I cannot run (production query, Tier 3). `subscribe` IS a real column — the consent value is
      STORED, not merely accepted and dropped: written at registration,
      then unreachable (no read path, no patch path, no unsubscribe). We
      are holding a consent flag we cannot show, cannot let them change,

--- a/frontend/src/__tests__/registrationConsent.test.ts
+++ b/frontend/src/__tests__/registrationConsent.test.ts
@@ -1,0 +1,116 @@
+/**
+ * LEGAL1 — registration collects nothing it cannot honour, and the
+ * browser is told this is a new account.
+ *
+ * ═══ THE CONSENT WITH NO LIFECYCLE ═══
+ *
+ * `subscribe` was captured at registration and written to `users`, and
+ * then appeared NOWHERE ELSE across 119 endpoints: not in any response,
+ * not on `/users/profile`, not in admin search or export. `ProfilePatch`
+ * accepts only `default_county` and `onboarding_completed`. There was no
+ * unsubscribe endpoint and no email-preferences endpoint — while
+ * `/admin/emails` and `/admin/emails/stats` both exist.
+ *
+ * So the consent was unreadable, unmodifiable by the person who gave it,
+ * unproducible by support, and had no opt-out path. Mailing a list whose
+ * consent cannot be produced and which offers no way out is a CAN-SPAM
+ * problem, not a UX gap.
+ *
+ * Owner-ruled: stop collecting it. **Collecting consent we cannot honour
+ * is worse than not collecting it** — it manufactures a record that
+ * looks like permission and cannot function as one.
+ *
+ * The lifecycle gets built when there is a real reason to mail anyone,
+ * and then all of it at once: stored, readable on the profile, patchable
+ * by the user, a real unsubscribe path, and a List-Unsubscribe header on
+ * any non-transactional send. This pin is what stops half of it
+ * reappearing.
+ *
+ * ═══ AND THE BROWSER FILLING A PASSWORD NOBODY CHOSE ═══
+ *
+ * Without `autocomplete="new-password"`, Chrome does not recognise the
+ * form as registration, reads a password field, and offers a saved
+ * credential. The audit caught it exactly: eight dots and a "Good"
+ * strength bar present before a single keystroke, with Confirm empty.
+ *
+ * Somebody can create an account with a password they never chose and do
+ * not know they reused — and the strength meter tells them it is good.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
+
+const SRC = path.join(__dirname, '..');
+const REGISTER = fs.readFileSync(
+  path.join(SRC, 'app', 'register', 'page.tsx'), 'utf8');
+const CODE = codeOnly(REGISTER);
+
+describe('registration does not collect a consent it cannot honour', () => {
+  it('has no marketing-consent checkbox', () => {
+    expect(CODE).not.toContain('id="subscribe"');
+    expect(CODE).not.toContain('name="subscribe"');
+  });
+
+  it('does not hold it in form state or send it', () => {
+    // The checkbox going while the field stays would be the worst of
+    // both: still collected, now without even asking.
+    expect(CODE).not.toContain('subscribe:');
+    expect(CODE).not.toContain('formData.subscribe');
+  });
+
+  it('does not offer the wording either', () => {
+    expect(CODE).not.toMatch(/product updates and tips/i);
+  });
+});
+
+describe('the browser is told this is a NEW password', () => {
+  it('both password fields carry autocomplete="new-password"', () => {
+    /**
+     * THE PIN THIS FILE EXISTS FOR, and it counts rather than merely
+     * finding one: the defect is per-FIELD, and a form where Confirm
+     * carries the attribute and Password does not is the exact failure
+     * the audit photographed.
+     *
+     * Counted against the PASSWORD INPUTS, not against `type="password"`
+     * — the fields use a show/hide toggle, so their type is
+     * `{showPassword ? "text" : "password"}` and a literal match finds
+     * zero. The first draft of this pin asserted the literal and failed
+     * on correct code, which is its own small lesson: an assertion about
+     * markup has to match the markup that exists.
+     */
+    const inputs = CODE.match(/\? "text" : "password"/g) || [];
+    expect(inputs.length).toBe(2);
+    // One per input, and no more — a stray third would mean the
+    // attribute landed somewhere it does not belong.
+    const attrs = CODE.match(/^\s*autoComplete="new-password"$/gm) || [];
+    expect(attrs.length).toBe(2);
+  });
+
+  it('never says current-password on the registration form', () => {
+    // `current-password` is the value that ASKS for the saved credential.
+    expect(CODE).not.toContain('current-password');
+  });
+
+  it('the attribute sits on the password inputs, not merely in the file', () => {
+    // A string-presence check would pass with both attributes on the
+    // email field. Anchor each to its own input.
+    for (const name of ['password', 'confirmPassword']) {
+      const at = CODE.indexOf(`name="${name}"`);
+      expect(at).toBeGreaterThan(-1);
+      const window = CODE.slice(at, at + 400);
+      expect(window).toContain('autoComplete="new-password"');
+    }
+  });
+});
+
+describe('the rest of the form autofills the things it should', () => {
+  it('names the fields a browser can helpfully fill', () => {
+    // Helping with an address and a company is good. Helping with a
+    // password is the bug — the difference is that these cannot be
+    // wrong without the person noticing.
+    for (const value of ['email', 'name', 'organization', 'tel']) {
+      expect(CODE).toContain(`autoComplete="${value}"`);
+    }
+  });
+});

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -98,7 +98,6 @@ export default function RegisterPage() {
     phone: "",
     state: "",
     agreeTerms: false,
-    subscribe: false,
   })
 
   const validateForm = () => {
@@ -176,7 +175,6 @@ export default function RegisterPage() {
             phone: formData.phone || null,
             state: formData.state,
             agree_terms: formData.agreeTerms,
-            subscribe: formData.subscribe,
           }),
         },
       )
@@ -288,6 +286,7 @@ export default function RegisterPage() {
                   type="email"
                   id="email"
                   name="email"
+                  autoComplete="email"
                   value={formData.email}
                   onChange={handleChange}
                   className={`${inputBase} ${validationErrors.email ? "border-error-500" : "border-gray-200"}`}
@@ -303,10 +302,19 @@ export default function RegisterPage() {
                     Password <span className="text-error-500">*</span>
                   </label>
                   <div className="relative">
+                    {/* LEGAL1: WITHOUT autoComplete="new-password", CHROME FILLS A
+                          SAVED CREDENTIAL. It does not recognise this as a
+                          registration form, reads a password field, and
+                          offers a login it has stored — the audit caught
+                          eight dots and a "Good" strength bar before a
+                          single keystroke, with Confirm empty. Somebody can
+                          create an account with a password they never chose
+                          and do not know they reused. */}
                     <input
                       type={showPassword ? "text" : "password"}
                       id="password"
                       name="password"
+                      autoComplete="new-password"
                       value={formData.password}
                       onChange={handleChange}
                       className={`${inputBase} pr-12 ${
@@ -350,6 +358,7 @@ export default function RegisterPage() {
                       type={showConfirmPassword ? "text" : "password"}
                       id="confirmPassword"
                       name="confirmPassword"
+                      autoComplete="new-password"
                       value={formData.confirmPassword}
                       onChange={handleChange}
                       className={`${inputBase} pr-12 ${
@@ -381,6 +390,7 @@ export default function RegisterPage() {
                   type="text"
                   id="fullName"
                   name="fullName"
+                  autoComplete="name"
                   value={formData.fullName}
                   onChange={handleChange}
                   className={`${inputBase} ${validationErrors.fullName ? "border-error-500" : "border-gray-200"}`}
@@ -448,6 +458,7 @@ export default function RegisterPage() {
                     type="text"
                     id="companyName"
                     name="companyName"
+                    autoComplete="organization"
                     value={formData.companyName}
                     onChange={handleChange}
                     className={`${inputBase} border-gray-200`}
@@ -485,6 +496,7 @@ export default function RegisterPage() {
                   type="tel"
                   id="phone"
                   name="phone"
+                  autoComplete="tel"
                   value={formData.phone}
                   onChange={handleChange}
                   className={`${inputBase} border-gray-200`}
@@ -519,19 +531,19 @@ export default function RegisterPage() {
                   <p className="ml-7 text-sm text-error-500">{validationErrors.agreeTerms}</p>
                 )}
 
-                <div className="flex items-start">
-                  <input
-                    type="checkbox"
-                    id="subscribe"
-                    name="subscribe"
-                    checked={formData.subscribe}
-                    onChange={handleChange}
-                    className="mt-1 h-4 w-4 text-brand-500 border-gray-200 rounded focus:ring-brand-500 focus:ring-2"
-                  />
-                  <label htmlFor="subscribe" className="ml-3 text-sm text-gray-700">
-                    Send me product updates and tips via email
-                  </label>
-                </div>
+                {/* LEGAL1 — THE MARKETING CONSENT CHECKBOX IS GONE.
+                    It was collected here and written to the users table,
+                    then appeared nowhere else in 119 endpoints: no
+                    response carried it, /users/profile did not show it,
+                    ProfilePatch could not change it, and there was no
+                    unsubscribe endpoint — while /admin/emails existed.
+
+                    Consent that cannot be read back, changed by the
+                    person who gave it, produced by support, or acted on
+                    is not consent. Owner-ruled: stop collecting it. The
+                    lifecycle gets built when there is a reason to mail
+                    anyone, and then all of it at once — profile field,
+                    patch path, unsubscribe, List-Unsubscribe header. */}
               </div>
 
               {/* Submit Button */}


### PR DESCRIPTION
Both items as ruled. Branches off main (post-#185).

## 1. The consent with no lifecycle

`subscribe` was accepted by `UserRegister` and written to `users`, then appeared **nowhere else across 119 endpoints**: no response carried it, `/users/profile` did not show it, `ProfilePatch` takes only `default_county` and `onboarding_completed`, and there was no unsubscribe endpoint and no email-preferences endpoint — while `/admin/emails` and `/admin/emails/stats` both exist.

Unreadable, unmodifiable by the person who gave it, unproducible by support, no opt-out. **Mailing a list whose consent cannot be produced and which offers no way out is a CAN-SPAM problem, not a UX gap.**

Removed: the checkbox, the form state, the payload field, the request model field, and the INSERT column.

**The database column stays and existing rows are untouched.** Dropping a column is a data operation, and those values are evidence of what was collected even though they are unusable as permission. The count of rows carrying `true` is a production query and remains on the owner's card — it's the one part of this ticket I can't run.

Two pins, because half a lifecycle is the likely regression: one asserts the model does not accept it, one asserts the INSERT does not write it. Collection comes back with a read path, a patch path, an unsubscribe endpoint and a `List-Unsubscribe` header — or not at all.

## 2. The browser was filling a password nobody chose

Without `autocomplete="new-password"`, Chrome doesn't recognise the form as registration, reads a password field, and offers a saved credential. The audit caught it exactly: eight dots and a "Good" strength bar before a single keystroke, Confirm empty.

Somebody could create an account with a password **they never chose and didn't know they'd reused** — while the strength meter told them it was good.

Both password fields carry it now. The rest of the form names what a browser *can* helpfully fill — `email`, `name`, `organization`, `tel`. The difference is that those can't be wrong without the person noticing.

The password pin **counts per-field** rather than finding one, because a form where Confirm has the attribute and Password does not is precisely the failure the audit photographed. It also anchors each attribute to its own input, so both landing on the email field wouldn't pass.

Its own first draft asserted `type="password"` and **failed on correct code** — the fields use a show/hide toggle, so their type is `{showPassword ? "text" : "password"}`. Recorded at the site: an assertion about markup has to match the markup that exists.

## Gates

| gate | result |
|---|---|
| pytest (with DB) | 1179 passed |
| jest | 819 passed, 57 suites |
| tsc baseline | 88 (holds) |
| six-flow | green |
| banned-claims | clean |
| `next build` | clean |
| mutation probes | 2 run, 2 caught |

Probes: `new-password` removed from one field only (caught — the per-field count is what catches it); the consent field returns to the model.

**Branch note, as standing practice:** fresh per-ticket branch off current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_