### PR TITLE
Two rulings, and the sixth sighting closes with a rendered page

### DIFF
--- a/backend/services/deed_page.py
+++ b/backend/services/deed_page.py
@@ -244,13 +244,49 @@ DEED_STATES = frozenset({
 #: job is telling a state from an action. A pin caught the collision;
 #: renaming it was cheaper than teaching every reader which one is meant.
 ACTION_KINDS = frozenset({
-    "resume", "share_for_review", "open_signing", "download", "none"})
+    "resume", "share_for_review", "request_signing", "open_signing",
+    "download", "none"})
+
+#: Every key a state block carries, asserted by `_state` before it
+#: leaves. `secondary_action` is present on EVERY state — as None where
+#: there is none — because a payload whose shape depends on its content
+#: gives the screen two contracts and the second is the one nothing
+#: tests. Same reason the page payload keeps its shape when disqualified.
+STATE_BLOCK_KEYS = frozenset({
+    "state", "headline", "sentence", "next_action", "secondary_action",
+    "signing_request_id", "asserted_at"})
 
 
 def _action(kind: str, label: str) -> Dict[str, str]:
     if kind not in ACTION_KINDS:
         raise ValueError(f"{kind!r} is not an action this page offers")
     return {"kind": kind, "label": label}
+
+
+def _state(**block: Any) -> Dict[str, Any]:
+    """One state block, with its shape asserted rather than trusted.
+
+    ═══ WHY THERE IS AT MOST ONE SECONDARY ═══
+
+    "One state, one obvious action" is still the rule, and `ready` is the
+    single deliberate exception (owner-ruled): a generated deed has two
+    genuinely common next moves, and reaching the second one only through
+    a dialog about the first is an affordance problem rather than a
+    simplification.
+
+    The field is SINGULAR on purpose. A list would grow, and a wall of
+    equal choices is exactly what the one-action rule exists to prevent —
+    the ruling was "do not hide the second most common move", not "offer
+    everything".
+    """
+    block.setdefault("secondary_action", None)
+    block.setdefault("signing_request_id", None)
+    if set(block) != STATE_BLOCK_KEYS:
+        raise ValueError(
+            "the state block no longer matches its contract: "
+            f"extra={sorted(set(block) - STATE_BLOCK_KEYS)} "
+            f"missing={sorted(STATE_BLOCK_KEYS - set(block))}")
+    return block
 
 
 def state_and_next(
@@ -287,91 +323,105 @@ def state_and_next(
         # who said it and when they said it, because the alternative is a
         # bare "Recorded" that reads as though we checked.
         number = (deed.get("instrument_number") or "").strip()
-        return {
-            "state": "recorded",
-            "headline": "Marked as recorded",
-            "sentence": (
+        return _state(
+            state="recorded",
+            headline="Marked as recorded",
+            sentence=(
                 "You recorded this instrument"
                 + (f" as {number}" if number else "")
                 + ". That is your statement — we are not told by the county."
             ),
-            "next_action": _action("download", "Download the instrument"),
-            "asserted_at": _iso(deed.get("recording_asserted_at")),
-        }
+            next_action=_action("download", "Download the instrument"),
+            asserted_at=_iso(deed.get("recording_asserted_at")),
+        )
 
     if not completed:
-        return {
-            "state": "draft",
-            "headline": "Draft",
-            "sentence": "Not generated yet. Nothing has been sent to anyone.",
-            "next_action": _action("resume", "Continue this deed"),
-            "asserted_at": None,
-        }
+        return _state(
+            state="draft",
+            headline="Draft",
+            sentence="Not generated yet. Nothing has been sent to anyone.",
+            next_action=_action("resume", "Continue this deed"),
+            asserted_at=None,
+        )
 
     live = [s for s in signings if s.get("live")]
     if live:
         first = live[0]
-        return {
-            "state": "signing",
-            "headline": "Out for signing",
+        return _state(
+            state="signing",
+            headline="Out for signing",
             # WHICH signing. Without it the page can only offer "request
             # a signing", and offering that on a deed that already has
             # one is an invitation to create a second — three more
             # emails and two notaries who each think they have it.
             # CANCEL1 item 4 found exactly this on Past Deeds.
-            "signing_request_id": first.get("id"),
+            signing_request_id=first.get("id"),
             # The server's sentence about a scheduling state is
             # signing_loop's, already composed. Rewriting it here would
             # be the second opinion §13 rule 3 exists to prevent.
-            "sentence": first.get("summary") or "A signing is in progress.",
-            "next_action": _action("open_signing", "Open the signing"),
-            "asserted_at": None,
-        }
+            sentence=first.get("summary") or "A signing is in progress.",
+            next_action=_action("open_signing", "Open the signing"),
+            asserted_at=None,
+        )
 
     decisions = [(s.get("status") or "").strip().lower() for s in shares]
     if "rejected" in decisions:
-        return {
-            "state": "changes_requested",
-            "headline": "Changes requested",
-            "sentence": (
+        return _state(
+            state="changes_requested",
+            headline="Changes requested",
+            sentence=(
                 "A reviewer asked for changes. Read what they said before "
                 "sending this anywhere else."
             ),
-            "next_action": _action("share_for_review", "See the review"),
-            "asserted_at": None,
-        }
+            next_action=_action("share_for_review", "See the review"),
+            asserted_at=None,
+        )
     outstanding = [d for d in decisions if d in ("sent", "viewed", "")]
     if outstanding:
-        return {
-            "state": "in_review",
-            "headline": "Out for review",
-            "sentence": "Sent for review. No answer yet.",
-            "next_action": _action("share_for_review", "See who has it"),
-            "asserted_at": None,
-        }
+        return _state(
+            state="in_review",
+            headline="Out for review",
+            sentence="Sent for review. No answer yet.",
+            next_action=_action("share_for_review", "See who has it"),
+            asserted_at=None,
+        )
     if "approved" in decisions:
-        return {
-            "state": "approved",
-            "headline": "Approved — ready to record",
-            "sentence": (
+        return _state(
+            state="approved",
+            headline="Approved — ready to record",
+            sentence=(
                 "A reviewer approved it. Recording happens at the county; "
                 "this product does not do that part and is not told when "
                 "it is done."
             ),
-            "next_action": _action("download", "Download the instrument"),
-            "asserted_at": None,
-        }
+            next_action=_action("download", "Download the instrument"),
+            asserted_at=None,
+        )
 
-    return {
-        "state": "ready",
-        "headline": "Generated",
-        "sentence": (
+    # ═══ THE ONE STATE WITH TWO ACTIONS (owner-ruled) ═══
+    #
+    # A generated deed has two genuinely common next moves and no basis
+    # for guessing which. The first build offered only review, and
+    # starting a signing was reachable only through the share modal's
+    # "did you mean a signing?" switch — which is FLOW1 item 1's
+    # affordance problem one screen over: the second most common move
+    # discoverable only by opening a dialog about the first.
+    #
+    # "One state, one obvious action" means DO NOT PRESENT A WALL OF
+    # EQUAL CHOICES. It does not mean hide the other one. The two are
+    # ranked rather than equal — review is primary — and there is no
+    # third, because `secondary_action` is singular by construction.
+    return _state(
+        state="ready",
+        headline="Generated",
+        sentence=(
             "The instrument exists and has not been sent to anyone. "
             "Send it for review, or out for signing."
         ),
-        "next_action": _action("share_for_review", "Send for review"),
-        "asserted_at": None,
-    }
+        next_action=_action("share_for_review", "Send for review"),
+        secondary_action=_action("request_signing", "Request signing"),
+        asserted_at=None,
+    )
 
 
 def _iso(value: Any) -> Optional[str]:

--- a/backend/tests/test_deed_page.py
+++ b/backend/tests/test_deed_page.py
@@ -26,9 +26,22 @@ import pytest
 
 from services.deed_page import (
     ACTION_KINDS, CONTACT_FRAGMENTS, DEED_PAGE_KEYS, DEED_STATES,
-    ContactOnTheDocument, deed_page, disqualification, document_parties,
-    document_party, refuse_contact, state_and_next, working_parties,
+    STATE_BLOCK_KEYS, ContactOnTheDocument, deed_page, disqualification,
+    document_parties, document_party, refuse_contact, state_and_next,
+    working_parties,
 )
+
+#: Every state, with the rows that produce it. Used by the sweeps below
+#: so a new state cannot be added without appearing in all of them.
+EVERY_STATE = [
+    ("draft", {"status": "draft"}, [], []),
+    ("ready", {}, [], []),
+    ("in_review", {}, [{"status": "sent"}], []),
+    ("approved", {}, [{"status": "approved"}], []),
+    ("changes_requested", {}, [{"status": "rejected"}], []),
+    ("signing", {}, [], [{"id": 3, "live": True, "summary": "x"}]),
+    ("recorded", {"recorded_at": "2026-08-05T00:00:00Z"}, [], []),
+]
 
 
 def _deed(**over):
@@ -142,18 +155,83 @@ def test_the_signing_sentence_is_the_servers_not_a_second_one():
     assert got["sentence"] == "Waiting on Maria and two signers."
 
 
-def test_every_state_offers_exactly_one_action_of_a_known_kind():
-    for row, shares, signings in [
-        (_deed(status="draft"), [], []),
-        (_deed(), [], []),
-        (_deed(), [{"status": "sent"}], []),
-        (_deed(), [{"status": "approved"}], []),
-        (_deed(), [{"status": "rejected"}], []),
-        (_deed(), [], [{"live": True, "summary": "x"}]),
-        (_deed(recorded_at="2026-08-05T00:00:00Z"), [], []),
-    ]:
-        action = state_and_next(row, shares=shares, signings=signings)["next_action"]
-        assert action["kind"] in ACTION_KINDS
+def test_every_state_offers_a_primary_action_of_a_known_kind():
+    for name, over, shares, signings in EVERY_STATE:
+        got = state_and_next(_deed(**over), shares=shares, signings=signings)
+        assert got["next_action"]["kind"] in ACTION_KINDS, name
+
+
+# ── The one state with two actions (owner-ruled) ─────────────────────
+
+def test_ready_offers_review_AND_signing():
+    """THE RULING THIS BLOCK EXISTS FOR.
+
+    The first build offered review alone, and starting a signing was
+    reachable only through the share modal's "did you mean a signing?"
+    switch — FLOW1 item 1's affordance problem one screen over: the
+    second most common move discoverable only by opening a dialog about
+    the first.
+
+    "One state, one obvious action" means DO NOT PRESENT A WALL OF EQUAL
+    CHOICES. It does not mean hide the other one.
+    """
+    got = state_and_next(_deed())
+    assert got["state"] == "ready"
+    assert got["next_action"] == {"kind": "share_for_review",
+                                  "label": "Send for review"}
+    assert got["secondary_action"] == {"kind": "request_signing",
+                                       "label": "Request signing"}
+
+
+def test_the_two_actions_are_ranked_not_equal():
+    """Review is the primary. If they were interchangeable this would be
+    a list, and a list is what the one-action rule prevents."""
+    got = state_and_next(_deed())
+    assert got["next_action"]["kind"] != got["secondary_action"]["kind"]
+
+
+def test_ready_is_the_ONLY_state_with_a_second_action():
+    """The exception is one state wide, deliberately. Every other state
+    has one obvious move, and a second offered beside it would be this
+    page drifting back into a menu."""
+    for name, over, shares, signings in EVERY_STATE:
+        got = state_and_next(_deed(**over), shares=shares, signings=signings)
+        if name == "ready":
+            assert got["secondary_action"] is not None
+        else:
+            assert got["secondary_action"] is None, name
+
+
+def test_there_can_never_be_a_third():
+    """`secondary_action` is SINGULAR by construction — a list would
+    grow. This is the pin that makes that structural rather than a
+    convention somebody remembers."""
+    for name, over, shares, signings in EVERY_STATE:
+        got = state_and_next(_deed(**over), shares=shares, signings=signings)
+        assert not isinstance(got["secondary_action"], list), name
+        assert set(got) == STATE_BLOCK_KEYS, name
+
+
+def test_starting_a_signing_and_opening_one_are_different_verbs():
+    """`request_signing` creates; `open_signing` opens the one that
+    exists. Collapsing them is how a deed with a live signing gets a
+    second one — three more emails and two notaries who each think they
+    have it (CANCEL1 item 4)."""
+    ready = state_and_next(_deed())
+    live = state_and_next(_deed(), signings=[{"id": 3, "live": True, "summary": "x"}])
+    assert ready["secondary_action"]["kind"] == "request_signing"
+    assert live["next_action"]["kind"] == "open_signing"
+    assert live["secondary_action"] is None
+
+
+def test_every_state_block_carries_the_same_keys():
+    """A payload whose shape depends on its content gives the screen two
+    contracts, and the second is the one nothing tests. `secondary_action`
+    and `signing_request_id` are present everywhere, as None where there
+    is none."""
+    for name, over, shares, signings in EVERY_STATE:
+        got = state_and_next(_deed(**over), shares=shares, signings=signings)
+        assert set(got) == STATE_BLOCK_KEYS, name
 
 
 # ── THE LADDER STOPS AT READY TO RECORD ──────────────────────────────
@@ -173,18 +251,17 @@ def test_no_state_claims_a_county_did_anything():
     forbidden = ("was recorded by", "the county has", "filed with the county",
                  "accepted by the recorder", "rejected by the recorder",
                  "recording confirmed")
-    for row, shares, signings in [
-        (_deed(status="draft"), [], []),
-        (_deed(), [], []),
-        (_deed(), [{"status": "sent"}], []),
-        (_deed(), [{"status": "approved"}], []),
-        (_deed(), [{"status": "rejected"}], []),
-        (_deed(), [], [{"live": True, "summary": "x"}]),
-    ]:
-        got = state_and_next(row, shares=shares, signings=signings)
-        blob = f"{got['headline']} {got['sentence']}".lower()
+    for name, over, shares, signings in EVERY_STATE:
+        if name == "recorded":
+            continue  # attributed to her; its own stricter test below
+        got = state_and_next(_deed(**over), shares=shares, signings=signings)
+        blob = " ".join([
+            got["headline"], got["sentence"],
+            (got["next_action"] or {}).get("label", ""),
+            (got["secondary_action"] or {}).get("label", ""),
+        ]).lower()
         for phrase in forbidden:
-            assert phrase not in blob, f"{got['state']} claims: {phrase}"
+            assert phrase not in blob, f"{name} claims: {phrase}"
 
 
 def test_recorded_is_attributed_to_her_and_never_to_us():

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -868,6 +868,105 @@ we reach it.
   because the key-set assert raised the SAME EXCEPTION TYPE. Matching the
   reason rather than the type is the same fix at a smaller scale.
 
+- **RULED 2026-08-13 — the `ready` state offers BOTH actions**, review
+  primary, signing beside it. My own flag on the DEEDDETAIL report was
+  right and the ruling confirms it.
+
+  **"One state, one obvious action" means do not present a wall of equal
+  choices. It does not mean hide the second most common move.** Reaching
+  signing only through the share modal's "did you mean a signing?"
+  switch is FLOW1 item 1's affordance problem one screen over — the
+  thing you want discoverable only by opening a dialog about a different
+  thing.
+
+  `secondary_action` is SINGULAR in both languages, and `ready` is the
+  only state that has one. Both pinned, so a third action or a second
+  exception is a decision rather than a drift.
+
+- **RULED 2026-08-13 — the matter section STAYS on the deed page.** My
+  proposed cut is overruled.
+
+  The ranking argument was accepted and the conclusion was not: the cost
+  I named — an officer arriving cold from a notification — **is the case
+  the page exists for.** "Which file is this on" is the question she has
+  before she has any other.
+
+  The success page's matter block is not a substitute. It serves
+  somebody who just MADE the deed and might start a related one; this
+  serves somebody RETURNING to one. Cut later only on evidence nobody
+  uses it. The ruling is recorded in the page source, where somebody
+  would go to cut it.
+
+- **FOLLOW-UP — the PCOR and BOE-502-D offers exist ONLY on the success
+  page** (surfaced confirming DEEDDETAIL's premise, 2026-08-13).
+
+  A pre-filled companion form, built from facts the deed already holds,
+  reachable for exactly one page view. Leave and it is gone: nothing on
+  the deed page, Past Deeds or the tracker offers it, and the officer
+  has no way to know it ever existed.
+
+  Every conveyance is legally incomplete without a concurrent BOE-502-A
+  (R&T §480.3), so this is not a convenience that expires — it is the
+  companion document, lost on navigation.
+
+  Not built: it is not in the ruled order for the deed page, and adding
+  it there is a decision about that page's contents rather than a
+  defect fix. Sized: the endpoints exist (`/deeds/{id}/pcor`,
+  `/deeds/{id}/death-statement`) and the deed page already fetches one
+  payload, so it is a section and a download handler.
+
+- **FOLLOW-UP — `handleShare` on the success page still navigates**
+  (same investigation, 2026-08-13).
+
+  `router.push('/past-deeds?id=X&action=share')` — the exact pattern
+  #178 replaced on the preview page with a dialog opened in place. It
+  sends her to a list to re-find the deed she is looking at, so she can
+  be asked a question that could have been asked where she stood.
+
+  Left alone deliberately: it is the success page's, not the deed
+  page's, and folding it into Unit 2 would have widened that diff.
+  Small — the modal and its provider are already imported on pages
+  either side of it.
+
+- **SIXTH SIGHTING, one hour after recording the fifth — and the fix
+  that finally generalises** (2026-08-13).
+
+  The pins protecting the matter-section ruling asserted that
+  `data-testid="matter"` APPEARS IN THE SOURCE. A probe changed the
+  guard to `{false && detail.matter && (` — the section gone from every
+  screen, every string still present — and all 31 pins passed.
+
+  **The ledger entry recording the fifth sighting was written an hour
+  earlier, by me, and I wrote three more of the same pin immediately
+  after.** That is not carelessness; it is the entry's own claim
+  demonstrated: the lesson does not transfer by being known.
+
+  **What changed this time:** for a service, "convert the assertion to a
+  call" means calling the function. For a PAGE it means RENDERING it —
+  and until now nothing in this suite ever had. `jest-environment-jsdom`
+  and `@testing-library/react` were both installed and entirely unused
+  across 60 suites of source-text pins.
+
+  `deedPageRender.test.tsx` asks what an officer SEES for a given
+  payload. It does not replace the source pins beside it: those assert
+  rules about how the code is WRITTEN (no state vocabulary in the
+  screen, sentences rendered verbatim), which rendering cannot check.
+  One proves the rule is stated, the other proves it is reached.
+
+  **The class is now closed for this page** and the technique is
+  available to every other one. The parked string-presence audit (43
+  files, ~600 assertions) should be re-scoped against it: the branch-
+  subject pins on RENDERED surfaces have a real fix now, not just a
+  warning.
+
+  A second trap worth recording, found building it: `jest.mock` is only
+  hoisted above the imports when babel sees the GLOBAL `jest`. Every
+  other file here imports `jest` from `@jest/globals`, which silently
+  disables hoisting — the page loaded first, captured the real
+  `useRequireAuth`, found no token, and rendered an empty string with no
+  error and no warning. **A test that produces nothing looks exactly
+  like a test with nothing to say** — the same disease one level up.
+
 ## Parked tickets (scoped, not scheduled)
 
 - **Audit the string-presence pins whose subject is a BRANCH** (CANCEL1

--- a/frontend/src/__tests__/deedDetailPage.test.ts
+++ b/frontend/src/__tests__/deedDetailPage.test.ts
@@ -157,6 +157,73 @@ describe('both languages declare the same contract', () => {
   });
 });
 
+describe('the ready state offers both, ranked (owner-ruled)', () => {
+  it('the page renders a secondary action when there is one', () => {
+    /**
+     * The first build offered review alone, and starting a signing was
+     * reachable only through the share modal's "did you mean a
+     * signing?" switch — FLOW1 item 1's affordance problem one screen
+     * over. "One obvious action" means do not present a wall of equal
+     * choices, not hide the second most common move.
+     */
+    expect(PAGE).toContain('detail.state.secondary_action');
+    expect(PAGE).toContain('data-testid="secondary-action"');
+    expect(PAGE).toContain("act(detail.state.secondary_action!.kind)");
+  });
+
+  it('and renders it as subordinate, not as a twin', () => {
+    // Ranked rather than equal. Two identical buttons is the wall.
+    const at = PAGE.indexOf('data-testid="secondary-action"');
+    const block = PAGE.slice(at, at + 500);
+    expect(block).not.toContain('bg-[#7C4DFF] text-white');
+    expect(block).toContain('border-2 border-slate-300');
+  });
+
+  it('starting a signing and opening one are different verbs', () => {
+    // Collapsing them is how a deed with a live signing gets a second
+    // one — CANCEL1 item 4, one screen over.
+    expect(PAGE).toContain("kind === 'request_signing'");
+    expect(PAGE).toContain("kind === 'open_signing'");
+  });
+
+  it('there is no third action, in either language', () => {
+    // Singular by construction. A list would grow.
+    expect(PAGE).not.toContain('secondary_actions');
+    const block = PY.slice(PY.indexOf('STATE_BLOCK_KEYS = frozenset({'));
+    expect(block.slice(0, block.indexOf('})'))).toContain('"secondary_action"');
+    expect(block.slice(0, block.indexOf('})'))).not.toContain('"secondary_actions"');
+  });
+});
+
+describe('the matter section stays (a proposed cut was overruled)', () => {
+  it('it is still rendered', () => {
+    /**
+     * The ranking argument for cutting it was accepted; the conclusion
+     * was not. An officer arriving cold from a notification is the case
+     * this page exists for, and "which file is this on" is the question
+     * she has before she has any other.
+     *
+     * The success page's matter block is not a substitute: it serves
+     * somebody who just MADE the deed. This serves somebody RETURNING.
+     */
+    expect(PAGE).toContain('data-testid="matter"');
+    expect(PAGE).toContain('detail.matter.documents.map');
+  });
+
+  it('and it links each sibling to its own deed page', () => {
+    // The orphan resolved one more way: a file is only navigable if the
+    // documents on it are.
+    expect(PAGE).toContain('href={`/deeds/${d.id}`}');
+  });
+
+  it('the ruling is recorded where somebody would go to cut it', () => {
+    // A decision that lives only in a PR body is one the next reader
+    // re-derives from scratch.
+    const raw = read('app', 'deeds', '[id]', 'page.tsx');
+    expect(raw).toContain('OWNER-RULED TO STAY');
+  });
+});
+
 describe('the activity keeps the distinction the API went to trouble over', () => {
   it('an event and a derived timestamp are told apart', () => {
     expect(isRecordedAct({ kind: 'event' })).toBe(true);

--- a/frontend/src/__tests__/deedPageRender.test.tsx
+++ b/frontend/src/__tests__/deedPageRender.test.tsx
@@ -1,0 +1,304 @@
+/**
+ * The deed page, RENDERED — because reading the source cannot tell
+ * REACHABLE from PRESENT.
+ *
+ * ═══ THE PROBE THAT MADE THIS FILE ═══
+ *
+ * The matter-section pins asserted that `data-testid="matter"` and
+ * `detail.matter.documents.map` APPEAR IN THE SOURCE. A mutation probe
+ * changed the guard to `{false && detail.matter && (` — the section
+ * gone from every screen, the strings all still there — and all 31 pins
+ * passed.
+ *
+ * That is the SIXTH sighting of this class, and it landed on the pin
+ * protecting the ruling that records the fifth. The ledger's own
+ * conclusion is the point: **the lesson does not transfer by being
+ * known.** Knowing that a string-presence pin cannot see a dead branch
+ * did not stop me writing three more of them an hour later.
+ *
+ * The only thing that catches it is executing the branch. For a service
+ * that means calling the function; for a page it means rendering it.
+ * jsdom and Testing Library were already installed and — until this
+ * file — entirely unused: every test in this suite reads source text.
+ *
+ * ═══ AND ONE TRAP WORTH THE COMMENT ═══
+ *
+ * `jest` is used from the GLOBAL here rather than imported from
+ * `@jest/globals`, which every other file in this suite does. Babel only
+ * hoists `jest.mock` calls above the imports when it sees the global; an
+ * imported `jest` leaves them in place, so the module under test loads
+ * FIRST and captures the real dependencies.
+ *
+ * The symptom is silent: the page rendered an empty string, no error, no
+ * warning — because the real `useRequireAuth` found no token and
+ * returned `checked: false`. Which is this file's own subject arriving
+ * one level up: a test that produces nothing looks exactly like a test
+ * with nothing to say.
+ *
+ * ═══ WHAT THIS FILE IS FOR, AND WHAT IT IS NOT ═══
+ *
+ * It asks what an officer SEES for a given payload. It is not a
+ * replacement for the source pins next door — those assert rules about
+ * how the code is written (no state vocabulary, sentences rendered
+ * verbatim), which rendering cannot check. These two are complements:
+ * one proves the rule is stated, the other proves it is reached.
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, expect, it, beforeEach } from '@jest/globals';
+import type { jest as JestObject } from '@jest/globals';
+
+/**
+ * The global `jest`, typed FILE-LOCALLY.
+ *
+ * `@types/jest` is not installed, so TS sees only a `jest` NAMESPACE and
+ * refuses it as a value. Declaring `var jest` in a global .d.ts fixes
+ * this file and breaks others: it conflicts with the ambient namespace
+ * `@testing-library/jest-dom` contributes, TS drops that declaration
+ * file, and `integration/fault-injection.test.ts` — which calls
+ * `describe`/`it`/`expect` as globals with no imports — gained 13 errors.
+ *
+ * Measured, not guessed: 88 → 101 with the global declaration, 88
+ * without. A file-local shadow satisfies this file and is invisible to
+ * the rest of the program.
+ */
+declare const jest: typeof JestObject;
+
+/** The mock's own type, borrowed from the same place. */
+type Mock = ReturnType<typeof JestObject.fn>;
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+// BOTH entries, deliberately.
+//
+// `/jest-globals` augments the `expect` imported from `@jest/globals`,
+// which is what this file uses. The bare entry carries the AMBIENT
+// declarations that other suites in this repo lean on — dropping it
+// added 13 tsc errors in `integration/fault-injection.test.ts`, which
+// calls `describe`/`it`/`expect` as globals and has no imports at all.
+//
+// A test file is part of the type-checked program. Changing what it
+// pulls in changes what every other file can see.
+import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/jest-globals';
+
+// The page pulls in a sidebar, a partners provider and two modals; none
+// of them is what these tests are about, and all of them fetch. Stubbed
+// to the smallest thing that still lets the page mount.
+jest.mock('next/navigation', () => ({
+  useParams: () => ({ id: '7' }),
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+  usePathname: () => '/deeds/7',
+  useSearchParams: () => new URLSearchParams(),
+}));
+jest.mock('@/components/Sidebar', () => ({
+  __esModule: true, default: () => <nav data-testid="sidebar" />,
+}));
+jest.mock('@/hooks/useRequireAuth', () => ({
+  useRequireAuth: () => ({ checked: true }),
+}));
+jest.mock('@/features/partners/PartnersContext', () => ({
+  PartnersProvider: ({ children }: any) => <>{children}</>,
+  usePartners: () => ({ partners: [], loading: false, error: null,
+                        create: jest.fn(), refresh: jest.fn() }),
+}));
+jest.mock('@/features/signing/ShareForReviewModal', () => ({
+  ShareForReviewModal: () => <div data-testid="share-modal" />,
+}));
+jest.mock('@/features/signing/RequestSigningModal', () => ({
+  RequestSigningModal: () => <div data-testid="signing-modal" />,
+}));
+jest.mock('@/features/signing/SigningDetail', () => ({
+  SigningDetail: () => <div data-testid="signing-panel" />,
+}));
+
+jest.mock('@/lib/apiClient', () => ({
+  apiFetch: jest.fn(),
+  SessionExpiredError: class SessionExpiredError extends Error {},
+}));
+
+import DeedPage from '@/app/deeds/[id]/page';
+import { apiFetch as rawApiFetch } from '@/lib/apiClient';
+
+const apiFetch = rawApiFetch as unknown as Mock;
+
+/** A payload in the shape `services/deed_page.py` asserts. */
+const payload = (over: Record<string, unknown> = {}) => ({
+  deed_id: 7,
+  disqualified: null,
+  state: {
+    state: 'ready', headline: 'Generated',
+    sentence: 'The instrument exists and has not been sent to anyone.',
+    next_action: { kind: 'share_for_review', label: 'Send for review' },
+    secondary_action: { kind: 'request_signing', label: 'Request signing' },
+    signing_request_id: null, asserted_at: null,
+  },
+  activity: [],
+  matter: {
+    key: { kind: 'escrow_no', value: 'ESC-789' },
+    documents: [{ id: 12, deed_type: 'grant-deed', status: 'completed',
+                  property_address: '9 Other St', parties: ['Jane Doe'] }],
+  },
+  instrument: { deed_type: 'grant-deed', property_address: '123 Baseline St',
+                county: 'Los Angeles', apn: '1234-567-890',
+                completed_at: '2026-08-01T00:00:00Z', available: true },
+  on_the_document: [{ role: 'Grantor', name: 'Jane Doe' },
+                    { role: 'Grantee', name: 'John Roe' }],
+  working_on_it: [],
+  ...over,
+});
+
+const serve = (body: unknown) => {
+  apiFetch.mockReset();
+  apiFetch.mockResolvedValue({ ok: true, json: async () => body });
+};
+
+beforeEach(() => { apiFetch.mockReset(); });
+
+describe('the matter section is actually on the screen', () => {
+  it('renders the file and its other documents', async () => {
+    /** THE PIN THIS FILE EXISTS FOR — owner-ruled to stay, and a source
+     *  pin could not tell "rendered" from "written down". */
+    serve(payload());
+    render(<DeedPage />);
+    expect(await screen.findByTestId('matter')).toBeInTheDocument();
+    expect(screen.getByText(/ESC-789/)).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /#12/ }))
+      .toHaveAttribute('href', '/deeds/12');
+  });
+
+  it('and is absent only when the deed is on no file', async () => {
+    serve(payload({ matter: null }));
+    render(<DeedPage />);
+    await screen.findByTestId('state');
+    expect(screen.queryByTestId('matter')).not.toBeInTheDocument();
+  });
+});
+
+describe('the ready state offers both actions, ranked', () => {
+  it('both buttons are on the screen', async () => {
+    serve(payload());
+    render(<DeedPage />);
+    expect(await screen.findByRole('button', { name: /Send for review/ }))
+      .toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Request signing/ }))
+      .toBeInTheDocument();
+  });
+
+  it('a state with no secondary shows exactly one', async () => {
+    serve(payload({
+      state: { ...payload().state, state: 'in_review', headline: 'Out for review',
+               sentence: 'Sent for review. No answer yet.',
+               next_action: { kind: 'share_for_review', label: 'See who has it' },
+               secondary_action: null },
+    }));
+    render(<DeedPage />);
+    await screen.findByTestId('state');
+    expect(screen.queryByTestId('secondary-action')).not.toBeInTheDocument();
+  });
+});
+
+describe('the disqualification REPLACES the page', () => {
+  it('a superseded deed shows the warning and NOTHING else', async () => {
+    /**
+     * The rule the whole page is organised around, checked the only way
+     * that actually proves it: by looking at what is on the screen.
+     *
+     * A source pin can show the JSX is nested inside a guard. It cannot
+     * show that the guard is reached, which is the entire question.
+     */
+    serve(payload({
+      disqualified: {
+        kind: 'superseded',
+        headline: 'This deed was corrected and replaced.',
+        sentence: 'A later deed supersedes this one.',
+        go_to_deed_id: 9,
+      },
+    }));
+    render(<DeedPage />);
+    expect(await screen.findByTestId('disqualified')).toBeInTheDocument();
+
+    // Every section that could invite work on the wrong document.
+    for (const id of ['state', 'activity', 'participants', 'matter', 'instrument']) {
+      expect(screen.queryByTestId(id)).not.toBeInTheDocument();
+    }
+    // And specifically no next action anywhere.
+    expect(screen.queryByRole('button', { name: /Send for review/ }))
+      .not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Request signing/ }))
+      .not.toBeInTheDocument();
+  });
+
+  it('but still offers the way out', async () => {
+    serve(payload({
+      disqualified: { kind: 'superseded', headline: 'Corrected.',
+                      sentence: 'Superseded.', go_to_deed_id: 9 },
+    }));
+    render(<DeedPage />);
+    expect(await screen.findByRole('link', { name: /replacement/ }))
+      .toHaveAttribute('href', '/deeds/9');
+  });
+});
+
+describe('what the officer is told when things are missing', () => {
+  it('an empty activity feed says nothing happened, and invents nothing', async () => {
+    serve(payload({ activity: [] }));
+    render(<DeedPage />);
+    expect(await screen.findByText(/Nothing recorded on this deed yet/))
+      .toBeInTheDocument();
+  });
+
+  it('a draft offers no download link', async () => {
+    serve(payload({
+      instrument: { ...payload().instrument, available: false, completed_at: null },
+    }));
+    render(<DeedPage />);
+    await screen.findByTestId('instrument');
+    expect(screen.getByText(/Not generated yet/)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^Download$/ }))
+      .not.toBeInTheDocument();
+  });
+
+  it('a failed load says so rather than showing an empty deed', async () => {
+    apiFetch.mockReset();
+    apiFetch.mockResolvedValue({
+      ok: false, status: 404,
+      json: async () => ({ detail: 'Deed not found' }),
+    });
+    render(<DeedPage />);
+    expect(await screen.findByText(/Deed not found/)).toBeInTheDocument();
+    expect(screen.queryByTestId('state')).not.toBeInTheDocument();
+  });
+
+  it('an unrecognised state is a visible gap, not a confident guess', async () => {
+    serve(payload({
+      state: { ...payload().state, state: 'recorded_by_county',
+               headline: 'Recorded by the county' },
+    }));
+    render(<DeedPage />);
+    await screen.findByTestId('state');
+    expect(screen.getByText(/does not recognise yet/)).toBeInTheDocument();
+    // And it does NOT print the headline it cannot vouch for.
+    expect(screen.queryByText('Recorded by the county')).not.toBeInTheDocument();
+  });
+});
+
+describe('the participants split, on the screen', () => {
+  it('both headings render and the document side carries no control', async () => {
+    serve(payload());
+    render(<DeedPage />);
+    await screen.findByTestId('participants');
+    const onDoc = screen.getByTestId('on-the-document');
+    expect(onDoc).toHaveTextContent('Jane Doe');
+    expect(onDoc.querySelectorAll('button, a')).toHaveLength(0);
+  });
+});
+
+describe('the page asks once', () => {
+  it('one request, to the one endpoint', async () => {
+    serve(payload());
+    render(<DeedPage />);
+    await screen.findByTestId('state');
+    await waitFor(() => expect(apiFetch).toHaveBeenCalled());
+    const paths = apiFetch.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(paths).toEqual(['/deeds/7/detail']);
+  });
+});

--- a/frontend/src/app/deeds/[id]/page.tsx
+++ b/frontend/src/app/deeds/[id]/page.tsx
@@ -119,6 +119,7 @@ function DeedPageInner() {
   const act = (kind: string) => {
     if (kind === 'resume') router.push(`/create-deed?resume=${deedId}`);
     else if (kind === 'share_for_review') setShowShare(true);
+    else if (kind === 'request_signing') setShowSigning(true);
     // `open_signing` scrolls to the panel that is already on the page —
     // it never opens the CREATE modal. Offering "request a signing" on a
     // deed that already has one is an invitation to make a second, which
@@ -201,15 +202,34 @@ function DeedPageInner() {
                     This deed is in a state this page does not recognise yet.
                   </p>
                 )}
-                {detail.state.next_action && detail.state.next_action.kind !== 'none' && (
-                  <button
-                    onClick={() => act(detail.state.next_action!.kind)}
-                    className="mt-5 inline-flex items-center gap-2 bg-[#7C4DFF] text-white font-semibold px-5 py-3 rounded-lg"
-                  >
-                    {detail.state.next_action.label}
-                    <ArrowRight className="w-4 h-4" />
-                  </button>
-                )}
+                {/* Primary, and at most ONE secondary beside it. The
+                    secondary is visually subordinate — ranked, not equal
+                    — because "one obvious action" means do not present a
+                    wall of choices, not hide the second most common
+                    move. Owner-ruled after the first build offered only
+                    review and left signing reachable solely through the
+                    share dialog's switch. */}
+                <div className="mt-5 flex flex-wrap items-center gap-3">
+                  {detail.state.next_action && detail.state.next_action.kind !== 'none' && (
+                    <button
+                      onClick={() => act(detail.state.next_action!.kind)}
+                      className="inline-flex items-center gap-2 bg-[#7C4DFF] text-white font-semibold px-5 py-3 rounded-lg"
+                    >
+                      {detail.state.next_action.label}
+                      <ArrowRight className="w-4 h-4" />
+                    </button>
+                  )}
+                  {detail.state.secondary_action
+                    && detail.state.secondary_action.kind !== 'none' && (
+                    <button
+                      data-testid="secondary-action"
+                      onClick={() => act(detail.state.secondary_action!.kind)}
+                      className="inline-flex items-center gap-2 border-2 border-slate-300 text-slate-700 font-semibold px-5 py-3 rounded-lg hover:bg-white"
+                    >
+                      {detail.state.secondary_action.label}
+                    </button>
+                  )}
+                </div>
               </section>
 
               {/* THE SIGNING, IN FULL — the panel that used to expand
@@ -310,7 +330,19 @@ function DeedPageInner() {
                 </div>
               </section>
 
-              {/* ══ 4. ONE LEVEL OUT ══════════════════════════════════ */}
+              {/* ══ 4. ONE LEVEL OUT ══════════════════════════════════
+                  OWNER-RULED TO STAY (a proposed cut was overruled).
+
+                  The ranking argument for cutting it was accepted and
+                  the conclusion was not: an officer arriving cold from a
+                  notification is the case this page exists for, and
+                  "which file is this on" is the question she has before
+                  she has any other.
+
+                  The success page's matter block is not a substitute —
+                  it serves somebody who just MADE the deed and might
+                  start a related one. This serves somebody RETURNING to
+                  it. Cut only on evidence nobody uses it. */}
               {detail.matter && (
                 <section data-testid="matter" className="mb-10">
                   <h2 className="flex items-center gap-2 text-lg font-semibold text-slate-800 mb-3">

--- a/frontend/src/features/deed/deedDetail.ts
+++ b/frontend/src/features/deed/deedDetail.ts
@@ -41,7 +41,8 @@ export type DeedState = (typeof DEED_STATES)[number];
  * payload whose job is telling a state from an action. A pin caught it.
  */
 export const ACTION_KINDS = [
-  'resume', 'share_for_review', 'open_signing', 'download', 'none'] as const;
+  'resume', 'share_for_review', 'request_signing', 'open_signing',
+  'download', 'none'] as const;
 export type ActionKind = (typeof ACTION_KINDS)[number];
 
 export interface DeedAction {
@@ -54,10 +55,21 @@ export interface DeedStateBlock {
   headline: string;
   sentence: string;
   next_action: DeedAction | null;
+  /**
+   * The one deliberate exception to "one state, one obvious action"
+   * (owner-ruled): `ready` offers review AND signing, ranked rather than
+   * equal.
+   *
+   * SINGULAR by construction, in both languages. A list would grow, and
+   * a wall of equal choices is what the one-action rule exists to
+   * prevent — the ruling was "do not hide the second most common move",
+   * not "offer everything".
+   */
+  secondary_action: DeedAction | null;
   asserted_at: string | null;
   /** Present on `signing`: WHICH signing, so "open the signing" opens
    *  the one that exists rather than starting a second. */
-  signing_request_id?: number | null;
+  signing_request_id: number | null;
 }
 
 export interface Disqualification {


### PR DESCRIPTION
Both rulings reached me after #190 was written. Folded in here, plus the two follow-ups #190's premise check surfaced.

## 1. The `ready` state offers both actions

Review primary, "Request signing" beside it. My own flag on the report was right: **"one state, one obvious action" means do not present a wall of equal choices — it does not mean hide the second most common move.** Reaching signing only through the share modal's "did you mean a signing?" switch is FLOW1 item 1's affordance problem one screen over: the thing you want, discoverable only by opening a dialog about a different thing.

The two are **ranked, not equal** — the secondary renders as an outline button, pinned so it can't quietly become a twin of the primary.

Three things made structural rather than conventional:
- `secondary_action` is **singular** in both languages. A list would grow.
- `ready` is the **only** state with one, swept across every state.
- `request_signing` and `open_signing` are **separate verbs** — one creates, one opens the request that already exists. Collapsing them is how a deed with a live signing gets a second one, which is CANCEL1 item 4.

Every state block now goes through `_state()`, which asserts its key set. `secondary_action` and `signing_request_id` are present on **every** state, as `None` where there is none — a payload whose shape depends on its content gives the screen two contracts, and the second is the one nothing tests.

## 2. The matter section stays

Cut overruled. The ranking argument was accepted and the conclusion was not: an officer arriving cold from a notification **is the case the page exists for**, and the success page's block serves somebody who just *made* the deed rather than somebody returning to it. The ruling is recorded in the page source, where somebody would go to cut it — a decision that lives only in a PR body is one the next reader re-derives from scratch.

## The sixth sighting, and the fix that generalises

The pins protecting that ruling asserted `data-testid="matter"` **appears in the source**. A probe changed the guard to `{false && detail.matter && (` — section gone from every screen, every string still present — and **all 31 pins passed**.

The ledger entry recording the *fifth* sighting was written an hour earlier, by me, and I wrote three more of the same pin immediately after. That is not carelessness; it is that entry's own claim demonstrated: **the lesson does not transfer by being known.**

What changed this time: for a service, "convert the assertion to a call" means calling the function. **For a page it means rendering it** — and nothing in this suite ever had. `jest-environment-jsdom` and `@testing-library/react` were both installed and entirely unused across 60 suites of source-text pins.

`deedPageRender.test.tsx` asks what an officer **sees** for a given payload. It does not replace the source pins beside it: those assert rules about how the code is *written* (no state vocabulary in the screen, sentences rendered verbatim), which rendering cannot check. One proves the rule is stated, the other proves it is reached.

**The class is now closed for this page**, and the technique is available to every other one. The parked string-presence audit (43 files, ~600 assertions) should be re-scoped against it — branch-subject pins on rendered surfaces have a real fix now, not just a warning.

### Two traps found building it, both recorded in the file

- **`jest.mock` is only hoisted when babel sees the GLOBAL `jest`.** Every other file here imports it from `@jest/globals`, which silently disables hoisting — so the page loaded first, captured the real `useRequireAuth`, found no token, and rendered an empty string. No error, no warning. Which is this file's own subject one level up: *a test that produces nothing looks exactly like a test with nothing to say.*
- **Typing that global in a shared `.d.ts` breaks other files.** `declare var jest` conflicts with the ambient namespace `@testing-library/jest-dom` contributes; TS drops that declaration file and `integration/fault-injection.test.ts` — which calls `describe`/`it`/`expect` as globals with no imports — gains 13 errors. Measured at **88 → 101**, so the declaration is file-local instead. A test file is part of the type-checked program; changing what it pulls in changes what every other file can see.

## Also ledgered (from #190's premise check)

- **The PCOR and BOE-502-D offers exist only on the success page.** A pre-filled companion form, built from facts the deed already holds, reachable for exactly one page view. Every conveyance is legally incomplete without a concurrent BOE-502-A (R&T §480.3), so this is not a convenience that expires — it is the companion document, lost on navigation. Sized, not built: the endpoints exist and the deed page already fetches one payload.
- **`handleShare` on the success page still navigates** — `/past-deeds?id=X&action=share`, the exact pattern #178 replaced on the preview page with a dialog opened in place.

## Gates

| gate | result |
|---|---|
| pytest | 1282 passed |
| jest | 897 passed, 61 suites |
| tsc | 88 — baseline held (see the 101 note above) |
| six-flow | green |
| banned-claims | clean |
| next build | clean |
| OpenAPI snapshot | unchanged — no route moved |
| mutation probes | 8 run, **8 caught** |

The probes include the re-run of the green one: cutting the matter section now fails, and three new render probes (disqualification as a banner, the secondary never rendered, an unknown state printed anyway) each fail where the source pins alone could not see them.

**Branch note, as standing practice:** fresh per-ticket branch off current main, not the stale branch named in session config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_