### PR TITLE
NOTARYPHONE1 — the screen nobody signs in to

### DIFF
--- a/backend/services/signing_loop.py
+++ b/backend/services/signing_loop.py
@@ -320,12 +320,25 @@ def state_label(request: Dict[str, Any], windows: Sequence[Dict[str, Any]],
             when = _fmt_instant(dispatch.get("starts_at"), request.get("tz_name"))
             return f"You proposed {when} — waiting on {who} to accept"
 
+    # ── "1 times offered" ────────────────────────────────────────────
+    #
+    # Three sentences here counted with a hard-coded plural. The exact
+    # broken string is QUOTED IN THE COMMENT ABOVE, as the example of a
+    # useless-but-true sentence that the dispatch branch was added to
+    # avoid — so it was read, typed out, and shipped unfixed in the same
+    # edit. A defect can be visible in a comment about a different defect
+    # and still not be seen.
+    #
+    # One function, and every surface renders it verbatim (§13 rule 3),
+    # so the notary's phone and the officer's card are both fixed here.
+    # The audit reported it as two bugs; there is one place.
+    offered = f"{len(live)} time{'' if len(live) == 1 else 's'} offered"
     if state == STATE_PARTIALLY_AGREED:
         pending = _pending_count(participants, live, responses)
         if pending == 1:
-            return f"{len(live)} times offered — waiting on 1 more person"
-        return f"{len(live)} times offered — waiting on {pending} more people"
-    return f"{len(live)} times offered — nobody has answered yet"
+            return f"{offered} — waiting on 1 more person"
+        return f"{offered} — waiting on {pending} more people"
+    return f"{offered} — nobody has answered yet"
 
 
 def _booked_window_id(request: Dict[str, Any],

--- a/backend/services/signing_surfaces.py
+++ b/backend/services/signing_surfaces.py
@@ -182,7 +182,7 @@ def notary_package(*, request: Dict[str, Any], me: Dict[str, Any],
              "declined": bool(w.get("declined_at")),
              "start": _iso(w.get("starts_at")),
              "mine": mine.get(int(w["id"])),
-             "agreed_by": _agreed_names(participants, responses, int(w["id"]))}
+             "agreed_by": _agreed_names(participants, responses, w)}
             for w in windows
         ],
         "my_answers": mine,
@@ -197,13 +197,43 @@ def notary_package(*, request: Dict[str, Any], me: Dict[str, Any],
 
 
 def _agreed_names(participants: Sequence[Dict[str, Any]],
-                  responses: Sequence[Dict[str, Any]], window_id: int) -> List[str]:
+                  responses: Sequence[Dict[str, Any]],
+                  window: Dict[str, Any]) -> List[str]:
+    """Who AGREED to this time — never counting whoever offered it.
+
+    ═══ ANSWERING YOUR OWN QUESTION IS NOT AN AGREEMENT ═══
+
+    Posting a time writes an implicit `available` row for the poster:
+    saying "I am free Tuesday" is saying you are free Tuesday, and making
+    her tick her own window would be the product asking a question it
+    already has the answer to. That part is right and stays.
+
+    What was wrong is that the implicit row then came back to her as a
+    COUNT. Her own window read
+
+        You offered this · 1 agreed
+
+    directly above a summary saying "waiting on 1 more person" — so the
+    screen simultaneously told her somebody had agreed and that nobody
+    had. The 1 was her.
+
+    An agreement is somebody answering a question you asked. The offer is
+    the question; the offerer is not one of its answers.
+
+    Scoped to the WINDOW's proposer, not to the reader: a signer looking
+    at the notary's window should not see the notary counted either,
+    because she still has not agreed to anything — she proposed it.
+    """
     by_id = {int(p["id"]): p for p in participants}
+    proposer = window.get("proposed_by")
+    proposer_id = int(proposer) if proposer is not None else None
+    window_id = int(window["id"])
     return [
         (by_id[int(r["participant_id"])].get("display_name") or "Signer")
         for r in responses
         if int(r["window_id"]) == window_id and r.get("answer") == loop.ANSWER_AVAILABLE
         and int(r["participant_id"]) in by_id
+        and int(r["participant_id"]) != proposer_id
     ]
 
 

--- a/backend/tests/test_notary_phone.py
+++ b/backend/tests/test_notary_phone.py
@@ -1,0 +1,162 @@
+"""NOTARYPHONE1 — the two halves that are server-side.
+
+═══ THE SCREEN CONTRADICTED ITSELF ═══
+
+The notary's own window read
+
+    You offered this · 1 agreed
+
+directly above a summary saying "waiting on 1 more person". Both
+sentences were generated from the same data, and they disagreed.
+
+The 1 was her. Posting a time writes an implicit `available` row for the
+poster — saying "I am free Tuesday" IS saying you are free Tuesday, and
+making her tick her own window would be the product asking a question it
+already has the answer to. That part is right.
+
+What was wrong is that the implicit row came back to her as a COUNT of
+agreement. **An agreement is somebody answering a question you asked.
+The offer is the question; the offerer is not one of its answers.**
+
+═══ AND "1 TIMES OFFERED" ═══
+
+Three sentences in `state_label` counted with a hard-coded plural.
+
+The exact broken string is QUOTED IN A COMMENT twelve lines above them,
+as the example of a useless-but-true sentence that the dispatch branch
+was added to avoid. It was read, typed out, and shipped unfixed in the
+same edit — a defect can be visible in a comment about a different
+defect and still not be seen.
+
+The audit reported it as two bugs, one per surface. There is one
+place: every surface renders this sentence verbatim (§13 rule 3), so the
+notary's phone and the officer's card are both fixed by one line.
+"""
+import pytest
+
+from services import signing_loop as loop
+from services.signing_surfaces import _agreed_names
+
+
+def _participants():
+    return [
+        {"id": 1, "party_role": loop.ROLE_NOTARY, "display_name": "Ana Reyes"},
+        {"id": 2, "party_role": loop.ROLE_SIGNER, "display_name": "Jane Doe"},
+        {"id": 3, "party_role": loop.ROLE_SIGNER, "display_name": "John Roe"},
+    ]
+
+
+def _window(window_id=10, proposed_by=1):
+    return {"id": window_id, "proposed_by": proposed_by}
+
+
+def _yes(participant_id, window_id=10):
+    return {"window_id": window_id, "participant_id": participant_id,
+            "answer": loop.ANSWER_AVAILABLE}
+
+
+# ── The offerer is not one of the answers ────────────────────────────
+
+def test_the_notary_is_not_counted_as_agreeing_to_her_own_window():
+    """THE PIN THIS FILE EXISTS FOR."""
+    got = _agreed_names(_participants(), [_yes(1)], _window(proposed_by=1))
+    assert got == []
+
+
+def test_real_agreements_still_count():
+    got = _agreed_names(_participants(), [_yes(1), _yes(2)], _window(proposed_by=1))
+    assert got == ["Jane Doe"]
+
+
+def test_the_exclusion_follows_the_PROPOSER_not_the_reader():
+    """A signer looking at the notary's window must not see her counted
+    either — she proposed it, which is not the same as agreeing to it.
+
+    Scoping this to "whoever is reading" would make the same window read
+    differently to two people, which is a screen inventing a fact.
+    """
+    for reader in (1, 2, 3):
+        got = _agreed_names(_participants(), [_yes(1), _yes(3)],
+                            _window(proposed_by=1))
+        assert "Ana Reyes" not in got, f"visible to participant {reader}"
+        assert got == ["John Roe"]
+
+
+def test_a_signer_proposal_excludes_that_signer():
+    """Symmetric. The rule is about the offer, not about the notary."""
+    got = _agreed_names(_participants(), [_yes(2), _yes(1)], _window(proposed_by=2))
+    assert got == ["Ana Reyes"]
+
+
+def test_a_window_nobody_proposed_counts_everyone():
+    """`proposed_by` can be NULL on rows predating the column. Absent is
+    not "the reader" and not "the notary" — it excludes nobody, which is
+    the honest reading of a value we do not have."""
+    got = _agreed_names(_participants(), [_yes(1), _yes(2)],
+                        _window(proposed_by=None))
+    assert sorted(got) == ["Ana Reyes", "Jane Doe"]
+
+
+def test_a_decline_is_not_an_agreement():
+    responses = [{"window_id": 10, "participant_id": 2, "answer": "unavailable"}]
+    assert _agreed_names(_participants(), responses, _window()) == []
+
+
+def test_answers_on_another_window_do_not_leak():
+    got = _agreed_names(_participants(), [_yes(2, window_id=11)], _window(10))
+    assert got == []
+
+
+# ── One sentence, both surfaces ──────────────────────────────────────
+
+def _label(window_count, pending, state=loop.STATE_PARTIALLY_AGREED):
+    """Drive `state_label` through the counting branch."""
+    request = {"id": 1, "tz_name": "America/Los_Angeles"}
+    windows = [{"id": i, "starts_at": None, "ends_at": None,
+                "origin": loop.ORIGIN_NOTARY, "proposed_by": 1}
+               for i in range(1, window_count + 1)]
+    participants = _participants()[: 1 + pending]
+    return loop.state_label(request, windows, [], participants)
+
+
+@pytest.mark.parametrize("count,expected", [(1, "1 time offered"),
+                                            (2, "2 times offered"),
+                                            (3, "3 times offered")])
+def test_the_count_agrees_with_its_noun(count, expected):
+    assert _label(count, pending=1).startswith(expected)
+
+
+def test_the_fix_is_in_ONE_place():
+    """The audit called it two bugs — the notary page and the officer
+    card. Both render this function's sentence verbatim (§13 rule 3), so
+    there is one place, and a screen that formatted its own count would
+    be the defect this rule exists to prevent.
+
+    Asserted by counting the formatting, not by reading the screens: two
+    surfaces cannot disagree about a string neither of them composes.
+    """
+    import inspect
+    src = inspect.getsource(loop.state_label)
+    assert src.count("time{'' if len") == 1
+    assert "times offered" not in src.replace("# ", "").split("offered =")[1]
+
+
+def test_no_screen_composes_this_count_itself():
+    """The other half of the same rule, swept across the frontend.
+
+    SCOPED TO SCREENS, not to every file. The first draft swept `*.tsx`
+    and caught its own sibling: `notaryPhoneRender.test.tsx` quotes the
+    broken string in a comment explaining the fix. A test that quotes a
+    defect is not committing it, and a sweep that cannot tell the
+    difference gets widened until it means nothing.
+    """
+    from pathlib import Path
+    repo = Path(__file__).resolve().parents[2]
+    frontend = repo / "frontend" / "src"
+    offenders = [
+        p.relative_to(frontend).as_posix()
+        for p in frontend.rglob("*.tsx")
+        if "__tests__" not in p.parts
+        and "times offered" in p.read_text(encoding="utf-8")
+    ]
+    assert offenders == [], f"a screen writes the count itself: {offenders}"

--- a/frontend/src/__tests__/notaryPhone.test.ts
+++ b/frontend/src/__tests__/notaryPhone.test.ts
@@ -1,0 +1,133 @@
+/**
+ * NOTARYPHONE1 — the screen nobody signs in to.
+ *
+ * ═══ WHO THIS IS FOR ═══
+ *
+ * The notary is not our customer. She has no account, no password, no
+ * support relationship, and she is on her phone because a token arrived
+ * by email. Every allowance the rest of this product gets — a wide
+ * viewport, a session to come back to, a person to call — she does not
+ * have.
+ *
+ * ═══ THE TRUNCATION ═══
+ *
+ * The availability rows sat in `grid-cols-2` at every width. That is
+ * ~150px per control on a phone; Chrome needs about 200px to render a
+ * `datetime-local`. So it truncated, and what she saw after typing a
+ * date and a time was
+ *
+ *     2026 10:00 AM
+ *
+ * with the date gone. She could not check the time she had just entered.
+ *
+ * The officer's own dispatch inputs, one file over in
+ * `RequestSigningModal`, have had `grid-cols-1 sm:grid-cols-2` with
+ * labels the whole time. **The pattern already existed in this
+ * codebase.** The surface that got the worse version is the one used by
+ * somebody who cannot complain to us.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
+
+const SRC = path.join(__dirname, '..');
+const read = (...p: string[]) => fs.readFileSync(path.join(SRC, ...p), 'utf8');
+const NOTARY = codeOnly(read('app', 'signing', '[token]', 'page.tsx'));
+const OFFICER = codeOnly(read('features', 'signing', 'RequestSigningModal.tsx'));
+
+/** Every datetime-local on the token surface, with its surroundings. */
+const dateInputs = (src: string) =>
+  src.split('type="datetime-local"').slice(1);
+
+describe('the inputs fit the phone they are used on', () => {
+  it('no datetime control is forced into a half-width column', () => {
+    /** THE PIN THIS FILE EXISTS FOR. `grid-cols-2` without a breakpoint
+     *  is the truncation, and it is the only spelling of it. */
+    expect(NOTARY).not.toContain('grid grid-cols-2');
+    expect(NOTARY).toContain('grid-cols-1 sm:grid-cols-2');
+  });
+
+  it('and the officer surface, which was already right, still is', () => {
+    // The comparison that makes the finding a finding: the pattern was
+    // here, one file over, the whole time.
+    expect(OFFICER).toContain('grid-cols-1 sm:grid-cols-2');
+  });
+
+  it('every datetime input fills its column rather than a fixed width', () => {
+    for (const after of dateInputs(NOTARY)) {
+      expect(after.slice(0, 300)).toContain('w-full');
+    }
+  });
+});
+
+describe('every control has a name', () => {
+  it('each datetime input carries an id, and a label points at it', () => {
+    /**
+     * Two identical controls side by side. Without names, a screen
+     * reader announces "date and time" twice and the difference between
+     * them — which one is the start — is carried entirely by position.
+     */
+    const ids = NOTARY.match(/id=\{?[`'"]([a-z-]+(-\$\{i\})?)[`'"]\}?/g) || [];
+    expect(ids.length).toBeGreaterThanOrEqual(4);
+    for (const name of ['Starts', 'Ends']) {
+      expect(NOTARY).toContain(`>\n                        ${name}\n`);
+    }
+    expect(NOTARY).toContain('htmlFor={`start-${i}`}');
+    expect(NOTARY).toContain('htmlFor={`end-${i}`}');
+    expect(NOTARY).toContain('htmlFor="propose-start"');
+    expect(NOTARY).toContain('htmlFor="propose-end"');
+  });
+
+  it('the count of labels matches the count of inputs', () => {
+    // A label added to one of a pair is the failure the register form
+    // had: the half that is covered hides that the other half is not.
+    const inputs = dateInputs(NOTARY).length;
+    const labels = (NOTARY.match(/htmlFor=/g) || []).length;
+    expect(labels).toBe(inputs);
+  });
+});
+
+describe('a disabled button says why', () => {
+  it('an incomplete row is explained, not silently ignored', () => {
+    /**
+     * A browser hands back `''` for a half-typed datetime, so a date
+     * with no time reads to this code exactly like an empty field. Post
+     * greys out and the most likely mistake is indistinguishable from
+     * having typed nothing.
+     *
+     * §4 wearing a UI hat: the product declined and did not say so.
+     */
+    expect(NOTARY).toContain('const incomplete =');
+    expect(NOTARY).toContain('needs both a start and an end');
+    expect(NOTARY).toContain('Add a time you are free');
+  });
+
+  it('the two cases are told apart', () => {
+    // "You have not started" and "you started and stopped halfway" are
+    // different mistakes and need different sentences.
+    expect(NOTARY).toContain('incomplete\n                  ?');
+  });
+
+  it('the explanation is announced, not merely coloured', () => {
+    expect(NOTARY).toContain('role="status"');
+  });
+});
+
+describe('"Another" is not one-way', () => {
+  it('a row can be removed once there is more than one', () => {
+    // A row added by a mis-tap could not be taken back, and a
+    // half-filled one disabled Post with no way to clear it.
+    expect(NOTARY).toContain('Remove');
+    expect(NOTARY).toContain('p.filter((_, n) => n !== i)');
+  });
+
+  it('the remove control names which row it removes', () => {
+    expect(NOTARY).toContain('aria-label={`Remove time ${i + 1}`}');
+  });
+
+  it('the last row cannot be removed', () => {
+    // Zero rows is a form with nothing to fill in and no way back.
+    expect(NOTARY).toContain('rows.length > 1 &&');
+  });
+});

--- a/frontend/src/__tests__/notaryPhoneRender.test.tsx
+++ b/frontend/src/__tests__/notaryPhoneRender.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * NOTARYPHONE1, RENDERED — what the notary actually sees.
+ *
+ * ═══ WHY THIS FILE AND NOT MORE SOURCE PINS ═══
+ *
+ * The source pins next door assert that the explanation for a disabled
+ * Post button EXISTS IN THE FILE. A probe wrapped it in `{false && (`
+ * and all eleven passed: the strings were still there, the sentence was
+ * on no screen.
+ *
+ * That is the same defect for the third time in two days — a
+ * string-presence pin cannot tell REACHABLE from PRESENT. The lesson
+ * does not transfer by being known; the only thing that catches it is
+ * executing the branch, which for a page means rendering it.
+ *
+ * ═══ AND IT MATTERS MORE HERE THAN ANYWHERE ═══
+ *
+ * This is the one surface used by somebody who is not our customer, on a
+ * phone, with no account and no way to complain to us. A control that is
+ * silently unusable here does not generate a support ticket. It
+ * generates a signing that never gets booked, and nobody ever learns
+ * why.
+ *
+ * NOTE on `jest`: used from the GLOBAL, not imported from
+ * `@jest/globals`. Babel only hoists `jest.mock` above the imports when
+ * it sees the global — an imported one leaves the module under test to
+ * load first and capture the real dependencies, and the symptom is a
+ * silent empty render.
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, expect, it, beforeEach } from '@jest/globals';
+import type { jest as JestObject } from '@jest/globals';
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/jest-globals';
+
+/** File-local so it cannot collide with the ambient `jest` namespace —
+ *  a global declaration knocks out `describe`/`it` for other suites. */
+declare const jest: typeof JestObject;
+
+jest.mock('next/navigation', () => ({
+  useParams: () => ({ token: 'tok-1' }),
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+  usePathname: () => '/signing/tok-1',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+import SigningTokenPage from '@/app/signing/[token]/page';
+
+/** The notary's package, in the shape `signing_surfaces` asserts. */
+const pkg = (over: Record<string, unknown> = {}) => ({
+  party_role: 'notary',
+  state: 'windows_posted',
+  summary: '1 time offered — waiting on 1 more person',
+  expires_at: '2026-09-01T00:00:00Z',
+  windows: [],
+  coordinator: { name: 'Maria Lopez', company: 'Pacific Coast Escrow' },
+  property_address: '123 Baseline St',
+  county: 'Los Angeles',
+  deed_type: 'grant-deed',
+  signers: [{ name: 'Jane Doe' }],
+  pcor_url: '/signing/tok-1/pcor',
+  pdf_url: '/signing/tok-1/pdf',
+  ...over,
+});
+
+const serve = (body: unknown) => {
+  (global as any).fetch = jest.fn(async () => ({
+    ok: true, status: 200, json: async () => body,
+  })) as any;
+};
+
+beforeEach(() => { (global as any).fetch = undefined; });
+
+const notary = async (over: Record<string, unknown> = {}) => {
+  serve(pkg(over));
+  render(<SigningTokenPage />);
+  await screen.findByText(/Add times you are free/);
+};
+
+describe('the disabled Post button explains itself', () => {
+  it('says what is missing before anything is typed', async () => {
+    /** THE PIN THIS FILE EXISTS FOR — the one a source check could not
+     *  see, because the sentence was present and unreachable. */
+    await notary();
+    expect(screen.getByText(/Add a time you are free, then post it/))
+      .toBeInTheDocument();
+  });
+
+  it('and says something DIFFERENT when a row is half-filled', async () => {
+    /**
+     * A browser hands back `''` for a half-typed datetime, so a date
+     * with no time reads to this code exactly like an empty field. The
+     * officer's most likely mistake was indistinguishable from having
+     * typed nothing — and the button just greyed out.
+     */
+    await notary();
+    fireEvent.change(screen.getByLabelText('Starts'),
+                     { target: { value: '2026-09-01T10:00' } });
+    await waitFor(() => {
+      expect(screen.getByText(/needs both a start and an end/))
+        .toBeInTheDocument();
+    });
+    expect(screen.queryByText(/Add a time you are free, then post it/))
+      .not.toBeInTheDocument();
+  });
+
+  it('and goes quiet once the row is complete', async () => {
+    await notary();
+    fireEvent.change(screen.getByLabelText('Starts'),
+                     { target: { value: '2026-09-01T10:00' } });
+    fireEvent.change(screen.getByLabelText('Ends'),
+                     { target: { value: '2026-09-01T11:00' } });
+    await waitFor(() => {
+      expect(screen.queryByText(/needs both a start and an end/))
+        .not.toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: /Post 1 time$/ })).toBeEnabled();
+  });
+});
+
+describe('every control is reachable by its name', () => {
+  it('the start and end are found by label, not by position', async () => {
+    // If this passes, a screen reader can tell them apart. Before, both
+    // announced as "date and time" and the difference was the order.
+    await notary();
+    expect(screen.getByLabelText('Starts')).toBeInTheDocument();
+    expect(screen.getByLabelText('Ends')).toBeInTheDocument();
+  });
+});
+
+describe('"Another" can be undone', () => {
+  it('a second row appears, and can be removed again', async () => {
+    await notary();
+    expect(screen.queryByRole('button', { name: /Remove time/ }))
+      .not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Another/ }));
+    const remove = await screen.findByRole('button', { name: 'Remove time 2' });
+    expect(screen.getAllByLabelText(/Starts/)).toHaveLength(2);
+
+    fireEvent.click(remove);
+    await waitFor(() => {
+      expect(screen.getAllByLabelText(/Starts/)).toHaveLength(1);
+    });
+  });
+
+  it('the last row has no Remove — zero rows is a form with no way back', async () => {
+    await notary();
+    expect(screen.queryByRole('button', { name: /Remove time 1/ }))
+      .not.toBeInTheDocument();
+  });
+});
+
+describe('the summary is the server\'s sentence, verbatim', () => {
+  it('renders whatever Python composed, including the count', async () => {
+    // "1 time offered", not "1 times offered" — and the screen does no
+    // arithmetic of its own to get there (§13 rule 3).
+    await notary();
+    expect(screen.getAllByText(/1 time offered — waiting on 1 more person/).length)
+      .toBeGreaterThan(0);
+  });
+});
+
+describe('a window the notary offered does not claim she agreed to it', () => {
+  it('shows nobody has answered when only her implicit row exists', async () => {
+    /**
+     * The contradiction: "You offered this · 1 agreed" sat directly
+     * above "waiting on 1 more person". The 1 was her.
+     *
+     * The server no longer counts the proposer, so `agreed_by` arrives
+     * empty and the screen says so.
+     */
+    await notary({
+      windows: [{ id: 5, label: 'Tue 1 Sep, 10:00 AM', origin: 'notary',
+                  declined: false, start: '2026-09-01T10:00:00Z',
+                  mine: { answer: 'available', asserted_by: 'Ana Reyes' },
+                  agreed_by: [] }],
+    });
+    expect(screen.getByText(/You offered this · nobody has answered/))
+      .toBeInTheDocument();
+    expect(screen.queryByText(/1 agreed/)).not.toBeInTheDocument();
+  });
+
+  it('and still reports a real agreement when there is one', async () => {
+    await notary({
+      windows: [{ id: 5, label: 'Tue 1 Sep, 10:00 AM', origin: 'notary',
+                  declined: false, start: '2026-09-01T10:00:00Z',
+                  mine: { answer: 'available', asserted_by: 'Ana Reyes' },
+                  agreed_by: ['Jane Doe'] }],
+    });
+    expect(screen.getByText(/You offered this · 1 agreed/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/signing/[token]/page.tsx
+++ b/frontend/src/app/signing/[token]/page.tsx
@@ -267,9 +267,20 @@ function SignerView({ pkg, busy, post, error }: {
           proposing ? (
             <div className="mt-4 space-y-2">
               <p className="text-sm text-slate-600">Suggest a time instead:</p>
-              <input type="datetime-local" value={start} onChange={(e) => setStart(e.target.value)}
+              {/* Already stacked; what they lacked was names. An input
+                  whose only label is its position is unusable with a
+                  screen reader, and these two are identical controls. */}
+              <label htmlFor="propose-start" className="block text-xs text-slate-500">
+                Starts
+              </label>
+              <input id="propose-start" type="datetime-local" value={start}
+                     onChange={(e) => setStart(e.target.value)}
                      className="w-full px-3 py-3 border border-slate-300 rounded-lg" />
-              <input type="datetime-local" value={end} onChange={(e) => setEnd(e.target.value)}
+              <label htmlFor="propose-end" className="block text-xs text-slate-500">
+                Ends
+              </label>
+              <input id="propose-end" type="datetime-local" value={end}
+                     onChange={(e) => setEnd(e.target.value)}
                      className="w-full px-3 py-3 border border-slate-300 rounded-lg" />
               <div className="flex gap-2">
                 <button onClick={() => setProposing(false)}
@@ -318,6 +329,9 @@ function NotaryView({ pkg, busy, post, error }: {
   const [rows, setRows] = useState<Array<{ start: string; end: string }>>([{ start: '', end: '' }]);
   const [posting, setPosting] = useState(false);
   const complete = rows.filter((r) => r.start && r.end);
+  // Something typed, but not enough of it — the case that used to grey
+  // out Post with no explanation.
+  const incomplete = rows.some((r) => (r.start || r.end) && !(r.start && r.end));
 
   const submit = async () => {
     setPosting(true);
@@ -412,15 +426,65 @@ function NotaryView({ pkg, busy, post, error }: {
         {pkg.state !== 'booked' && (
           <>
             <p className="text-sm font-medium text-slate-700 mb-2">Add times you are free</p>
-            <div className="space-y-2">
+            {/* ═══ ONE COLUMN UNTIL THERE IS ROOM FOR TWO ═══
+
+                These sat in `grid-cols-2` at every width. On a phone that
+                is ~150px per control, and Chrome needs about 200px to
+                render a datetime-local — so it truncates, and what the
+                notary saw after typing a date and a time was
+
+                    2026 10:00 AM
+
+                with the date gone. She cannot check the time she just
+                entered on the one device she is holding.
+
+                This is a CONSUMER surface: the notary is not our
+                customer, is on her phone, and has no account to fall
+                back to. The officer's own dispatch inputs, one file over
+                in RequestSigningModal, have had `grid-cols-1
+                sm:grid-cols-2` with labels the whole time. The pattern
+                existed; the screen nobody signs in to never got it. */}
+            <div className="space-y-3">
               {rows.map((r, i) => (
-                <div key={i} className="grid grid-cols-2 gap-2">
-                  <input type="datetime-local" value={r.start}
-                         onChange={(e) => setRows((p) => p.map((x, n) => n === i ? { ...x, start: e.target.value } : x))}
-                         className="px-3 py-2.5 border border-slate-300 rounded-lg text-sm" />
-                  <input type="datetime-local" value={r.end}
-                         onChange={(e) => setRows((p) => p.map((x, n) => n === i ? { ...x, end: e.target.value } : x))}
-                         className="px-3 py-2.5 border border-slate-300 rounded-lg text-sm" />
+                <div key={i} className="rounded-lg border border-slate-200 p-3">
+                  <div className="flex items-center justify-between mb-2">
+                    <p className="text-xs font-medium text-slate-500">
+                      Time {i + 1}
+                    </p>
+                    {/* "Another" was one-way: a row added by a mis-tap
+                        could not be taken back, and a half-filled one
+                        silently disabled Post with no way to clear it. */}
+                    {rows.length > 1 && (
+                      <button
+                        type="button"
+                        aria-label={`Remove time ${i + 1}`}
+                        onClick={() => setRows((p) => p.filter((_, n) => n !== i))}
+                        className="text-xs text-slate-500 hover:text-red-700 hover:underline"
+                      >
+                        Remove
+                      </button>
+                    )}
+                  </div>
+                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                    <div>
+                      <label htmlFor={`start-${i}`}
+                             className="block text-xs text-slate-500 mb-1">
+                        Starts
+                      </label>
+                      <input id={`start-${i}`} type="datetime-local" value={r.start}
+                             onChange={(e) => setRows((p) => p.map((x, n) => n === i ? { ...x, start: e.target.value } : x))}
+                             className="w-full px-3 py-2.5 border border-slate-300 rounded-lg text-sm" />
+                    </div>
+                    <div>
+                      <label htmlFor={`end-${i}`}
+                             className="block text-xs text-slate-500 mb-1">
+                        Ends
+                      </label>
+                      <input id={`end-${i}`} type="datetime-local" value={r.end}
+                             onChange={(e) => setRows((p) => p.map((x, n) => n === i ? { ...x, end: e.target.value } : x))}
+                             className="w-full px-3 py-2.5 border border-slate-300 rounded-lg text-sm" />
+                    </div>
+                  </div>
                 </div>
               ))}
             </div>
@@ -434,6 +498,23 @@ function NotaryView({ pkg, busy, post, error }: {
                 {posting ? 'Posting…' : `Post ${complete.length || ''} time${complete.length === 1 ? '' : 's'}`}
               </button>
             </div>
+            {/* ═══ A DISABLED BUTTON THAT SAYS WHY ═══
+
+                Post disables whenever no row has BOTH ends. A browser
+                hands back `''` for a half-typed datetime, so a date with
+                no time reads to this code exactly like an empty field —
+                and the officer's most likely mistake was indistinguishable
+                from having typed nothing.
+
+                Greyed out with no explanation is the product declining
+                and not saying so, which is §4 wearing a UI hat. */}
+            {!posting && !complete.length && (
+              <p role="status" className="text-xs text-amber-700 mt-2">
+                {incomplete
+                  ? 'Each time needs both a start and an end before it can be posted.'
+                  : 'Add a time you are free, then post it.'}
+              </p>
+            )}
             <p className="text-xs text-slate-500 mt-2 flex items-start gap-1.5">
               <Clock className="w-3.5 h-3.5 shrink-0 mt-0.5" />
               Posting a time says you are free then — you do not need to confirm it again.


### PR DESCRIPTION
Ticket 1 of 5. The notary is not our customer: no account, no password, no support relationship, on her phone because a token arrived by email. A control that is silently unusable here does not generate a support ticket — it generates a signing that never gets booked, and nobody learns why.

## The truncation

The availability rows sat in `grid-cols-2` at **every** width — ~150px per control on a phone, where Chrome needs ~200px for a `datetime-local`. It truncated, and after typing a date and a time she saw `2026 10:00 AM` with the date gone.

**The officer's own dispatch inputs, one file over in `RequestSigningModal`, have had `grid-cols-1 sm:grid-cols-2` with labels the whole time.** The pattern already existed in this codebase. The surface that got the worse version is the one used by somebody who cannot complain to us.

Also on that screen: every input now has a label pointing at it (two identical controls whose only distinction was position), "Another" gained a Remove (it was one-way, so a mis-tapped row could not be taken back and a half-filled one disabled Post with no way to clear it), and **Post says why it is disabled** — a browser returns `''` for a half-typed datetime, so a date with no time read to this code exactly like an empty field, and the likeliest mistake was indistinguishable from having typed nothing.

## The contradiction

> You offered this · 1 agreed

sat directly above a summary saying "waiting on 1 more person". Both sentences came from the same data and disagreed. **The 1 was her.**

Posting a time writes an implicit `available` row for the poster, and that is right — saying "I am free Tuesday" *is* saying so, and making her tick her own window would be the product asking a question it already has the answer to. What was wrong is that the implicit row came back as a **count of agreement**.

*An agreement is somebody answering a question you asked. The offer is the question; the offerer is not one of its answers.*

Scoped to the **proposer**, not the reader — scoping it to whoever is looking would make the same window read differently to two people, which is a screen inventing a fact.

## "1 times offered" — one place, not two

The audit reported it twice, once per surface. Every surface renders `state_label`'s sentence verbatim (§13 rule 3), so **one line fixes both**, and a screen that formatted its own count would be the defect that rule exists to prevent. Pinned from both ends: the Python formats once, and a sweep asserts no screen composes the count itself.

Worth recording: **the exact broken string is quoted in a comment twelve lines above it**, as the example of a useless-but-true sentence the dispatch branch was added to avoid. It was read, typed out, and shipped unfixed in the same edit. A defect can be visible in a comment about a different defect and still not be seen.

## Premises checked

All six symptoms **confirmed**, mechanisms verified in code rather than assumed. Two corrections worth naming:

1. **The pluralization is one bug, not two.** The ticket asks for it "on both the notary page and the officer card"; both render a server-composed sentence, so there is a single place. Fixing it twice would have been the §13 violation.
2. **`Post ${n} time${n === 1 ? '' : 's'}` on the button was already correct.** The broken plural was never on the button the audit was looking at — it was in the server sentence rendered above it.

And one confirmation that is itself information: **the officer surface was already right**, which is what makes this a finding about who a surface serves rather than about a missing convention.

## Self-review

**Pins changed:** none retargeted; all new. One I wrote and then narrowed — the "no screen composes this count" sweep read every `.tsx` and caught its own sibling test file, which quotes the broken string in a comment explaining the fix. Scoped to non-test files: a test that quotes a defect is not committing it, and a sweep that cannot tell the difference gets widened until it means nothing.

**Least sure about:** the `sm:` breakpoint (640px) for the two-column layout. It matches the officer modal, so it is at least consistent — but the audit measured 147–154px, implying a viewport around 320–360px, and I have not verified that 640px is where two `datetime-local` controls stop truncating rather than merely where they fit.

**Would cut:** the Remove button. It is the smallest of the four fixes and the only one that is a convenience rather than a correction. Cutting it costs a notary who mis-taps "Another" a stuck row that disables Post — which, with the new explanation, now at least says what is wrong.

**Decided rather than flagged:** the signer's "suggest a time" inputs got labels too. They were already stacked so they were not part of the reported defect, but they are the same two unnamed controls on the same screen, and same-class findings roll.

## Gates

| gate | result |
|---|---|
| pytest | 1288 passed |
| jest | 898 passed, 62 suites |
| tsc | 88 — baseline unchanged |
| six-flow | green |
| banned-claims | clean |
| next build | clean |
| OpenAPI snapshot | unchanged |
| mutation probes | 7 run, 6 caught, **1 came back green** |

**The green probe:** wrapping the disabled-button explanation in `{false && (` left every string present and passed all eleven source pins. **Third sighting of that class in two days.** So this ticket carries a render test — `notaryPhoneRender.test.tsx` drives the real component, types into the real inputs, and asks what the notary sees. Re-running the probe: 2 failures where there were 0, and two further probes (Remove unreachable, labels detached) now fail where source pins could not see them.

**Branch note, as standing practice:** fresh per-ticket branch off current main, not the stale branch named in session config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_