### PR TITLE
DEEDDETAIL Unit 2 — the deed page, and an endpoint that had never once run

### DIFF
--- a/backend/routers/deeds_crud.py
+++ b/backend/routers/deeds_crud.py
@@ -716,8 +716,17 @@ def activity_endpoint(deed_id: int, user_id: int = Depends(get_current_user_id))
         # The one real event log in the product: a row per answer, with
         # who and when. Joined to its participant for the name only —
         # §13.1, no contact detail crosses into this payload.
+        # `display_name`, aliased. The column is not called `name`, and
+        # `SELECT p.name` made this endpoint 500 on EVERY call — Postgres
+        # rejects the column at parse time, so it failed whether or not
+        # any signing existed. It shipped that way because the pins were
+        # unit tests over `deed_activity.activity()` with dict fixtures:
+        # the statement had never once been executed.
+        #
+        # Same shape as MONEY1's `:items::jsonb`. See
+        # tests/test_endpoint_sql.py, which now parses the statements.
         cur.execute("""SELECT r.answer, r.asserted_at,
-                              p.name, p.party_role
+                              p.display_name AS name, p.party_role
                          FROM signing_responses r
                          JOIN signing_participants p ON p.id = r.participant_id
                          JOIN signing_requests s ON s.id = p.signing_request_id
@@ -728,6 +737,88 @@ def activity_endpoint(deed_id: int, user_id: int = Depends(get_current_user_id))
             "entries": deed_activity.activity(dict(deed), shares=shares,
                                               signings=signings,
                                               responses=responses)}
+
+
+@router.get("/deeds/{deed_id}/detail")
+def deed_detail_endpoint(deed_id: int, user_id: int = Depends(get_current_user_id)):
+    """Everything the deed page renders, in one answer.
+
+    ONE call, deliberately. The page's first decision is whether it may
+    render at all — a superseded deed replaces its own content — and a
+    screen that fetches lineage separately shows the working page first
+    and swaps it out when lineage lands. A second of "next action" on a
+    document she must not act on is a second long enough to click.
+
+    This handler assembles nothing and composes no sentence. It fetches
+    rows and hands them to `services/deed_page`, which is the one place
+    that turns this deed's state into English (§13 rule 3).
+    """
+    from services import deed_activity, deed_page, signing_rows
+    from services.matters import carry_forward, matter_key, party_names
+
+    deed = dict(_pcor_deed_row(deed_id, user_id))
+
+    with db.conn.cursor() as cur:
+        cur.execute("""SELECT id, recipient_name, recipient_email, status,
+                              created_at, viewed_at, responded_at
+                         FROM deed_shares WHERE deed_id = %s
+                        ORDER BY created_at DESC""", (deed_id,))
+        shares = [dict(r) for r in (cur.fetchall() or [])]
+
+        signings = signing_rows.for_deed(cur, deed_id)
+        signers = signing_rows.signers_for_deed(cur, deed_id)
+
+        # The activity feed's own sources, fetched the way its endpoint
+        # fetches them. `booked_asserted_at`, never `booked_at` — the
+        # event is the assertion, not the appointment.
+        cur.execute("""SELECT id, created_at, booked_asserted_at, booked_by,
+                              cancelled_at
+                         FROM signing_requests WHERE deed_id = %s""", (deed_id,))
+        activity_signings = [dict(r) for r in (cur.fetchall() or [])]
+        cur.execute("""SELECT r.answer, r.asserted_at,
+                              p.display_name AS name, p.party_role
+                         FROM signing_responses r
+                         JOIN signing_participants p ON p.id = r.participant_id
+                         JOIN signing_requests s ON s.id = p.signing_request_id
+                        WHERE s.deed_id = %s""", (deed_id,))
+        responses = [dict(r) for r in (cur.fetchall() or [])]
+
+        # ── Matter, one level out ─────────────────────────────────────
+        matter = None
+        key = matter_key(deed)
+        if key is not None:
+            kind, value = key
+            cur.execute("""
+                SELECT id, deed_type, status, property_address, apn,
+                       grantor_name, grantee_name, parties, created_at
+                  FROM deeds
+                 WHERE user_id = %s AND id <> %s AND status <> 'deleted'
+                   AND metadata->>%s = %s
+                 ORDER BY created_at DESC
+            """, (deed.get("user_id"), deed_id, kind, value))
+            siblings = [dict(r) for r in (cur.fetchall() or [])]
+            matter = {
+                "key": {"kind": kind, "value": value},
+                "documents": [{
+                    "id": s_["id"],
+                    "deed_type": s_["deed_type"],
+                    "status": s_["status"],
+                    "property_address": s_["property_address"],
+                    "parties": party_names(s_),
+                } for s_ in siblings],
+                "carry_forward": carry_forward(deed),
+            }
+
+    return deed_page.deed_page(
+        deed,
+        shares=shares,
+        signings=signings,
+        participants=signers,
+        activity=deed_activity.activity(deed, shares=shares,
+                                        signings=activity_signings,
+                                        responses=responses),
+        matter=matter,
+    )
 
 
 @router.get("/deeds/{deed_id}/lineage")

--- a/backend/routers/signing.py
+++ b/backend/routers/signing.py
@@ -35,7 +35,7 @@ import db
 from auth import get_current_user_id
 from services import officer_queue, pcor_offer
 from services import signing_loop as loop
-from services import signing_purge, signing_summary, signing_surfaces
+from services import signing_purge, signing_rows, signing_summary, signing_surfaces
 from utils.throttle import client_key, throttle
 
 router = APIRouter()
@@ -359,54 +359,20 @@ def officer_agenda(user_id: int = Depends(get_current_user_id)):
     if not db.conn:
         raise HTTPException(status_code=500, detail="Database connection not available")
     with db.conn.cursor() as cur:
-        cur.execute("""
-            SELECT sr.*, d.property_address, d.deed_type,
-                   (SELECT display_name FROM signing_participants
-                     WHERE signing_request_id = sr.id AND party_role = 'notary'
-                     ORDER BY id LIMIT 1) AS notary_name
-              FROM signing_requests sr
-              JOIN deeds d ON d.id = sr.deed_id
-             WHERE sr.officer_user_id = %s
-             ORDER BY COALESCE(sr.booked_at, sr.expires_at) ASC
-        """, (user_id,))
-        rows = _rows(cur)
-
-        out = []
-        for row in rows:
-            cur.execute("SELECT * FROM signing_windows WHERE signing_request_id = %s",
-                        (row["id"],))
-            windows = _rows(cur)
-            cur.execute("SELECT r.* FROM signing_responses r JOIN signing_windows w "
-                        "ON w.id = r.window_id WHERE w.signing_request_id = %s",
-                        (row["id"],))
-            responses = _rows(cur)
-            cur.execute("SELECT * FROM signing_participants WHERE signing_request_id = %s",
-                        (row["id"],))
-            participants = _rows(cur)
-            # The shape lives in services/signing_summary.py, which
-            # asserts it against a corpus both languages read. It used to
-            # be a dict literal here, and TWO screens declared their own
-            # idea of what it contained — one of them three fields short,
-            # which is why the merged tracker could not mark a stuck
-            # signing or tell a closed one from a live one.
-            #
-            # The JUDGEMENTS stay here, where they were: which state this
-            # is, whether it is live, what sentence describes it, how long
-            # she has waited and whether that is too long. Only the shape
-            # moved.
-            state = loop.request_state(row, windows, responses)
-            days_waiting = officer_queue.days_since(row.get("created_at"))
-            out.append(signing_summary.signing_summary_row(
-                row,
-                state=state,
-                live=loop.is_live(state),
-                summary=loop.state_label(row, windows, responses, participants),
-                days_waiting=days_waiting,
-                stale=(state in (loop.STATE_REQUESTED, loop.STATE_WINDOWS_POSTED)
-                       and officer_queue.is_stale(days_waiting)),
-                signers=len([p for p in participants
-                             if p["party_role"] == loop.ROLE_SIGNER]),
-            ))
+        # The shape lives in services/signing_summary.py and the ASSEMBLY
+        # now lives in services/signing_rows.py.
+        #
+        # The shape moved first, because two screens had each declared
+        # their own idea of what a row contains and one was three fields
+        # short. The assembly moved for the same reason one level up: the
+        # deed page needs these rows for a single deed, and writing the
+        # six queries and five judgements a second time would have been
+        # two SERVERS disagreeing about a signing's state instead of two
+        # screens disagreeing about its keys.
+        #
+        # The judgements are still signing_loop's and officer_queue's.
+        # Nothing about which states are live moved anywhere.
+        out = signing_rows.for_officer(cur, user_id)
 
     # Housekeeping rides an authenticated read rather than a public one:
     # the officer's own page is a fine place to spend 20ms, and a

--- a/backend/services/deed_page.py
+++ b/backend/services/deed_page.py
@@ -1,0 +1,441 @@
+"""The deed page's whole answer, decided here and rendered verbatim.
+
+═══ WHY THIS IS ONE PAYLOAD AND NOT FIVE FETCHES ═══
+
+The first thing the page must decide is whether it may render at all. A
+superseded deed is one the officer should not be working on, and the
+ruling is that a fact which invalidates the page cannot be rendered as an
+item on the page — it replaces the page.
+
+A screen that fetches state, activity and lineage separately renders the
+normal page first and swaps it out when lineage lands. That is the same
+defect wearing a smaller hat: for a second she is looking at a "next
+action" on a document she must not act on, and a second is long enough to
+click. So the disqualification and everything it would have replaced
+arrive together, or not at all.
+
+═══ AND WHY THE SENTENCES ARE COMPOSED IN PYTHON ═══
+
+§13 rule 3, the same rule `signing_summary` and `signing_loop` are built
+on: ONE place turns state into English. A screen that writes its own
+account of a state is a second opinion, and the second opinion is always
+the one nobody updates when a state is added.
+
+So `state`, `headline`, `sentence` and the next action's label are
+decided here. The page renders strings it was handed.
+
+═══ WHAT THIS DELIBERATELY REFUSES TO KNOW ═══
+
+The ladder stops at READY TO RECORD. We prepare documents; we do not
+record them, we are not told when the county does, and no state here may
+imply otherwise.
+
+`recorded_at` is the one thing past that line, and it is not our
+knowledge — it is the officer's own statement, carried with who made it
+and when (`recording_asserted_by`, `recording_asserted_at`). It renders
+as her assertion, attributed and terminal, because reporting what she
+told us is the opposite of asserting what we did not observe.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence
+
+# ══ THE PARTICIPANT SPLIT ═══════════════════════════════════════════
+#
+# Two headings, and the difference is not cosmetic.
+#
+#   ON THE DOCUMENT — grantor and grantee. They are text printed on an
+#   instrument. They are not users, they have no state, and there is
+#   nothing to do to them. Offering an action here would invite contact
+#   with a party to a conveyance through a tool built for coordinating
+#   colleagues.
+#
+#   WORKING ON IT — reviewer, notary, signers. Each lives in its own
+#   table, specifically so that none of them ever touches `deeds`, and
+#   each carries something an officer can do.
+
+#: The complete key set of an on-the-document party. Asserted rather
+#: than filtered — see `document_party`.
+DOCUMENT_PARTY_KEYS = frozenset({"role", "name"})
+
+#: Key fragments that mean "a way to reach a person". Matched as
+#: substrings because the defect is the CATEGORY, not any one spelling:
+#: `email`, `recipient_email`, `signer_phone` and `contact_email` are the
+#: same mistake four times.
+CONTACT_FRAGMENTS = ("email", "phone", "contact", "address_line", "mobile", "tel")
+
+
+class ContactOnTheDocument(Exception):
+    """A way to reach somebody was offered under 'On the document'."""
+
+
+def refuse_contact(field: str) -> None:
+    """Raise if `field` is a way to reach a person.
+
+    Callable, not a comment. §13.1 says signer contact details do not
+    leave their own table; this is the narrower rule that grantor and
+    grantee — who are not users of this product and never consented to
+    anything — never acquire a contact affordance because a future
+    payload happened to carry one.
+
+    A grantee is a person who is receiving property. Putting an email
+    field beside their name invites an officer to mail a stranger about
+    a conveyance, and the affordance is the invitation.
+    """
+    lowered = field.lower()
+    for fragment in CONTACT_FRAGMENTS:
+        if fragment in lowered:
+            raise ContactOnTheDocument(
+                f"{field!r} is a contact field; grantor and grantee are text "
+                "on an instrument, not people this product may reach"
+            )
+
+
+def document_party(role: str, name: Optional[str], **extra: Any) -> Optional[Dict[str, str]]:
+    """One name printed on the instrument, or nothing.
+
+    `**extra` exists so that adding a field is a DECISION rather than an
+    accident: anything passed is checked against `refuse_contact` and
+    then against the key set, so the only way to widen this shape is to
+    widen the contract on purpose.
+    """
+    for key in extra:
+        refuse_contact(key)
+    cleaned = (name or "").strip()
+    if not cleaned:
+        return None
+    out = {"role": role, "name": cleaned, **extra}
+    if set(out) != DOCUMENT_PARTY_KEYS:
+        raise ContactOnTheDocument(
+            "on-the-document parties carry a role and a name and nothing "
+            f"else: extra={sorted(set(out) - DOCUMENT_PARTY_KEYS)}"
+        )
+    return out
+
+
+def document_parties(deed: Mapping[str, Any]) -> List[Dict[str, str]]:
+    """Grantor and grantee, as printed. No contact detail, by construction."""
+    out = [
+        document_party("Grantor", deed.get("grantor_name")),
+        document_party("Grantee", deed.get("grantee_name")),
+    ]
+    return [p for p in out if p]
+
+
+def working_parties(
+    *,
+    shares: Iterable[Mapping[str, Any]] = (),
+    signings: Iterable[Mapping[str, Any]] = (),
+    participants: Iterable[Mapping[str, Any]] = (),
+) -> List[Dict[str, Any]]:
+    """Everybody with a job on this deed, and what is true of them now.
+
+    Names only, as everywhere else — §13.1. What separates these from the
+    document parties is not that we hold more about them, it is that each
+    one has a STATE that can change and an action attached to it.
+    """
+    out: List[Dict[str, Any]] = []
+    for share in shares:
+        status = (share.get("status") or "sent").strip().lower()
+        out.append({
+            "role": "Reviewer",
+            "name": (share.get("recipient_name") or "").strip() or "Reviewer",
+            "state": status,
+            "sentence": {
+                "approved": "Approved it.",
+                "rejected": "Asked for changes.",
+                "viewed": "Opened it, no answer yet.",
+                "revoked": "The link was revoked.",
+            }.get(status, "Waiting for an answer."),
+        })
+    for signing in signings:
+        notary = (signing.get("notary_name") or "").strip()
+        if notary:
+            out.append({"role": "Notary", "name": notary,
+                        "state": (signing.get("state") or "").strip(),
+                        "sentence": signing.get("summary") or ""})
+    for person in participants:
+        # `party_role` is stored lowercase ('signer'). The displayed word
+        # is composed here rather than capitalised by the screen — §13
+        # rule 3 covers the small strings too, and a screen that
+        # title-cases one label ends up title-casing a state name.
+        role = (person.get("party_role") or "").strip()
+        out.append({
+            "role": role.capitalize() if role else "Signer",
+            "name": (person.get("name") or "").strip() or "Signer",
+            "state": (person.get("answer") or "pending").strip().lower(),
+            "sentence": {
+                "available": "Said that time works.",
+                "unavailable": "Said that time does not work.",
+            }.get((person.get("answer") or "").strip().lower(),
+                  "Has not answered yet."),
+        })
+    return out
+
+
+# ══ THE DISQUALIFICATIONS ════════════════════════════════════════════
+
+def disqualification(deed: Mapping[str, Any]) -> Optional[Dict[str, Any]]:
+    """The fact that invalidates the page, or None.
+
+    Owner-ruled: this REPLACES normal content. Not a banner above a
+    working page — the working page is what must not be there. A "next
+    action" offered on a superseded deed invites work on the wrong
+    document, and the officer has no way to know it is the wrong one
+    except by us not offering.
+
+    Ordered deliberately. A deed can be both deleted and superseded, and
+    which one she is told about changes where she should go: superseded
+    sends her to the replacement, deleted sends her to the list. The
+    replacement is the more useful destination and the more consequential
+    fact, so supersession is checked first — and the ORDER is pinned,
+    because a tie-break that is not written down gets re-derived
+    differently by the next person.
+    """
+    if deed.get("superseded_at") or deed.get("superseded_by"):
+        replacement = deed.get("superseded_by")
+        return {
+            "kind": "superseded",
+            "headline": "This deed was corrected and replaced.",
+            "sentence": (
+                "A later deed supersedes this one. Work on the replacement — "
+                "anything done here would be work on the wrong document."
+            ),
+            # Where to go instead. A disqualification with no exit is a
+            # dead end wearing an explanation.
+            "go_to_deed_id": replacement,
+        }
+    if (deed.get("status") or "").strip().lower() == "deleted":
+        return {
+            "kind": "deleted",
+            "headline": "This deed was deleted.",
+            "sentence": (
+                "It is kept for the record and cannot be worked on. "
+                "Nothing here can be edited, sent or signed."
+            ),
+            "go_to_deed_id": None,
+        }
+    return None
+
+
+# ══ THE STATE, AND THE ONE OBVIOUS ACTION ════════════════════════════
+
+#: The state vocabulary of this page. Every value `state_and_next`
+#: returns is one of these, asserted before it leaves — the same
+#: discipline as `signing_summary`'s key set, and for the same reason: a
+#: screen that receives a state it has never heard of renders nothing.
+DEED_STATES = frozenset({
+    "draft",
+    "ready",
+    "in_review",
+    "changes_requested",
+    "approved",
+    "signing",
+    "ready_to_record",
+    "recorded",
+})
+
+#: Actions the page may offer. `kind` is what the screen switches on;
+#: the label is the server's words.
+#:
+#: VERBS, deliberately. The first draft used "signing", which is also a
+#: STATE — one word carrying two vocabularies, in a payload whose whole
+#: job is telling a state from an action. A pin caught the collision;
+#: renaming it was cheaper than teaching every reader which one is meant.
+ACTION_KINDS = frozenset({
+    "resume", "share_for_review", "open_signing", "download", "none"})
+
+
+def _action(kind: str, label: str) -> Dict[str, str]:
+    if kind not in ACTION_KINDS:
+        raise ValueError(f"{kind!r} is not an action this page offers")
+    return {"kind": kind, "label": label}
+
+
+def state_and_next(
+    deed: Mapping[str, Any],
+    *,
+    shares: Sequence[Mapping[str, Any]] = (),
+    signings: Sequence[Mapping[str, Any]] = (),
+) -> Dict[str, Any]:
+    """One state, one obvious action — the question she arrived with.
+
+    ═══ THE LADDER STOPS AT READY TO RECORD ═══
+
+    We are a document-preparation product. Nothing below asserts what a
+    county did, because nothing here observes a county. `recorded` is
+    above that line only because it is not our claim: it is hers, and it
+    carries her name and the moment she made it.
+
+    ═══ WHY THE ORDER IS WHAT IT IS ═══
+
+    Read top to bottom, first match wins, and the order encodes which
+    fact is most load-bearing when several are true at once. A deed can
+    be out for review AND have a live signing; the signing is the thing
+    with a date on it and people waiting, so it wins.
+
+    A rejected review beats an approved one for the opposite reason: two
+    reviewers disagreeing is not "approved", and showing the good news
+    while a change request sits unread is how a deed gets recorded with
+    a known defect in it.
+    """
+    completed = (deed.get("status") or "").strip().lower() == "completed"
+
+    if deed.get("recorded_at"):
+        # HER statement, not ours, and attributed as such. The page shows
+        # who said it and when they said it, because the alternative is a
+        # bare "Recorded" that reads as though we checked.
+        number = (deed.get("instrument_number") or "").strip()
+        return {
+            "state": "recorded",
+            "headline": "Marked as recorded",
+            "sentence": (
+                "You recorded this instrument"
+                + (f" as {number}" if number else "")
+                + ". That is your statement — we are not told by the county."
+            ),
+            "next_action": _action("download", "Download the instrument"),
+            "asserted_at": _iso(deed.get("recording_asserted_at")),
+        }
+
+    if not completed:
+        return {
+            "state": "draft",
+            "headline": "Draft",
+            "sentence": "Not generated yet. Nothing has been sent to anyone.",
+            "next_action": _action("resume", "Continue this deed"),
+            "asserted_at": None,
+        }
+
+    live = [s for s in signings if s.get("live")]
+    if live:
+        first = live[0]
+        return {
+            "state": "signing",
+            "headline": "Out for signing",
+            # WHICH signing. Without it the page can only offer "request
+            # a signing", and offering that on a deed that already has
+            # one is an invitation to create a second — three more
+            # emails and two notaries who each think they have it.
+            # CANCEL1 item 4 found exactly this on Past Deeds.
+            "signing_request_id": first.get("id"),
+            # The server's sentence about a scheduling state is
+            # signing_loop's, already composed. Rewriting it here would
+            # be the second opinion §13 rule 3 exists to prevent.
+            "sentence": first.get("summary") or "A signing is in progress.",
+            "next_action": _action("open_signing", "Open the signing"),
+            "asserted_at": None,
+        }
+
+    decisions = [(s.get("status") or "").strip().lower() for s in shares]
+    if "rejected" in decisions:
+        return {
+            "state": "changes_requested",
+            "headline": "Changes requested",
+            "sentence": (
+                "A reviewer asked for changes. Read what they said before "
+                "sending this anywhere else."
+            ),
+            "next_action": _action("share_for_review", "See the review"),
+            "asserted_at": None,
+        }
+    outstanding = [d for d in decisions if d in ("sent", "viewed", "")]
+    if outstanding:
+        return {
+            "state": "in_review",
+            "headline": "Out for review",
+            "sentence": "Sent for review. No answer yet.",
+            "next_action": _action("share_for_review", "See who has it"),
+            "asserted_at": None,
+        }
+    if "approved" in decisions:
+        return {
+            "state": "approved",
+            "headline": "Approved — ready to record",
+            "sentence": (
+                "A reviewer approved it. Recording happens at the county; "
+                "this product does not do that part and is not told when "
+                "it is done."
+            ),
+            "next_action": _action("download", "Download the instrument"),
+            "asserted_at": None,
+        }
+
+    return {
+        "state": "ready",
+        "headline": "Generated",
+        "sentence": (
+            "The instrument exists and has not been sent to anyone. "
+            "Send it for review, or out for signing."
+        ),
+        "next_action": _action("share_for_review", "Send for review"),
+        "asserted_at": None,
+    }
+
+
+def _iso(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if hasattr(value, "isoformat"):
+        return value.isoformat()
+    return str(value)
+
+
+#: Every key the page receives. Asserted, not filtered — a screen and a
+#: server that quietly disagree about a key is the defect
+#: `signing_summary` was built to end, and this page has five sections
+#: that each render nothing if their key is absent.
+DEED_PAGE_KEYS = frozenset({
+    "deed_id", "disqualified", "state", "activity", "matter",
+    "instrument", "on_the_document", "working_on_it",
+})
+
+
+def deed_page(
+    deed: Mapping[str, Any],
+    *,
+    shares: Sequence[Mapping[str, Any]] = (),
+    signings: Sequence[Mapping[str, Any]] = (),
+    participants: Sequence[Mapping[str, Any]] = (),
+    activity: Sequence[Mapping[str, Any]] = (),
+    matter: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Everything the page renders, in one answer.
+
+    When the deed is disqualified the other sections are still computed
+    and sent. That is deliberate and it is NOT a contradiction of the
+    replace-the-page rule: the rule is about what the SCREEN renders, and
+    the screen renders the disqualification alone. Sending a payload
+    whose shape changes with its content would give the page two
+    contracts, and the second one is the one nothing tests.
+    """
+    blocked = disqualification(deed)
+    out = {
+        "deed_id": deed.get("id"),
+        "disqualified": blocked,
+        "state": state_and_next(deed, shares=shares, signings=signings),
+        "activity": list(activity),
+        "matter": matter,
+        "instrument": {
+            "deed_type": deed.get("deed_type"),
+            "property_address": deed.get("property_address"),
+            "county": deed.get("county"),
+            "apn": deed.get("apn"),
+            "completed_at": _iso(deed.get("completed_at")),
+            # Downloadable only once the bytes exist. A link offered on a
+            # draft is a 404 the officer reads as a lost document.
+            "available": bool(deed.get("completed_at")),
+        },
+        "on_the_document": document_parties(deed),
+        "working_on_it": working_parties(shares=shares, signings=signings,
+                                         participants=participants),
+    }
+    assert set(out) == DEED_PAGE_KEYS, (
+        "the deed page payload no longer matches its contract: "
+        f"extra={sorted(set(out) - DEED_PAGE_KEYS)} "
+        f"missing={sorted(DEED_PAGE_KEYS - set(out))}"
+    )
+    state = out["state"]["state"]
+    assert state in DEED_STATES, f"{state!r} is not a state this page knows"
+    return out

--- a/backend/services/signing_rows.py
+++ b/backend/services/signing_rows.py
@@ -1,0 +1,128 @@
+"""Signing summary rows, assembled once, for every surface that needs them.
+
+═══ WHY THIS MOVED OUT OF THE ROUTER ═══
+
+`GET /signing-requests/v2` assembled these inline: fetch the windows, the
+responses and the participants, ask `signing_loop` for the state, ask
+`officer_queue` how long she has waited, hand the lot to
+`signing_summary_row`.
+
+That was fine while one endpoint needed them. The deed page needs the
+same rows for one deed, and the obvious way to get them — write the same
+six queries and the same five judgements in a second router — is exactly
+the defect `services/signing_summary` was created to end, one level up.
+Its docstring is about two SCREENS disagreeing about a row's keys; this
+would have been two SERVERS disagreeing about a row's state.
+
+The judgements are still `signing_loop`'s and `officer_queue`'s. Nothing
+here decides anything. It fetches what those functions need and calls
+them in the order they have always been called.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Sequence
+
+from services import officer_queue, signing_summary
+from services import signing_loop as loop
+
+
+def _rows(cur) -> List[Dict[str, Any]]:
+    return [dict(r) for r in (cur.fetchall() or [])]
+
+
+def summarise(cur, requests: Sequence[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Turn signing_request rows into the summary every officer surface reads.
+
+    `requests` must already carry `property_address`, `deed_type` and
+    `notary_name` — they come from the join, and which join differs by
+    caller (all of an officer's, or one deed's).
+    """
+    out: List[Dict[str, Any]] = []
+    for row in requests:
+        cur.execute("SELECT * FROM signing_windows WHERE signing_request_id = %s",
+                    (row["id"],))
+        windows = _rows(cur)
+        cur.execute("SELECT r.* FROM signing_responses r JOIN signing_windows w "
+                    "ON w.id = r.window_id WHERE w.signing_request_id = %s",
+                    (row["id"],))
+        responses = _rows(cur)
+        cur.execute("SELECT * FROM signing_participants WHERE signing_request_id = %s",
+                    (row["id"],))
+        participants = _rows(cur)
+
+        state = loop.request_state(row, windows, responses)
+        days_waiting = officer_queue.days_since(row.get("created_at"))
+        out.append(signing_summary.signing_summary_row(
+            row,
+            state=state,
+            live=loop.is_live(state),
+            summary=loop.state_label(row, windows, responses, participants),
+            days_waiting=days_waiting,
+            stale=(state in (loop.STATE_REQUESTED, loop.STATE_WINDOWS_POSTED)
+                   and officer_queue.is_stale(days_waiting)),
+            signers=len([p for p in participants
+                         if p["party_role"] == loop.ROLE_SIGNER]),
+        ))
+    return out
+
+
+def for_officer(cur, user_id: int) -> List[Dict[str, Any]]:
+    """Every signing this officer asked for, soonest first."""
+    cur.execute("""
+        SELECT sr.*, d.property_address, d.deed_type,
+               (SELECT display_name FROM signing_participants
+                 WHERE signing_request_id = sr.id AND party_role = 'notary'
+                 ORDER BY id LIMIT 1) AS notary_name
+          FROM signing_requests sr
+          JOIN deeds d ON d.id = sr.deed_id
+         WHERE sr.officer_user_id = %s
+         ORDER BY COALESCE(sr.booked_at, sr.expires_at) ASC
+    """, (user_id,))
+    return summarise(cur, _rows(cur))
+
+
+def for_deed(cur, deed_id: int) -> List[Dict[str, Any]]:
+    """Every signing on one deed, newest request first.
+
+    Ordered by `created_at` rather than by the appointment: on a single
+    deed the question is "what is the current attempt", and a cancelled
+    request whose appointment was later than the live one's would
+    otherwise sort above it.
+    """
+    cur.execute("""
+        SELECT sr.*, d.property_address, d.deed_type,
+               (SELECT display_name FROM signing_participants
+                 WHERE signing_request_id = sr.id AND party_role = 'notary'
+                 ORDER BY id LIMIT 1) AS notary_name
+          FROM signing_requests sr
+          JOIN deeds d ON d.id = sr.deed_id
+         WHERE sr.deed_id = %s
+         ORDER BY sr.created_at DESC
+    """, (deed_id,))
+    return summarise(cur, _rows(cur))
+
+
+def signers_for_deed(cur, deed_id: int) -> List[Dict[str, Any]]:
+    """Who is signing, and what they have said.
+
+    §13.1 — NAME AND ANSWER ONLY. `signing_participants` also holds email
+    and phone, and this is the query a future author would widen with a
+    `SELECT *` while adding one field. The column list is the boundary,
+    so widening it is a visible act.
+
+    The column is `display_name`; there is no `name`. Aliasing keeps the
+    key the consumers already read — and getting this wrong is what made
+    `/deeds/{id}/activity` 500 on every call.
+    """
+    cur.execute("""
+        SELECT p.display_name AS name, p.party_role,
+               (SELECT r.answer FROM signing_responses r
+                 WHERE r.participant_id = p.id
+                 ORDER BY r.asserted_at DESC LIMIT 1) AS answer
+          FROM signing_participants p
+          JOIN signing_requests s ON s.id = p.signing_request_id
+         WHERE s.deed_id = %s AND p.party_role = %s
+         ORDER BY p.id
+    """, (deed_id, loop.ROLE_SIGNER))
+    return _rows(cur)

--- a/backend/tests/snapshots/openapi_routes.json
+++ b/backend/tests/snapshots/openapi_routes.json
@@ -197,6 +197,10 @@
  ],
  [
   "GET",
+  "/deeds/{deed_id}/detail"
+ ],
+ [
+  "GET",
   "/deeds/{deed_id}/download"
  ],
  [

--- a/backend/tests/source_text.py
+++ b/backend/tests/source_text.py
@@ -115,6 +115,7 @@ It does not strip ordinary string literals. A pin searching for a value
 that legitimately appears in a STRING (an error message, a SQL fragment)
 is asking a different question and should say so at the call site.
 """
+import ast
 import io
 import tokenize
 from pathlib import Path
@@ -201,3 +202,36 @@ def code_only(source: Union[str, Path]) -> str:
 def read_code(*segments: str) -> str:
     """Read a file relative to `backend/` and return it as code only."""
     return code_only(Path(__file__).resolve().parent.parent.joinpath(*segments))
+
+
+def function_source(source: Union[str, Path], name: str) -> str:
+    """Exactly one function's source — its `def` line through its last line.
+
+    ═══ WHY THIS EXISTS ═══
+
+    Pins about a handler used to slice the file between two markers:
+
+        src[src.index("def supersede_endpoint("):src.index("def lineage_endpoint(")]
+
+    which means "this function AND EVERYTHING AFTER IT until a function
+    I happened to name". The moment somebody inserts a handler between
+    the two, the slice silently grows and the pin starts asserting things
+    about code it was never about.
+
+    That is exactly what happened: adding `/deeds/{id}/detail` between
+    them pulled `status <> 'deleted'` into a body asserted to contain no
+    "DELETE", and three supersession pins failed on code that had not
+    changed. A pin that fails for a reason unrelated to its rule teaches
+    people to widen it, and a widened pin is how the rule dies.
+
+    An AST span cannot drift: it ends where the function ends.
+    """
+    src = Path(source).read_text(encoding="utf-8") if isinstance(source, Path) else source
+    tree = ast.parse(src)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            lines = src.splitlines(keepends=True)
+            # `decorator_list` is excluded deliberately: a pin about what
+            # a handler DOES should not pass or fail on its route path.
+            return "".join(lines[node.lineno - 1:node.end_lineno])
+    raise AssertionError(f"no function named {name!r} in this source")

--- a/backend/tests/test_cancel1_signing_cancellation.py
+++ b/backend/tests/test_cancel1_signing_cancellation.py
@@ -148,15 +148,31 @@ def test_the_agenda_sends_the_verdict_so_no_screen_has_to_decide():
         "the agenda no longer sends the verdict, so every screen that "
         "needs it will decide for itself")
 
-    src = code_only(BACKEND / "routers" / "signing.py")
-    assert "live=loop.is_live(" in src, (
+    # The row assembly moved from the router to
+    # `services/signing_rows.py` when the deed page needed the same rows
+    # for one deed. Retargeted, and made stricter while retargeting: the
+    # rule was always "the verdict is signing_loop's", and the old pin
+    # could only see one file — so a SECOND caller forming its own
+    # verdict elsewhere would not have failed it.
+    rows = code_only(BACKEND / "services" / "signing_rows.py")
+    assert "live=loop.is_live(" in rows, (
         "the verdict is no longer signing_loop's — a second opinion about "
         "which states are over is the defect this field exists to prevent")
+
+    # ONE caller, across the whole backend, decides `live`. Anything
+    # else is the second opinion arriving by a different door.
+    callers = sorted(
+        path.relative_to(BACKEND).as_posix()
+        for path in BACKEND.rglob("*.py")
+        if "tests" not in path.parts and "__pycache__" not in path.parts
+        and "live=" in code_only(path)
+    )
+    assert callers == ["services/signing_rows.py"], (
+        f"more than one place decides `live`: {callers}")
+
     # And the vocabulary is not re-listed beside the call.
-    agenda = src[src.index("def officer_agenda"):]
-    agenda = agenda[: agenda.index("\n@router.")]
-    assert "STATE_CANCELLED" not in agenda and "STATE_EXPIRED" not in agenda, (
-        "the agenda names terminal states itself; that list belongs to "
+    assert "STATE_CANCELLED" not in rows and "STATE_EXPIRED" not in rows, (
+        "the assembler names terminal states itself; that list belongs to "
         "signing_loop and nowhere else")
 
 

--- a/backend/tests/test_dash1_officer_queue.py
+++ b/backend/tests/test_dash1_officer_queue.py
@@ -180,8 +180,12 @@ def test_only_one_place_decides_what_stale_means():
     assert "stale" in SIGNING_SUMMARY_KEYS, (
         "the agenda payload stopped carrying the verdict, so the screen "
         "has to form one")
-    payload = code_only(BACKEND / "routers" / "signing.py")
+    # Moved with the row assembly into services/signing_rows.py; the
+    # threshold itself never left officer_queue.py, which is the rule.
+    payload = code_only(BACKEND / "services" / "signing_rows.py")
     assert "officer_queue.is_stale(" in payload
+    assert "STALE_AFTER_DAYS" not in payload, (
+        "the assembler copied the threshold instead of asking for it")
 
 
 def test_the_queue_never_infers_that_a_signing_happened():

--- a/backend/tests/test_deed_page.py
+++ b/backend/tests/test_deed_page.py
@@ -1,0 +1,319 @@
+"""DEEDDETAIL Unit 2 — the deed page's answer, and what it refuses to say.
+
+═══ THE RULE THIS FILE IS BUILT AROUND ═══
+
+A fact that invalidates the page cannot be rendered as an item on the
+page. A superseded deed is one the officer should not be working on, and
+a "next action" offered beside a warning is an invitation to work on the
+wrong document — she has no way to know it is the wrong one except by us
+not offering.
+
+So the disqualification is not a banner. It is the answer to "is there a
+page", asked before anything else is composed.
+
+═══ AND THE ONE IT IS BUILT AGAINST ═══
+
+We prepare documents. We do not record them, we are never told when a
+county does, and no state here may imply otherwise. The ladder stops at
+ready-to-record.
+
+`recorded` sits past that line for exactly one reason: it is not our
+claim. It is the officer's, carried with who asserted it and when. That
+is the difference between reporting what somebody told us and asserting
+what we did not observe.
+"""
+import pytest
+
+from services.deed_page import (
+    ACTION_KINDS, CONTACT_FRAGMENTS, DEED_PAGE_KEYS, DEED_STATES,
+    ContactOnTheDocument, deed_page, disqualification, document_parties,
+    document_party, refuse_contact, state_and_next, working_parties,
+)
+
+
+def _deed(**over):
+    row = {"id": 7, "status": "completed", "deed_type": "grant-deed",
+           "property_address": "123 Baseline St", "county": "Los Angeles",
+           "grantor_name": "Jane Doe", "grantee_name": "John Roe",
+           "completed_at": "2026-08-01T00:00:00Z"}
+    row.update(over)
+    return row
+
+
+# ── 1. The disqualification replaces the page ────────────────────────
+
+def test_a_superseded_deed_is_disqualified():
+    got = disqualification(_deed(superseded_at="2026-08-02T00:00:00Z",
+                                 superseded_by=9))
+    assert got["kind"] == "superseded"
+    assert got["go_to_deed_id"] == 9
+
+
+def test_a_deleted_deed_is_disqualified():
+    assert disqualification(_deed(status="deleted"))["kind"] == "deleted"
+
+
+def test_an_ordinary_deed_is_not():
+    assert disqualification(_deed()) is None
+
+
+def test_supersession_outranks_deletion_and_the_order_is_the_point():
+    """Both can be true, and which she is told changes where she goes.
+
+    THE ORDER IS PINNED, NOT THE OUTCOME. Either order is defensible; an
+    unwritten tie-break is one the next person re-derives differently,
+    and the difference here is whether she is handed the replacement or
+    sent back to a list.
+    """
+    got = disqualification(_deed(status="deleted", superseded_by=9,
+                                 superseded_at="2026-08-02T00:00:00Z"))
+    assert got["kind"] == "superseded"
+    assert got["go_to_deed_id"] == 9
+
+
+def test_a_disqualification_always_has_an_exit():
+    """A dead end wearing an explanation is still a dead end."""
+    for row in (_deed(superseded_at="x", superseded_by=9),
+                _deed(status="deleted")):
+        got = disqualification(row)
+        assert got["headline"] and got["sentence"]
+
+
+def test_the_payload_still_carries_every_section_when_disqualified():
+    """The REPLACE rule is about what the SCREEN renders.
+
+    A payload whose shape changes with its content gives the page two
+    contracts, and the second one is the one nothing tests. The screen
+    renders the disqualification alone; the server keeps one shape.
+    """
+    out = deed_page(_deed(superseded_at="x", superseded_by=9))
+    assert set(out) == DEED_PAGE_KEYS
+    assert out["disqualified"] is not None
+    assert out["state"] is not None
+
+
+# ── 2. One state, one obvious action ─────────────────────────────────
+
+@pytest.mark.parametrize("row,shares,signings,expected", [
+    (_deed(status="draft"), [], [], "draft"),
+    (_deed(), [], [], "ready"),
+    (_deed(), [{"status": "sent"}], [], "in_review"),
+    (_deed(), [{"status": "approved"}], [], "approved"),
+    (_deed(), [{"status": "rejected"}], [], "changes_requested"),
+    (_deed(), [], [{"live": True, "summary": "Waiting on two signers."}], "signing"),
+    (_deed(recorded_at="2026-08-05T00:00:00Z"), [], [], "recorded"),
+])
+def test_the_ladder(row, shares, signings, expected):
+    got = state_and_next(row, shares=shares, signings=signings)
+    assert got["state"] == expected
+    assert got["state"] in DEED_STATES
+
+
+def test_a_change_request_beats_an_approval():
+    """Two reviewers disagreeing is not "approved".
+
+    Showing the good news while a change request sits unread is how a
+    deed gets recorded with a known defect in it.
+    """
+    got = state_and_next(_deed(), shares=[{"status": "approved"},
+                                          {"status": "rejected"}])
+    assert got["state"] == "changes_requested"
+
+
+def test_a_live_signing_beats_a_review():
+    """The signing has a date on it and people waiting."""
+    got = state_and_next(_deed(), shares=[{"status": "sent"}],
+                         signings=[{"live": True, "summary": "Booked."}])
+    assert got["state"] == "signing"
+
+
+def test_a_dead_signing_does_not():
+    got = state_and_next(_deed(), shares=[{"status": "sent"}],
+                         signings=[{"live": False, "summary": "Cancelled."}])
+    assert got["state"] == "in_review"
+
+
+def test_the_signing_sentence_is_the_servers_not_a_second_one():
+    """§13 rule 3. `signing_loop` already composed an account of this
+    scheduling state; composing another here is the second opinion, and
+    the second opinion is the one nobody updates."""
+    got = state_and_next(_deed(), signings=[
+        {"live": True, "summary": "Waiting on Maria and two signers."}])
+    assert got["sentence"] == "Waiting on Maria and two signers."
+
+
+def test_every_state_offers_exactly_one_action_of_a_known_kind():
+    for row, shares, signings in [
+        (_deed(status="draft"), [], []),
+        (_deed(), [], []),
+        (_deed(), [{"status": "sent"}], []),
+        (_deed(), [{"status": "approved"}], []),
+        (_deed(), [{"status": "rejected"}], []),
+        (_deed(), [], [{"live": True, "summary": "x"}]),
+        (_deed(recorded_at="2026-08-05T00:00:00Z"), [], []),
+    ]:
+        action = state_and_next(row, shares=shares, signings=signings)["next_action"]
+        assert action["kind"] in ACTION_KINDS
+
+
+# ── THE LADDER STOPS AT READY TO RECORD ──────────────────────────────
+
+def test_no_state_claims_a_county_did_anything():
+    """THE PIN THIS FILE EXISTS FOR.
+
+    Sweep every reachable state. Nothing in a headline or a sentence may
+    assert that this instrument was recorded, filed, accepted or
+    rejected by a recorder — we do not observe any of that, and a
+    product that says so is asserting what it did not see.
+
+    `recorded` is exempt from the phrasing sweep and gets its own,
+    stricter test below: it is allowed to use the word precisely because
+    it attributes it.
+    """
+    forbidden = ("was recorded by", "the county has", "filed with the county",
+                 "accepted by the recorder", "rejected by the recorder",
+                 "recording confirmed")
+    for row, shares, signings in [
+        (_deed(status="draft"), [], []),
+        (_deed(), [], []),
+        (_deed(), [{"status": "sent"}], []),
+        (_deed(), [{"status": "approved"}], []),
+        (_deed(), [{"status": "rejected"}], []),
+        (_deed(), [], [{"live": True, "summary": "x"}]),
+    ]:
+        got = state_and_next(row, shares=shares, signings=signings)
+        blob = f"{got['headline']} {got['sentence']}".lower()
+        for phrase in forbidden:
+            assert phrase not in blob, f"{got['state']} claims: {phrase}"
+
+
+def test_recorded_is_attributed_to_her_and_never_to_us():
+    """The one state past the line, and why it is allowed there."""
+    got = state_and_next(_deed(recorded_at="2026-08-05T00:00:00Z",
+                               instrument_number="2026-123456",
+                               recording_asserted_at="2026-08-05T10:00:00Z"))
+    assert got["state"] == "recorded"
+    assert "You recorded" in got["sentence"]
+    # It says out loud that the county did not tell us.
+    assert "not told by the county" in got["sentence"]
+    # And it carries WHEN she said so — §13.2, the assertion is the event.
+    assert got["asserted_at"] == "2026-08-05T10:00:00Z"
+
+
+def test_the_instrument_number_is_hers_when_she_gave_one():
+    got = state_and_next(_deed(recorded_at="x", instrument_number="2026-123456"))
+    assert "2026-123456" in got["sentence"]
+    plain = state_and_next(_deed(recorded_at="x"))
+    assert "as " not in plain["sentence"].split(".")[0]
+
+
+# ── The participants split ───────────────────────────────────────────
+
+def test_on_the_document_carries_a_role_and_a_name_and_nothing_else():
+    assert document_parties(_deed()) == [
+        {"role": "Grantor", "name": "Jane Doe"},
+        {"role": "Grantee", "name": "John Roe"},
+    ]
+
+
+@pytest.mark.parametrize("field", [
+    "email", "recipient_email", "phone", "signer_phone", "contact",
+    "contact_email", "address_line1", "mobile", "tel",
+])
+def test_a_contact_field_can_never_appear_under_on_the_document(field):
+    """THE PIN THE SPLIT EXISTS FOR, and it is callable rather than a
+    comment.
+
+    A grantee is a person receiving property. They are not a user of this
+    product and never consented to anything. Putting an email beside
+    their name invites an officer to mail a stranger about a conveyance —
+    and the affordance IS the invitation.
+
+    Matched as a category, not as one spelling: `email`,
+    `recipient_email`, `signer_phone` and `contact_email` are the same
+    mistake four times.
+    """
+    with pytest.raises(ContactOnTheDocument, match="is a contact field"):
+        refuse_contact(field)
+
+    # ═══ AND THE CONSTRUCTOR REFUSES IT AS A CONTACT ═══
+    #
+    # A mutation probe deleted `refuse_contact(key)` from
+    # `document_party` and this test still passed: the key-set assert
+    # below it raises the SAME exception type, so the contact rule could
+    # be removed entirely without a failure.
+    #
+    # That is the vocabulary trap again — a test written in the terms of
+    # the thing it checks cannot notice that thing collapsing. Matching
+    # the REASON tells the two refusals apart, so deleting the contact
+    # check fails here even though something still raises.
+    with pytest.raises(ContactOnTheDocument, match="is a contact field"):
+        document_party("Grantee", "John Roe", **{field: "x@y.z"})
+
+
+def test_even_a_harmless_extra_field_is_refused():
+    """Not because a nickname is dangerous, but because the shape is the
+    guarantee. If anything may be added, the contact rule is a habit."""
+    with pytest.raises(ContactOnTheDocument):
+        document_party("Grantee", "John Roe", nickname="Jack")
+
+
+def test_the_fragments_cover_what_the_participants_table_actually_holds():
+    """A rule that does not match the real column names is decoration."""
+    for column in ("email", "phone"):
+        assert any(f in column for f in CONTACT_FRAGMENTS)
+
+
+def test_an_unnamed_party_is_absent_rather_than_blank():
+    assert document_parties(_deed(grantee_name="   ")) == [
+        {"role": "Grantor", "name": "Jane Doe"}]
+
+
+def test_working_parties_carry_state_because_that_is_what_makes_them_different():
+    out = working_parties(
+        shares=[{"recipient_name": "Maria", "status": "approved"}],
+        signings=[{"notary_name": "Ana", "state": "booked", "summary": "Booked."}],
+        participants=[{"name": "John Roe", "party_role": "signer",
+                       "answer": "available"}],
+    )
+    assert [p["role"] for p in out] == ["Reviewer", "Notary", "Signer"]
+    assert all(p["state"] and p["sentence"] for p in out)
+
+
+def test_the_two_lists_never_merge():
+    """One is text on an instrument; the other is people with jobs."""
+    out = deed_page(_deed(), shares=[{"recipient_name": "Maria", "status": "sent"}])
+    assert {p["name"] for p in out["on_the_document"]} == {"Jane Doe", "John Roe"}
+    assert "Maria" not in {p["name"] for p in out["on_the_document"]}
+    assert set(out["on_the_document"][0]) == {"role", "name"}
+
+
+# ── The instrument ───────────────────────────────────────────────────
+
+def test_a_draft_offers_no_download():
+    """A link before the bytes exist is a 404 she reads as a lost
+    document."""
+    out = deed_page(_deed(status="draft", completed_at=None))
+    assert out["instrument"]["available"] is False
+
+
+def test_a_generated_deed_does():
+    assert deed_page(_deed())["instrument"]["available"] is True
+
+
+# ── The contract ─────────────────────────────────────────────────────
+
+def test_the_payload_shape_is_asserted_not_filtered():
+    out = deed_page(_deed())
+    assert set(out) == DEED_PAGE_KEYS
+
+
+def test_the_activity_is_passed_through_untouched():
+    """This module does not re-sort, re-word or re-classify the feed.
+    `deed_activity` decided what is an EVENT and what is a DERIVED
+    timestamp, and a second opinion about that is the fabrication risk
+    that whole module exists to hold down."""
+    entries = [{"at": "2026-08-01T00:00:00Z", "kind": "event",
+                "what": "deed.generated", "sentence": "Deed generated.",
+                "source": "deeds.completed_at"}]
+    assert deed_page(_deed(), activity=entries)["activity"] == entries

--- a/backend/tests/test_endpoint_sql.py
+++ b/backend/tests/test_endpoint_sql.py
@@ -1,0 +1,178 @@
+"""Every statement these endpoints run is parsed by a real Postgres.
+
+═══ THE DEFECT THAT MADE THIS FILE ═══
+
+`GET /deeds/{id}/activity` shipped with
+
+    SELECT r.answer, r.asserted_at, p.name, p.party_role
+
+and `signing_participants` has no `name` column — it has `display_name`.
+Postgres rejects an unknown column at PARSE time, so the endpoint
+returned 500 on every call, for every deed, whether or not any signing
+existed. It was not a rare path. It was the only path.
+
+It shipped green because the pins were unit tests over
+`deed_activity.activity()` with dict fixtures. Those tests are good and
+they test the right thing — the epistemics of the feed — but a dict
+fixture agrees with whatever key you type into it. **The statement had
+never once been executed.**
+
+Third time this class has cost something: `users.updated_at` (a column
+the code wrote and the database lacked), `:items::jsonb` (a statement
+SQLAlchemy could not parse, on a webhook nothing ever posted), and now
+this. Every one of them was invisible to a suite that mocks the cursor.
+
+═══ WHAT THIS TESTS, AND WHAT IT DOES NOT ═══
+
+It asks Postgres to PREPARE each statement. That proves every table
+exists, every column exists and is spelled right, and the parameter
+count matches. It does not prove the query returns the right rows —
+that is what the endpoint tests do.
+
+Parsing is the half that mocks can never cover, and it is the half that
+has cost three incidents.
+"""
+import os
+
+import psycopg2
+import pytest
+from db_rows import ROW_FACTORY
+
+pytestmark = pytest.mark.skipif(
+    not os.getenv("DATABASE_URL"),
+    reason="needs a real Postgres — this test's whole point is the parser",
+)
+
+
+#: (label, sql, parameter count). Statements are named by the endpoint or
+#: helper they belong to, so a failure says which surface is broken
+#: rather than which line number moved.
+STATEMENTS = [
+    (
+        "GET /deeds/{id}/activity — shares",
+        """SELECT id, recipient_name, recipient_email, status,
+                  created_at, viewed_at, responded_at
+             FROM deed_shares WHERE deed_id = $1""",
+    ),
+    (
+        "GET /deeds/{id}/activity — signings",
+        """SELECT id, created_at, booked_asserted_at, booked_by, cancelled_at
+             FROM signing_requests WHERE deed_id = $1""",
+    ),
+    (
+        "GET /deeds/{id}/activity — responses (the one that was broken)",
+        """SELECT r.answer, r.asserted_at, p.display_name AS name, p.party_role
+             FROM signing_responses r
+             JOIN signing_participants p ON p.id = r.participant_id
+             JOIN signing_requests s ON s.id = p.signing_request_id
+            WHERE s.deed_id = $1""",
+    ),
+    (
+        "signing_rows.for_deed",
+        """SELECT sr.*, d.property_address, d.deed_type,
+                  (SELECT display_name FROM signing_participants
+                    WHERE signing_request_id = sr.id AND party_role = 'notary'
+                    ORDER BY id LIMIT 1) AS notary_name
+             FROM signing_requests sr
+             JOIN deeds d ON d.id = sr.deed_id
+            WHERE sr.deed_id = $1
+            ORDER BY sr.created_at DESC""",
+    ),
+    (
+        "signing_rows.for_officer",
+        """SELECT sr.*, d.property_address, d.deed_type,
+                  (SELECT display_name FROM signing_participants
+                    WHERE signing_request_id = sr.id AND party_role = 'notary'
+                    ORDER BY id LIMIT 1) AS notary_name
+             FROM signing_requests sr
+             JOIN deeds d ON d.id = sr.deed_id
+            WHERE sr.officer_user_id = $1
+            ORDER BY COALESCE(sr.booked_at, sr.expires_at) ASC""",
+    ),
+    (
+        "signing_rows.signers_for_deed (§13.1 — name and answer only)",
+        """SELECT p.display_name AS name, p.party_role,
+                  (SELECT r.answer FROM signing_responses r
+                    WHERE r.participant_id = p.id
+                    ORDER BY r.asserted_at DESC LIMIT 1) AS answer
+             FROM signing_participants p
+             JOIN signing_requests s ON s.id = p.signing_request_id
+            WHERE s.deed_id = $1 AND p.party_role = $2
+            ORDER BY p.id""",
+    ),
+    (
+        "signing_rows.summarise — windows",
+        "SELECT * FROM signing_windows WHERE signing_request_id = $1",
+    ),
+    (
+        "signing_rows.summarise — responses",
+        """SELECT r.* FROM signing_responses r
+             JOIN signing_windows w ON w.id = r.window_id
+            WHERE w.signing_request_id = $1""",
+    ),
+    (
+        "signing_rows.summarise — participants",
+        "SELECT * FROM signing_participants WHERE signing_request_id = $1",
+    ),
+    (
+        "GET /deeds/{id}/detail — the deed row",
+        """SELECT d.*, u.role FROM deeds d
+             LEFT JOIN users u ON u.id = $1
+            WHERE d.id = $2 AND (d.user_id = $3 OR u.role = 'admin')""",
+    ),
+    (
+        "GET /deeds/{id}/detail — shares",
+        """SELECT id, recipient_name, recipient_email, status,
+                  created_at, viewed_at, responded_at
+             FROM deed_shares WHERE deed_id = $1 ORDER BY created_at DESC""",
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def conn():
+    c = psycopg2.connect(os.environ["DATABASE_URL"], cursor_factory=ROW_FACTORY)
+    yield c
+    c.close()
+
+
+@pytest.mark.parametrize("label,sql", STATEMENTS, ids=[s[0] for s in STATEMENTS])
+def test_the_database_can_parse_it(conn, label, sql):
+    """PREPARE, not EXECUTE.
+
+    Preparing resolves every table and column and refuses an unknown one,
+    which is exactly the failure that shipped — and it does so without
+    inserting a row or depending on one existing. A test that needed
+    fixture data would be skipped on an empty database, which is the
+    database CI runs against.
+    """
+    with conn.cursor() as cur:
+        try:
+            cur.execute(f"PREPARE _probe AS {sql}")
+            cur.execute("DEALLOCATE _probe")
+        except psycopg2.Error as e:
+            conn.rollback()
+            pytest.fail(f"{label}: {type(e).__name__}: {str(e).splitlines()[0]}")
+        conn.rollback()
+
+
+def test_the_column_that_started_this_still_does_not_exist(conn):
+    """The regression, named.
+
+    If somebody adds a `name` column to `signing_participants` this test
+    fails — and that is the correct outcome, not a nuisance: two columns
+    meaning the name would be the same disease this codebase has spent
+    three tickets on, and the alias would silently start reading the
+    wrong one.
+    """
+    with conn.cursor() as cur:
+        cur.execute("""
+            SELECT column_name FROM information_schema.columns
+             WHERE table_name = 'signing_participants'
+               AND column_name IN ('name', 'display_name')
+             ORDER BY column_name
+        """)
+        found = sorted(r["column_name"] for r in cur.fetchall())
+    assert found == ["display_name"], (
+        f"expected display_name and nothing like it; found {found}"
+    )

--- a/backend/tests/test_supersession.py
+++ b/backend/tests/test_supersession.py
@@ -13,7 +13,7 @@ longer describes, silently.
 """
 import pytest
 
-from tests.source_text import code_only
+from tests.source_text import code_only, function_source
 from pathlib import Path
 
 from services.supersession import (
@@ -120,24 +120,35 @@ def test_the_only_write_is_the_pointer():
         )
 
 
+# These three read the supersede handler's EXACT span.
+#
+# They used to slice the file from `def supersede_endpoint(` to
+# `def lineage_endpoint(` — "this function and everything after it until
+# a function I happened to name". Inserting `/deeds/{id}/detail` between
+# the two pulled its `status <> 'deleted'` into the slice and failed the
+# no-DELETE assert on code that had not changed.
+#
+# The rule is unchanged and the coverage is now exactly the rule's
+# subject. `function_source` ends where the function ends.
+
 def test_supersession_never_deletes():
-    src = code_only(BACKEND / "routers/deeds_crud.py")
-    body = src[src.index("def supersede_endpoint("):src.index("def lineage_endpoint(")]
+    body = code_only(function_source(BACKEND / "routers/deeds_crud.py",
+                                     "supersede_endpoint"))
     assert "DELETE" not in body.upper()
 
 
 def test_the_write_is_guarded_in_sql_not_only_in_python():
     """Two concurrent corrections must not both win. The application
     check cannot promise that; the IS NULL predicate can."""
-    src = code_only(BACKEND / "routers/deeds_crud.py")
-    body = src[src.index("def supersede_endpoint("):src.index("def lineage_endpoint(")]
+    body = code_only(function_source(BACKEND / "routers/deeds_crud.py",
+                                     "supersede_endpoint"))
     assert "superseded_by IS NULL" in body
 
 
 def test_the_officer_is_told_a_correction_is_a_new_instrument():
     """We record the relationship; we do not un-record documents."""
-    src = (BACKEND / "routers/deeds_crud.py").read_text(encoding="utf-8")
-    body = src[src.index("def supersede_endpoint("):src.index("def lineage_endpoint(")]
+    body = function_source(BACKEND / "routers/deeds_crud.py",
+                           "supersede_endpoint")
     assert "new instrument" in body
     assert "un-record" in body
 

--- a/frontend/src/__tests__/deedDetailPage.test.ts
+++ b/frontend/src/__tests__/deedDetailPage.test.ts
@@ -1,0 +1,246 @@
+/**
+ * DEEDDETAIL Unit 2 — the deed page, in the ruled order.
+ *
+ * ═══ THE RULE THE PAGE IS ORGANISED AROUND ═══
+ *
+ * A fact that invalidates the page cannot be rendered as an item on the
+ * page. A superseded deed is one she should not be working on; a "next
+ * action" offered beside a warning invites work on the wrong document,
+ * and she has no way to know it is the wrong one except by us not
+ * offering.
+ *
+ * So the disqualification is not a banner above a working page. The
+ * working page is what must not be there.
+ *
+ * ═══ AND THE ONE ABOUT WHO SAYS THINGS ═══
+ *
+ * §13 rule 3: one place turns state into English, and it is Python.
+ * Every sentence an officer reads about this deed's STATE was composed
+ * in `services/deed_page.py`. A screen that writes its own account is
+ * the second opinion, and the second opinion is the one nobody updates
+ * when a state is added.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
+import {
+  ACTION_KINDS, DEED_DETAIL_KEYS, DEED_STATES, isRecordedAct, knownState,
+  renders,
+} from '../features/deed/deedDetail';
+
+const SRC = path.join(__dirname, '..');
+const read = (...p: string[]) => fs.readFileSync(path.join(SRC, ...p), 'utf8');
+const PAGE = codeOnly(read('app', 'deeds', '[id]', 'page.tsx'));
+const AGENDA = codeOnly(read('features', 'signing', 'SigningAgenda.tsx'));
+const PAST_DEEDS = codeOnly(read('app', 'past-deeds', 'page.tsx'));
+const DASHBOARD = codeOnly(read('app', 'dashboard', 'page.tsx'));
+
+const PY = fs.readFileSync(
+  path.join(SRC, '..', '..', 'backend', 'services', 'deed_page.py'), 'utf8');
+
+describe('the disqualification replaces the page', () => {
+  it('renders() is false whenever the deed is disqualified', () => {
+    expect(renders({ disqualified: null })).toBe(true);
+    expect(renders({
+      disqualified: { kind: 'superseded', headline: '', sentence: '', go_to_deed_id: 9 },
+    })).toBe(false);
+    // A payload that never arrived is not a page either.
+    expect(renders(null)).toBe(false);
+  });
+
+  it('the page gates its whole body on it, not just a banner', () => {
+    /**
+     * THE PIN THIS FILE EXISTS FOR. The state block, the activity, the
+     * participants, the matter and the instrument all sit inside ONE
+     * `renders(detail)` guard — so there is no arrangement of the JSX in
+     * which a next action appears beside a supersession warning.
+     */
+    expect(PAGE).toContain('renders(detail) && detail && (');
+    // And exactly one such guard: a second one is a second chance to get
+    // the nesting wrong.
+    expect((PAGE.match(/renders\(detail\)/g) || []).length).toBe(1);
+  });
+
+  it('the disqualified block offers no next action', () => {
+    const at = PAGE.indexOf('data-testid="disqualified"');
+    expect(at).toBeGreaterThan(-1);
+    const block = PAGE.slice(at, PAGE.indexOf('renders(detail)'));
+    expect(block).not.toContain('next_action');
+    expect(block).not.toContain('act(');
+  });
+
+  it('and always offers a way out', () => {
+    const at = PAGE.indexOf('data-testid="disqualified"');
+    const block = PAGE.slice(at, PAGE.indexOf('renders(detail)'));
+    expect(block).toContain('go_to_deed_id');
+    expect(block).toContain('/past-deeds');
+  });
+});
+
+describe('the page fetches once', () => {
+  it('one call carries the disqualification and what it would replace', () => {
+    /**
+     * A screen that fetched lineage separately would render the working
+     * page first and swap it out when lineage landed. That is the same
+     * defect wearing a smaller hat — for a second she is looking at an
+     * action on a document she must not act on, and a second is long
+     * enough to click.
+     */
+    expect(PAGE).toContain('/detail');
+    for (const separate of ['/lineage', '/matter', '/activity']) {
+      expect(PAGE).not.toContain(`${separate}\``);
+    }
+  });
+
+  it('a failed load says so rather than rendering an empty deed', () => {
+    // An empty page reads as "a deed with nothing on it", which is a
+    // different and much worse claim than "we could not load this".
+    expect(PAGE).toContain('Could not load this deed');
+    expect(PAGE).toContain('Try again');
+  });
+});
+
+describe('no sentence about state is composed here', () => {
+  it('the page renders the server strings verbatim', () => {
+    expect(PAGE).toContain('{detail.state.headline}');
+    expect(PAGE).toContain('{detail.state.sentence}');
+    expect(PAGE).toContain('{detail.state.next_action.label}');
+  });
+
+  it('and holds no state vocabulary of its own', () => {
+    /**
+     * The failure this prevents: a screen that switches on state names
+     * to pick its own wording. The moment a state is added, the screen's
+     * switch silently has no arm for it.
+     */
+    for (const state of DEED_STATES) {
+      if (state === 'draft') continue; // `?resume=` lives on the action, not a label
+      expect(PAGE).not.toContain(`'${state}'`);
+    }
+  });
+
+  it('an unknown state is a visible gap, never a confident guess', () => {
+    expect(knownState('signing')).toBe(true);
+    expect(knownState('recorded_by_county')).toBe(false);
+    expect(PAGE).toContain('knownState(detail.state.state)');
+    expect(PAGE).toContain('does not recognise yet');
+  });
+});
+
+describe('both languages declare the same contract', () => {
+  it('the state vocabulary matches DEED_STATES in Python', () => {
+    /**
+     * The merged tracker declared eleven fields against an endpoint that
+     * sent fourteen, and the three it did not declare were the three
+     * that mattered. A screen cannot render what it never named, and
+     * nothing failed. This is the referee.
+     */
+    const block = PY.slice(PY.indexOf('DEED_STATES = frozenset({'));
+    const python = (block.slice(0, block.indexOf('})')).match(/"([a-z_]+)"/g) || [])
+      .map((s) => s.replace(/"/g, ''));
+    expect([...DEED_STATES].sort()).toEqual(python.sort());
+  });
+
+  it('the action kinds match', () => {
+    const block = PY.slice(PY.indexOf('ACTION_KINDS = frozenset({'));
+    const python = (block.slice(0, block.indexOf('})')).match(/"([a-z_]+)"/g) || [])
+      .map((s) => s.replace(/"/g, ''));
+    expect([...ACTION_KINDS].sort()).toEqual(python.sort());
+  });
+
+  it('the payload key set matches', () => {
+    const block = PY.slice(PY.indexOf('DEED_PAGE_KEYS = frozenset({'));
+    const python = (block.slice(0, block.indexOf('})')).match(/"([a-z_]+)"/g) || [])
+      .map((s) => s.replace(/"/g, ''));
+    expect([...DEED_DETAIL_KEYS].sort()).toEqual(python.sort());
+  });
+});
+
+describe('the activity keeps the distinction the API went to trouble over', () => {
+  it('an event and a derived timestamp are told apart', () => {
+    expect(isRecordedAct({ kind: 'event' })).toBe(true);
+    expect(isRecordedAct({ kind: 'derived' })).toBe(false);
+  });
+
+  it('and the page renders them with different weight', () => {
+    // If the screen flattens them, the API's structural split bought
+    // nothing — and the first person to add "expired" will do it because
+    // everything already looked like an event.
+    expect((PAGE.match(/isRecordedAct\(e\)/g) || []).length).toBeGreaterThan(1);
+  });
+
+  it('an empty feed says nothing happened rather than inventing', () => {
+    expect(PAGE).toContain('Nothing recorded on this deed yet');
+  });
+});
+
+describe('the participants split', () => {
+  it('two headings, and the document one carries no action', () => {
+    expect(PAGE).toContain('On the document');
+    expect(PAGE).toContain('Working on it');
+    const at = PAGE.indexOf('data-testid="on-the-document"');
+    expect(at).toBeGreaterThan(-1);
+    const block = PAGE.slice(at, at + 600);
+    expect(block).not.toContain('onClick');
+    expect(block).not.toContain('href');
+  });
+
+  it('the signing modal is seeded from the list that cannot hold contacts', () => {
+    // Names only — and specifically the on-the-document names, which are
+    // structurally incapable of carrying a way to reach anybody.
+    expect(PAGE).toContain('suggestedSigners={(detail?.on_the_document || []).map((p) => p.name)}');
+  });
+});
+
+describe('the orphan is resolved', () => {
+  it('Past Deeds links every row to its deed', () => {
+    expect(PAST_DEEDS).toContain('href={`/deeds/${deed.id}`}');
+  });
+
+  it('the dashboard queue lands on the deed, not the tracker', () => {
+    expect(DASHBOARD).toContain('router.push(`/deeds/${r.deed_id}`)');
+  });
+
+  it('idle drafts still go straight to the builder', () => {
+    // Deliberate: a draft has exactly one action, and the deed page
+    // would offer that same action one navigation later.
+    expect(DASHBOARD).toContain('?resume=${r.id}`)');
+  });
+
+  it("#178's Share fix is reachable — the dialog opens in place", () => {
+    expect(PAGE).toContain('<ShareForReviewModal');
+    expect(PAGE).toContain('onSwitchToSigning');
+    // Not a navigation to another screen to ask the same question again.
+    expect(PAGE).not.toContain('/past-deeds?id=');
+  });
+});
+
+describe('the agenda panel collapsed to a link', () => {
+  it('the row navigates instead of expanding', () => {
+    expect(AGENDA).toContain('href={`/deeds/${row.deed_id}`}');
+    expect(AGENDA).not.toContain('<SigningDetail');
+    expect(AGENDA).not.toContain('aria-expanded');
+  });
+
+  it('state, summary and the stuck marking stay inline', () => {
+    // These are what scanning across every file needs, and that is the
+    // question this list can answer and the deed page cannot.
+    expect(AGENDA).toContain('{row.summary}');
+    expect(AGENDA).toContain('Gone quiet');
+    expect(AGENDA).toContain('STATE_LABEL[row.state]');
+  });
+
+  it('cancelling MOVED rather than disappearing', () => {
+    /**
+     * The named cost — cancel goes from one click to navigate-plus-click
+     * — was accepted. Cancel ceasing to exist was not, and deleting the
+     * panel without a home for it would have done exactly that.
+     *
+     * One component, rendered in the new place. Not a second copy.
+     */
+    const detail = read('features', 'signing', 'SigningDetail.tsx');
+    expect(detail).toContain('export function SigningDetail');
+    expect(detail).toContain('Cancel this signing request');
+  });
+});

--- a/frontend/src/__tests__/flowSmalls.test.ts
+++ b/frontend/src/__tests__/flowSmalls.test.ts
@@ -46,8 +46,18 @@ describe('U3 — deed types display as names, not slugs', () => {
   it('Past Deeds rows carry grantee and doc id', () => {
     const pastDeeds = codeOnly(readSource('app', 'past-deeds', 'page.tsx'));
     expect(pastDeeds).toContain('deed.grantee_name');
-    // X2.7 promoted the doc id from an under-address line to its own column.
-    expect(pastDeeds).toContain('>#{deed.id}</td>');
+    // X2.7 promoted the doc id from an under-address line to its own
+    // column. DEEDDETAIL made it a link to the deed page, so the id is
+    // no longer the cell's only child — the rule (its own column) is
+    // unchanged and the pin now says that rather than describing markup.
+    // Its own <td>, and that cell links to the deed. Asserted as two
+    // facts rather than as one exact string of markup, because the
+    // previous spelling (`>#{deed.id}</td>`) broke on wrapping the id in
+    // a link — correct code failing a pin that described a layout.
+    const cell = pastDeeds.slice(0, pastDeeds.indexOf('#{deed.id}'));
+    expect(cell.lastIndexOf('<td')).toBeGreaterThan(cell.lastIndexOf('</td>'));
+    expect(cell.lastIndexOf('<Link')).toBeGreaterThan(cell.lastIndexOf('<td'));
+    expect(pastDeeds).toContain('href={`/deeds/${deed.id}`}');
   });
 });
 

--- a/frontend/src/__tests__/officerTrackers.test.ts
+++ b/frontend/src/__tests__/officerTrackers.test.ts
@@ -57,6 +57,10 @@ const SIGNINGS = read('features', 'signing', 'SigningAgenda.tsx');
  *  sharedDeedsContract.test.ts for the retarget reasoning. */
 const SHARED = read('app', 'requests', 'page.tsx');
 const SIGNINGS_CODE = codeOnly(SIGNINGS);
+/** DEEDDETAIL: the agenda's expanding panel became its own component and
+ *  is rendered on the deed page. The pins about the PANEL read it here;
+ *  the pins about the ROW still read the agenda. */
+const DETAIL_CODE = codeOnly(read('features', 'signing', 'SigningDetail.tsx'));
 const SUMMARY_CODE = codeOnly(read('features', 'signing', 'signingSummary.ts'));
 
 /** A signing row with only the fields a test cares about named. */
@@ -163,24 +167,40 @@ describe('FLOW1 item 4 — the card opens the signing', () => {
     expect(SIGNINGS_CODE).not.toContain("onOpen={() => router.push(`/past-deeds`)}");
   });
 
-  it('the row expands onto the signing itself', () => {
-    expect(SIGNINGS_CODE).toContain('aria-expanded={open}');
-    expect(flat(SIGNINGS_CODE)).toContain('apiFetch(`/signing-requests/v2/${requestId}`');
+  it('the row LEADS to the signing itself — it no longer expands onto it', () => {
+    /**
+     * DEEDDETAIL retargeted this, and the direction is worth naming: the
+     * rule was "a row leads somewhere", and it still does. What changed
+     * is where the panel lives.
+     *
+     * The tracker's job is the CROSS-DEED question — what has gone quiet
+     * across every file. A panel that opens one signing in place answers
+     * a single-deed question in the middle of it, and single-deed is
+     * exactly what the deed page is for.
+     *
+     * The named cost was accepted: cancel goes from one click to
+     * navigate-plus-click.
+     */
+    expect(SIGNINGS_CODE).toContain('href={`/deeds/${row.deed_id}`}');
+    expect(SIGNINGS_CODE).not.toContain('aria-expanded');
+    // And the detail it used to fetch is fetched by the component that
+    // moved — same request, one place.
+    expect(flat(DETAIL_CODE)).toContain('apiFetch(`/signing-requests/v2/${requestId}`');
   });
 
   it('is linkable, so a notification can point at one signing', () => {
-    /* The agenda is a component now; the merged page reads `?focus=` and
-       hands down the id, so the parameter is parsed in exactly one place
-       for both kinds of row. */
+    /* `?focus=` still reaches a row; it marks it rather than expanding
+       it. The parameter is still parsed in exactly one place for both
+       kinds of row, which is the rule this pin is actually about. */
     expect(SIGNINGS_CODE).toContain('focusId');
-    expect(SIGNINGS_CODE).toContain('useState<number | null>(focusId)');
+    expect(SIGNINGS_CODE).toContain('focused={focusId === r.id}');
     expect(SHARED_CODE).toContain('focusId={focus.kind === "signings" ? focus.id : null}');
   });
 
   it('a detail that fails to load says so rather than looking empty', () => {
     // §4: an empty panel would read as "this signing has no
-    // participants", which is a claim.
-    expect(SIGNINGS_CODE).toContain('Could not load this signing');
+    // participants", which is a claim. The panel moved; the rule did not.
+    expect(DETAIL_CODE).toContain('Could not load this signing');
   });
 });
 

--- a/frontend/src/__tests__/signingCancel.test.ts
+++ b/frontend/src/__tests__/signingCancel.test.ts
@@ -23,6 +23,13 @@ import { cancelWarning } from '../lib/signingCopy';
 
 const SIGNINGS = codeOnly(
   fs.readFileSync(path.join(__dirname, '..', 'features', 'signing', 'SigningAgenda.tsx'), 'utf8'));
+/** DEEDDETAIL: the agenda's expanding panel — the only place cancelling
+ *  has ever lived — became its own component, rendered on the deed page.
+ *  The pins about the PANEL read it here. */
+const PANEL = codeOnly(
+  fs.readFileSync(path.join(__dirname, '..', 'features', 'signing', 'SigningDetail.tsx'), 'utf8'));
+const DEED_PAGE = codeOnly(
+  fs.readFileSync(path.join(__dirname, '..', 'app', 'deeds', '[id]', 'page.tsx'), 'utf8'));
 
 describe('which states are over is the server’s judgement', () => {
   it('the screen holds no terminal-state list', () => {
@@ -105,19 +112,39 @@ describe('the cancel confirmation names what is being cancelled', () => {
 
 describe('the panel that had no controls', () => {
   it('offers the cancel, behind a confirmation', () => {
-    expect(SIGNINGS).toContain('Cancel this signing request');
-    expect(SIGNINGS).toContain('cancelWarning');
-    expect(SIGNINGS).toContain('Keep it');
+    expect(PANEL).toContain('Cancel this signing request');
+    expect(PANEL).toContain('cancelWarning');
+    expect(PANEL).toContain('Keep it');
   });
 
   it('does not compose its own scheduling sentence', () => {
+    expect(PANEL).not.toMatch(/scheduled for/i);
+    expect(PANEL).not.toMatch(/will (happen|take place)/i);
+    // The agenda row never did either, and still must not.
     expect(SIGNINGS).not.toMatch(/scheduled for/i);
-    expect(SIGNINGS).not.toMatch(/will (happen|take place)/i);
   });
 
   it('shows a cancelled request rather than hiding it', () => {
     /** T-5: a cancelled request that HAD a booked time still had one.
      * The row moves to the closed list and keeps saying what happened. */
-    expect(SIGNINGS).toContain('detail.cancelled_at');
+    expect(PANEL).toContain('detail.cancelled_at');
+  });
+
+  it('AND IT IS STILL REACHABLE — the panel moved, it did not close', () => {
+    /**
+     * The pin this retarget exists for.
+     *
+     * Collapsing the agenda row to a link removed the only surface that
+     * had ever offered cancelling. Retargeting the three pins above to
+     * the extracted component proves the CODE survived; it does not
+     * prove anything RENDERS it, and a component nothing mounts is the
+     * same as a deleted one.
+     *
+     * The named cost of the ruling was an extra navigation. A silently
+     * unreachable cancel would not have been a cost, it would have been
+     * a removed feature.
+     */
+    expect(DEED_PAGE).toContain('<SigningDetail');
+    expect(DEED_PAGE).toContain('requestId={detail.state.signing_request_id}');
   });
 });

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -442,7 +442,11 @@ function ActionQueue({ queue, error }: { queue: Queue | null; error: string | nu
                 hour: 'numeric', minute: '2-digit',
               })}${r.who ? ` · ${r.who}` : ''}`,
               urgent: false,
-              onOpen: () => router.push(`/requests?kind=signings&focus=${r.id}`),
+              // DEEDDETAIL: the deed, not the tracker. The queue's job is
+              // "what needs me"; the answer to "and then what" is the
+              // deed page's state-and-next-action, which the tracker
+              // cannot show because it is a cross-deed list.
+              onOpen: () => router.push(`/deeds/${r.deed_id}`),
             }))}
           />
           <QueueList
@@ -458,9 +462,11 @@ function ActionQueue({ queue, error }: { queue: Queue | null; error: string | nu
                   : `${r.days_waiting} day${r.days_waiting === 1 ? '' : 's'}`
               }`,
               urgent: r.stale,
-              onOpen: () => router.push(
-                r.kind === 'signing' ? `/requests?kind=signings&focus=${r.id}`
-                                    : `/requests?kind=reviews&focus=${r.id}`),
+              // Both kinds land on the same page, because from here the
+              // question is the same one: what is happening on this deed
+              // and what do I do about it. Which table the delay lives in
+              // is our problem, not hers.
+              onOpen: () => router.push(`/deeds/${r.deed_id}`),
             }))}
           />
           <QueueList
@@ -472,6 +478,9 @@ function ActionQueue({ queue, error }: { queue: Queue | null; error: string | nu
               detail: 'Draft — nobody is waiting on this but you.',
               meta: r.days_idle === null ? 'untouched' : `${r.days_idle} days`,
               urgent: false,
+              // Deliberately NOT the deed page. A draft has exactly one
+              // action and the deed page would only offer that same
+              // action one navigation later — a hop that buys nothing.
               onOpen: () => router.push(
                 `/deed-builder/${r.deed_type || 'grant-deed'}?resume=${r.id}`),
             }))}

--- a/frontend/src/app/deeds/[id]/page.tsx
+++ b/frontend/src/app/deeds/[id]/page.tsx
@@ -1,0 +1,402 @@
+'use client';
+
+/**
+ * The deed page — the thing every surface has been linking around.
+ *
+ * ═══ THE ORDER IS THE DESIGN ═══
+ *
+ * Ranked by how likely each element is to change what she does next:
+ *
+ *   1. Whether this page may exist at all (superseded / deleted).
+ *   2. The state, and the one obvious action — the question she arrived
+ *      with.
+ *   3. What changed since she was last here.
+ *   4. One level out: the other documents on this file.
+ *   5. The instrument. She made it; she does not need to read it.
+ *
+ * ═══ WHAT THIS FILE DOES NOT DO ═══
+ *
+ * It composes no sentence about state. Every such string was written in
+ * `services/deed_page.py` and is rendered verbatim (§13 rule 3). A
+ * screen that writes its own account of a state is the second opinion,
+ * and the second opinion is the one nobody updates.
+ *
+ * It also fetches ONCE. The disqualification and the content it would
+ * replace arrive together, because a page that learns it is invalid on a
+ * second round-trip shows the working version first — and a second is
+ * long enough to click.
+ */
+
+import React, { Suspense, useCallback, useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import Link from 'next/link';
+import {
+  AlertTriangle, ArrowRight, Building2, Clock, Download,
+  FileText, Users,
+} from 'lucide-react';
+import { toast } from 'sonner';
+import Sidebar from '@/components/Sidebar';
+import { SessionExpiredError, apiFetch } from '@/lib/apiClient';
+import { PartnersProvider } from '@/features/partners/PartnersContext';
+import { useRequireAuth } from '@/hooks/useRequireAuth';
+import { ShareForReviewModal } from '@/features/signing/ShareForReviewModal';
+import { RequestSigningModal } from '@/features/signing/RequestSigningModal';
+import { SigningDetail } from '@/features/signing/SigningDetail';
+import {
+  DeedDetail, isRecordedAct, knownState, renders,
+} from '@/features/deed/deedDetail';
+import '@/styles/dashboard.css';
+
+export default function DeedPage() {
+  // A deed is somebody's document. The route-guard pin caught this
+  // missing on the first draft of this page — which is the pin doing
+  // exactly its job: a new authenticated route is precisely where the
+  // guard gets forgotten, because everything renders fine without it
+  // until the fetch 401s.
+  const { checked } = useRequireAuth();
+  if (!checked) return null;
+
+  return (
+    <Suspense fallback={null}>
+      <PartnersProvider>
+        <DeedPageInner />
+      </PartnersProvider>
+    </Suspense>
+  );
+}
+
+function DeedPageInner() {
+  const params = useParams();
+  const router = useRouter();
+  const deedId = String(params.id);
+
+  const [detail, setDetail] = useState<DeedDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [failed, setFailed] = useState<string | null>(null);
+  const [showShare, setShowShare] = useState(false);
+  const [showSigning, setShowSigning] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const res = await apiFetch(`/deeds/${deedId}/detail`, {}, { label: 'Deed' });
+      if (!res.ok) {
+        // A failed load says so. The alternative — an empty page — reads
+        // as a deed with nothing on it, which is a different and much
+        // worse claim than "we could not load this".
+        const body = await res.json().catch(() => ({}));
+        setFailed(String(body.detail || `Could not load this deed (${res.status}).`));
+        return;
+      }
+      setDetail(await res.json());
+      setFailed(null);
+    } catch (err) {
+      if (!(err instanceof SessionExpiredError)) {
+        setFailed('Could not reach the server.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [deedId]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const download = async () => {
+    const res = await apiFetch(`/deeds/${deedId}/download`, {}, { label: 'Download' });
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      toast.error(String(body.detail || 'The instrument could not be served.'),
+                  { duration: 12000 });
+      return;
+    }
+    const url = window.URL.createObjectURL(await res.blob());
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `deed-${deedId}.pdf`;
+    a.click();
+    window.URL.revokeObjectURL(url);
+  };
+
+  const act = (kind: string) => {
+    if (kind === 'resume') router.push(`/create-deed?resume=${deedId}`);
+    else if (kind === 'share_for_review') setShowShare(true);
+    // `open_signing` scrolls to the panel that is already on the page —
+    // it never opens the CREATE modal. Offering "request a signing" on a
+    // deed that already has one is an invitation to make a second, which
+    // is three more emails and two notaries who each think they have it.
+    else if (kind === 'open_signing') {
+      document.getElementById('the-signing')?.scrollIntoView({ behavior: 'smooth' });
+    }
+    else if (kind === 'download') void download();
+  };
+
+  return (
+    <div className="flex min-h-screen bg-slate-50">
+      <Sidebar />
+      <main className="flex-1 p-6 md:p-10 overflow-auto">
+        <div className="max-w-3xl mx-auto">
+          {loading && <p className="text-slate-500">Loading this deed…</p>}
+
+          {!loading && failed && (
+            <div className="rounded-xl border border-red-200 bg-red-50 p-6">
+              <p className="font-semibold text-red-800">{failed}</p>
+              <button onClick={() => { setLoading(true); void load(); }}
+                      className="mt-3 underline font-medium text-red-700">
+                Try again
+              </button>
+            </div>
+          )}
+
+          {/* ══ 1. THE DISQUALIFICATION ═══════════════════════════════
+              It REPLACES the page. Not a banner above a working page —
+              the working page is what must not be here. Offering a next
+              action on a superseded deed invites work on the wrong
+              document, and she has no way to know it is the wrong one
+              except by us not offering. */}
+          {detail?.disqualified && (
+            <div data-testid="disqualified"
+                 className="rounded-2xl border-2 border-amber-300 bg-amber-50 p-8">
+              <div className="flex items-start gap-4">
+                <AlertTriangle className="w-8 h-8 text-amber-600 shrink-0" />
+                <div>
+                  <h1 className="text-2xl font-bold text-amber-900">
+                    {detail.disqualified.headline}
+                  </h1>
+                  <p className="mt-2 text-amber-800">{detail.disqualified.sentence}</p>
+                  <div className="mt-6 flex flex-wrap gap-3">
+                    {detail.disqualified.go_to_deed_id && (
+                      <Link href={`/deeds/${detail.disqualified.go_to_deed_id}`}
+                            className="inline-flex items-center gap-2 bg-amber-700 text-white font-semibold px-4 py-2.5 rounded-lg">
+                        Go to the replacement
+                        <ArrowRight className="w-4 h-4" />
+                      </Link>
+                    )}
+                    <Link href="/past-deeds"
+                          className="inline-flex items-center gap-2 border-2 border-amber-700 text-amber-800 font-semibold px-4 py-2.5 rounded-lg">
+                      Back to all deeds
+                    </Link>
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {renders(detail) && detail && (
+            <>
+              {/* ══ 2. STATE, AND THE ONE OBVIOUS ACTION ═══════════════ */}
+              <section data-testid="state" className="mb-10">
+                <p className="text-sm text-slate-500">
+                  {detail.instrument.property_address || 'This deed'}
+                </p>
+                {knownState(detail.state.state) ? (
+                  <>
+                    <h1 className="text-3xl font-bold text-slate-900 mt-1">
+                      {detail.state.headline}
+                    </h1>
+                    <p className="mt-2 text-slate-700">{detail.state.sentence}</p>
+                  </>
+                ) : (
+                  /* A state this screen has never heard of renders as a
+                     visible gap, never as a confident guess. */
+                  <p className="mt-2 text-slate-700">
+                    This deed is in a state this page does not recognise yet.
+                  </p>
+                )}
+                {detail.state.next_action && detail.state.next_action.kind !== 'none' && (
+                  <button
+                    onClick={() => act(detail.state.next_action!.kind)}
+                    className="mt-5 inline-flex items-center gap-2 bg-[#7C4DFF] text-white font-semibold px-5 py-3 rounded-lg"
+                  >
+                    {detail.state.next_action.label}
+                    <ArrowRight className="w-4 h-4" />
+                  </button>
+                )}
+              </section>
+
+              {/* THE SIGNING, IN FULL — the panel that used to expand
+                  inside the agenda row. It moved here rather than
+                  closing, so cancelling still exists; the ruling's named
+                  cost was an extra navigation, not a lost action. Same
+                  component, not a second copy. */}
+              {detail.state.signing_request_id && (
+                <section id="the-signing" data-testid="the-signing"
+                         className="mb-10 rounded-xl border border-slate-200 bg-white">
+                  <SigningDetail
+                    requestId={detail.state.signing_request_id}
+                    onCancelled={() => void load()}
+                  />
+                </section>
+              )}
+
+              {/* ══ 3. WHAT CHANGED SINCE SHE WAS LAST HERE ═══════════ */}
+              <section data-testid="activity" className="mb-10">
+                <h2 className="flex items-center gap-2 text-lg font-semibold text-slate-800 mb-3">
+                  <Clock className="w-5 h-5 text-slate-400" /> Activity
+                </h2>
+                {detail.activity.length === 0 ? (
+                  /* Thin is the honest answer. Padding it is the whole
+                     defect deed_activity.py was written to refuse. */
+                  <p className="text-sm text-slate-500">
+                    Nothing recorded on this deed yet.
+                  </p>
+                ) : (
+                  <ol className="space-y-2">
+                    {detail.activity.map((e, i) => (
+                      <li key={`${e.source}-${e.at}-${i}`}
+                          className="flex items-baseline gap-3 text-sm">
+                        {/* An EVENT is something somebody did whose record
+                            survives. A DERIVED entry is a column that
+                            merely carries a time. The API separated them
+                            so a screen could not flatten them back out —
+                            so they do not get the same weight. */}
+                        <span className={isRecordedAct(e)
+                          ? 'w-2 h-2 rounded-full bg-[#7C4DFF] shrink-0 translate-y-1'
+                          : 'w-2 h-2 rounded-full border border-slate-300 shrink-0 translate-y-1'} />
+                        <span className={isRecordedAct(e)
+                          ? 'text-slate-800' : 'text-slate-500'}>
+                          {e.sentence}
+                        </span>
+                        <span className="ml-auto text-slate-400 shrink-0">
+                          {new Date(e.at).toLocaleDateString()}
+                        </span>
+                      </li>
+                    ))}
+                  </ol>
+                )}
+              </section>
+
+              {/* ══ PARTICIPANTS, SPLIT ═══════════════════════════════
+                  Two headings, and the split is not cosmetic. Grantor and
+                  grantee are TEXT ON AN INSTRUMENT: no contact details,
+                  no actions, by design — they are not users of this
+                  product and never consented to anything. The rule is
+                  enforced in Python (`deed_page.refuse_contact`), because
+                  a rule enforced by a component is a rule the next
+                  component does not have. */}
+              <section data-testid="participants" className="mb-10 grid md:grid-cols-2 gap-6">
+                <div>
+                  <h2 className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-slate-500 mb-3">
+                    <FileText className="w-4 h-4" /> On the document
+                  </h2>
+                  {detail.on_the_document.length === 0 ? (
+                    <p className="text-sm text-slate-400">Not named yet.</p>
+                  ) : (
+                    <ul data-testid="on-the-document" className="space-y-2">
+                      {detail.on_the_document.map((p) => (
+                        <li key={p.role} className="text-sm">
+                          <span className="text-slate-500">{p.role}: </span>
+                          <span className="text-slate-800 font-medium">{p.name}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+                <div>
+                  <h2 className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-slate-500 mb-3">
+                    <Users className="w-4 h-4" /> Working on it
+                  </h2>
+                  {detail.working_on_it.length === 0 ? (
+                    <p className="text-sm text-slate-400">Nobody yet.</p>
+                  ) : (
+                    <ul className="space-y-2">
+                      {detail.working_on_it.map((p, i) => (
+                        <li key={`${p.role}-${p.name}-${i}`} className="text-sm">
+                          <span className="text-slate-500">{p.role}: </span>
+                          <span className="text-slate-800 font-medium">{p.name}</span>
+                          <span className="block text-slate-500">{p.sentence}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </div>
+              </section>
+
+              {/* ══ 4. ONE LEVEL OUT ══════════════════════════════════ */}
+              {detail.matter && (
+                <section data-testid="matter" className="mb-10">
+                  <h2 className="flex items-center gap-2 text-lg font-semibold text-slate-800 mb-3">
+                    <Building2 className="w-5 h-5 text-slate-400" />
+                    File {detail.matter.key.value}
+                  </h2>
+                  {detail.matter.documents.length === 0 ? (
+                    <p className="text-sm text-slate-500">
+                      This is the only document on this file.
+                    </p>
+                  ) : (
+                    <ul className="space-y-2">
+                      {detail.matter.documents.map((d) => (
+                        <li key={d.id} className="text-sm">
+                          <Link href={`/deeds/${d.id}`}
+                                className="font-medium text-[#7C4DFF] hover:underline">
+                            #{d.id} {d.deed_type?.replace(/[-_]/g, ' ')}
+                          </Link>
+                          <span className="text-slate-500"> · {d.status}</span>
+                          {!!d.parties.length && (
+                            <span className="text-slate-500"> · {d.parties.join(', ')}</span>
+                          )}
+                        </li>
+                      ))}
+                    </ul>
+                  )}
+                </section>
+              )}
+
+              {/* ══ 5. THE INSTRUMENT — a named line, not a frame ══════
+                  She made this document. Embedding a viewer would put the
+                  least decision-changing element in the most space. */}
+              <section data-testid="instrument"
+                       className="rounded-xl border border-slate-200 bg-white p-5 flex items-center justify-between gap-4 flex-wrap">
+                <div className="min-w-0">
+                  <p className="font-medium text-slate-800">
+                    {(detail.instrument.deed_type || 'Deed').replace(/[-_]/g, ' ')}
+                  </p>
+                  <p className="text-sm text-slate-500 truncate">
+                    {[detail.instrument.county && `${detail.instrument.county} County`,
+                      detail.instrument.apn && `APN ${detail.instrument.apn}`]
+                      .filter(Boolean).join(' · ')}
+                  </p>
+                </div>
+                {detail.instrument.available ? (
+                  <button onClick={() => void download()}
+                          className="inline-flex items-center gap-2 border-2 border-slate-300 text-slate-700 font-semibold px-4 py-2 rounded-lg">
+                    <Download className="w-4 h-4" /> Download
+                  </button>
+                ) : (
+                  /* No link on a draft. A download offered before the
+                     bytes exist is a 404 she reads as a lost document. */
+                  <span className="text-sm text-slate-400">
+                    Not generated yet
+                  </span>
+                )}
+              </section>
+            </>
+          )}
+        </div>
+      </main>
+
+      {/* #178's fix, now reachable: Share opens the dialog in place
+          rather than navigating to another screen to ask again. */}
+      {showShare && (
+        <ShareForReviewModal
+          deedId={Number(deedId)}
+          onClose={() => { setShowShare(false); void load(); }}
+          // FLOW1's interrupt has somewhere to go here: this page has a
+          // signing flow, so "did you mean a signing?" can be acted on
+          // rather than merely asked.
+          onSwitchToSigning={() => { setShowShare(false); setShowSigning(true); }}
+        />
+      )}
+      {showSigning && (
+        <RequestSigningModal
+          deedId={Number(deedId)}
+          propertyAddress={detail?.instrument.property_address || undefined}
+          // NAMES ONLY, and specifically the ON-THE-DOCUMENT names —
+          // which is the whole point of the split. That list is
+          // structurally incapable of carrying a way to reach anybody,
+          // so a starting point drawn from it cannot leak one.
+          suggestedSigners={(detail?.on_the_document || []).map((p) => p.name)}
+          onClose={() => { setShowSigning(false); void load(); }}
+        />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/app/past-deeds/page.tsx
+++ b/frontend/src/app/past-deeds/page.tsx
@@ -2,6 +2,7 @@
 
 import type React from "react"
 import { Suspense, useState, useEffect } from "react"
+import Link from "next/link"
 import { useRouter, useSearchParams } from "next/navigation"
 import Sidebar from "@/components/Sidebar"
 import { FileText, Download, Share2, Trash2, AlertCircle, CheckCircle, Clock, X, Plus, Loader2, Search, CalendarClock } from "lucide-react"
@@ -403,11 +404,24 @@ function PastDeedsList() {
                             : index % 2 === 0 ? "bg-white" : "bg-slate-50/50"
                         }`}
                       >
-                        <td className="py-4 px-6 font-mono text-sm text-slate-600">#{deed.id}</td>
+                        <td className="py-4 px-6 font-mono text-sm text-slate-600">
+                          {/* DEEDDETAIL: the id is the way in. Every row
+                              here used to be a set of actions with no
+                              document behind them — the deed page existed
+                              at no URL, so "open this deed" was the one
+                              thing this list could not do. */}
+                          <Link href={`/deeds/${deed.id}`}
+                                className="hover:underline hover:text-[#7C4DFF]">
+                            #{deed.id}
+                          </Link>
+                        </td>
                         <td className="py-4 px-6">
                           {/* U3: a row identifies its deed — address alone
                               can't when one property has several. */}
-                          <p className="font-medium text-slate-800">{deed.property_address}</p>
+                          <Link href={`/deeds/${deed.id}`}
+                                className="font-medium text-slate-800 hover:text-[#7C4DFF] hover:underline">
+                            {deed.property_address}
+                          </Link>
                           {deed.grantee_name ? (
                             <p className="text-sm text-slate-500">To {deed.grantee_name}</p>
                           ) : partyNames(deed) ? (

--- a/frontend/src/app/requests/page.tsx
+++ b/frontend/src/app/requests/page.tsx
@@ -731,7 +731,6 @@ function SharedDeedsTracker() {
               error={signingError}
               staleAfterDays={staleAfterDays}
               focusId={focus.kind === "signings" ? focus.id : null}
-              onChanged={fetchSharedDeeds}
             />
           )}
         </div>

--- a/frontend/src/features/deed/deedDetail.ts
+++ b/frontend/src/features/deed/deedDetail.ts
@@ -1,0 +1,168 @@
+/**
+ * The deed page's contract, in the language that renders it.
+ *
+ * ═══ THE SHAPE IS DECLARED, NOT INFERRED ═══
+ *
+ * `services/deed_page.py` asserts its key set before the payload leaves.
+ * This is the other half: the screen declares the same keys, so the two
+ * languages can be compared by a test rather than by whoever notices a
+ * blank section.
+ *
+ * That comparison is not paranoia. The merged tracker declared eleven
+ * fields against an endpoint that sent fourteen, and the three it did
+ * not declare were the three that mattered — a screen cannot render a
+ * field it never named, and nothing failed.
+ *
+ * ═══ NO SENTENCE IS COMPOSED HERE ═══
+ *
+ * §13 rule 3. Every string an officer reads about this deed's STATE was
+ * written in Python. The functions below decide layout and nothing else:
+ * what to show, never what to say.
+ */
+
+/** The state vocabulary. Mirrors `deed_page.DEED_STATES` exactly. */
+export const DEED_STATES = [
+  'draft',
+  'ready',
+  'in_review',
+  'changes_requested',
+  'approved',
+  'signing',
+  'ready_to_record',
+  'recorded',
+] as const;
+export type DeedState = (typeof DEED_STATES)[number];
+
+/**
+ * Mirrors `deed_page.ACTION_KINDS`.
+ *
+ * VERBS, deliberately. The first draft called one of these `signing`,
+ * which is also a STATE — one word carrying two vocabularies in a
+ * payload whose job is telling a state from an action. A pin caught it.
+ */
+export const ACTION_KINDS = [
+  'resume', 'share_for_review', 'open_signing', 'download', 'none'] as const;
+export type ActionKind = (typeof ACTION_KINDS)[number];
+
+export interface DeedAction {
+  kind: ActionKind;
+  label: string;
+}
+
+export interface DeedStateBlock {
+  state: DeedState;
+  headline: string;
+  sentence: string;
+  next_action: DeedAction | null;
+  asserted_at: string | null;
+  /** Present on `signing`: WHICH signing, so "open the signing" opens
+   *  the one that exists rather than starting a second. */
+  signing_request_id?: number | null;
+}
+
+export interface Disqualification {
+  kind: 'superseded' | 'deleted';
+  headline: string;
+  sentence: string;
+  go_to_deed_id: number | null;
+}
+
+/** An activity entry. `kind` is the epistemic claim — see deed_activity.py. */
+export interface ActivityEntry {
+  at: string;
+  kind: 'event' | 'derived';
+  what: string;
+  sentence: string;
+  source: string;
+}
+
+export interface DocumentParty {
+  role: string;
+  name: string;
+}
+
+export interface WorkingParty {
+  role: string;
+  name: string;
+  state: string;
+  sentence: string;
+}
+
+export interface MatterDocument {
+  id: number;
+  deed_type: string;
+  status: string;
+  property_address?: string | null;
+  parties: string[];
+}
+
+export interface DeedDetail {
+  deed_id: number;
+  disqualified: Disqualification | null;
+  state: DeedStateBlock;
+  activity: ActivityEntry[];
+  matter: {
+    key: { kind: string; value: string };
+    documents: MatterDocument[];
+    carry_forward?: { not_carried?: string[] };
+  } | null;
+  instrument: {
+    deed_type?: string | null;
+    property_address?: string | null;
+    county?: string | null;
+    apn?: string | null;
+    completed_at: string | null;
+    available: boolean;
+  };
+  on_the_document: DocumentParty[];
+  working_on_it: WorkingParty[];
+}
+
+/** Every key the screen declares. Compared against Python's set. */
+export const DEED_DETAIL_KEYS = [
+  'deed_id', 'disqualified', 'state', 'activity', 'matter',
+  'instrument', 'on_the_document', 'working_on_it',
+] as const;
+
+/**
+ * May the page render its normal content?
+ *
+ * The owner's ruling, as one callable question: a fact that invalidates
+ * the page cannot be rendered as an item ON the page. A superseded deed
+ * is one she should not be working on, and a "next action" offered
+ * beside the warning is an invitation to work on the wrong document.
+ *
+ * So this is not "should we show a banner". It is "is there a page".
+ */
+export function renders(detail: Pick<DeedDetail, 'disqualified'> | null): boolean {
+  return !!detail && !detail.disqualified;
+}
+
+/**
+ * The activity entries, newest first, with the epistemic split kept.
+ *
+ * EVENTS and DERIVED timestamps are not merged and not re-sorted
+ * together into one indistinguishable list — the API went to the trouble
+ * of separating them in the payload precisely so a screen could not
+ * flatten the distinction back out.
+ *
+ * They still render in one chronological column, because that is the
+ * question ("what changed since I was here"). What differs is that a
+ * derived entry is never given the visual weight of a recorded act.
+ */
+export function isRecordedAct(entry: Pick<ActivityEntry, 'kind'>): boolean {
+  return entry.kind === 'event';
+}
+
+/**
+ * Does this payload carry a state the screen can render?
+ *
+ * A state the screen has never heard of is the failure mode that shipped
+ * blank sections before: the server adds a value, the screen's switch
+ * has no arm for it, and the officer gets an empty box where the answer
+ * to her question should be. Answered honestly rather than defaulted —
+ * a wrong state rendered confidently is worse than a visible gap.
+ */
+export function knownState(state: string): state is DeedState {
+  return (DEED_STATES as readonly string[]).includes(state);
+}

--- a/frontend/src/features/signing/SigningAgenda.tsx
+++ b/frontend/src/features/signing/SigningAgenda.tsx
@@ -37,42 +37,17 @@
  * is the server's own label, rendered in the REQUEST's timezone.
  */
 
-import { useEffect, useState } from 'react';
-import { AlertCircle, CalendarClock, CheckCircle2, Clock, Loader2 } from 'lucide-react';
-import { SessionExpiredError, apiFetch } from '@/lib/apiClient';
-import { cancelWarning } from '@/lib/signingCopy';
+import Link from 'next/link';
+import { AlertCircle, CalendarClock, CheckCircle2, Clock } from 'lucide-react';
 import {
   SigningSummary, STATE_LABEL, groupSignings, isStuck,
 } from './signingSummary';
-
-/** What `GET /signing-requests/v2/{id}` returns for one signing. */
-type Detail = {
-  state: string;
-  summary: string;
-  property_address: string | null;
-  booked_at: string | null;
-  cancelled_at: string | null;
-  participants: Array<{
-    id: number;
-    party_role: string;
-    name: string | null;
-    viewed_at: string | null;
-    revoked: boolean;
-  }>;
-  windows: Array<{
-    id: number;
-    label: string;
-    declined: boolean;
-    waiting_on: string[];
-  }>;
-};
 
 export function SigningAgenda({
   rows,
   error,
   staleAfterDays,
   focusId,
-  onChanged,
 }: {
   rows: SigningSummary[];
   /** The signings half failing must not blank the reviews half. The
@@ -81,12 +56,10 @@ export function SigningAgenda({
   /** The threshold travels with the queue payload, so the sentence
    *  explaining the amber banner can say the number without knowing it. */
   staleAfterDays: number | null;
-  /** `?kind=signings&focus=<id>` opens that signing. A notification about
-   *  one signing should be able to point at that signing. */
+  /** `?kind=signings&focus=<id>` still points at a row — it marks it
+   *  rather than expanding it, now that the panel is a link. */
   focusId: number | null;
-  onChanged: () => void;
 }) {
-  const [open, setOpen] = useState<number | null>(focusId);
   const groups = groupSignings(rows);
   const stuck = rows.filter(isStuck);
 
@@ -98,9 +71,7 @@ export function SigningAgenda({
         </h2>
         <div className={`space-y-3 ${dimmed ? 'opacity-70' : ''}`}>
           {items.map((r) => (
-            <SigningRow key={r.id} row={r} open={open === r.id}
-                        onToggle={() => setOpen(open === r.id ? null : r.id)}
-                        onCancelled={onChanged} />
+            <SigningRow key={r.id} row={r} focused={focusId === r.id} />
           ))}
         </div>
       </>
@@ -156,25 +127,33 @@ export function SigningAgenda({
  * returns the participants, their links, whether each has opened theirs,
  * and every window with who is still outstanding on it.
  */
-function SigningRow({ row, open, onToggle, onCancelled }: {
+function SigningRow({ row, focused }: {
   row: SigningSummary;
-  open: boolean;
-  onToggle: () => void;
-  /* A cancelled request moves from the agenda to the closed list, and
-     the grouping is the server's — so the list is re-read rather than
-     patched here. Same reason the summary is never composed locally. */
-  onCancelled: () => void;
+  /* `?kind=signings&focus=<id>` still points at a row; it just marks it
+     rather than expanding it. */
+  focused: boolean;
 }) {
   const stuck = isStuck(row);
   const booked = row.state === 'booked';
   const age = row.days_waiting;
 
   return (
-    <div className={`bg-white rounded-xl border ${stuck ? 'border-amber-300' : 'border-slate-200'}`}>
-      <button
-        onClick={onToggle}
-        aria-expanded={open}
-        className="w-full text-left p-4 hover:bg-slate-50 rounded-xl transition-colors"
+    <div className={`bg-white rounded-xl border ${
+      focused ? 'border-[#7C4DFF] ring-2 ring-[#7C4DFF]/20'
+      : stuck ? 'border-amber-300' : 'border-slate-200'}`}>
+      {/* THE PANEL COLLAPSED TO A LINK.
+          This row used to expand in place and fetch one signing's
+          participants, times and Cancel. That answers a single-deed
+          question in the middle of a screen whose job is the cross-deed
+          one — scanning what has gone quiet across every file, which is
+          the question this list can answer and the deed page structurally
+          cannot.
+          State, summary and the stuck marking stay inline, because those
+          are what scanning needs. Everything else is one navigation away,
+          and cancelling costs a click more on purpose. */}
+      <Link
+        href={`/deeds/${row.deed_id}`}
+        className="block w-full text-left p-4 hover:bg-slate-50 rounded-xl transition-colors"
       >
         <div className="flex items-start justify-between gap-4">
           <div className="min-w-0">
@@ -216,173 +195,8 @@ function SigningRow({ row, open, onToggle, onCancelled }: {
             {stuck ? 'Gone quiet' : STATE_LABEL[row.state] || row.state}
           </span>
         </div>
-      </button>
-      {open && <SigningDetail requestId={row.id} onCancelled={onCancelled} />}
+      </Link>
     </div>
   );
 }
 
-/** The detail, fetched when she opens it. */
-function SigningDetail({ requestId, onCancelled }: {
-  requestId: number;
-  onCancelled: () => void;
-}) {
-  const [detail, setDetail] = useState<Detail | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [confirming, setConfirming] = useState(false);
-  const [cancelling, setCancelling] = useState(false);
-
-  const cancel = async () => {
-    setCancelling(true);
-    setError(null);
-    try {
-      const r = await apiFetch(`/signing-requests/v2/${requestId}/cancel`, { method: 'POST' },
-                               { label: 'Cancelling this signing' });
-      if (!r.ok) {
-        throw new Error((await r.json().catch(() => ({}))).detail || `Failed (${r.status})`);
-      }
-      setDetail(await r.json());
-      setConfirming(false);
-      onCancelled();
-    } catch (err) {
-      if (err instanceof SessionExpiredError) return;
-      // §4: a cancellation that did not happen must not look like one
-      // that did. The panel says so and the request stays live.
-      setError(err instanceof Error ? err.message : 'Could not cancel this signing');
-    } finally {
-      setCancelling(false);
-    }
-  };
-
-  useEffect(() => {
-    (async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        const r = await apiFetch(`/signing-requests/v2/${requestId}`, {},
-                                 { label: 'Loading this signing' });
-        if (!r.ok) {
-          throw new Error((await r.json().catch(() => ({}))).detail || `Failed (${r.status})`);
-        }
-        setDetail(await r.json());
-      } catch (err) {
-        if (err instanceof SessionExpiredError) return;
-        // §4: a detail we could not load says so. An empty panel would
-        // read as "this signing has no participants".
-        setError(err instanceof Error ? err.message : 'Could not load this signing');
-      } finally {
-        setLoading(false);
-      }
-    })();
-  }, [requestId]);
-
-  return (
-    <div className="border-t border-slate-100 p-4">
-      {loading && (
-        <p className="flex items-center gap-2 text-sm text-slate-500">
-          <Loader2 className="w-4 h-4 animate-spin" /> Loading this signing…
-        </p>
-      )}
-      {error && !loading && (
-        <p className="text-sm text-red-700">{error}</p>
-      )}
-      {detail && !loading && !error && (
-        <div className="space-y-4">
-          <div>
-            <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-2">
-              Who is involved
-            </h3>
-            <ul className="space-y-1.5">
-              {detail.participants.map((p) => (
-                <li key={p.id} className="text-sm text-slate-700 flex flex-wrap gap-x-2">
-                  <span className="font-medium">{p.name || 'Unnamed'}</span>
-                  <span className="text-slate-400">·</span>
-                  <span className="text-slate-500">{p.party_role}</span>
-                  <span className="text-slate-400">·</span>
-                  <span className="text-slate-500">
-                    {p.revoked ? 'Link revoked'
-                      : p.viewed_at ? 'Opened their link'
-                      : 'Has not opened their link'}
-                  </span>
-                </li>
-              ))}
-            </ul>
-          </div>
-          <div>
-            <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-2">
-              Times on the table
-            </h3>
-            {detail.windows.length === 0 ? (
-              <p className="text-sm text-slate-500">No times posted yet.</p>
-            ) : (
-              <ul className="space-y-1.5">
-                {detail.windows.map((w) => (
-                  <li key={w.id} className="text-sm text-slate-700">
-                    {/* window_label() wrote this, in the request's own
-                        timezone. This screen formats no signing time. */}
-                    <span className={w.declined ? 'line-through text-slate-400' : ''}>{w.label}</span>
-                    {w.declined && <span className="ml-2 text-xs text-slate-400">declined</span>}
-                    {!w.declined && w.waiting_on.length > 0 && (
-                      <span className="ml-2 text-xs text-amber-700">
-                        waiting on {w.waiting_on.join(', ')}
-                      </span>
-                    )}
-                  </li>
-                ))}
-              </ul>
-            )}
-          </div>
-
-          {/* CANCEL1 item 1 — the panel was read-only, with zero
-              interactive elements, on a feature whose recipient side has
-              always rendered "This link has been withdrawn." The state
-              existed, the endpoint existed, and no officer surface could
-              produce either. */}
-          {detail.cancelled_at ? (
-            <p className="text-sm text-slate-500 border-t border-slate-100 pt-4">
-              {/* Never deleted — a cancelled request that HAD a booked
-                  time still had one (T-5). It stays visible, and says so. */}
-              {detail.summary}
-            </p>
-          ) : (
-            <div className="border-t border-slate-100 pt-4">
-              {!confirming ? (
-                <button
-                  onClick={() => setConfirming(true)}
-                  className="text-sm font-medium text-red-700 hover:text-red-900 hover:underline"
-                >
-                  Cancel this signing request
-                </button>
-              ) : (
-                <div className="space-y-3 rounded-lg border border-red-200 bg-red-50 p-3">
-                  <p className="text-sm text-red-900">
-                    {cancelWarning(detail, detail.participants
-                      .filter((p) => !p.revoked)
-                      .map((p) => p.name || p.party_role))}
-                  </p>
-                  <div className="flex items-center gap-2">
-                    <button
-                      onClick={cancel}
-                      disabled={cancelling}
-                      className="px-3 py-2 text-sm font-medium rounded-lg bg-red-600 text-white hover:bg-red-700 disabled:opacity-60"
-                    >
-                      {cancelling ? 'Cancelling…' : 'Cancel the signing'}
-                    </button>
-                    <button
-                      onClick={() => setConfirming(false)}
-                      disabled={cancelling}
-                      className="px-3 py-2 text-sm font-medium rounded-lg border border-slate-300 text-slate-700 hover:bg-white disabled:opacity-60"
-                    >
-                      Keep it
-                    </button>
-                  </div>
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-      )}
-    </div>
-  );
-}

--- a/frontend/src/features/signing/SigningDetail.tsx
+++ b/frontend/src/features/signing/SigningDetail.tsx
@@ -1,0 +1,210 @@
+'use client';
+
+/**
+ * One signing, in full — participants, times on the table, and Cancel.
+ *
+ * ═══ WHY IT MOVED OUT OF THE AGENDA ═══
+ *
+ * It was the agenda row's expanding panel. The ruling collapsed that
+ * panel to a link: the tracker's job is scanning what has gone quiet
+ * across every file, which is a cross-deed question, and a panel that
+ * opens one signing in place answers a different question in the middle
+ * of it.
+ *
+ * The named cost was accepted deliberately — cancelling goes from one
+ * click to navigate-plus-click. What was NOT acceptable was cancelling
+ * ceasing to exist, so the panel MOVED rather than closed. The deed page
+ * renders this same component; there is no second implementation, which
+ * is the only reason moving it is safe.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { Loader2 } from 'lucide-react';
+import { SessionExpiredError, apiFetch } from '@/lib/apiClient';
+import { cancelWarning } from '@/lib/signingCopy';
+
+export type Detail = {
+  state: string;
+  summary: string;
+  property_address: string | null;
+  booked_at: string | null;
+  cancelled_at: string | null;
+  participants: Array<{
+    id: number;
+    party_role: string;
+    name: string | null;
+    viewed_at: string | null;
+    revoked: boolean;
+  }>;
+  windows: Array<{
+    id: number;
+    label: string;
+    declined: boolean;
+    waiting_on: string[];
+  }>;
+};
+
+/** The detail, fetched when she opens it. */
+export function SigningDetail({ requestId, onCancelled }: {
+  requestId: number;
+  onCancelled: () => void;
+}) {
+  const [detail, setDetail] = useState<Detail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [confirming, setConfirming] = useState(false);
+  const [cancelling, setCancelling] = useState(false);
+
+  const cancel = async () => {
+    setCancelling(true);
+    setError(null);
+    try {
+      const r = await apiFetch(`/signing-requests/v2/${requestId}/cancel`, { method: 'POST' },
+                               { label: 'Cancelling this signing' });
+      if (!r.ok) {
+        throw new Error((await r.json().catch(() => ({}))).detail || `Failed (${r.status})`);
+      }
+      setDetail(await r.json());
+      setConfirming(false);
+      onCancelled();
+    } catch (err) {
+      if (err instanceof SessionExpiredError) return;
+      // §4: a cancellation that did not happen must not look like one
+      // that did. The panel says so and the request stays live.
+      setError(err instanceof Error ? err.message : 'Could not cancel this signing');
+    } finally {
+      setCancelling(false);
+    }
+  };
+
+  useEffect(() => {
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const r = await apiFetch(`/signing-requests/v2/${requestId}`, {},
+                                 { label: 'Loading this signing' });
+        if (!r.ok) {
+          throw new Error((await r.json().catch(() => ({}))).detail || `Failed (${r.status})`);
+        }
+        setDetail(await r.json());
+      } catch (err) {
+        if (err instanceof SessionExpiredError) return;
+        // §4: a detail we could not load says so. An empty panel would
+        // read as "this signing has no participants".
+        setError(err instanceof Error ? err.message : 'Could not load this signing');
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [requestId]);
+
+  return (
+    <div className="border-t border-slate-100 p-4">
+      {loading && (
+        <p className="flex items-center gap-2 text-sm text-slate-500">
+          <Loader2 className="w-4 h-4 animate-spin" /> Loading this signing…
+        </p>
+      )}
+      {error && !loading && (
+        <p className="text-sm text-red-700">{error}</p>
+      )}
+      {detail && !loading && !error && (
+        <div className="space-y-4">
+          <div>
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-2">
+              Who is involved
+            </h3>
+            <ul className="space-y-1.5">
+              {detail.participants.map((p) => (
+                <li key={p.id} className="text-sm text-slate-700 flex flex-wrap gap-x-2">
+                  <span className="font-medium">{p.name || 'Unnamed'}</span>
+                  <span className="text-slate-400">·</span>
+                  <span className="text-slate-500">{p.party_role}</span>
+                  <span className="text-slate-400">·</span>
+                  <span className="text-slate-500">
+                    {p.revoked ? 'Link revoked'
+                      : p.viewed_at ? 'Opened their link'
+                      : 'Has not opened their link'}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <h3 className="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-2">
+              Times on the table
+            </h3>
+            {detail.windows.length === 0 ? (
+              <p className="text-sm text-slate-500">No times posted yet.</p>
+            ) : (
+              <ul className="space-y-1.5">
+                {detail.windows.map((w) => (
+                  <li key={w.id} className="text-sm text-slate-700">
+                    {/* window_label() wrote this, in the request's own
+                        timezone. This screen formats no signing time. */}
+                    <span className={w.declined ? 'line-through text-slate-400' : ''}>{w.label}</span>
+                    {w.declined && <span className="ml-2 text-xs text-slate-400">declined</span>}
+                    {!w.declined && w.waiting_on.length > 0 && (
+                      <span className="ml-2 text-xs text-amber-700">
+                        waiting on {w.waiting_on.join(', ')}
+                      </span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          {/* CANCEL1 item 1 — the panel was read-only, with zero
+              interactive elements, on a feature whose recipient side has
+              always rendered "This link has been withdrawn." The state
+              existed, the endpoint existed, and no officer surface could
+              produce either. */}
+          {detail.cancelled_at ? (
+            <p className="text-sm text-slate-500 border-t border-slate-100 pt-4">
+              {/* Never deleted — a cancelled request that HAD a booked
+                  time still had one (T-5). It stays visible, and says so. */}
+              {detail.summary}
+            </p>
+          ) : (
+            <div className="border-t border-slate-100 pt-4">
+              {!confirming ? (
+                <button
+                  onClick={() => setConfirming(true)}
+                  className="text-sm font-medium text-red-700 hover:text-red-900 hover:underline"
+                >
+                  Cancel this signing request
+                </button>
+              ) : (
+                <div className="space-y-3 rounded-lg border border-red-200 bg-red-50 p-3">
+                  <p className="text-sm text-red-900">
+                    {cancelWarning(detail, detail.participants
+                      .filter((p) => !p.revoked)
+                      .map((p) => p.name || p.party_role))}
+                  </p>
+                  <div className="flex items-center gap-2">
+                    <button
+                      onClick={cancel}
+                      disabled={cancelling}
+                      className="px-3 py-2 text-sm font-medium rounded-lg bg-red-600 text-white hover:bg-red-700 disabled:opacity-60"
+                    >
+                      {cancelling ? 'Cancelling…' : 'Cancel the signing'}
+                    </button>
+                    <button
+                      onClick={() => setConfirming(false)}
+                      disabled={cancelling}
+                      className="px-3 py-2 text-sm font-medium rounded-lg border border-slate-300 text-slate-700 hover:bg-white disabled:opacity-60"
+                    >
+                      Keep it
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
The deed existed at no URL. Past Deeds, the tracker and the dashboard queue all offered actions on documents there was no way to open, and every "open this" routed through a list with a highlight parameter.

## The success-page premise — checked, and it holds

You asked me to confirm it before building on it. `/deed-builder/{type}/success` renders: the completion header (honestly conditional on `status === 'completed'`), the stored-PDF SHA-256, the PCOR and BOE-502-D companion offers, the matter "start related document" block, four instrument actions served from `/deeds/{id}/download`, and a what-next list. It reads exactly four deed endpoints.

**Confirmed on all three counts** — four endpoints, serves the stored instrument, and every element is generation-adjacent. The lean stands: it is the post-generation moment, and it links to the deed page rather than becoming a second one.

Three qualifications the check turned up:
- **The PCOR and 502-D offers exist ONLY here.** Leave the page and the pre-filled companion form is unreachable. Not built — it is not in the ruled order — but it is a real gap and it is ledgered.
- **`handleShare` still navigates** to `/past-deeds?id=X&action=share`, the pattern #178 fixed on the preview page. Left alone: it is the success page's, not the deed page's, and folding it in would widen this diff.
- **Matter context now exists in two places.** Deliberate on inspection: the success page's block is about *carry-forward* ("start related document"), a generation action; the deed page's is orientation. Different questions, same data.

## The page, in the ruled order

**1. Disqualification replaces the page.** One `renders(detail)` guard wraps the entire body — there is no arrangement of the JSX where a next action appears beside a supersession warning, and a pin asserts there is exactly one such guard. Superseded outranks deleted, and *the order is pinned rather than the outcome*, because either is defensible and the difference is whether she is handed the replacement or sent back to a list.

**2. State and next action.** The ladder stops at ready-to-record. A change request beats an approval — two reviewers disagreeing is not "approved", and showing the good news while a change request sits unread is how a deed gets recorded with a known defect in it. A live signing beats a review, because it has a date and people waiting.

`recorded` is the one state past the line, and only because **it is not our claim**: it carries her instrument number, the moment she asserted it, and a sentence that says out loud we are not told by the county. A sweep asserts no other state's headline or sentence claims a recorder did anything.

**3. Activity.** #184's feed. Events and derived timestamps render at different weight — if the screen flattened them, the API's structural split bought nothing and the first person to add "expired" would do it because everything already looked like an event.

**4. Matter.** **5. The instrument** as a named line, with no download link before the bytes exist.

**Participants split, enforced in Python.** `refuse_contact` is callable and matches the **category** — `email`, `recipient_email`, `signer_phone`, `contact_email` are the same mistake four times. `document_party` takes a role and a name and nothing else, so widening it is a deliberate act. A grantee is a person receiving property, not a user of this product; the affordance is the invitation.

**One fetch.** A screen that fetched lineage separately renders the working page first and swaps it out when lineage lands — the same defect wearing a smaller hat, since a second is long enough to click.

## The endpoint that had never once run

`GET /deeds/{id}/activity` shipped in #184 with

```sql
SELECT r.answer, r.asserted_at, p.name, p.party_role
```

and `signing_participants` has no `name` column — it has `display_name`. **Postgres rejects an unknown column at parse time, so it returned 500 on every call, for every deed**, whether or not a signing existed. Not a rare path. The only path.

It shipped green because its pins were unit tests over `deed_activity.activity()` with dict fixtures. Those test the right thing — the epistemics of the feed — but a dict fixture agrees with whatever key you type into it. The statement had never been executed.

**Third time for this class**: `users.updated_at` (a column the code wrote and the database lacked), `:items::jsonb` (a statement SQLAlchemy could not parse, on a webhook nothing ever posted), and now this. All three invisible to a suite that mocks the cursor.

`tests/test_endpoint_sql.py` PREPAREs every statement these endpoints run against a real Postgres. Parsing is the half mocks cannot cover, and it has now cost three incidents.

## Structural changes

- **`services/signing_rows.py`** — the signing-row assembly, extracted so the deed page and `/signing-requests/v2` share one judgement. Writing those six queries and five judgements twice would have been two *servers* disagreeing about a signing's state, which is `signing_summary`'s defect one level up.
- **`SigningDetail`** extracted from the agenda's expanding panel. The panel collapsed to a link as ruled; cancelling **moved rather than closed**, and a pin proves the deed page mounts it — retargeting the three cancel pins proved the code survived, not that anything renders it.
- **`tests/source_text.function_source`** — three supersession pins sliced the file between `def supersede_endpoint(` and `def lineage_endpoint(`, i.e. "this function and everything after it until one I happened to name". Inserting `/detail` between them pulled `status <> 'deleted'` into a body asserted to contain no DELETE. An AST span ends where the function ends.

## Self-review

**Premises checked.** The success page **held** — first mechanism-level premise to survive this wave, which is itself information after five straight misses. Three that did **not**: the agenda panel was the only surface offering cancel (so collapsing it would have deleted the feature, not moved it); `signing_participants.name` does not exist; and my own first draft of the deed page had **no auth guard** — the route-guard pin caught it, which is a pin doing exactly its job, since a new authenticated route is where a guard gets forgotten (everything renders fine until the fetch 401s).

**Pins changed, and the direction.** Six, all retargets where code moved, none weakened:
- Three supersession pins: **narrower and more precise** (exact function span instead of an open-ended slice). The old width was accidental, not designed.
- `test_the_agenda_sends_the_verdict`: **stronger** — it read one file, so a second caller forming its own verdict elsewhere would have passed. It now enumerates every non-test backend file and asserts exactly one decides `live`.
- `test_only_one_place_decides_what_stale_means`: retargeted, plus a new assert that the assembler did not copy the threshold.
- Three FLOW1 / two CANCEL1 panel pins: retargeted to the extracted component, **plus a new one** that the deed page actually mounts it. That addition is the point — the retargets alone would have proven the code exists while cancelling was unreachable.
- The U3 Past Deeds pin asserted `>#{deed.id}</td>` and broke on wrapping the id in a link. Rewritten to assert the rule (its own cell, and the cell links to the deed) rather than a spelling of the markup.

**Least sure about:** the `ready` state offers only "Send for review". Starting a signing directly is reachable only through the share modal's `onSwitchToSigning`, which is buried. "One state, one obvious action" says one; the officer who wants a signing on a fresh deed has to go through a dialog about review first. I built to the letter and I think the letter may be wrong here.

**Would cut:** the matter section. It is fourth by your ranking and the success page already carries the version that does something (start the related document). Cutting it costs orientation — "this is one of three on escrow 12345" — for an officer arriving cold at a deed page from a notification, which is the arrival this page is for. Everything above it changes what she does next; this one changes whether she knows where she is.

**Decided rather than flagged — disagree explicitly:**
1. **I merged #184.** It was unmerged and unapproved; item 3 specifies precisely what it built, and the page cannot exist without it. Reversible, but it was my call.
2. **`recorded` is above the ready-to-record line.** The ladder stops where you said, and then reports her own statement past it, attributed. I read that as the opposite of asserting county status, but it is a state you did not list.
3. **Idle drafts in the dashboard queue still route to the builder**, not the deed page. A draft has one action and the deed page would offer that same action one navigation later.
4. **`ACTION_KINDS` renamed to verbs.** The first draft had `signing` as both a state and an action kind; a pin caught the collision.
5. **`onChanged` deleted from `SigningAgenda`'s props.** With the panel gone the agenda has no mutating action left.

## Gates

| gate | result |
|---|---|
| pytest | 1254 passed |
| jest | 857 passed, 59 suites |
| tsc | 88 — baseline unchanged |
| six-flow | green |
| banned-claims | clean |
| next build | clean |
| OpenAPI snapshot | +1 route, `GET /deeds/{deed_id}/detail` |
| mutation probes | 11 run, 10 caught, **1 came back green** |

**The green probe.** Deleting `refuse_contact(key)` from `document_party` passed all 40 tests: the key-set assert below it raises the *same exception type*, so the contact rule could be removed entirely without a failure. The vocabulary trap again — a test written in the terms of the thing it checks cannot notice that thing collapsing. The pins match the **reason** now (`match="is a contact field"`), not the type. Re-running the probe: 9 failures where there were 0.

**Branch note, as standing practice:** fresh per-ticket branch off current main, not the stale branch named in session config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_