### PR TITLE
SETTINGS1 — the save that reported success without asking anybody

### DIFF
--- a/backend/routers/users_auth.py
+++ b/backend/routers/users_auth.py
@@ -380,7 +380,7 @@ async def get_user_profile_endpoint(user_id: int = Depends(get_current_user_id))
         # from this response, never from localStorage alone (bug #10).
         with db.conn.cursor() as cur:
             cur.execute("""
-                SELECT default_county, onboarding_completed
+                SELECT default_county, onboarding_completed, business_address
                 FROM user_profiles WHERE user_id = %s
             """, (user_id,))
             prof = cur.fetchone()
@@ -394,6 +394,11 @@ async def get_user_profile_endpoint(user_id: int = Depends(get_current_user_id))
         return {
             "default_county": prof[0] if prof else None,
             "onboarding_completed": bool(prof[1]) if prof else False,
+            # SETTINGS1 — the address the Settings form always wanted and
+            # never had. The column was in `user_profiles` the whole
+            # time; the form was built against street/city/ZIP, which
+            # exist nowhere and never did.
+            "business_address": (prof[2] if prof and len(prof) > 2 else None),
             "total_deeds": total_deeds,
             "id": user[0],
             "email": user[1],
@@ -452,8 +457,51 @@ async def get_user_profile_endpoint(user_id: int = Depends(get_current_user_id))
         raise HTTPException(status_code=500, detail=f"Failed to get profile: {str(e)}")
 
 class ProfilePatch(BaseModel):
+    """SETTINGS1 — the fields the Settings form can actually save.
+
+    ═══ WHY THIS GREW ═══
+
+    Settings rendered nine fields and a Save button whose handler was:
+
+        const handleSave = () => { toast.success("Profile saved!") }
+
+    Three lines, no request, and a SUCCESS TOAST. Not a missing
+    confirmation — a fabricated one, on the single screen where somebody
+    is deliberately entrusting us with their details. That is why nine
+    fields vanished on reload with nobody suspecting a bug: the product
+    told her it had worked.
+
+    Wiring the button was not enough, because there was nothing to wire
+    it to: this model accepted `default_county` and
+    `onboarding_completed` and nothing else. No name, no company, no
+    phone.
+
+    ═══ WHAT IS HERE AND WHAT IS NOT ═══
+
+    Every field below has a COLUMN. Nothing is accepted that cannot be
+    stored — the LEGAL1 rule one screen over: a field we take and cannot
+    keep is worse than a field we do not offer.
+
+    `full_name` stays ONE field (owner-ruled). The form showed First and
+    Last; the server has only `full_name`. Splitting a name to satisfy a
+    form is a data-model decision made backwards, and Recording Requested
+    By prints a name AS WRITTEN, not as parsed.
+
+    Street/city/ZIP are NOT here. There are no such columns and never
+    were — the form was built against imaginary ones. What does exist is
+    `user_profiles.business_address`, already in the schema and unused by
+    that form, so the address is one field backed by the column that was
+    there all along.
+    """
     default_county: Optional[str] = None
     onboarding_completed: Optional[bool] = None
+    # users
+    full_name: Optional[str] = None
+    company_name: Optional[str] = None
+    phone: Optional[str] = None
+    state: Optional[str] = None
+    # user_profiles
+    business_address: Optional[str] = None
 
 @router.patch("/users/profile")
 async def patch_user_profile(
@@ -463,29 +511,52 @@ async def patch_user_profile(
     """Partial profile update (F3 — the endpoint onboarding used to PATCH
     didn't exist, bug #9). Only touches the fields provided; unlike
     POST /users/profile/enhanced it never clobbers unspecified columns."""
-    if patch.default_county is None and patch.onboarding_completed is None:
+    given = patch.dict(exclude_unset=True)
+    if not given:
         raise HTTPException(status_code=400, detail="No fields to update")
     conn = None
     try:
         conn = db.get_db_connection()
         with conn.cursor() as cur:
-            cur.execute("""
-                INSERT INTO user_profiles (user_id, default_county, onboarding_completed)
-                VALUES (%s, %s, COALESCE(%s, FALSE))
-                ON CONFLICT (user_id) DO UPDATE SET
-                    default_county = COALESCE(EXCLUDED.default_county,
-                                              user_profiles.default_county),
-                    onboarding_completed = COALESCE(%s,
-                                              user_profiles.onboarding_completed),
-                    updated_at = CURRENT_TIMESTAMP
-            """, (user_id, patch.default_county, patch.onboarding_completed,
-                  patch.onboarding_completed))
+            # ── users: name, company, phone, state ────────────────────
+            #
+            # Whitespace normalised at the WRITE and case left alone —
+            # these print on deed faces and in emails, and a name is
+            # spelled the way its owner spells it.
+            user_fields = {
+                "full_name": clean_profile_text(patch.full_name),
+                "company_name": clean_profile_text(patch.company_name),
+                "phone": clean_profile_text(patch.phone),
+                "state": (patch.state or "").upper() or None,
+            }
+            user_fields = {k: v for k, v in user_fields.items() if k in given}
+            if user_fields:
+                sets = ", ".join(f"{k} = %s" for k in user_fields)
+                cur.execute(f"UPDATE users SET {sets} WHERE id = %s",
+                            (*user_fields.values(), user_id))
+
+            # ── user_profiles: county, onboarding, business address ───
+            profile_fields = {"default_county", "onboarding_completed",
+                              "business_address"}
+            if profile_fields & set(given):
+                cur.execute("""
+                    INSERT INTO user_profiles (user_id, default_county,
+                                               onboarding_completed, business_address)
+                    VALUES (%s, %s, COALESCE(%s, FALSE), %s)
+                    ON CONFLICT (user_id) DO UPDATE SET
+                        default_county = COALESCE(EXCLUDED.default_county,
+                                                  user_profiles.default_county),
+                        onboarding_completed = COALESCE(%s,
+                                                  user_profiles.onboarding_completed),
+                        business_address = COALESCE(EXCLUDED.business_address,
+                                                  user_profiles.business_address),
+                        updated_at = CURRENT_TIMESTAMP
+                """, (user_id, patch.default_county, patch.onboarding_completed,
+                      patch.business_address, patch.onboarding_completed))
             conn.commit()
-        return {
-            "status": "updated",
-            "default_county": patch.default_county,
-            "onboarding_completed": patch.onboarding_completed,
-        }
+        # What was actually written, echoed back — so the screen renders
+        # the server's answer rather than the value it hoped for.
+        return {"status": "updated", **given}
     except Exception as e:
         try:
             if conn and not conn.closed:

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -683,6 +683,33 @@ we reach it.
   feature has to read ONE of them and picking the wrong one is a field
   that silently disagrees with Settings.
 
+- **Checkout returns to the WRONG TAB, and the confirmation is already
+  built** (tabled by the owner 2026-08-13, after verifying the first
+  successful payment in the product's history end to end — card charged,
+  webhook received, plan flipped to professional).
+
+  `success_url` is `{FRONTEND_URL}/account-settings?success=true` with no
+  tab, and `activeTab` defaults to `"profile"`. So somebody who has just
+  paid $99 lands on a form asking for their phone number and has to hunt
+  for evidence that anything happened.
+
+  **The confirmation is not missing — it is unreachable.** MONEY1's
+  banner renders under `activeTab === "billing" && checkout`, and the
+  retry/refetch effect fires correctly on `?success=true` regardless of
+  tab. The plan updates, the banner is composed, and she never sees it.
+
+  Same shape this wave keeps finding: the thing exists and nothing
+  connects to it — the orphaned `/deeds/{id}/preview`, the unused
+  `user_profiles.business_address`, now this.
+
+  **Fix:** deep-link the return to the billing tab — `success_url` gains
+  a tab parameter and the page reads it — alongside the `?success=true`
+  retry and refetch already ruled and shipped. Both halves of the same
+  return trip.
+
+  **OWNER-RULED: fold into the next billing-adjacent PR, do not fire
+  standalone.** Small, and it belongs with the work it completes.
+
 ## Parked tickets (scoped, not scheduled)
 
 - **Audit the string-presence pins whose subject is a BRANCH** (CANCEL1

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -654,6 +654,35 @@ we reach it.
   page's activity list is a UNION of real timestamp columns, which is
   honest but is not the log this table nearly is.
 
+- **The officer's company reaches a deed by DEFAULT, not by becoming a
+  partner** (SETTINGS1 item 5, owner ruling reversed on the report,
+  2026-08-13). She gave us her company at signup and typed it again in
+  Settings; "Recording Requested By" is a Partner picker, so she would
+  have had to enter it a third time.
+
+  Auto-creating a partner row is cheap — `partners` needs `company_name`,
+  `created_by_user_id`, `category`, `role`, all of which we have — and
+  it is still the wrong move. **A partner is a COUNTERPARTY**: somebody
+  you send things to. Her own company is not one, and auto-inserting it
+  makes the picker a list where one entry means something categorically
+  different from the rest. That is the two-populations problem ruled in
+  DEEDDETAIL, one table over.
+
+  So: the requested-by field DEFAULTS from `user_profiles.company_name`,
+  and the picker stays for actual counterparties. Not built in
+  SETTINGS1 — it is a builder change and belongs with the builder.
+
+- **`users.company_name` and `user_profiles.company_name` both exist**
+  (found 2026-08-13 while extending ProfilePatch; NOT resolved). Two
+  columns for one fact, in two tables. `/users/profile` returns the
+  `users` one; SETTINGS1 patches that one. `user_profiles.company_name`
+  is written by the enhanced-profile endpoint and read by nothing this
+  ticket touched.
+
+  Ruling wanted before the requested-by default is built, because that
+  feature has to read ONE of them and picking the wrong one is a field
+  that silently disagrees with Settings.
+
 ## Parked tickets (scoped, not scheduled)
 
 - **Audit the string-presence pins whose subject is a BRANCH** (CANCEL1

--- a/frontend/src/__tests__/settingsSave.test.ts
+++ b/frontend/src/__tests__/settingsSave.test.ts
@@ -1,0 +1,158 @@
+/**
+ * SETTINGS1 — the save that reported success without asking anybody.
+ *
+ * ═══ THE DEFECT, IN THREE LINES ═══
+ *
+ *     const handleSave = () => { toast.success("Profile saved!") }
+ *
+ * No request. A SUCCESS TOAST. Not a missing confirmation — a fabricated
+ * one, on the single screen where somebody is deliberately entrusting us
+ * with their details. That is why nine fields vanished on every reload
+ * with nobody suspecting a bug: the product had told her it worked.
+ *
+ * Invariant #4 in its purest form. A failure that announces itself is a
+ * bad afternoon; a failure that announces SUCCESS is a user who stops
+ * checking.
+ *
+ * ═══ AND THERE WAS NOWHERE TO SEND IT ═══
+ *
+ * `ProfilePatch` accepted `default_county` and `onboarding_completed`
+ * and nothing else. "Wire the button to the endpoint" named an endpoint
+ * that could not take the data. The patch surface had to come first.
+ *
+ * ═══ AND THE FORM WAS READING KEYS THE SERVER NEVER SENT ═══
+ *
+ * Six of nine: `first_name`, `last_name`, `company`, `street_address`,
+ * `city`, `zip_code`. The server sends `full_name` and `company_name`,
+ * and never had an address in that shape. A missing key is `undefined`,
+ * `undefined` renders blank, and the page showed somebody their own
+ * account with their name and company missing — which reads as "we lost
+ * your data".
+ *
+ * FLOW1 item 0's defect in its FOURTH habitat.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
+
+const SRC = path.join(__dirname, '..');
+const read = (...p: string[]) => codeOnly(fs.readFileSync(path.join(SRC, ...p), 'utf8'));
+const SETTINGS = read('app', 'account-settings', 'page.tsx');
+const ONBOARDING = read('app', 'onboarding', 'page.tsx');
+
+describe('Save Changes issues a request', () => {
+  it('actually calls the profile endpoint', () => {
+    // The whole ticket. A button that reports an outcome it never
+    // requested is the defect; this is its absence.
+    expect(SETTINGS).toContain('method: "PATCH"');
+    expect(SETTINGS).toContain('/users/profile');
+  });
+
+  it('never announces success before the response', () => {
+    /**
+     * The pin that would have caught the original. `toast.success` must
+     * not be reachable without a completed request — so it appears only
+     * AFTER the `!response.ok` throw, never before the fetch.
+     */
+    const handler = SETTINGS.slice(SETTINGS.indexOf('const handleSave'));
+    const body = handler.slice(0, handler.indexOf('const field'));
+    const fetchAt = body.indexOf('await fetch');
+    const okCheck = body.indexOf('!response.ok');
+    const success = body.indexOf('toast.success');
+    expect(fetchAt).toBeGreaterThan(-1);
+    expect(okCheck).toBeGreaterThan(fetchAt);
+    expect(success).toBeGreaterThan(okCheck);
+  });
+
+  it('a failed save is visible, and says why', () => {
+    // §4: the reason travels. "Something went wrong" sends her to
+    // support with nothing; the server's detail sends her to the cause.
+    expect(SETTINGS).toContain('data.detail');
+    expect(SETTINGS).toContain('toast.error');
+    expect(SETTINGS).toContain('setError(message)');
+  });
+
+  it('re-reads the profile rather than trusting what it sent', () => {
+    // The server normalises whitespace and upper-cases the state, so
+    // what she sees after saving is what is STORED, not what she typed.
+    expect(SETTINGS).toContain('onSaved()');
+  });
+});
+
+describe('the form reads the names the server actually sends', () => {
+  it('holds no key the profile payload does not carry', () => {
+    const form = SETTINGS.slice(SETTINGS.indexOf('function ProfileTab'));
+    for (const dead of ['first_name', 'last_name', 'street_address',
+                        'zip_code', 'formData.city']) {
+      expect(form).not.toContain(dead);
+    }
+  });
+
+  it('uses full_name and company_name', () => {
+    expect(SETTINGS).toContain('full_name');
+    expect(SETTINGS).toContain('company_name');
+  });
+
+  it('keeps ONE name field rather than splitting it', () => {
+    /**
+     * Owner-ruled. The server has `full_name`; the form showed First and
+     * Last. Splitting a name to satisfy a form is a data-model decision
+     * made backwards — and Recording Requested By prints a name AS
+     * WRITTEN, not as parsed.
+     */
+    expect(SETTINGS).not.toMatch(/>First Name</);
+    expect(SETTINGS).not.toMatch(/>Last Name</);
+  });
+
+  it('has ONE address field, backed by the column that already existed', () => {
+    // `user_profiles.business_address` was in the schema the whole time.
+    // The three-field section was built against columns that never
+    // existed anywhere — the form invented its own storage.
+    expect(SETTINGS).toContain('business_address');
+    expect(SETTINGS).not.toMatch(/>Street Address</);
+    expect(SETTINGS).not.toMatch(/>ZIP Code</);
+  });
+
+  it('does not offer to edit the login identity', () => {
+    // Showing email as editable and then not saving it would be the
+    // same lie in a smaller place.
+    expect(SETTINGS).toContain('readOnly');
+  });
+});
+
+describe('skipping onboarding may leave, but may not lie', () => {
+  it('retries before giving up', () => {
+    // The first action anybody takes in the product, against a service
+    // that cold-starts. One attempt is a coin flip.
+    expect(ONBOARDING).toContain('saveProfileOnce');
+    expect(ONBOARDING).toMatch(/for \(const wait of \[0, \d+\]\)/);
+  });
+
+  it('tells her when the skip was not recorded', () => {
+    /**
+     * THE TRAP LOOP. This used to swallow the failure entirely:
+     * `onboarding_completed` stayed false, the dashboard gate re-fired,
+     * and she was returned to onboarding forever with no indication
+     * why.
+     *
+     * Worse than a lost field — a lost field is noticed once; a loop is
+     * noticed every time and explains itself never.
+     */
+    expect(ONBOARDING).toContain('setSkipNotice(true)');
+    expect(ONBOARDING).toContain('you may be asked');
+  });
+
+  it('still leaves, because skip means leave', () => {
+    // Holding her hostage to our own 503 would be a second failure on
+    // top of the first.
+    const skip = ONBOARDING.slice(ONBOARDING.indexOf('const handleSkip'));
+    expect(skip.slice(0, skip.indexOf('\n  const '))).toContain('router.push("/dashboard")');
+  });
+
+  it('the county step keeps its own honest failure', () => {
+    // It always had one — it throws, catches, shows the error and does
+    // NOT navigate. The audit's observation was the skip path.
+    expect(ONBOARDING).toContain("Couldn't save your county");
+  });
+});

--- a/frontend/src/app/account-settings/page.tsx
+++ b/frontend/src/app/account-settings/page.tsx
@@ -10,15 +10,12 @@ import { TIERS, priceLabel } from "@/lib/pricing"
 type Tab = "profile" | "billing" | "notifications" | "security"
 
 interface UserProfile {
-  first_name?: string
-  last_name?: string
+  full_name?: string
   email?: string
   phone?: string
-  company?: string
-  street_address?: string
-  city?: string
+  company_name?: string
+  business_address?: string
   state?: string
-  zip_code?: string
   plan?: string
   plan_limits?: any
   /* PRICING1: the Widget Add-on TAB is deleted (owner-ruled). It priced
@@ -271,7 +268,10 @@ function AccountSettingsPage() {
 
             {/* Tab Content */}
             <div className="p-8">
-              {activeTab === "profile" && <ProfileTab userProfile={userProfile} />}
+              {activeTab === "profile" && (
+                <ProfileTab userProfile={userProfile}
+                            onSaved={() => fetchUserProfile({ silent: true })} />
+              )}
               {/* MONEY1 — back from checkout, saying only what is known.
                   Stripe redirected, so the payment is OBSERVED. Whether
                   the plan has caught up is a separate fact, and while it
@@ -325,131 +325,178 @@ function AccountSettingsPage() {
 }
 
 // Profile Tab Component
-function ProfileTab({ userProfile }: { userProfile: UserProfile | null }) {
+/**
+ * SETTINGS1 — the tab that told her it had saved.
+ *
+ * ═══ WHAT `handleSave` USED TO BE ═══
+ *
+ *     const handleSave = () => { toast.success("Profile saved!") }
+ *
+ * Three lines. No request, and a SUCCESS TOAST. Not a missing
+ * confirmation — a fabricated one, on the one screen where somebody is
+ * deliberately handing us their details. Nine fields vanished on every
+ * reload and nobody suspected a bug, because the product had said it
+ * worked.
+ *
+ * Wiring the button was not enough: `ProfilePatch` accepted
+ * `default_county` and `onboarding_completed` and nothing else, so
+ * there was no endpoint to wire it TO. The patch surface came first.
+ *
+ * ═══ AND THE FIELDS WERE READING KEYS THE SERVER NEVER SENT ═══
+ *
+ * `first_name`, `last_name`, `company`, `street_address`, `city`,
+ * `zip_code` — six of nine. The server sends `full_name` and
+ * `company_name`, and has never had an address in that shape. A missing
+ * key is `undefined`, `undefined` renders blank, and the page showed
+ * somebody their own account with their name and company missing. That
+ * reads as "we lost your data".
+ *
+ * FLOW1 item 0's defect in its fourth habitat. The fix is the same:
+ * ONE set of names, and both halves use it.
+ *
+ * ═══ THE RULINGS BAKED IN HERE ═══
+ *
+ * ONE NAME FIELD. First/Last is gone. The server has `full_name`;
+ * splitting a name to satisfy a form is a data-model decision made
+ * backwards, and Recording Requested By prints a name AS WRITTEN, not as
+ * parsed.
+ *
+ * ONE ADDRESS FIELD, backed by `user_profiles.business_address` — which
+ * was in the schema the whole time. The three-field section was built
+ * against columns that never existed anywhere.
+ *
+ * EMAIL IS READ-ONLY. It is the login identity; changing it is an
+ * account operation with a verification step, not a text input on a
+ * settings form. Showing it as editable and then not saving it would be
+ * the same lie in a smaller place.
+ */
+function ProfileTab({ userProfile, onSaved }: {
+  userProfile: UserProfile | null
+  onSaved: () => void
+}) {
   const [formData, setFormData] = useState({
-    first_name: userProfile?.first_name || "",
-    last_name: userProfile?.last_name || "",
-    email: userProfile?.email || "",
+    full_name: userProfile?.full_name || "",
+    company_name: userProfile?.company_name || "",
     phone: userProfile?.phone || "",
-    company: userProfile?.company || "",
-    street_address: userProfile?.street_address || "",
-    city: userProfile?.city || "",
     state: userProfile?.state || "",
-    zip_code: userProfile?.zip_code || "",
+    business_address: userProfile?.business_address || "",
   })
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
 
-  const handleSave = () => {
-    toast.success("Profile saved!")
+  // The profile arrives after mount, so the form follows it in. Without
+  // this the fields stay empty even once the data lands — which was
+  // half of what "the page does not load what we have" looked like.
+  useEffect(() => {
+    if (!userProfile) return
+    setFormData({
+      full_name: userProfile.full_name || "",
+      company_name: userProfile.company_name || "",
+      phone: userProfile.phone || "",
+      state: userProfile.state || "",
+      business_address: userProfile.business_address || "",
+    })
+  }, [userProfile])
+
+  const handleSave = async () => {
+    setSaving(true)
+    setError(null)
+    try {
+      const api = process.env.NEXT_PUBLIC_API_URL || "https://deedpro-main-api.onrender.com"
+      const token = localStorage.getItem("access_token")
+      const response = await fetch(`${api}/users/profile`, {
+        method: "PATCH",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(formData),
+      })
+      if (!response.ok) {
+        const data = await response.json().catch(() => ({}))
+        throw new Error(data.detail || `Save failed (${response.status})`)
+      }
+      // Re-read rather than trusting what we sent: the server normalises
+      // whitespace and upper-cases the state, so what she sees after
+      // saving is what is stored, not what she typed.
+      onSaved()
+      toast.success("Profile saved")
+    } catch (err) {
+      // §4: a save that did not happen must never look like one that
+      // did. THIS IS THE WHOLE TICKET — the previous version of this
+      // function reported success unconditionally.
+      const message = err instanceof Error ? err.message : "Could not save your profile"
+      setError(message)
+      toast.error(message)
+    } finally {
+      setSaving(false)
+    }
   }
+
+  const field = (label: string, key: keyof typeof formData, type = "text") => (
+    <div>
+      <label className="block text-sm font-medium text-slate-700 mb-2">{label}</label>
+      <input
+        type={type}
+        value={formData[key]}
+        onChange={(e) => setFormData({ ...formData, [key]: e.target.value })}
+        className="w-full px-4 py-3 border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF] transition-colors"
+      />
+    </div>
+  )
 
   return (
     <div className="space-y-8">
-      {/* Personal Information */}
       <div>
-        <h3 className="text-xl font-bold text-slate-800 mb-6">Personal Information</h3>
+        <h3 className="text-xl font-bold text-slate-800 mb-6">Your details</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div>
-            <label className="block text-sm font-medium text-slate-700 mb-2">First Name</label>
-            <input
-              type="text"
-              value={formData.first_name}
-              onChange={(e) => setFormData({ ...formData, first_name: e.target.value })}
-              className="w-full px-4 py-3 border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF] transition-colors"
-            />
+          <div className="md:col-span-2">
+            {field("Name", "full_name")}
+            <p className="mt-2 text-xs text-slate-500">
+              Printed as written on deeds and in emails.
+            </p>
           </div>
           <div>
-            <label className="block text-sm font-medium text-slate-700 mb-2">Last Name</label>
-            <input
-              type="text"
-              value={formData.last_name}
-              onChange={(e) => setFormData({ ...formData, last_name: e.target.value })}
-              className="w-full px-4 py-3 border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF] transition-colors"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-slate-700 mb-2">Email Address</label>
+            <label className="block text-sm font-medium text-slate-700 mb-2">Email</label>
             <input
               type="email"
-              value={formData.email}
-              onChange={(e) => setFormData({ ...formData, email: e.target.value })}
-              className="w-full px-4 py-3 border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF] transition-colors"
+              value={userProfile?.email || ""}
+              readOnly
+              className="w-full px-4 py-3 border border-slate-200 bg-slate-50 text-slate-500 rounded-lg"
             />
+            <p className="mt-2 text-xs text-slate-500">
+              This is how you sign in. Contact us to change it.
+            </p>
           </div>
-          <div>
-            <label className="block text-sm font-medium text-slate-700 mb-2">Phone Number</label>
-            <input
-              type="tel"
-              value={formData.phone}
-              onChange={(e) => setFormData({ ...formData, phone: e.target.value })}
-              className="w-full px-4 py-3 border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF] transition-colors"
-            />
-          </div>
+          {field("Phone", "phone", "tel")}
+          {field("Company", "company_name")}
+          {field("State", "state")}
           <div className="md:col-span-2">
-            <label className="block text-sm font-medium text-slate-700 mb-2">Company</label>
-            <input
-              type="text"
-              value={formData.company}
-              onChange={(e) => setFormData({ ...formData, company: e.target.value })}
-              className="w-full px-4 py-3 border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF] transition-colors"
-            />
+            {field("Business address", "business_address")}
+            <p className="mt-2 text-xs text-slate-500">
+              Used as the return address on deeds you record.
+            </p>
           </div>
         </div>
       </div>
 
-      {/* Address Information */}
-      <div>
-        <h3 className="text-xl font-bold text-slate-800 mb-6">Address Information</h3>
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-          <div className="md:col-span-2">
-            <label className="block text-sm font-medium text-slate-700 mb-2">Street Address</label>
-            <input
-              type="text"
-              value={formData.street_address}
-              onChange={(e) => setFormData({ ...formData, street_address: e.target.value })}
-              className="w-full px-4 py-3 border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF] transition-colors"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-slate-700 mb-2">City</label>
-            <input
-              type="text"
-              value={formData.city}
-              onChange={(e) => setFormData({ ...formData, city: e.target.value })}
-              className="w-full px-4 py-3 border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF] transition-colors"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-slate-700 mb-2">State</label>
-            <input
-              type="text"
-              value={formData.state}
-              onChange={(e) => setFormData({ ...formData, state: e.target.value })}
-              className="w-full px-4 py-3 border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF] transition-colors"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-slate-700 mb-2">ZIP Code</label>
-            <input
-              type="text"
-              value={formData.zip_code}
-              onChange={(e) => setFormData({ ...formData, zip_code: e.target.value })}
-              className="w-full px-4 py-3 border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF] transition-colors"
-            />
-          </div>
+      {error && (
+        <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+          {error}
         </div>
-      </div>
+      )}
 
       <button
         onClick={handleSave}
-        className="px-8 py-4 bg-[#7C4DFF] hover:bg-[#6a3de8] text-white font-semibold rounded-xl shadow-md hover:shadow-lg transition-all"
+        disabled={saving}
+        className="px-8 py-4 bg-[#7C4DFF] hover:bg-[#6a3de8] disabled:opacity-60 text-white font-semibold rounded-xl shadow-md hover:shadow-lg transition-all"
       >
-        Save Changes
+        {saving ? "Saving…" : "Save Changes"}
       </button>
     </div>
   )
 }
 
-// Billing Tab Component
 function BillingTab({
   userProfile,
   onUpgrade,

--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -29,9 +29,37 @@ export default function OnboardingPage() {
   const router = useRouter()
   const [county, setCounty] = useState("Los Angeles")
   const [loading, setLoading] = useState(false)
+  const [skipping, setSkipping] = useState(false)
+  // Set when the skip could not be recorded — she is told before
+  // the navigation, because the consequence lands on another day.
+  const [skipNotice, setSkipNotice] = useState(false)
   const [error, setError] = useState("")
 
+  /**
+   * SETTINGS1 — RETRY, because the first thing anybody does in this
+   * product is the thing we least want to lose.
+   *
+   * The audit saw this PATCH return 503. A single attempt against a
+   * service that cold-starts is a coin flip at the worst possible
+   * moment, so it is attempted twice with a pause between.
+   *
+   * Retrying is asking again, not deciding: a failure that survives both
+   * attempts is REPORTED, never swallowed.
+   */
   const saveProfile = async (body: { default_county?: string; onboarding_completed: boolean }) => {
+    let lastError: Error | null = null
+    for (const wait of [0, 1200]) {
+      if (wait) await new Promise((r) => setTimeout(r, wait))
+      try {
+        return await saveProfileOnce(body)
+      } catch (err) {
+        lastError = err instanceof Error ? err : new Error("Save failed")
+      }
+    }
+    throw lastError
+  }
+
+  const saveProfileOnce = async (body: { default_county?: string; onboarding_completed: boolean }) => {
     const token = localStorage.getItem("access_token")
     const response = await fetch(
       `${process.env.NEXT_PUBLIC_API_URL || "https://deedpro-main-api.onrender.com"}/users/profile`,
@@ -71,13 +99,34 @@ export default function OnboardingPage() {
   }
 
   const handleSkip = async () => {
-    // Skip still records completion server-side so the dashboard gate stops
-    // re-prompting; if the save fails, this device passes via localStorage
-    // and a fresh device gets asked again — which is the honest outcome.
+    /**
+     * SETTINGS1 — SKIP MAY LEAVE, BUT IT MAY NOT LIE.
+     *
+     * This swallowed the failure entirely. The comment called that "the
+     * honest outcome" because a fresh device would ask again — but that
+     * describes the SYSTEM's state, not what the person knows. What
+     * actually happened: `onboarding_completed` stayed false, the
+     * dashboard gate re-fired, and she was returned to onboarding
+     * forever with no indication why.
+     *
+     * A trap loop, and worse than a lost field: a lost field is noticed
+     * once, a loop is noticed every time and explains itself never.
+     *
+     * Skipping still navigates — "skip" means get me out of here, and
+     * holding her hostage to our own 503 would be a second failure on
+     * top of the first. But she is TOLD, so a repeat prompt is a thing
+     * she was warned about rather than a product that will not let her
+     * past.
+     */
+    setSkipping(true)
     try {
       await saveProfile({ onboarding_completed: true })
     } catch {
-      // non-blocking: skip means "get me out of here"
+      setSkipNotice(true)
+      // Long enough to read before the page changes under her.
+      await new Promise((r) => setTimeout(r, 2600))
+    } finally {
+      setSkipping(false)
     }
     localStorage.setItem("onboarding_completed", "true")
     router.push("/dashboard")
@@ -97,11 +146,22 @@ export default function OnboardingPage() {
           <button
             type="button"
             onClick={handleSkip}
-            className="text-sm font-medium text-gray-500 hover:text-gray-900 transition-colors"
+            disabled={skipping}
+            className="text-sm font-medium text-gray-500 hover:text-gray-900 transition-colors disabled:opacity-60"
           >
-            Skip for now
+            {skipping ? "Skipping…" : "Skip for now"}
           </button>
         </div>
+        {/* SETTINGS1: the skip was not recorded. She is told BEFORE the
+            navigation, because the consequence — being asked again —
+            arrives on a different day and would otherwise look like the
+            product refusing to let her past. */}
+        {skipNotice && (
+          <div className="max-w-6xl mx-auto mt-3 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+            We could not record that you skipped setup, so you may be asked
+            again next time you sign in. Taking you to your dashboard now.
+          </div>
+        )}
       </header>
 
       {/* Centered single-step */}


### PR DESCRIPTION
All five rulings. Branches off main.

## Item 1 — build the patch surface, then wire the button

`handleSave` was three lines: no request, and `toast.success("Profile saved!")`. **Not a missing confirmation — a fabricated one**, on the single screen where somebody is deliberately entrusting us with their details. That's why nine fields vanished on every reload with nobody suspecting a bug: the product had told her it worked.

And there was nowhere to send it. `ProfilePatch` accepted `default_county` and `onboarding_completed` and nothing else. The patch surface came first: `full_name`, `company_name`, `phone`, `state` on `users`; `business_address` on `user_profiles`. **Every field has a column** — nothing is accepted that cannot be stored, which is LEGAL1's rule one screen over.

The pin asserts ordering, not just presence: `toast.success` must appear *after* the `!response.ok` throw, which is unreachable without a completed request.

## Item 2 — the contract fix

Six of nine fields read keys the server never sends: `first_name`, `last_name`, `company`, `street_address`, `city`, `zip_code`. A missing key is `undefined`, `undefined` renders blank, and the page showed somebody their own account with their name and company missing. **FLOW1 item 0's defect in its fourth habitat** — and the page was fetching correctly the whole time.

**One name field**, as ruled. Splitting a name to satisfy a form is a data-model decision made backwards, and Recording Requested By prints a name as written, not as parsed.

**Email is read-only** — it's the login identity. Offering it as editable and not saving it would be the same lie in a smaller place.

## Item 3 — the columns were already there

One address field backed by `user_profiles.business_address`, which was in the schema all along. **The three-field section was built against columns that never existed anywhere** — the form invented its own storage, then couldn't find it.

## Item 4 — the trap loop

The county step always handled failure correctly: it throws, catches, shows the error, and does **not** navigate. What the audit saw was `handleSkip`, which swallowed the failure entirely — `onboarding_completed` stayed false, the dashboard gate re-fired, and she was returned to onboarding forever with no indication why.

**Worse than a lost field**: a lost field is noticed once; a loop is noticed every time and explains itself never.

Now: retry (two attempts — the first thing anybody does in the product, against a service that cold-starts), and if it still fails she is **told before the navigation**. Skip still leaves, because holding her hostage to our own 503 would be a second failure on top of the first.

## Item 5 — ledgered, not built

The requested-by default from `user_profiles.company_name` is a builder change and belongs with the builder. Recorded with the reasoning: a partner is a **counterparty**, her own company isn't one, and auto-inserting it makes the picker a list where one entry means something categorically different from the rest.

**And a new finding while extending the patch:** both `users.company_name` and `user_profiles.company_name` exist — two columns for one fact, in two tables. `/users/profile` returns the `users` one and this PR patches that one; the other is written by the enhanced-profile endpoint. **The requested-by feature has to read one of them**, and picking the wrong one is a field that silently disagrees with Settings. Ruling wanted before that gets built.

## Gates

| gate | result |
|---|---|
| pytest (with DB) | 1179 passed |
| jest | 832 passed, 58 suites |
| tsc baseline | 88 (holds) |
| six-flow | green |
| banned-claims | clean |
| OpenAPI snapshot | unchanged |
| `next build` | clean |
| mutation probes | 3 run, 3 caught |

Probes: the success toast moves before the fetch; the failed save stops being visible; skip swallows the failure again.

**Branch note, as standing practice:** fresh per-ticket branch off current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_