### PR TITLE
SETTINGS1 item 5 — company_name has one home, and a default stops minting deeds

### DIFF
--- a/backend/ai_assist.py
+++ b/backend/ai_assist.py
@@ -39,8 +39,19 @@ def suggest_defaults(user_data, deed_data, recent_properties=None):
     # Auto-populate company/business information
     if profile.get('auto_populate_company_info', True):
         if not deed_data.get('recordingRequestedBy') and profile.get('company_name'):
-            suggestions['recordingRequestedBy'] = f"{profile['company_name']} - {profile.get('role', 'Escrow Officer').title()}"
-        
+            # The company, and only the company.
+            #
+            # This used to append the role: `f"{company} - {role.title()}"`,
+            # which on the stored value 'escrow_officer' produces
+            # "Escrow_Officer" — the underscore survives .title(). That
+            # string is a deed face, printed in the recorder's top-left box.
+            #
+            # A job title does not belong there in any case: the box names
+            # the PARTY requesting recording, and the live path (the
+            # builder's partner picker) has always put a bare company name
+            # in it. One field, one meaning, whichever path fills it.
+            suggestions['recordingRequestedBy'] = profile['company_name']
+
         if not deed_data.get('mailTo') and profile.get('business_address'):
             suggestions['mailTo'] = profile['business_address']
     

--- a/backend/database.py
+++ b/backend/database.py
@@ -1324,17 +1324,51 @@ def get_user_deeds(user_id):
 
 # User profile functions
 def get_user_profile(user_id):
-    """Get user profile data for AI suggestions"""
+    """Profile facts used to pre-fill a deed. Company comes from `users`.
+
+    ═══ ONE FACT, ONE HOME ═══
+
+    `company_name` existed in BOTH `users` and `user_profiles`, written by
+    different endpoints and read by different screens. Settings writes
+    `users.company_name`; this read used `user_profiles.company_name`. So
+    an officer who corrected her company on the Settings page did not
+    change the company that pre-fills Recording Requested By — and
+    nothing anywhere told her the two were different columns.
+
+    Owner-ruled: `users.company_name` is canonical. The join reads it
+    from there. `user_profiles.company_name` is no longer written (see
+    `update_user_profile`) and is retired in a separate, owner-run step
+    after the row counts are read.
+
+    ═══ WHY LEFT JOIN, AND WHY THE COALESCE ═══
+
+    Anchoring on `users` means a person with no `user_profiles` row still
+    has a company. That changes this function's None contract: it now
+    returns a dict for any real user, so callers testing `if profile` are
+    asking "does this user exist", which is what they meant.
+
+    `auto_populate_company_info` MUST be coalesced. An absent profile row
+    yields SQL NULL, `.get()` returns None, and `suggest_defaults` reads
+    that as auto-populate OFF — the column's own DEFAULT TRUE never
+    applies to a row that was never inserted. A missing row would have
+    silently turned off the pre-fill for every officer who never opened
+    the old profile endpoint.
+    """
     conn = get_db_connection()
     if not conn:
         return None
-    
+
     try:
         cursor = conn.cursor()
         cursor.execute("""
-            SELECT company_name, business_address, license_number, role, 
-                   default_county, preferred_deed_type, auto_populate_company_info
-            FROM user_profiles WHERE user_id = %s
+            SELECT u.company_name,
+                   p.business_address, p.license_number, p.role,
+                   p.default_county, p.preferred_deed_type,
+                   COALESCE(p.auto_populate_company_info, TRUE)
+                       AS auto_populate_company_info
+            FROM users u
+            LEFT JOIN user_profiles p ON p.user_id = u.id
+            WHERE u.id = %s
         """, (user_id,))
         profile = cursor.fetchone()
         cursor.close()
@@ -1361,41 +1395,82 @@ def clean_profile_text(value):
     return cleaned or None
 
 
+def _profile_text(value):
+    """Deed-face string, normalized at the write choke point."""
+    return clean_profile_text(value)
+
+
+def _profile_asis(value):
+    """A flag or an enum — nothing to normalize, and nothing to guess."""
+    return value
+
+
+# The columns this writer owns, and how each is cleaned on the way in.
+#
+# `company_name` is NOT here and must not be added back: it lives in
+# `users` (see `get_user_profile`). `PROFILE_ELSEWHERE` names it and says
+# where it went, because a caller that posts a field and is silently
+# ignored is told its save worked.
+PROFILE_COLUMNS = {
+    'business_address': _profile_text,
+    'license_number': _profile_text,
+    'role': _profile_asis,
+    'default_county': _profile_text,
+    'preferred_deed_type': _profile_asis,
+    'auto_populate_company_info': _profile_asis,
+}
+
+PROFILE_ELSEWHERE = {
+    'company_name': 'users.company_name (write it with PATCH /users/profile)',
+}
+
+
 def update_user_profile(user_id, profile_data):
-    """Update or create user profile for AI defaults"""
+    """Write the profile columns actually given. Returns False if none were.
+
+    ═══ IT USED TO CLOBBER EVERY COLUMN, GIVEN OR NOT ═══
+
+    The old `ON CONFLICT DO UPDATE` set all eight columns from `EXCLUDED`
+    unconditionally, and `EXCLUDED` for an omitted key is None. So a call
+    carrying only `default_county` NULLed the business address, the
+    licence number and the company — a partial update that erased
+    everything it did not mention.
+
+    That was survivable while nothing else owned those columns. SETTINGS1
+    gave `business_address` to `PATCH /users/profile`, and an officer can
+    now save her address on the Settings page and have this endpoint wipe
+    it seconds later. The set of columns written is now the set of keys
+    supplied, so an omitted field is left alone.
+
+    An unrecognised key is not silently dropped either — the caller gets
+    False and the endpoint turns that into a 400 naming what it accepts.
+    """
+    given = {k: fn(profile_data[k])
+             for k, fn in PROFILE_COLUMNS.items()
+             if k in profile_data}
+    if not given:
+        return False
+
     conn = get_db_connection()
     if not conn:
         return False
 
     try:
+        cols = list(given)
+        # Column names come from PROFILE_COLUMNS, never from the caller —
+        # the interpolation below is over a fixed vocabulary, and the
+        # values stay bound.
+        placeholders = ", ".join(["%s"] * len(cols))
+        assignments = ", ".join(f"{c} = EXCLUDED.{c}" for c in cols)
         cursor = conn.cursor()
-        cursor.execute("""
-            INSERT INTO user_profiles (user_id, company_name, business_address, 
-                                     license_number, role, default_county, 
-                                     preferred_deed_type, auto_populate_company_info)
-            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
-            ON CONFLICT (user_id) 
-            DO UPDATE SET 
-                company_name = EXCLUDED.company_name,
-                business_address = EXCLUDED.business_address,
-                license_number = EXCLUDED.license_number,
-                role = EXCLUDED.role,
-                default_county = EXCLUDED.default_county,
-                preferred_deed_type = EXCLUDED.preferred_deed_type,
-                auto_populate_company_info = EXCLUDED.auto_populate_company_info,
+        cursor.execute(f"""
+            INSERT INTO user_profiles (user_id, {", ".join(cols)})
+            VALUES (%s, {placeholders})
+            ON CONFLICT (user_id)
+            DO UPDATE SET
+                {assignments},
                 updated_at = CURRENT_TIMESTAMP
-        """, (
-            user_id,
-            # Deed-face fields are normalized at the write choke point —
-            # whatever endpoint or script feeds this, the row is clean.
-            clean_profile_text(profile_data.get('company_name')),
-            clean_profile_text(profile_data.get('business_address')),
-            clean_profile_text(profile_data.get('license_number')),
-            profile_data.get('role', 'escrow_officer'),
-            clean_profile_text(profile_data.get('default_county')),
-            profile_data.get('preferred_deed_type', 'grant_deed'),
-            profile_data.get('auto_populate_company_info', True)
-        ))
+        """, (user_id, *[given[c] for c in cols]))
         conn.commit()
         cursor.close()
         conn.close()

--- a/backend/routers/users_auth.py
+++ b/backend/routers/users_auth.py
@@ -20,7 +20,10 @@ from auth import (
     get_password_hash, verify_password, create_access_token,
     get_current_user_id, is_admin_role, AuthUtils
 )
-from database import clean_profile_text, get_user_profile, update_user_profile, get_recent_properties
+from database import (
+    PROFILE_COLUMNS, PROFILE_ELSEWHERE, clean_profile_text, get_user_profile,
+    update_user_profile, get_recent_properties,
+)
 
 router = APIRouter()
 
@@ -820,12 +823,38 @@ async def update_enhanced_user_profile(
     profile_data: dict = Body(...),
     user_id: int = Depends(get_current_user_id)
 ):
-    """Update user profile for AI-enhanced deed generation"""
+    """Update the deed-prefill profile columns.
+
+    Takes an untyped dict, so it says out loud what it will and will not
+    write. A field posted here and quietly discarded would come back
+    "Profile updated successfully" — the caller would believe a save that
+    never happened, which is the class of defect the whole billing story
+    was made of.
+    """
+    moved = sorted(set(profile_data) & set(PROFILE_ELSEWHERE))
+    if moved:
+        raise HTTPException(
+            status_code=400,
+            detail="; ".join(
+                f"'{k}' is not stored here — it lives in {PROFILE_ELSEWHERE[k]}"
+                for k in moved
+            ),
+        )
+
+    accepted = sorted(set(profile_data) & set(PROFILE_COLUMNS))
+    if not accepted:
+        raise HTTPException(
+            status_code=400,
+            detail="No profile fields to update. This endpoint writes: "
+                   + ", ".join(sorted(PROFILE_COLUMNS)),
+        )
+
     try:
         success = update_user_profile(user_id, profile_data)
-        if success:
-            return {"status": "updated", "message": "Profile updated successfully - AI suggestions will improve!"}
-        else:
-            raise HTTPException(status_code=500, detail="Failed to update profile")
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Profile update failed: {str(e)}")
+    if not success:
+        raise HTTPException(status_code=500, detail="Failed to update profile")
+    # Echo what was written rather than a cheerful sentence: the fields
+    # named here are the fields that changed, and nothing else did.
+    return {"status": "updated", "updated": accepted}

--- a/backend/scripts/company_name_consolidation.py
+++ b/backend/scripts/company_name_consolidation.py
@@ -1,0 +1,199 @@
+"""Count, then move, then (separately, by hand) drop.
+
+═══ WHAT THIS IS FOR ═══
+
+`company_name` lived in two tables. `users.company_name` is written by
+registration, by the Settings page and by admin; `user_profiles.
+company_name` was written by `POST /users/profile/enhanced` and read by
+the deed pre-fill. Nothing kept them equal and nothing told anybody they
+were different columns, so an officer who fixed her company on the
+Settings page did not change the company that pre-fills Recording
+Requested By.
+
+Owner-ruled: `users.company_name` is canonical. The read has already
+moved (`database.get_user_profile`) and the duplicate write is gone
+(`database.update_user_profile`). What is left is the data.
+
+═══ WHY COUNTING IS ITS OWN STEP ═══
+
+The owner's ruling was explicit: report row counts before dropping
+anything. A column that turns out to hold the ONLY copy of some
+officer's company is not a duplicate, it is the record — and the only
+way to know which one it is, is to count first.
+
+`--apply` copies `user_profiles.company_name` into `users.company_name`
+for the rows where `users` has nothing and `user_profiles` does. It never
+overwrites a non-blank canonical value: where the two disagree, `users`
+wins by the ruling, and the disagreements are listed in the report so the
+decision is made by a person looking at them.
+
+═══ WHY THE DROP IS NOT IN HERE ═══
+
+Dropping a column is irreversible and owner-only. This script PRINTS the
+statement and refuses to run it. A script that can drop a column is a
+script that can drop a column by accident, and the accident is not
+recoverable from a report.
+
+Usage (where DATABASE_URL points at the database being consolidated):
+
+    python scripts/company_name_consolidation.py            # report only
+    python scripts/company_name_consolidation.py --apply    # backfill users
+"""
+import argparse
+import os
+import sys
+
+import psycopg2
+from db_rows import ROW_FACTORY
+from services.db_identity import (WrongDatabase, assert_tables, describe,
+                                  expected_database)
+
+# Blank-or-absent, in one place, so the report and the backfill cannot
+# disagree about what "has a company name" means. `clean_profile_text`
+# collapses whitespace to NULL on the way in, but rows predating it can
+# still hold '   '.
+HAS = "COALESCE(NULLIF(BTRIM({col}), ''), NULL) IS NOT NULL"
+
+
+def counts(cur):
+    """Every number the ruling asked for, from one pass over the join."""
+    cur.execute(f"""
+        SELECT
+          COUNT(*)                                             AS users_total,
+          COUNT(*) FILTER (WHERE {HAS.format(col='u.company_name')})
+                                                               AS users_have,
+          COUNT(*) FILTER (WHERE p.user_id IS NOT NULL)        AS profiles_total,
+          COUNT(*) FILTER (WHERE {HAS.format(col='p.company_name')})
+                                                               AS profiles_have,
+          COUNT(*) FILTER (WHERE {HAS.format(col='u.company_name')}
+                             AND {HAS.format(col='p.company_name')}
+                             AND BTRIM(u.company_name) = BTRIM(p.company_name))
+                                                               AS agree,
+          COUNT(*) FILTER (WHERE {HAS.format(col='u.company_name')}
+                             AND {HAS.format(col='p.company_name')}
+                             AND BTRIM(u.company_name) <> BTRIM(p.company_name))
+                                                               AS disagree,
+          COUNT(*) FILTER (WHERE NOT {HAS.format(col='u.company_name')}
+                             AND {HAS.format(col='p.company_name')})
+                                                               AS only_profile,
+          COUNT(*) FILTER (WHERE {HAS.format(col='u.company_name')}
+                             AND NOT {HAS.format(col='p.company_name')})
+                                                               AS only_users
+        FROM users u
+        LEFT JOIN user_profiles p ON p.user_id = u.id
+    """)
+    return dict(cur.fetchone())
+
+
+def disagreements(cur, limit=50):
+    """The rows a person has to look at. Ids only — no contact details."""
+    cur.execute(f"""
+        SELECT u.id, BTRIM(u.company_name) AS canonical,
+               BTRIM(p.company_name) AS duplicate
+        FROM users u
+        JOIN user_profiles p ON p.user_id = u.id
+        WHERE {HAS.format(col='u.company_name')}
+          AND {HAS.format(col='p.company_name')}
+          AND BTRIM(u.company_name) <> BTRIM(p.company_name)
+        ORDER BY u.id
+        LIMIT %s
+    """, (limit,))
+    return [dict(r) for r in cur.fetchall()]
+
+
+def backfill(cur):
+    """Copy the duplicate into the canonical column where it is the only copy.
+
+    The WHERE clause is the whole safety argument: a row whose canonical
+    value is already set is not touched, so running this twice changes
+    nothing the second time and a disagreement is never silently resolved
+    in favour of the column that is being retired.
+    """
+    cur.execute(f"""
+        UPDATE users u
+        SET company_name = BTRIM(p.company_name)
+        FROM user_profiles p
+        WHERE p.user_id = u.id
+          AND NOT {HAS.format(col='u.company_name')}
+          AND {HAS.format(col='p.company_name')}
+    """)
+    return cur.rowcount
+
+
+DROP_STATEMENT = "ALTER TABLE user_profiles DROP COLUMN company_name;"
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true",
+                        help="copy user_profiles.company_name into users where "
+                             "users has none")
+    args = parser.parse_args()
+
+    db_url = os.getenv("DATABASE_URL")
+    if not db_url:
+        sys.exit("DATABASE_URL is required")
+
+    conn = psycopg2.connect(db_url, cursor_factory=ROW_FACTORY)
+
+    # WHICH DATABASE, BEFORE COUNTING ANYTHING OUT OF IT.
+    #
+    # A report is a decision input, and a report from the wrong database
+    # is worse than no report — it looks exactly like the right one.
+    try:
+        with conn.cursor() as cur:
+            assert_tables(cur, ["users", "user_profiles"],
+                          expect_database=expected_database())
+            print(describe(cur))
+    except WrongDatabase as e:
+        conn.close()
+        sys.exit(str(e))
+
+    with conn.cursor() as cur:
+        before = counts(cur)
+        clashes = disagreements(cur)
+
+    print("\n── company_name, both homes ─────────────────────────────")
+    print(f"  users rows                          {before['users_total']:>7}")
+    print(f"  users.company_name set              {before['users_have']:>7}")
+    print(f"  user_profiles rows                  {before['profiles_total']:>7}")
+    print(f"  user_profiles.company_name set      {before['profiles_have']:>7}")
+    print(f"  both set and EQUAL                  {before['agree']:>7}")
+    print(f"  both set and DIFFERENT              {before['disagree']:>7}")
+    print(f"  only user_profiles has it           {before['only_profile']:>7}"
+          "   <- what --apply moves")
+    print(f"  only users has it                   {before['only_users']:>7}")
+
+    if clashes:
+        print("\n── disagreements (users wins by the ruling) ─────────────")
+        for row in clashes:
+            print(f"  user {row['id']:>6}: users={row['canonical']!r} "
+                  f"profiles={row['duplicate']!r}")
+        print("  These are NOT changed by --apply. If any of them is a "
+              "correction\n  the officer made in the old profile endpoint, "
+              "it needs a person.")
+
+    if args.apply:
+        with conn.cursor() as cur:
+            moved = backfill(cur)
+            conn.commit()
+            after = counts(cur)
+        print(f"\n  backfilled: {moved} row(s)")
+        print(f"  users.company_name set is now {after['users_have']} "
+              f"(was {before['users_have']})")
+        print(f"  only user_profiles has it is now {after['only_profile']} "
+              "(0 means nothing is left only in the retiring column)")
+    else:
+        print("\n  Report only. Re-run with --apply to backfill.")
+
+    print("\n── retirement (NOT run by this script) ──────────────────")
+    print("  Safe to run once 'only user_profiles has it' reads 0 AND the")
+    print("  deploy carrying the read/write changes is live:")
+    print(f"\n      {DROP_STATEMENT}\n")
+    print("  Irreversible, so it is owner-run by hand, not automated here.")
+
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_profile_hygiene.py
+++ b/backend/tests/test_profile_hygiene.py
@@ -31,13 +31,21 @@ def test_clean_profile_text_blank_collapses_to_none():
 
 
 def test_update_user_profile_normalizes_deed_face_fields():
+    """SETTINGS1 item 5 moved `company_name` out of this writer (it lives
+    in `users` now) and made the column list the set of keys supplied —
+    so the parameters are no longer at fixed positions. The rule under
+    test is unchanged: whitespace is fixed at the write, case is not.
+
+    Company-name normalization did not disappear with the column; it
+    happens where the column now is (`clean_profile_text(patch.company_name)`
+    in PATCH /users/profile, and in the registration INSERT below).
+    """
     conn = MagicMock()
     cursor = MagicMock()
     conn.cursor.return_value = cursor
 
     with patch("database.get_db_connection", return_value=conn):
         ok = update_user_profile(7, {
-            "company_name": "  Pacific COast TItle ",
             "business_address": " 123  Main   St ",
             "license_number": "  LIC-99  ",
             "default_county": " Los   Angeles ",
@@ -45,10 +53,18 @@ def test_update_user_profile_normalizes_deed_face_fields():
 
     assert ok is True
     params = cursor.execute.call_args[0][1]
-    assert params[1] == "Pacific COast TItle"   # trimmed, case untouched
-    assert params[2] == "123 Main St"
-    assert params[3] == "LIC-99"
-    assert params[5] == "Los Angeles"
+    assert params[0] == 7
+    assert set(params[1:]) == {"123 Main St", "LIC-99", "Los Angeles"}
+
+
+def test_company_name_normalization_did_not_go_missing_with_the_column():
+    """A pin that would otherwise have been deleted along with the case
+    it covered. `clean_profile_text` on the company still has to run —
+    'Pacific COast TItle ' printed on deeds, trailing space and all."""
+    import inspect
+    import routers.users_auth as mod
+    src = inspect.getsource(mod.patch_user_profile)
+    assert "clean_profile_text(patch.company_name)" in src
 
 
 def test_registration_normalizes_and_rejects_blank_names():

--- a/backend/tests/test_profile_one_home.py
+++ b/backend/tests/test_profile_one_home.py
@@ -1,0 +1,324 @@
+"""SETTINGS1 item 5 — `company_name` has one home, and a partial write
+stops erasing everything it did not mention.
+
+═══ ONE FACT, TWO COLUMNS, NOBODY TOLD ═══
+
+`company_name` existed in `users` AND in `user_profiles`. Registration,
+the Settings page and admin wrote the first; `POST /users/profile/enhanced`
+wrote the second; the deed pre-fill READ the second. So an officer who
+corrected her company on the Settings page did not change the company
+that pre-fills Recording Requested By, and no screen anywhere hinted
+that there were two columns.
+
+Owner-ruled: `users.company_name` is canonical. `get_user_profile` reads
+it from there, `update_user_profile` no longer writes the duplicate, and
+the column is retired by hand after the row counts are read
+(`scripts/company_name_consolidation.py`).
+
+═══ AND THE CLOBBERING WRITER FOUND WHILE CONFIRMING IT ═══
+
+`update_user_profile`'s `ON CONFLICT DO UPDATE` set all eight columns
+from `EXCLUDED` unconditionally, and `EXCLUDED` for an omitted key is
+None. A call carrying one field NULLed the other seven.
+
+That was survivable while nothing else owned those columns. SETTINGS1
+gave `business_address` to `PATCH /users/profile` — so an officer could
+save her address in Settings and have this endpoint wipe it seconds
+later. Same disease as the ruling, approached from the other end: the
+first wrote a column nobody read, this reads a column somebody else now
+writes.
+"""
+import inspect
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import database
+from database import (PROFILE_COLUMNS, PROFILE_ELSEWHERE, get_user_profile,
+                      update_user_profile)
+
+
+def _cursor():
+    conn = MagicMock()
+    cursor = MagicMock()
+    conn.cursor.return_value = cursor
+    return conn, cursor
+
+
+# ── the read ────────────────────────────────────────────────────────
+
+def test_company_name_is_read_from_users_not_user_profiles():
+    conn, cursor = _cursor()
+    cursor.fetchone.return_value = {"company_name": "Pacific Coast Escrow"}
+    with patch("database.get_db_connection", return_value=conn):
+        get_user_profile(7)
+    sql = " ".join(cursor.execute.call_args[0][0].split())
+    assert "u.company_name" in sql
+    # The retiring column must not be in the SELECT list at all — reading
+    # both and picking one is how the two stay alive.
+    assert "p.company_name" not in sql
+    assert "FROM users u" in sql
+    assert "LEFT JOIN user_profiles p" in sql
+
+
+def test_auto_populate_is_coalesced_so_a_missing_row_does_not_disable_prefill():
+    """The column DEFAULT never applies to a row that was never inserted.
+
+    Anchoring the read on `users` means a person with no `user_profiles`
+    row now comes back as a dict of NULLs rather than as None. Without
+    the COALESCE, `suggest_defaults` reads `auto_populate_company_info`
+    as None -> falsy -> pre-fill silently OFF, for every officer who
+    never opened the old profile endpoint.
+    """
+    conn, cursor = _cursor()
+    cursor.fetchone.return_value = {}
+    with patch("database.get_db_connection", return_value=conn):
+        get_user_profile(7)
+    sql = " ".join(cursor.execute.call_args[0][0].split())
+    assert "COALESCE(p.auto_populate_company_info, TRUE)" in sql
+
+
+# ── the write ───────────────────────────────────────────────────────
+
+def test_company_name_is_not_written_here_at_all():
+    assert "company_name" not in PROFILE_COLUMNS
+    # And it says where it went, so the endpoint can too.
+    assert "company_name" in PROFILE_ELSEWHERE
+    assert "users.company_name" in PROFILE_ELSEWHERE["company_name"]
+
+
+def test_a_partial_write_touches_only_what_it_was_given():
+    """THE PIN THIS FILE EXISTS FOR."""
+    conn, cursor = _cursor()
+    with patch("database.get_db_connection", return_value=conn):
+        ok = update_user_profile(7, {"default_county": "Los Angeles"})
+    assert ok is True
+    sql = " ".join(cursor.execute.call_args[0][0].split())
+    for untouched in ("business_address", "license_number",
+                      "preferred_deed_type", "auto_populate_company_info"):
+        assert untouched not in sql, f"{untouched} written by a call that omitted it"
+    assert "default_county = EXCLUDED.default_county" in sql
+    assert cursor.execute.call_args[0][1] == (7, "Los Angeles")
+
+
+def test_the_business_address_settings_just_saved_survives():
+    """The concrete loss this prevents, spelled out as a scenario.
+
+    Asserted against the SQL rather than a mock's memory: what makes the
+    address safe is that the statement never names its column.
+    """
+    conn, cursor = _cursor()
+    with patch("database.get_db_connection", return_value=conn):
+        update_user_profile(7, {"preferred_deed_type": "quitclaim"})
+    sql = cursor.execute.call_args[0][0]
+    assert "business_address" not in sql
+
+
+def test_every_given_column_is_written():
+    conn, cursor = _cursor()
+    payload = {k: "x" for k in PROFILE_COLUMNS}
+    with patch("database.get_db_connection", return_value=conn):
+        update_user_profile(7, payload)
+    sql = " ".join(cursor.execute.call_args[0][0].split())
+    for col in PROFILE_COLUMNS:
+        assert f"{col} = EXCLUDED.{col}" in sql, f"{col} given but not written"
+
+
+def test_nothing_to_write_is_reported_rather_than_committed():
+    """A no-op that returns success is a save the caller believes in."""
+    conn, cursor = _cursor()
+    with patch("database.get_db_connection", return_value=conn):
+        assert update_user_profile(7, {"unknown_field": "x"}) is False
+        assert update_user_profile(7, {}) is False
+    cursor.execute.assert_not_called()
+    conn.commit.assert_not_called()
+
+
+def test_deed_face_strings_are_still_normalized_at_the_write():
+    """#65's rule survives the rewrite: whitespace is machine noise and is
+    fixed here; CASE is the owner's text and is never touched."""
+    conn, cursor = _cursor()
+    with patch("database.get_db_connection", return_value=conn):
+        update_user_profile(7, {
+            "business_address": " 123  Main   St ",
+            "license_number": "  LIC-99  ",
+            "default_county": " Los   Angeles ",
+        })
+    params = cursor.execute.call_args[0][1]
+    assert params[0] == 7
+    assert set(params[1:]) == {"123 Main St", "LIC-99", "Los Angeles"}
+
+
+def test_column_names_never_come_from_the_caller():
+    """The statement is f-string assembled, so the vocabulary must be
+    fixed. A key the caller invents is dropped before it reaches SQL."""
+    conn, cursor = _cursor()
+    with patch("database.get_db_connection", return_value=conn):
+        update_user_profile(7, {
+            "default_county": "Los Angeles",
+            "role); DROP TABLE users; --": "x",
+        })
+    sql = cursor.execute.call_args[0][0]
+    assert "DROP TABLE" not in sql
+
+
+# ── the endpoint ────────────────────────────────────────────────────
+
+def _post_enhanced(body):
+    """Call the endpoint for real, with the writer stubbed.
+
+    ═══ WHY THESE THREE ARE CALLS AND NOT GREPS ═══
+
+    The first draft of this block asserted that "PROFILE_ELSEWHERE" and
+    "status_code=400" APPEAR IN THE SOURCE. A mutation probe deleted the
+    refusal — `moved = []`, leaving the raise block intact and
+    unreachable — and all three tests passed.
+
+    A string-presence pin cannot tell REACHABLE from PRESENT. It reads
+    the code the way a person skimming it does, which is precisely the
+    reading that misses dead branches. Called, the endpoint has to
+    actually refuse.
+    """
+    import asyncio
+
+    from routers.users_auth import update_enhanced_user_profile
+    with patch("routers.users_auth.update_user_profile") as writer:
+        writer.return_value = True
+        try:
+            result = asyncio.run(
+                update_enhanced_user_profile(profile_data=body, user_id=7))
+        except Exception as e:  # HTTPException included, on purpose
+            return e, writer
+    return result, writer
+
+
+def test_the_endpoint_refuses_company_name_and_says_where_it_lives():
+    """Accepting it and dropping it would return "updated" for a save
+    that did not happen — the class of defect the billing story was made
+    of. The refusal has to name the new home, or the caller has nowhere
+    to go."""
+    from fastapi import HTTPException
+    raised, writer = _post_enhanced({"company_name": "Pacific Coast Escrow"})
+    assert isinstance(raised, HTTPException)
+    assert raised.status_code == 400
+    assert "users.company_name" in raised.detail
+    assert "PATCH /users/profile" in raised.detail
+    # And nothing was written on the way to refusing.
+    writer.assert_not_called()
+
+
+def test_it_refuses_even_when_a_valid_field_rides_along():
+    """The dangerous shape: a caller sends county AND company, the county
+    saves, the company does not, and the response says "updated". A
+    partial success reported as a success is the same lie."""
+    from fastapi import HTTPException
+    raised, writer = _post_enhanced(
+        {"default_county": "Los Angeles", "company_name": "Pacific Coast"})
+    assert isinstance(raised, HTTPException)
+    assert raised.status_code == 400
+    writer.assert_not_called()
+
+
+def test_a_body_with_nothing_recognisable_is_a_400_not_a_cheerful_200():
+    from fastapi import HTTPException
+    raised, writer = _post_enhanced({"favourite_colour": "blue"})
+    assert isinstance(raised, HTTPException)
+    assert raised.status_code == 400
+    # It names what it does accept — a refusal that does not say what
+    # would have worked gets retried verbatim.
+    for col in PROFILE_COLUMNS:
+        assert col in raised.detail
+    writer.assert_not_called()
+
+
+def test_the_endpoint_does_not_swallow_its_own_refusal():
+    """The old body wrapped everything in `except Exception`, which
+    catches the HTTPException it just raised and re-reports it as a 500.
+    A 400 that arrives as a 500 sends the caller looking at our logs for
+    their own bad request.
+
+    Proven by the status codes above being 400 rather than 500 — this
+    asserts it directly so the reason is recorded with the case."""
+    raised, _ = _post_enhanced({"company_name": "x"})
+    assert getattr(raised, "status_code", None) != 500
+
+
+def test_the_endpoint_echoes_what_it_wrote():
+    result, writer = _post_enhanced(
+        {"default_county": "Los Angeles", "license_number": "LIC-1"})
+    assert result == {"status": "updated",
+                      "updated": ["default_county", "license_number"]}
+    writer.assert_called_once()
+
+
+def test_a_failed_write_is_not_reported_as_updated():
+    """`update_user_profile` returning False means nothing was written.
+    Saying "updated" anyway is the billing defect in miniature."""
+    import asyncio
+
+    from fastapi import HTTPException
+    from routers.users_auth import update_enhanced_user_profile
+    with patch("routers.users_auth.update_user_profile", return_value=False):
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(update_enhanced_user_profile(
+                profile_data={"default_county": "LA"}, user_id=7))
+    assert exc.value.status_code == 500
+
+
+# ── the deed face ───────────────────────────────────────────────────
+
+def test_the_requested_by_suggestion_is_the_company_and_only_the_company():
+    """`f"{company} - {role.title()}"` on the stored value
+    'escrow_officer' produces "Escrow_Officer" — .title() does not touch
+    the underscore. That string is a deed face, printed in the
+    recorder's top-left box.
+
+    A job title does not belong there in any case: the box names the
+    PARTY requesting recording, and the live path (the builder's partner
+    picker) has always put a bare company name in it.
+    """
+    from ai_assist import suggest_defaults
+    out = suggest_defaults(
+        {"profile": {"company_name": "Pacific Coast Escrow",
+                     "role": "escrow_officer",
+                     "auto_populate_company_info": True}},
+        {},
+    )
+    assert out["recordingRequestedBy"] == "Pacific Coast Escrow"
+    assert "_" not in out["recordingRequestedBy"]
+
+
+# ── the consolidation script ────────────────────────────────────────
+
+def test_the_script_will_not_drop_the_column():
+    """Irreversible and owner-only. A script that CAN drop a column is a
+    script that can drop one by accident, and a report does not recover
+    from that."""
+    import scripts.company_name_consolidation as mod
+    src = inspect.getsource(mod)
+    assert "DROP COLUMN" in mod.DROP_STATEMENT
+    # Named in exactly one place — the constant it prints — and never
+    # handed to a cursor.
+    assert src.count("DROP COLUMN") == 1
+    assert "execute(DROP_STATEMENT" not in src
+    assert "cur.execute(f\"\"\"\n        ALTER TABLE" not in src
+
+
+def test_the_backfill_never_overwrites_the_canonical_value():
+    """Where the two disagree, `users` wins by the ruling — and the
+    disagreements go in the report for a person to read, because a
+    difference might be a correction the officer made in the old
+    endpoint."""
+    import scripts.company_name_consolidation as mod
+    src = inspect.getsource(mod.backfill)
+    assert "NOT " in src and "u.company_name" in src
+    assert "UPDATE users u" in src
+
+
+@pytest.mark.parametrize("fn", ["counts", "disagreements", "backfill"])
+def test_blankness_is_defined_in_one_place(fn):
+    """The report and the backfill must not disagree about what "has a
+    company name" means, or --apply moves rows the report did not count."""
+    import scripts.company_name_consolidation as mod
+    src = inspect.getsource(getattr(mod, fn))
+    assert "HAS.format(" in src

--- a/frontend/src/__tests__/d2BuilderTrio.test.ts
+++ b/frontend/src/__tests__/d2BuilderTrio.test.ts
@@ -39,8 +39,26 @@ describe('D2.1 — Next buttons on typed sections, never confirm affordances', (
 });
 
 describe('D2.2 — the requesting-party address travels the full path', () => {
-  it('selecting a partner carries the address into state', () => {
-    expect(RECORDING).toContain('requestedByAddress: partner?.address');
+  it('selecting an entry carries the address into state', () => {
+    /**
+     * SETTINGS1 item 5 renamed `partner` to `chosen` — the picker now
+     * offers the officer's own company alongside the rolodex, and both
+     * kinds carry an address. The rule is unchanged and the pin follows
+     * the identifier.
+     *
+     * That this pin broke on a pure rename is the small lesson: it
+     * asserts a LINE rather than the behaviour, so it fails on correct
+     * code. The behavioural half is the payload test below, which is
+     * why that one did not move.
+     */
+    expect(RECORDING).toContain('requestedByAddress: chosen?.address');
+  });
+
+  it('the own-company entry carries an address too', () => {
+    // Recording under your own company should fill the address line the
+    // same way a partner does — the value is on the profile either way,
+    // and typing it again is how the two copies diverge.
+    expect(RECORDING).toContain('requestedByChoices(partners, companyName, companyAddress)');
   });
 
   it('the address is editable as its own field', () => {

--- a/frontend/src/__tests__/requestedByDefault.test.ts
+++ b/frontend/src/__tests__/requestedByDefault.test.ts
@@ -1,0 +1,241 @@
+/**
+ * SETTINGS1 item 5 — Recording Requested By starts on something, and the
+ * something it starts on does not create a deed.
+ *
+ * ═══ ONE FACT, ONE HOME ═══
+ *
+ * `company_name` sat in `users` AND in `user_profiles`. Settings wrote
+ * the first; the deed pre-fill read the second. So an officer who fixed
+ * her company on the Settings page did not change the company that
+ * pre-fills the recorder's top-left box, and nothing on either screen
+ * suggested they were different columns.
+ *
+ * Owner-ruled: `users.company_name` is canonical. This is the frontend
+ * half — the value reaches the builder through `/users/profile`, which
+ * is the endpoint Settings writes.
+ *
+ * ═══ AND THE PREFILL THAT WAS MINTING DEEDS ═══
+ *
+ * `hasMeaningfulData` carries the comment "an untouched builder must not
+ * mint rows", and `requestedBy` is one of the fields it counts. The
+ * localStorage prefill fills `requestedBy` as soon as the Recording
+ * section is expanded — so that stated rule stopped being true the day
+ * it shipped: opening Recording to see what is in it, and leaving it for
+ * the 2.5s autosave debounce, created a deed row holding one company
+ * name, for every officer who had ever picked a partner.
+ *
+ * Adding a second prefill without settling this would have extended it
+ * to everyone with a company on their profile. A default is not typing.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
+import {
+  OWN_COMPANY_ID,
+  defaultRequestedBy,
+  isPrefillOnly,
+  requestedByChoices,
+} from '../lib/requestedByDefault';
+import { hasMeaningfulData } from '../lib/deedPayload';
+import type { DeedBuilderState } from '../types/builder';
+
+const SRC = path.join(__dirname, '..');
+const SECTION = codeOnly(fs.readFileSync(
+  path.join(SRC, 'components', 'builder', 'sections', 'RecordingSection.tsx'), 'utf8'));
+const PAYLOAD = codeOnly(fs.readFileSync(
+  path.join(SRC, 'lib', 'deedPayload.ts'), 'utf8'));
+
+const PARTNERS = [
+  { id: 'p-1', label: 'Chicago Title', address: '1 Wacker, Chicago, IL 60601' },
+  { id: 'p-2', label: 'Fidelity National' },
+];
+
+const empty = (over: Partial<DeedBuilderState> = {}): DeedBuilderState => ({
+  deedType: 'grant_deed',
+  property: null,
+  grantor: '',
+  grantee: '',
+  vesting: '',
+  dtt: null,
+  requestedBy: '',
+  requestedByAddress: '',
+  returnTo: '',
+  titleOrderNo: '',
+  escrowNo: '',
+  ...over,
+}) as DeedBuilderState;
+
+describe('the officer\'s own company is a real option, not a bare string', () => {
+  it('appears first, labelled, with a reserved id', () => {
+    const choices = requestedByChoices(PARTNERS, 'Pacific Coast Escrow');
+    expect(choices[0]).toMatchObject({ id: OWN_COMPANY_ID, label: 'Pacific Coast Escrow', own: true });
+    expect(choices).toHaveLength(3);
+  });
+
+  it('the reserved id cannot collide with a partner id', () => {
+    /**
+     * Partner ids are server-issued UUIDs. If the synthetic id could
+     * ever equal one, `defaultRequestedBy` would resolve the wrong
+     * entry and `lastPartnerUsed` would point at a partner that does
+     * not exist.
+     */
+    expect(OWN_COMPANY_ID).not.toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-/i);
+    const choices = requestedByChoices(
+      [{ id: OWN_COMPANY_ID, label: 'Impostor' }], 'Pacific Coast Escrow');
+    expect(choices.filter((c) => c.own)).toHaveLength(1);
+  });
+
+  it('is not offered when the profile has no company', () => {
+    for (const blank of [null, undefined, '', '   ']) {
+      expect(requestedByChoices(PARTNERS, blank).some((c) => c.own)).toBe(false);
+    }
+  });
+
+  it('is not offered twice when the company is already a partner', () => {
+    // Two identically-labelled options is a control that cannot show
+    // which one is selected — the `<select>` matches by value.
+    const choices = requestedByChoices(PARTNERS, ' Chicago Title ');
+    expect(choices).toHaveLength(2);
+    expect(choices.some((c) => c.own)).toBe(false);
+  });
+});
+
+describe('THE ORDERING, which is the decision this file pins', () => {
+  /**
+   * Both orders have a wrong case, so neither is derivable and the one
+   * chosen must be asserted rather than inferred from behaviour.
+   *
+   * Ruled: a partner she actually picked outranks the profile default.
+   * Her own company fills the case that used to be blank.
+   */
+  it('a last-used partner beats the own company', () => {
+    const choices = requestedByChoices(PARTNERS, 'Pacific Coast Escrow');
+    expect(defaultRequestedBy(choices, 'p-1')).toEqual({
+      value: 'Chicago Title', origin: 'last-partner',
+      address: '1 Wacker, Chicago, IL 60601',
+    });
+  });
+
+  it('the own company fills the previously-blank case', () => {
+    const choices = requestedByChoices(PARTNERS, 'Pacific Coast Escrow');
+    expect(defaultRequestedBy(choices, null)).toMatchObject({
+      value: 'Pacific Coast Escrow', origin: 'own-company',
+    });
+  });
+
+  it('a stale last-used id falls through rather than emptying the box', () => {
+    // localStorage outlives a deleted partner. That is exactly the case
+    // the fallback is for.
+    const choices = requestedByChoices(PARTNERS, 'Pacific Coast Escrow');
+    expect(defaultRequestedBy(choices, 'p-deleted').origin).toBe('own-company');
+  });
+
+  it('offers nothing when there is nothing to offer', () => {
+    expect(defaultRequestedBy(requestedByChoices([], ''), 'p-1'))
+      .toEqual({ value: '', origin: 'none' });
+  });
+
+  it('never invents a value', () => {
+    // Sweep: whatever comes back, it is one of the labels offered or it
+    // is empty. A default that is not in the list is a value the officer
+    // cannot see and cannot correct.
+    for (const last of [null, '', 'p-1', 'p-2', OWN_COMPANY_ID, 'nonsense']) {
+      for (const company of ['', 'Pacific Coast Escrow']) {
+        const choices = requestedByChoices(PARTNERS, company);
+        const got = defaultRequestedBy(choices, last);
+        if (got.value) {
+          expect(choices.map((c) => c.label)).toContain(got.value);
+        }
+      }
+    }
+  });
+});
+
+describe('a default is not typing, so it does not mint a deed', () => {
+  it('a builder holding ONLY a prefilled requested-by has nothing to save', () => {
+    /** THE PIN THIS FILE EXISTS FOR. */
+    expect(hasMeaningfulData(empty({
+      requestedBy: 'Pacific Coast Escrow', requestedByPrefilled: true,
+    }))).toBe(false);
+  });
+
+  it('the same value counts the moment she chooses it', () => {
+    expect(hasMeaningfulData(empty({
+      requestedBy: 'Pacific Coast Escrow', requestedByPrefilled: false,
+    }))).toBe(true);
+  });
+
+  it('an unmarked value counts — the flag is opt-in, never a way to lose work', () => {
+    // A resumed draft and every pre-existing state carry no flag. If the
+    // absent case read as "prefilled", resume would stop autosaving.
+    expect(hasMeaningfulData(empty({ requestedBy: 'Chicago Title' }))).toBe(true);
+  });
+
+  it('a prefill never suppresses REAL work sitting beside it', () => {
+    // The flag answers one question about one field. Anything else in
+    // the state still saves.
+    for (const real of [
+      { grantor: 'Jane Doe' },
+      { grantee: 'John Roe' },
+      { titleOrderNo: 'TC-1' },
+      { escrowNo: 'ESC-1' },
+    ]) {
+      expect(hasMeaningfulData(empty({
+        requestedBy: 'Pacific Coast Escrow', requestedByPrefilled: true, ...real,
+      }))).toBe(true);
+    }
+  });
+
+  it('isPrefillOnly needs BOTH the flag and a value', () => {
+    expect(isPrefillOnly('Acme', true)).toBe(true);
+    expect(isPrefillOnly('Acme', false)).toBe(false);
+    expect(isPrefillOnly('', true)).toBe(false);
+    expect(isPrefillOnly('   ', true)).toBe(false);
+    expect(isPrefillOnly(undefined, undefined)).toBe(false);
+  });
+
+  it('the rule is called from hasMeaningfulData, not merely exported', () => {
+    // A module nothing imports is a rule nothing enforces.
+    expect(PAYLOAD).toContain('isPrefillOnly(s.requestedBy, s.requestedByPrefilled)');
+  });
+});
+
+describe('the section uses the list it renders', () => {
+  it('renders the choices, so a defaulted value is visible and correctable', () => {
+    /**
+     * A `<select>` whose value matches no `<option>` renders as
+     * unselected. Writing the company into state without adding the
+     * option would print a name on the deed that the screen shows as
+     * blank — the exact shape of "state that exists and is not shown".
+     */
+    expect(SECTION).toContain('choices.map(');
+    expect(SECTION).toContain('requestedByChoices(');
+    expect(SECTION).toContain('defaultRequestedBy(');
+  });
+
+  it('marks what it filled, on every path that fills it', () => {
+    // Set on the prefill; cleared on both paths where she chooses. A
+    // path that forgets to clear it silently stops autosaving her work.
+    expect(SECTION).toContain('requestedByPrefilled: true');
+    expect((SECTION.match(/requestedByPrefilled: false/g) || []).length).toBe(2);
+  });
+
+  it('does not remember the own company as a last-used partner', () => {
+    // It is not a partner, and storing it would make the fallback
+    // outrank the profile it came from on the next deed — freezing a
+    // stale company name past the day she corrects it in Settings.
+    expect(SECTION).toContain('!chosen.own');
+  });
+
+  it('reads the company from the canonical source', () => {
+    expect(SECTION).toContain('useOwnCompany()');
+  });
+
+  it('the empty-list message counts the list it shows', () => {
+    // `partners.length === 0` would tell her there is nothing to pick
+    // while her own company sits in the dropdown.
+    expect(SECTION).toContain('choices.length === 0');
+    expect(SECTION).not.toContain('partners.length === 0');
+  });
+});

--- a/frontend/src/components/builder/InputPanel.tsx
+++ b/frontend/src/components/builder/InputPanel.tsx
@@ -272,6 +272,7 @@ export function InputPanel({
           <RecordingSection
             requestedBy={state.requestedBy}
             requestedByAddress={state.requestedByAddress}
+            requestedByPrefilled={state.requestedByPrefilled}
             returnTo={state.returnTo}
             titleOrderNo={state.titleOrderNo}
             escrowNo={state.escrowNo}

--- a/frontend/src/components/builder/sections/RecordingSection.tsx
+++ b/frontend/src/components/builder/sections/RecordingSection.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Building2, Plus } from 'lucide-react';
 import { usePartners } from '@/features/partners/PartnersContext';
 import { useAIAssist } from '@/contexts/AIAssistContext';
+import { useOwnCompany } from '@/hooks/useOwnCompany';
+import { defaultRequestedBy, requestedByChoices } from '@/lib/requestedByDefault';
 import { AISuggestion } from '../AISuggestion';
 import { AddPartnerModal, PartnerFormData } from '@/components/modals/AddPartnerModal';
 
@@ -11,44 +13,68 @@ interface RecordingSectionProps {
   requestedBy: string;
   /** D2: the requesting party's mailing address (prints under their name). */
   requestedByAddress?: string;
+  /** True while requestedBy holds a default nobody chose. */
+  requestedByPrefilled?: boolean;
   returnTo: string;
   titleOrderNo?: string;
   escrowNo?: string;
-  onChange: (updates: { requestedBy?: string; requestedByAddress?: string; returnTo?: string; titleOrderNo?: string; escrowNo?: string }) => void;
+  onChange: (updates: { requestedBy?: string; requestedByAddress?: string; requestedByPrefilled?: boolean; returnTo?: string; titleOrderNo?: string; escrowNo?: string }) => void;
 }
 
-export function RecordingSection({ requestedBy, requestedByAddress, returnTo, titleOrderNo, escrowNo, onChange }: RecordingSectionProps) {
+export function RecordingSection({ requestedBy, requestedByAddress, requestedByPrefilled, returnTo, titleOrderNo, escrowNo, onChange }: RecordingSectionProps) {
   const { enabled: aiEnabled } = useAIAssist();
   const [guidanceDismissed, setGuidanceDismissed] = useState(false);
   const [showAddModal, setShowAddModal] = useState(false);
   const { partners, create: createPartner, error: partnersError, refresh: refreshPartners } = usePartners();
-  
+  const { companyName, companyAddress } = useOwnCompany();
+
+  // The officer's own company, then the rolodex. The own entry is
+  // synthetic — the owner ruled against filing yourself as a partner —
+  // so it exists only in this list, and only while the profile has a
+  // company to put in it.
+  const choices = useMemo(
+    () => requestedByChoices(partners, companyName, companyAddress),
+    [partners, companyName, companyAddress],
+  );
+
   useEffect(() => {
-    if (!requestedBy && partners.length > 0) {
-      const lastUsed = localStorage.getItem('lastPartnerUsed');
-      if (lastUsed) {
-        const partner = partners.find(p => p.id === lastUsed);
-        if (partner) {
-          onChange({ requestedBy: partner.label });
-        }
-      }
-    }
-  }, [partners, requestedBy, onChange]);
+    // Fill the box on open, and REMEMBER that we filled it. Without the
+    // flag this prefill mints a draft deed for an officer who typed
+    // nothing — see hasMeaningfulData.
+    if (requestedBy || choices.length === 0) return;
+    const chosen = defaultRequestedBy(choices, localStorage.getItem('lastPartnerUsed'));
+    if (chosen.origin === 'none') return;
+    onChange({
+      requestedBy: chosen.value,
+      ...(chosen.address ? { requestedByAddress: chosen.address } : {}),
+      requestedByPrefilled: true,
+    });
+  }, [choices, requestedBy, onChange]);
 
   const handleSelectChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
     const value = e.target.value;
-    
+
     if (value === '__ADD_NEW__') {
       setShowAddModal(true);
       return;
     }
-    
+
     // D2: the partner record already carries the mailing address — selecting
     // a partner fills both the name and the address that print on the deed.
-    const partner = partners.find(p => p.label === value);
-    onChange({ requestedBy: value, requestedByAddress: partner?.address || requestedByAddress || '' });
-    if (partner) {
-      localStorage.setItem('lastPartnerUsed', partner.id);
+    const chosen = choices.find(c => c.label === value);
+    onChange({
+      requestedBy: value,
+      requestedByAddress: chosen?.address || requestedByAddress || '',
+      // Whatever this held before, it is now a decision rather than a
+      // default — and a decision is work worth saving.
+      requestedByPrefilled: false,
+    });
+    // Only a real partner is remembered as the last one used. Recording
+    // under your own company is the fallback, not a rolodex choice — and
+    // writing the synthetic id here would make it outrank the profile it
+    // came from on the next deed.
+    if (chosen && !chosen.own) {
+      localStorage.setItem('lastPartnerUsed', chosen.id);
     }
   };
 
@@ -74,7 +100,13 @@ export function RecordingSection({ requestedBy, requestedByAddress, returnTo, ti
           [newPartner.address_line1, newPartner.address_line2].filter(Boolean).join(' '),
           [newPartner.city, [newPartner.state, newPartner.postal_code].filter(Boolean).join(' ')].filter(Boolean).join(', '),
         ].filter(Boolean).join(', ');
-        onChange({ requestedBy: newPartner.company_name, requestedByAddress: addr });
+        // Creating a partner and having it selected is a choice, not a
+        // default — this draft is worth saving.
+        onChange({
+          requestedBy: newPartner.company_name,
+          requestedByAddress: addr,
+          requestedByPrefilled: false,
+        });
         localStorage.setItem('lastPartnerUsed', newPartner.id);
       }
       
@@ -87,7 +119,10 @@ export function RecordingSection({ requestedBy, requestedByAddress, returnTo, ti
   return (
     <div className="space-y-4">
       {/* AI Guidance */}
-      {aiEnabled && !guidanceDismissed && !requestedBy && (
+      {/* Shown while the box is empty OR merely pre-filled: a default is
+          not a decision, and the officer who most needs this explanation
+          is the one who has not chosen anything yet. */}
+      {aiEnabled && !guidanceDismissed && (!requestedBy || requestedByPrefilled) && (
         <AISuggestion
           message="Select who is submitting this deed for recording. This appears in the top-left corner of the deed."
           details="The 'Recording Requested By' is typically the title company, escrow officer, or attorney handling the transaction. 'Return To' specifies where the county recorder should mail the deed after recording — usually the same party, or directly to the new owner (grantee)."
@@ -107,10 +142,10 @@ export function RecordingSection({ requestedBy, requestedByAddress, returnTo, ti
             onChange={handleSelectChange}
             className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-brand-500 appearance-none bg-white"
           >
-            <option value="">Select partner...</option>
-            {partners.map((partner) => (
-              <option key={partner.id} value={partner.label}>
-                {partner.label}
+            <option value="">Select who is requesting recording...</option>
+            {choices.map((choice) => (
+              <option key={choice.id} value={choice.label}>
+                {choice.own ? `${choice.label} (your company)` : choice.label}
               </option>
             ))}
             <option value="__ADD_NEW__" className="text-brand-600 font-medium">
@@ -132,7 +167,10 @@ export function RecordingSection({ requestedBy, requestedByAddress, returnTo, ti
               Retry
             </button>
           </div>
-        ) : partners.length === 0 ? (
+        ) : choices.length === 0 ? (
+          // `choices`, not `partners`: with a company on the profile the
+          // list is not empty, and telling her there is nothing to pick
+          // while her own company sits in the dropdown is a plain lie.
           <p className="mt-1 text-xs text-gray-500">
             No partners yet. Select &quot;➕ Add New Partner&quot; to create one.
           </p>

--- a/frontend/src/hooks/useOwnCompany.ts
+++ b/frontend/src/hooks/useOwnCompany.ts
@@ -1,0 +1,69 @@
+'use client';
+
+/**
+ * The officer's own company, from the one column that holds it.
+ *
+ * `users.company_name` is canonical (owner-ruled) — the same value the
+ * Settings page writes and `GET /users/profile` returns. The builder
+ * reads it here so that correcting your company in Settings corrects
+ * what pre-fills Recording Requested By, which was not true while the
+ * pre-fill read a second copy in `user_profiles`.
+ *
+ * ═══ A FAILED FETCH IS NOT AN EMPTY COMPANY ═══
+ *
+ * Both come back as "no default offered", because there is nothing
+ * honest to put in the box either way. The difference matters to the
+ * caller only in that this hook never invents a company and never
+ * retries into a loop: one ask per mount, and the officer's own typing
+ * is unaffected by the answer.
+ *
+ * It is deliberately silent. This is a convenience default on a field
+ * with a visible, editable control — a toast about a background profile
+ * read would be noise on a screen where nothing is broken.
+ */
+import { useEffect, useState } from 'react';
+import { SessionExpiredError, apiFetch } from '@/lib/apiClient';
+
+export interface OwnCompany {
+  companyName: string;
+  /**
+   * The business address, so recording under your own company fills the
+   * address line the same way selecting a partner does. Both come from
+   * the record; neither is typed twice.
+   */
+  companyAddress: string;
+  /** True until the profile answers, so callers can avoid a flash. */
+  loading: boolean;
+}
+
+export function useOwnCompany(): OwnCompany {
+  const [companyName, setCompanyName] = useState('');
+  const [companyAddress, setCompanyAddress] = useState('');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let live = true;
+    (async () => {
+      try {
+        const res = await apiFetch('/users/profile', {}, {
+          label: 'Profile', silent: true,
+        });
+        if (!live) return;
+        if (res.ok) {
+          const body = await res.json();
+          setCompanyName((body?.company_name || '').trim());
+          setCompanyAddress((body?.business_address || '').trim());
+        }
+      } catch (err) {
+        if (!(err instanceof SessionExpiredError)) {
+          console.warn('[own-company] profile read failed:', err);
+        }
+      } finally {
+        if (live) setLoading(false);
+      }
+    })();
+    return () => { live = false; };
+  }, []);
+
+  return { companyName, companyAddress, loading };
+}

--- a/frontend/src/lib/deedPayload.ts
+++ b/frontend/src/lib/deedPayload.ts
@@ -13,6 +13,7 @@ import {
   buildPreflightOverridesPayload,
   buildProvenancePayload,
 } from '@/lib/provenance';
+import { isPrefillOnly } from '@/lib/requestedByDefault';
 import { formFamily, isSinglePartyType } from '@/lib/formRegistry';
 
 /**
@@ -150,6 +151,20 @@ export type DeedPayload = ReturnType<typeof buildDeedPayload>;
 /**
  * A draft is worth saving once the officer has entered ANYTHING that would
  * hurt to lose — not before (an untouched builder must not mint rows).
+ *
+ * ═══ THE RULE ABOVE WAS WRITTEN DOWN AND BROKEN BY A PREFILL ═══
+ *
+ * `requestedBy` gets filled the moment the Recording section is opened —
+ * by the last-used partner from localStorage, and now by the officer's
+ * own company. So "an untouched builder must not mint rows" stopped
+ * being true the day that prefill shipped: expanding Recording to see
+ * what is in it, and leaving it for the 2.5s autosave debounce, created
+ * a deed row containing one company name and nothing else.
+ *
+ * A default is not typing. `requestedByPrefilled` marks a value the
+ * product put there, and a state whose only content is that value is
+ * still an untouched builder. The instant she touches the control the
+ * flag clears and this counts it, because at that point it IS a choice.
  */
 export function hasMeaningfulData(s: DeedBuilderState): boolean {
   return !!(
@@ -158,7 +173,7 @@ export function hasMeaningfulData(s: DeedBuilderState): boolean {
     s.grantee?.trim() ||
     s.vesting ||
     s.dtt ||
-    s.requestedBy?.trim() ||
+    (!isPrefillOnly(s.requestedBy, s.requestedByPrefilled) && s.requestedBy?.trim()) ||
     s.titleOrderNo?.trim() ||
     s.escrowNo?.trim() ||
     // Typed instrument facts (affidavit/declaration families) are work

--- a/frontend/src/lib/requestedByDefault.ts
+++ b/frontend/src/lib/requestedByDefault.ts
@@ -1,0 +1,144 @@
+/**
+ * Who the Recording Requested By box starts on, and where that came from.
+ *
+ * ═══ THE FIELD HAD NO DEFAULT, AND ONE SOURCE ═══
+ *
+ * The control is a `<select>` over the partner rolodex. A returning
+ * officer got her last-used partner back from localStorage; a new officer
+ * got "Select partner..." and an empty box, with her own company sitting
+ * in her profile the whole time.
+ *
+ * Owner-ruled: the default comes from `users.company_name`. So the
+ * officer's own company becomes a REAL OPTION in the list rather than a
+ * bare string written into state — a `<select>` whose value matches no
+ * `<option>` renders as unselected, which would put a name on the deed
+ * that the screen shows as blank. A value the officer cannot see is a
+ * value she cannot correct.
+ *
+ * The owner also ruled against auto-creating a partner record for her own
+ * company: a partner is a counterparty, and the rolodex is not a place to
+ * file yourself. Hence a synthetic entry that lives only in this list.
+ *
+ * ═══ THE ORDERING IS PINNED, NOT THE OUTCOME ═══
+ *
+ * Two signals can fill the box and neither is obviously stronger:
+ *
+ *   - the last partner she picked — a choice she made, for this exact
+ *     field, in this product;
+ *   - her own company — a fact about her, and the ruled source.
+ *
+ * Both orders have a wrong case. Last-partner-wins re-imposes a title
+ * company she used once for an unusual deal. Own-company-wins re-imposes
+ * her own name on an officer who always records under a partner. There is
+ * no rule that is right in both, and picking one quietly is how a
+ * tie-break becomes a fact nobody checks.
+ *
+ * So: LAST-USED PARTNER WINS, own company fills the case that was
+ * previously blank — the narrowest reading that satisfies the ruling. The
+ * ordering is asserted directly in the tests, so changing it is a
+ * decision somebody makes rather than a behaviour that drifts.
+ */
+
+/**
+ * The synthetic option's id. Deliberately not a UUID shape: partner ids
+ * are server-issued UUIDs, so this cannot collide with one, and a
+ * `lastPartnerUsed` holding this value is recognisable as ours.
+ */
+export const OWN_COMPANY_ID = 'own-company';
+
+export interface RequestedByChoice {
+  id: string;
+  label: string;
+  address?: string;
+  /** True for the synthetic own-company entry — it is not a partner. */
+  own?: boolean;
+}
+
+interface PartnerLike {
+  id: string;
+  label: string;
+  address?: string;
+}
+
+/** Where a filled value came from. `none` means the box stays empty. */
+export type RequestedByOrigin = 'last-partner' | 'own-company' | 'none';
+
+export interface RequestedByDefault {
+  value: string;
+  origin: RequestedByOrigin;
+  /** The address that prints under the name, when the source carries one. */
+  address?: string;
+}
+
+/**
+ * The options the picker offers: the officer's own company first, then
+ * her partners.
+ *
+ * A company that already exists in the rolodex under the same name is NOT
+ * offered twice — two identically-labelled options in one select is a
+ * control that cannot show which one is chosen.
+ */
+export function requestedByChoices(
+  partners: readonly PartnerLike[],
+  companyName: string | null | undefined,
+  companyAddress?: string | null,
+): RequestedByChoice[] {
+  const own = (companyName || '').trim();
+  const list: RequestedByChoice[] = partners.map((p) => ({
+    id: p.id, label: p.label, address: p.address,
+  }));
+  if (!own) return list;
+  const already = list.some((p) => p.label.trim() === own);
+  if (already) return list;
+  return [
+    { id: OWN_COMPANY_ID, label: own, address: (companyAddress || '').trim() || undefined, own: true },
+    ...list,
+  ];
+}
+
+/**
+ * What to start the box on, given the choices and the last one used.
+ *
+ * `lastUsedId` is whatever localStorage holds — which is to say, an
+ * arbitrary string from a place this code does not control. An id that
+ * matches nothing yields the own-company default rather than an empty
+ * box: a stale id from a deleted partner is exactly the case where the
+ * fallback should do its job.
+ */
+export function defaultRequestedBy(
+  choices: readonly RequestedByChoice[],
+  lastUsedId: string | null | undefined,
+): RequestedByDefault {
+  const last = choices.find((c) => c.id === lastUsedId);
+  if (last) return { value: last.label, origin: 'last-partner', address: last.address };
+  const own = choices.find((c) => c.own);
+  if (own) return { value: own.label, origin: 'own-company', address: own.address };
+  return { value: '', origin: 'none' };
+}
+
+/**
+ * Is this value one the product filled in, rather than one a person
+ * chose?
+ *
+ * ═══ WHY THIS EXISTS AT ALL ═══
+ *
+ * The builder autosaves to a real deed row as soon as the state holds
+ * anything meaningful, and `requestedBy` counts. A pre-filled value
+ * therefore MINTS A DRAFT DEED for an officer who opened the builder,
+ * typed nothing, and walked away — a row in her deed list that she never
+ * made and cannot explain.
+ *
+ * That is not hypothetical and it is not new: the localStorage prefill
+ * has done it since it shipped, for every officer who ever picked a
+ * partner. Adding a second prefill without settling this would have
+ * extended it to everyone.
+ *
+ * Autosave exists to protect TYPING. A default is not typing, so a state
+ * whose only content is a default has nothing worth saving yet.
+ */
+export function isPrefillOnly(
+  requestedBy: string | null | undefined,
+  prefilled: boolean | undefined,
+): boolean {
+  return !!prefilled && !!(requestedBy || '').trim();
+}

--- a/frontend/src/types/builder.ts
+++ b/frontend/src/types/builder.ts
@@ -232,6 +232,17 @@ export interface DeedBuilderState {
   requestedBy: string;
   /** D2: the requesting party's mailing address (one line, optional). */
   requestedByAddress?: string;
+  /**
+   * True while `requestedBy` holds a DEFAULT nobody chose — the officer's
+   * own company or her last-used partner, filled on open.
+   *
+   * Deliberately not a `Sourced<string>`: this must never become
+   * confirmable by the affordance built for county-record transcriptions.
+   * It answers exactly one question, for `hasMeaningfulData` — is there
+   * work here worth minting a deed row for? — and is cleared the moment
+   * she touches the control.
+   */
+  requestedByPrefilled?: boolean;
   returnTo: string;
   titleOrderNo?: string;
   escrowNo?: string;


### PR DESCRIPTION
Item 5, built on the ruling. `users.company_name` is canonical.

## The read moved, and the write stopped duplicating

`get_user_profile` reads the company from `users`, anchored on that table so a person with no `user_profiles` row still has one.

`auto_populate_company_info` **must** be COALESCEd, and this is the part that would have been silent: the column's `DEFAULT TRUE` never applies to a row that was never inserted. A missing profile row yields SQL NULL, `.get()` returns None, `suggest_defaults` reads it as falsy — and the pre-fill turns off for every officer who never opened the old profile endpoint. Nothing would have failed; the feature would just have been absent.

## The clobbering writer, fixed

`update_user_profile`'s `ON CONFLICT DO UPDATE` set all eight columns from `EXCLUDED` unconditionally, and `EXCLUDED` for an omitted key is None. **A call carrying one field NULLed the other seven.**

Survivable while nothing else owned those columns. SETTINGS1 gave `business_address` to `PATCH /users/profile` — so an officer could save her address in Settings and have this endpoint wipe it seconds later. The columns written are now the keys supplied.

`POST /users/profile/enhanced` **refuses** `company_name` and names where it went. Accepting and silently dropping it would return "updated" for a save that did not happen — the class of defect the whole billing story was made of.

## Counting before dropping

`scripts/company_name_consolidation.py` reports every number the ruling asked for — including **both set and DIFFERENT**, listed row by row, because a disagreement might be a correction the officer made in the old endpoint and that needs a person, not a rule. The backfill only touches rows where the retiring column holds the **only** copy.

The DROP is printed and never executed. A script that can drop a column is a script that can drop one by accident, and a report does not recover from that.

## The default is a real option, not a bare string

A `<select>` whose value matches no `<option>` renders as unselected — writing the company into state without adding the option would print a name on the deed that the screen shows as blank. The own-company entry is synthetic (the owner ruled against filing yourself as a partner), carries the business address the way a partner record does, and is never stored as `lastPartnerUsed` — doing so would freeze a stale company past the day it is corrected in Settings.

**A last-used partner still wins over it.** Both orders have a wrong case: last-partner-wins re-imposes a title company used once for an unusual deal; own-company-wins re-imposes your own name on an officer who always records under a partner. Neither is derivable, so the ordering is asserted directly rather than left to emerge from behaviour. **Flagging it for a ruling** — the letter of item 5 says the default comes from `users.company_name`, and it now does in the case that was previously blank; which signal outranks which was not covered.

## A defect found in the path

`hasMeaningfulData` carries the comment *"an untouched builder must not mint rows"*, and `requestedBy` is one of the fields it counts. The localStorage prefill fills `requestedBy` as soon as the Recording section is expanded — so **that written-down rule stopped being true the day the prefill shipped**: expanding Recording to see what is in it, leaving it for the 2.5s autosave debounce, minted a deed row holding one company name and nothing else. Pre-existing, for every officer who had ever picked a partner; adding a second prefill would have extended it to everyone with a company on their profile.

A default is not typing. `requestedByPrefilled` marks a value the product put there, cleared on both paths where she chooses. Deliberately not a `Sourced<string>` — nothing that lacks the shape of a confirmable field can be confirmed by the affordance built for county-record transcriptions.

## The class sweep, including what it rejected

`users` and `user_profiles` also both carry `role`. It is **not** the same disease and merging them would be the bug: `users.role` is authorization (`user`/`admin`), `user_profiles.role` is professional (`escrow_officer`/`title_officer`/`notary`). A name collision, not a duplicated fact. Recorded because "we swept and found nothing else" is only credible if it says what it looked at.

Also fixed while there: the requested-by suggestion was `f"{company} - {role.title()}"`, which on the stored value `escrow_officer` produces **"Escrow_Officer"** — `.title()` does not touch the underscore. That string is a deed face. It is the bare company now, matching what the live partner picker has always put there.

## Gates

| gate | result |
|---|---|
| pytest | 1201 passed |
| jest | 853 passed, 59 suites |
| tsc | 88 — baseline unchanged |
| six-flow | green |
| banned-claims | clean |
| OpenAPI snapshot | unchanged — no route moved |
| mutation probes | 15 run, 14 caught, **1 came back green** |

**The green probe.** Three endpoint tests asserted that `PROFILE_ELSEWHERE` and `status_code=400` **appear in the source**. Deleting the refusal — `moved = []`, leaving the raise block intact and unreachable — passed all three. A string-presence pin cannot tell REACHABLE from PRESENT; it reads code the way a person skimming it does, which is exactly the reading that misses dead branches. Those tests call the endpoint now, and three more were added around it (a valid field riding along with the refused one, an unrecognised body, a failed write reported as updated). Re-running the probe: 2 failures where there were 0.

One pre-existing pin moved: `d2BuilderTrio` asserted the literal `requestedByAddress: partner?.address` and broke on a pure rename. Its own small lesson is noted in place — the behavioural half of that pair (the payload test) did not move.

## Not in this PR

`#184` (Unit 2 step 1, the activity endpoint) is still open and unmerged. Unit 2 step 2 builds against `GET /deeds/{id}/activity`, so the page cannot land on main until step 1 does, and stacking is out. #184 merges clean against current main and its OpenAPI snapshot is still accurate — it needs a merge decision, not rework.

**Branch note, as standing practice:** fresh per-ticket branch off current main, not the stale branch named in session config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_