### PR TITLE
SIGNUP1 — registration stops promising what the product cannot do

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -182,6 +182,11 @@ def create_tables():
             "ALTER TABLE users ADD COLUMN IF NOT EXISTS verified BOOLEAN DEFAULT FALSE",
             "ALTER TABLE users ADD COLUMN IF NOT EXISTS subscribe BOOLEAN DEFAULT FALSE",
             "ALTER TABLE users ADD COLUMN IF NOT EXISTS agree_terms BOOLEAN DEFAULT TRUE",
+            # SIGNUP1 — where somebody outside California told us they
+            # are. An interest signal, not an address: it is never used
+            # to serve anybody, and it is READABLE (admin user list)
+            # rather than write-only, which is the LEGAL1 bar.
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS interest_state VARCHAR(64)",
             "ALTER TABLE deeds ADD COLUMN IF NOT EXISTS grantor_name VARCHAR(255)",
             "ALTER TABLE deeds ADD COLUMN IF NOT EXISTS grantee_name VARCHAR(255)",
             "ALTER TABLE deeds ADD COLUMN IF NOT EXISTS pdf_url VARCHAR(500)",

--- a/backend/routers/admin_api_v2.py
+++ b/backend/routers/admin_api_v2.py
@@ -121,6 +121,7 @@ def admin_user_detail(user_id: int, admin=Depends(get_current_admin)):
     with db_connection() as conn, conn.cursor() as cur:
         cur.execute("""
             SELECT id, email, full_name, COALESCE(role,'') as role, plan, company_name, company_type,
+                   interest_state,
                    phone, state, verified, stripe_customer_id, last_login, created_at, is_active
             FROM users WHERE id = %s
         """, (user_id,))

--- a/backend/routers/users_auth.py
+++ b/backend/routers/users_auth.py
@@ -24,6 +24,13 @@ from database import (
     PROFILE_COLUMNS, PROFILE_ELSEWHERE, clean_profile_text, get_user_profile,
     update_user_profile, get_recent_properties,
 )
+from services.phone import normalize_phone
+
+#: The one state this product serves. Mirrors SERVED_STATE in
+#: frontend/src/lib/registerForm.ts; a jest/pytest pair holds them equal,
+#: because a screen that stops offering a state while the server keeps
+#: accepting it is the cosmetic version of this fix.
+SERVED_STATE = "CA"
 
 router = APIRouter()
 
@@ -39,6 +46,10 @@ class UserRegister(BaseModel):
     phone: Optional[str] = None
     state: str
     agree_terms: bool
+    # SIGNUP1 — an interest signal, not an order. Somebody outside
+    # California telling us where they are. Free text on purpose: a
+    # dropdown implies we would accept the answer.
+    interest_state: Optional[str] = None
     # ── LEGAL1: `subscribe` IS NO LONGER ACCEPTED ─────────────────────
     #
     # It was captured here and written to the users table, and then
@@ -101,9 +112,27 @@ async def register_user(user: UserRegister = Body(...)):
         if not AuthUtils.validate_email(user.email):
             raise HTTPException(status_code=400, detail="Invalid email format")
 
-        # Validate state code
+        # ── CALIFORNIA, AND THE REFUSAL IS REAL ───────────────────────
+        #
+        # The form no longer offers fifty states; it states one. That
+        # alone would be cosmetic — the endpoint is public and takes
+        # whatever it is sent, so an API caller could still register in
+        # Arizona and receive an account this product cannot serve.
+        #
+        # Owner-ruled: the catalog, chassis, DTT registry and county
+        # knowledge are California by construction. So the server refuses,
+        # and says what it does serve rather than "invalid".
         if not AuthUtils.validate_state_code(user.state):
             raise HTTPException(status_code=400, detail="Invalid state code")
+        if (user.state or "").strip().upper() != SERVED_STATE:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "DeedPro serves California today — our forms, transfer-tax "
+                    "rates and county requirements are California-specific. "
+                    "Tell us which state you are in and we will record it."
+                ),
+            )
 
         # Profile-hygiene: a name that is all whitespace is no name — the
         # value prints on deed faces and emails.
@@ -136,8 +165,8 @@ async def register_user(user: UserRegister = Body(...)):
         with conn.cursor() as cur:
             cur.execute("""
                 INSERT INTO users (email, password_hash, full_name, role, company_name,
-                                 company_type, phone, state, plan)
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                                 company_type, phone, state, plan, interest_state)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 RETURNING id
             """, (
                 # Profile-hygiene: name/company/phone print on deed faces
@@ -145,8 +174,18 @@ async def register_user(user: UserRegister = Body(...)):
                 user.email.lower(), hashed_password,
                 clean_profile_text(user.full_name), user.role,
                 clean_profile_text(user.company_name), user.company_type,
-                clean_profile_text(user.phone), user.state.upper(),
-                'free'
+                # SIGNUP1: E.164 at the write, using the normalizer
+                # PARTNER2 built and the partner API has used since.
+                # `clean_profile_text` only collapses whitespace, which is
+                # how "not-a-phone!!" was stored verbatim and how
+                # production came to hold a nine-digit number.
+                #
+                # The browser masks as she types AND the server normalizes
+                # here, deliberately: a rule only the browser enforces is
+                # a rule the API does not have.
+                normalize_phone(clean_profile_text(user.phone)) or None,
+                user.state.upper(),
+                'free', clean_profile_text(user.interest_state),
             ))
             result = cur.fetchone()
             if result:

--- a/backend/tests/test_signup1.py
+++ b/backend/tests/test_signup1.py
@@ -1,0 +1,169 @@
+"""SIGNUP1 — registration stops promising what the product cannot do.
+
+═══ FIFTY OPTIONS, ONE PRODUCT ═══
+
+The state dropdown offered fifty. The catalog, the chassis, the DTT rate
+registry and every county form in this product are CALIFORNIA by
+construction — 58 California counties, California code sections,
+California transfer tax. Fifty options is a promise broken the moment
+somebody in Arizona registers and finds no Arizona forms.
+
+Owner-ruled: California, displayed rather than chosen.
+
+**And the refusal has to be the SERVER's**, not the screen's. Removing
+the dropdown while the endpoint keeps accepting `AZ` is the cosmetic
+version of the fix: registration is public, so an API caller would still
+open an account this product cannot serve — and the person who opened it
+would find out by looking for forms that do not exist.
+
+═══ AND THE PHONE ═══
+
+`clean_profile_text` only collapses whitespace, so "not-a-phone!!" was
+stored verbatim and production holds a nine-digit number nobody can call.
+
+A full normalizer has existed in BOTH languages since PARTNER2 —
+`services/phone.py`, `frontend/src/lib/phone.ts`, and a shared corpus so
+the two are checked against one referee. The partner screens have used it
+all along. **Registration never called it.**
+
+That is the same shape NOTARYPHONE1 found hours earlier: the fix reached
+every surface where a customer could report a problem, and none where a
+stranger could not.
+"""
+import inspect
+
+import pytest
+
+import routers.users_auth as mod
+from routers.users_auth import SERVED_STATE
+from services.phone import normalize_phone
+
+
+# ── The state is refused on the server ───────────────────────────────
+
+def test_the_served_state_is_california():
+    assert SERVED_STATE == "CA"
+
+
+def test_registration_refuses_another_state_and_says_what_we_serve():
+    """THE PIN THIS FILE EXISTS FOR.
+
+    A refusal that says "invalid" teaches nothing — the state IS valid,
+    it is just not one we serve, and the difference is the whole point.
+    """
+    src = inspect.getsource(mod.register_user)
+    assert "!= SERVED_STATE" in src
+    assert "serves California today" in src
+    assert "California-specific" in src
+
+
+def test_the_refusal_comes_after_the_format_check_not_instead_of_it():
+    """`AAA` is a malformed code and `AZ` is a real state we do not
+    serve. Two different answers, and collapsing them would tell somebody
+    their typo was a business decision."""
+    src = inspect.getsource(mod.register_user)
+    assert src.index("validate_state_code") < src.index("!= SERVED_STATE")
+
+
+def test_both_languages_name_the_same_state():
+    """A screen that stops offering a state while the server keeps
+    accepting it is the pair that drifts because nobody compares it."""
+    from pathlib import Path
+    repo = Path(__file__).resolve().parents[2]
+    ts = (repo / "frontend" / "src" / "lib" / "registerForm.ts").read_text(
+        encoding="utf-8")
+    assert f"SERVED_STATE = '{SERVED_STATE}'" in ts
+
+
+# ── The phone is normalized where it is stored ───────────────────────
+
+def test_the_registration_insert_normalizes_the_phone():
+    src = inspect.getsource(mod.register_user)
+    assert "normalize_phone(clean_profile_text(user.phone))" in src
+
+
+def test_whitespace_cleaning_was_never_phone_validation():
+    """The distinction the defect turned on. `clean_profile_text` is
+    doing its job correctly and its job is not this one."""
+    from database import clean_profile_text
+    assert clean_profile_text("not-a-phone!!") == "not-a-phone!!"
+    # And the normalizer refuses to invent a number out of it — it
+    # returns the text verbatim rather than discarding what it cannot
+    # parse (services/phone.py's own rule).
+    assert normalize_phone("not-a-phone!!") == "not-a-phone!!"
+
+
+def test_a_real_number_reaches_storage_in_one_shape():
+    assert normalize_phone("(626) 555-0134") == "+16265550134"
+    assert normalize_phone("626.555.0134") == "+16265550134"
+
+
+def test_the_normalizer_was_already_here_and_already_used():
+    """The finding, pinned so it reads as a finding rather than a fix.
+
+    This is not new capability. It is capability that reached the
+    partner screens and not the signup form — the surface a stranger
+    meets first.
+    """
+    import services.partners as partners
+    assert "normalize_phone" in inspect.getsource(partners)
+
+
+# ── The interest signal is stored AND readable ───────────────────────
+
+def test_the_interest_signal_is_accepted_and_optional():
+    assert "interest_state" in mod.UserRegister.model_fields
+    assert mod.UserRegister.model_fields["interest_state"].default is None
+
+
+def test_it_is_written():
+    src = inspect.getsource(mod.register_user)
+    assert "interest_state" in src
+    assert "clean_profile_text(user.interest_state)" in src
+
+
+def test_it_is_READABLE_which_is_the_legal1_bar():
+    """LEGAL1's ruling, applied before the mistake rather than after.
+
+    `subscribe` was collected at registration, written to `users`, and
+    appeared in no response, no profile, no admin view and no export.
+    That manufactured a record which looked like information and could
+    not function as one, and it cost a ticket to undo.
+
+    A signal nobody can read is the same defect wearing a different
+    column name. This one reaches the admin user view.
+    """
+    import routers.admin_api_v2 as admin
+    assert "interest_state" in inspect.getsource(admin)
+
+
+def test_the_column_exists_in_the_one_schema_authority():
+    import database
+    src = inspect.getsource(database)
+    assert ("ALTER TABLE users ADD COLUMN IF NOT EXISTS interest_state"
+            in src)
+
+
+# ── The role guard still holds on the new path ───────────────────────
+
+def test_a_free_text_role_cannot_grant_privilege():
+    """SIGNUP1 opens a NEW WAY INTO `users.role`.
+
+    "Other" now resolves to whatever she typed, and `users.role` is the
+    column `is_admin_role()` reads to gate the admin console — the #103
+    escalation. The guard must sit on the resolved value, not on the
+    dropdown, or the free-text box is the escalation path reopened.
+
+    Verified structurally: the check reads `user.role`, which is what the
+    client sends after resolving "Other", so there is no second field
+    that bypasses it.
+    """
+    src = inspect.getsource(mod.register_user)
+    assert "is_admin_role(user.role)" in src
+    assert src.index("is_admin_role(user.role)") < src.index("INSERT INTO users")
+
+
+@pytest.mark.parametrize("claimed", ["admin", "Admin", "ADMIN"])
+def test_the_guard_is_case_insensitive_about_it(claimed):
+    from auth import is_admin_role
+    assert is_admin_role(claimed) is True

--- a/frontend/src/__tests__/signupRender.test.tsx
+++ b/frontend/src/__tests__/signupRender.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * SIGNUP1, RENDERED — the branch-guarded halves.
+ *
+ * The rules next door are called directly, which is the right shape for
+ * a rule. What a called rule cannot show is whether the SCREEN reaches
+ * it: the "Other" follow-ups, the interest field and the state fact are
+ * all conditional JSX, and a conditional that never fires passes every
+ * string-presence check ever written.
+ *
+ * Third file in this suite to make that argument, and the last time it
+ * needs making: the technique is now what we reach for when a pin's
+ * subject is a branch.
+ *
+ * NOTE on `jest`: from the GLOBAL, so babel hoists `jest.mock` above the
+ * imports. An imported one leaves the module under test to load first
+ * and capture the real dependencies — and the symptom is a silent empty
+ * render, which looks exactly like a test with nothing to say.
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, expect, it, beforeEach } from '@jest/globals';
+import type { jest as JestObject } from '@jest/globals';
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/jest-globals';
+
+/** File-local: a global declaration collides with the ambient `jest`
+ *  namespace and knocks `describe`/`it` out of other suites. */
+declare const jest: typeof JestObject;
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+  usePathname: () => '/register',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+import RegisterPage from '@/app/register/page';
+
+beforeEach(() => {
+  (global as any).fetch = jest.fn(async () => ({
+    ok: true, status: 200, json: async () => ({ access_token: 't' }),
+  })) as any;
+});
+
+describe('the state is stated, not asked', () => {
+  it('California is on the screen as a fact', () => {
+    render(<RegisterPage />);
+    expect(screen.getByText('California')).toBeInTheDocument();
+    expect(screen.getByText(/serves California today/)).toBeInTheDocument();
+  });
+
+  it('and there is no state control to choose from', () => {
+    /** THE PIN THIS FILE EXISTS FOR — a source check can see the list
+     *  is gone; only a render can see nothing replaced it. */
+    render(<RegisterPage />);
+    expect(screen.queryByLabelText(/^State/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Select your state')).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: 'Arizona' }))
+      .not.toBeInTheDocument();
+  });
+
+  it('the interest field is free text and reachable', () => {
+    render(<RegisterPage />);
+    const field = screen.getByLabelText(/Working outside California/);
+    expect(field.tagName).toBe('INPUT');
+    expect(screen.getByText(/not taking\s+orders outside California yet/))
+      .toBeInTheDocument();
+  });
+});
+
+describe('"Other" asks what it means', () => {
+  it('the role follow-up appears only when Other is chosen', async () => {
+    render(<RegisterPage />);
+    expect(screen.queryByLabelText(/What is your role/)).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/Professional role/),
+                     { target: { value: 'Other' } });
+    expect(await screen.findByLabelText(/What is your role/)).toBeInTheDocument();
+  });
+
+  it('and the company-type follow-up likewise', async () => {
+    render(<RegisterPage />);
+    expect(screen.queryByLabelText(/What kind of company/)).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/Company type/),
+                     { target: { value: 'Other' } });
+    expect(await screen.findByLabelText(/What kind of company/))
+      .toBeInTheDocument();
+  });
+
+  it('it disappears again when she picks a real answer', async () => {
+    render(<RegisterPage />);
+    const role = screen.getByLabelText(/Professional role/);
+    fireEvent.change(role, { target: { value: 'Other' } });
+    await screen.findByLabelText(/What is your role/);
+    fireEvent.change(role, { target: { value: 'Escrow Officer' } });
+    await waitFor(() => {
+      expect(screen.queryByLabelText(/What is your role/)).not.toBeInTheDocument();
+    });
+  });
+});
+
+describe('the asterisks mean something to a machine', () => {
+  it('required fields say so', () => {
+    render(<RegisterPage />);
+    expect(screen.getByLabelText(/Full name/)).toBeRequired();
+    expect(screen.getByLabelText(/Professional role/)).toBeRequired();
+  });
+
+  it('an optional one does not', () => {
+    render(<RegisterPage />);
+    expect(screen.getByLabelText(/Phone number/)).not.toBeRequired();
+  });
+});
+
+describe('an answer arrives before submit', () => {
+  it('leaving a short phone explains it, and links the explanation to the field', async () => {
+    /**
+     * "not-a-phone!!" was accepted, and production holds a nine-digit
+     * number. Every mistake used to surface only on submit, all at once,
+     * after the work.
+     *
+     * NOTE the case this drives: NINE DIGITS, not letters. `maskUS`
+     * strips non-digits as she types, so pure garbage can no longer be
+     * entered through this control at all — `phoneProblem`'s
+     * "does not look like a phone number" branch is reachable through
+     * the API and through paste, not through typing. Driving the
+     * unreachable case here would have tested the mask, not the rule.
+     */
+    render(<RegisterPage />);
+    const phone = screen.getByLabelText(/Phone number/);
+    fireEvent.change(phone, { target: { value: '626555013' } });
+    fireEvent.blur(phone);
+
+    const problem = await screen.findByRole('alert');
+    expect(problem).toHaveTextContent(/has 9/);
+    expect(phone).toHaveAttribute('aria-invalid', 'true');
+    expect(phone).toHaveAttribute('aria-describedby', 'phone-error');
+  });
+
+  it('a half-filled company pair is caught on the way out of it', async () => {
+    render(<RegisterPage />);
+    const type = screen.getByLabelText(/Company type/);
+    fireEvent.change(type, { target: { value: 'Title Company' } });
+    fireEvent.blur(type);
+    // The complaint lands on the NAME, which is the field that is empty.
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Company name/))
+        .toHaveAttribute('aria-invalid', 'true');
+    });
+  });
+
+  it('and stays quiet about fields she has not reached yet', async () => {
+    // Validating everything on the first blur would answer questions she
+    // has not asked, about work she has not done.
+    render(<RegisterPage />);
+    fireEvent.blur(screen.getByLabelText(/Phone number/));
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Full name/))
+        .not.toHaveAttribute('aria-invalid');
+    });
+  });
+});
+
+describe('the phone is masked while she types', () => {
+  it('digits become a readable number', () => {
+    render(<RegisterPage />);
+    const phone = screen.getByLabelText(/Phone number/) as HTMLInputElement;
+    fireEvent.change(phone, { target: { value: '6265550134' } });
+    expect(phone.value).toBe('(626) 555-0134');
+  });
+});

--- a/frontend/src/__tests__/signupRules.test.ts
+++ b/frontend/src/__tests__/signupRules.test.ts
@@ -1,0 +1,253 @@
+/**
+ * SIGNUP1 — the rules, asked directly.
+ *
+ * ═══ WHY THEY LEFT THE COMPONENT ═══
+ *
+ * `validateForm` was forty lines inside a seven-hundred-line page,
+ * called from one place, on submit. "Does a company type without a
+ * company name fail?" was answerable only by filling in a form and
+ * pressing a button — so nobody asked, and the answer was no.
+ *
+ * ═══ FIFTY OPTIONS, ONE PRODUCT ═══
+ *
+ * The state dropdown offered fifty. The catalog, the chassis, the DTT
+ * rate registry and every county form here are California by
+ * construction: 58 California counties, California code sections,
+ * California transfer tax. Fifty options is a promise the product breaks
+ * the moment somebody in Arizona registers and finds no Arizona forms.
+ *
+ * Owner-ruled: California, displayed rather than chosen, with an
+ * optional free-text interest signal and no dropdown implying we would
+ * accept the answer.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
+import {
+  OTHER, SERVED_STATE, SERVED_STATE_NAME, companyProblems, fieldProps,
+  otherProblems, phoneProblem, registrationPayload, validate,
+} from '../lib/registerForm';
+import type { RegisterFields } from '../lib/registerForm';
+
+const SRC = path.join(__dirname, '..');
+const PAGE = codeOnly(
+  fs.readFileSync(path.join(SRC, 'app', 'register', 'page.tsx'), 'utf8'));
+const PY = fs.readFileSync(
+  path.join(SRC, '..', '..', 'backend', 'routers', 'users_auth.py'), 'utf8');
+
+const ok = (over: Partial<RegisterFields> = {}): RegisterFields => ({
+  email: 'jane@example.com', password: 'Passw0rdy', confirmPassword: 'Passw0rdy',
+  fullName: 'Jane Doe', role: 'Escrow Officer', roleOther: '',
+  companyName: 'Pacific Coast Escrow', companyType: 'Independent Escrow Company',
+  companyTypeOther: '', phone: '', interestState: '', agreeTerms: true, ...over,
+});
+
+describe('the state is a fact, not a question', () => {
+  it('the page states California and offers no list', () => {
+    /** THE PIN THIS FILE EXISTS FOR. */
+    expect(PAGE).toContain('SERVED_STATE_NAME');
+    expect(PAGE).not.toContain('Select your state');
+    expect(PAGE).not.toContain('states.map');
+  });
+
+  it('and says plainly what we serve', () => {
+    expect(PAGE).toContain('serves California today');
+  });
+
+  it('the server refuses what the screen stopped offering', () => {
+    /**
+     * A screen that stops offering a state while the endpoint keeps
+     * accepting it is the COSMETIC version of this fix: registration is
+     * public, so an API caller could still open an Arizona account this
+     * product cannot serve.
+     */
+    expect(PY).toContain('!= SERVED_STATE');
+    expect(PY).toContain('serves California today');
+  });
+
+  it('both languages name the same state', () => {
+    // Two constants, one fact. The pair that drifts is the pair nobody
+    // compares.
+    const py = PY.match(/SERVED_STATE = "([A-Z]{2})"/)?.[1];
+    expect(py).toBe(SERVED_STATE);
+    expect(SERVED_STATE_NAME).toBe('California');
+  });
+
+  it('the payload sends the served state, never a form value', () => {
+    expect(registrationPayload(ok(), '').state).toBe(SERVED_STATE);
+  });
+});
+
+describe('the interest signal is recorded, and promises nothing', () => {
+  it('travels as its own field', () => {
+    expect(registrationPayload(ok({ interestState: ' Arizona ' }), '').interest_state)
+      .toBe('Arizona');
+  });
+
+  it('blank stays null rather than becoming an empty string', () => {
+    expect(registrationPayload(ok(), '').interest_state).toBeNull();
+  });
+
+  it('the copy makes no commitment', () => {
+    /**
+     * LEGAL1: a sentence like "we will let you know" would make this a
+     * consent, and a consent we cannot honour is what that ticket
+     * deleted. This records a fact she volunteered; it does not ask
+     * permission to contact her.
+     */
+    expect(PAGE).toContain('not taking\n                  orders outside California yet');
+    expect(PAGE).not.toMatch(/we.{0,12}(will|'ll) (let you know|notify|email|contact)/i);
+  });
+
+  it('and it is not a dropdown', () => {
+    const at = PAGE.indexOf('interestState');
+    const block = PAGE.slice(at - 200, at + 400);
+    expect(block).not.toContain('<select');
+  });
+});
+
+describe('the phone is checked, not merely typed into', () => {
+  it('accepts nothing, because it is optional', () => {
+    expect(phoneProblem('')).toBeNull();
+    expect(phoneProblem('   ')).toBeNull();
+  });
+
+  it('rejects the audited case', () => {
+    // "not-a-phone!!" was accepted.
+    expect(phoneProblem('not-a-phone!!')).toMatch(/does not look like/);
+  });
+
+  it('counts the digits, which is how a nine-digit number got in', () => {
+    expect(phoneProblem('(626) 555-013')).toMatch(/has 9/);
+    expect(phoneProblem('626-555-0134')).toBeNull();
+  });
+
+  it('accepts a leading country code', () => {
+    expect(phoneProblem('+1 (626) 555-0134')).toBeNull();
+  });
+
+  it('the page masks as she types, with the lib the partner screens use', () => {
+    // Not a second implementation. PARTNER2 built this in both
+    // languages with a shared corpus; registration never called it.
+    expect(PAGE).toContain('maskUS(e.target.value)');
+    expect(PAGE).toContain('inputMode="tel"');
+  });
+
+  it('and the server normalizes again at the write', () => {
+    // A rule only the browser enforces is a rule the API does not have.
+    expect(PY).toContain('normalize_phone(clean_profile_text(user.phone))');
+  });
+});
+
+describe('the company pair is checked both ways', () => {
+  it('a type with no name fails', () => {
+    expect(companyProblems({ companyName: '', companyType: 'Title Company',
+                             companyTypeOther: '' }).companyName).toBeTruthy();
+  });
+
+  it('a name with no type fails', () => {
+    expect(companyProblems({ companyName: 'Acme', companyType: '',
+                             companyTypeOther: '' }).companyType).toBeTruthy();
+  });
+
+  it('neither is still fine — the pair is optional, its halves are not', () => {
+    expect(companyProblems({ companyName: '', companyType: '',
+                             companyTypeOther: '' })).toEqual({});
+  });
+
+  it('both is fine', () => {
+    expect(companyProblems({ companyName: 'Acme', companyType: 'Law Firm',
+                             companyTypeOther: '' })).toEqual({});
+  });
+});
+
+describe('"Other" is not an answer', () => {
+  it('a role of Other must say what it is', () => {
+    expect(otherProblems({ role: OTHER, roleOther: '' }).roleOther).toBeTruthy();
+    expect(otherProblems({ role: OTHER, roleOther: 'Notary' })).toEqual({});
+  });
+
+  it('a company type of Other must too', () => {
+    expect(companyProblems({ companyName: 'Acme', companyType: OTHER,
+                             companyTypeOther: '' }).companyTypeOther).toBeTruthy();
+  });
+
+  it('and the free text REPLACES the literal rather than sitting beside it', () => {
+    /**
+     * The product recorded a professional role of literally "Other", for
+     * a column the deed face and the admin console both read. Storing
+     * both would be two columns disagreeing about one fact.
+     */
+    const payload = registrationPayload(
+      ok({ role: OTHER, roleOther: ' Notary ', companyType: OTHER,
+           companyTypeOther: ' Lender ' }), '');
+    expect(payload.role).toBe('Notary');
+    expect(payload.company_type).toBe('Lender');
+  });
+});
+
+describe('the asterisks stop being decoration', () => {
+  it('a required field says so to a machine, not just in red', () => {
+    /**
+     * No `required`, no `aria-required`, no `aria-invalid`, no
+     * `aria-describedby`. A screen-reader user could not learn which
+     * fields were mandatory before submitting, and afterwards could not
+     * learn which had failed — the error was a coloured paragraph with
+     * no relationship to its input.
+     */
+    expect(fieldProps('fullName', undefined, true)).toEqual({
+      id: 'fullName', name: 'fullName', required: true, 'aria-required': true,
+      'aria-invalid': undefined, 'aria-describedby': undefined,
+    });
+  });
+
+  it('a failing field points at its own explanation', () => {
+    expect(fieldProps('email', 'Email is required')).toMatchObject({
+      'aria-invalid': true, 'aria-describedby': 'email-error',
+    });
+  });
+
+  it('and the page wires every field through the one helper', () => {
+    // Eleven fields hand-wired is eleven chances to omit one, and the
+    // omitted one is invisible to everybody who can see.
+    const wired = (PAGE.match(/\{\.\.\.fieldProps\(/g) || []).length;
+    expect(wired).toBeGreaterThanOrEqual(7);
+    // Every error paragraph carries the id its input points at.
+    for (const name of ['fullName', 'role', 'phone', 'companyName', 'companyType']) {
+      expect(PAGE).toContain(`id="${name}-error"`);
+    }
+  });
+
+  it('errors are announced, not merely coloured', () => {
+    expect((PAGE.match(/role="alert"/g) || []).length).toBeGreaterThanOrEqual(5);
+  });
+});
+
+describe('validation does not wait for submit', () => {
+  it('the page answers as she leaves a field', () => {
+    expect(PAGE).toContain('const blur = (name: string)');
+    expect((PAGE.match(/onBlur=\{\(\) => blur\(/g) || []).length)
+      .toBeGreaterThanOrEqual(6);
+  });
+
+  it('but only about fields she has finished', () => {
+    // Validating every keystroke tells somebody their email is invalid
+    // while they are typing the @ — true, useless, and it reads as the
+    // product arguing with them.
+    expect(PAGE).toContain('.filter(([k]) => next[k])');
+  });
+});
+
+describe('the whole form, end to end', () => {
+  it('a good registration has nothing to say', () => {
+    expect(validate(ok())).toEqual({});
+  });
+
+  it('and every rule is reachable from the one entry point', () => {
+    expect(validate(ok({ phone: 'nope' })).phone).toBeTruthy();
+    expect(validate(ok({ companyType: '' })).companyType).toBeTruthy();
+    expect(validate(ok({ role: OTHER })).roleOther).toBeTruthy();
+    expect(validate(ok({ agreeTerms: false })).agreeTerms).toBeTruthy();
+  });
+});

--- a/frontend/src/app/register/page.tsx
+++ b/frontend/src/app/register/page.tsx
@@ -13,58 +13,20 @@ import { Eye, EyeOff, ShieldCheck } from "lucide-react"
 import { LogoLockup } from "@/components/brand/Logo"
 import { AuthManager } from "@/utils/auth"
 
-const states = [
-  { code: "AL", name: "Alabama" },
-  { code: "AK", name: "Alaska" },
-  { code: "AZ", name: "Arizona" },
-  { code: "AR", name: "Arkansas" },
-  { code: "CA", name: "California" },
-  { code: "CO", name: "Colorado" },
-  { code: "CT", name: "Connecticut" },
-  { code: "DE", name: "Delaware" },
-  { code: "FL", name: "Florida" },
-  { code: "GA", name: "Georgia" },
-  { code: "HI", name: "Hawaii" },
-  { code: "ID", name: "Idaho" },
-  { code: "IL", name: "Illinois" },
-  { code: "IN", name: "Indiana" },
-  { code: "IA", name: "Iowa" },
-  { code: "KS", name: "Kansas" },
-  { code: "KY", name: "Kentucky" },
-  { code: "LA", name: "Louisiana" },
-  { code: "ME", name: "Maine" },
-  { code: "MD", name: "Maryland" },
-  { code: "MA", name: "Massachusetts" },
-  { code: "MI", name: "Michigan" },
-  { code: "MN", name: "Minnesota" },
-  { code: "MS", name: "Mississippi" },
-  { code: "MO", name: "Missouri" },
-  { code: "MT", name: "Montana" },
-  { code: "NE", name: "Nebraska" },
-  { code: "NV", name: "Nevada" },
-  { code: "NH", name: "New Hampshire" },
-  { code: "NJ", name: "New Jersey" },
-  { code: "NM", name: "New Mexico" },
-  { code: "NY", name: "New York" },
-  { code: "NC", name: "North Carolina" },
-  { code: "ND", name: "North Dakota" },
-  { code: "OH", name: "Ohio" },
-  { code: "OK", name: "Oklahoma" },
-  { code: "OR", name: "Oregon" },
-  { code: "PA", name: "Pennsylvania" },
-  { code: "RI", name: "Rhode Island" },
-  { code: "SC", name: "South Carolina" },
-  { code: "SD", name: "South Dakota" },
-  { code: "TN", name: "Tennessee" },
-  { code: "TX", name: "Texas" },
-  { code: "UT", name: "Utah" },
-  { code: "VT", name: "Vermont" },
-  { code: "VA", name: "Virginia" },
-  { code: "WA", name: "Washington" },
-  { code: "WV", name: "West Virginia" },
-  { code: "WI", name: "Wisconsin" },
-  { code: "WY", name: "Wyoming" },
-]
+/* SIGNUP1 — THE FIFTY-STATE LIST IS GONE.
+   The catalog, the chassis, the DTT rate registry and every county form
+   in this product are California by construction: 58 California
+   counties, California code sections, California transfer tax. Fifty
+   options was a promise broken the moment somebody in Arizona
+   registered and found no Arizona forms.
+   Owner-ruled: California, displayed rather than chosen. The state now
+   lives in lib/registerForm.ts as a VALUE, not a default. */
+
+import { maskUS, normalizePhone } from "@/lib/phone"
+import {
+  FieldErrors, OTHER, SERVED_STATE_NAME, fieldProps, registrationPayload,
+  revealedBy, validate,
+} from "@/lib/registerForm"
 
 const roles = [
   "Escrow Officer",
@@ -95,56 +57,47 @@ export default function RegisterPage() {
     role: "",
     companyName: "",
     companyType: "",
+    companyTypeOther: "",
+    roleOther: "",
     phone: "",
-    state: "",
+    interestState: "",
     agreeTerms: false,
   })
+  /* Validation used to fire ONLY on submit, so every mistake was
+     discovered at the end, all at once, after the work. A field that has
+     been visited and left is a field she is done with — that is the
+     moment to answer, and not before. */
+  const [touched, setTouched] = useState<Record<string, boolean>>({})
 
+  /* The rules moved to lib/registerForm.ts. They were forty lines
+     inside a seven-hundred-line page, called from one place, on submit —
+     so "does a company type without a company name fail?" was answerable
+     only by filling in a form and pressing a button. Called, a test can
+     ask. */
   const validateForm = () => {
-    const errors: Record<string, string> = {}
-
-    // Email: Required, valid format
-    const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/
-    if (!formData.email) {
-      errors.email = "Email is required"
-    } else if (!emailRegex.test(formData.email)) {
-      errors.email = "Please enter a valid email address"
-    }
-
-    // Password: 8+ chars, uppercase, lowercase, number
-    if (!formData.password) {
-      errors.password = "Password is required"
-    } else {
-      if (formData.password.length < 8) {
-        errors.password = "Password must be at least 8 characters long"
-      } else if (!/(?=.*[a-z])/.test(formData.password)) {
-        errors.password = "Password must contain at least one lowercase letter"
-      } else if (!/(?=.*[A-Z])/.test(formData.password)) {
-        errors.password = "Password must contain at least one uppercase letter"
-      } else if (!/(?=.*\d)/.test(formData.password)) {
-        errors.password = "Password must contain at least one number"
-      }
-    }
-
-    // Confirm Password: Must match
-    if (!formData.confirmPassword) {
-      errors.confirmPassword = "Please confirm your password"
-    } else if (formData.password !== formData.confirmPassword) {
-      errors.confirmPassword = "Passwords do not match"
-    }
-
-    // Required text fields
-    if (!formData.fullName) errors.fullName = "Full name is required"
-    if (!formData.role) errors.role = "Role is required"
-    if (!formData.state) errors.state = "State is required"
-
-    // Terms checkbox
-    if (!formData.agreeTerms) {
-      errors.agreeTerms = "You must agree to the terms and conditions"
-    }
-
-    setValidationErrors(errors)
+    const errors = validate(formData)
+    setValidationErrors(errors as Record<string, string>)
     return Object.keys(errors).length === 0
+  }
+
+  /* Answer as she leaves a field, but only about fields she has
+     finished. Validating on every keystroke tells somebody their email
+     is invalid while they are typing the @ — which is true, useless, and
+     reads as the product arguing with them. */
+  const blur = (name: string) => {
+    /* Touching one half of a pair reveals both. The company name and
+       type are one fact in two inputs, and an error raised on the half
+       she has not visited would otherwise be filtered away — leaving a
+       silent form that refuses to submit. */
+    const next = { ...touched }
+    for (const k of revealedBy(name)) next[k] = true
+    setTouched(next)
+    const all = validate(formData) as FieldErrors
+    setValidationErrors(
+      Object.fromEntries(
+        Object.entries(all).filter(([k]) => next[k]),
+      ) as Record<string, string>,
+    )
   }
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -164,18 +117,15 @@ export default function RegisterPage() {
         {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            email: formData.email,
-            password: formData.password,
-            confirm_password: formData.confirmPassword,
-            full_name: formData.fullName,
-            role: formData.role,
-            company_name: formData.companyName || null,
-            company_type: formData.companyType || null,
-            phone: formData.phone || null,
-            state: formData.state,
-            agree_terms: formData.agreeTerms,
-          }),
+          /* One serializer, so the payload cannot drift from the rules
+             that validated it. The phone is normalized to E.164 HERE,
+             using the same lib the partner screens have used since
+             PARTNER2 — the server normalizes again at the write, because
+             a rule that only the browser enforces is a rule the API does
+             not have. */
+          body: JSON.stringify(
+            registrationPayload(formData, normalizePhone(formData.phone)),
+          ),
         },
       )
 
@@ -387,16 +337,20 @@ export default function RegisterPage() {
                   Full name <span className="text-error-500">*</span>
                 </label>
                 <input
+                  {...fieldProps("fullName", validationErrors.fullName, true)}
                   type="text"
-                  id="fullName"
-                  name="fullName"
                   autoComplete="name"
                   value={formData.fullName}
                   onChange={handleChange}
+                  onBlur={() => blur("fullName")}
                   className={`${inputBase} ${validationErrors.fullName ? "border-error-500" : "border-gray-200"}`}
                   placeholder="John Smith"
                 />
-                {validationErrors.fullName && <p className="mt-1 text-sm text-error-500">{validationErrors.fullName}</p>}
+                {validationErrors.fullName && (
+                  <p id="fullName-error" role="alert" className="mt-1 text-sm text-error-500">
+                    {validationErrors.fullName}
+                  </p>
+                )}
               </div>
 
               {/* Role & State */}
@@ -406,10 +360,10 @@ export default function RegisterPage() {
                     Professional role <span className="text-error-500">*</span>
                   </label>
                   <select
-                    id="role"
-                    name="role"
+                    {...fieldProps("role", validationErrors.role, true)}
                     value={formData.role}
                     onChange={handleChange}
+                    onBlur={() => blur("role")}
                     className={`${inputBase} bg-white ${
                       validationErrors.role ? "border-error-500" : "border-gray-200"
                     }`}
@@ -421,30 +375,54 @@ export default function RegisterPage() {
                       </option>
                     ))}
                   </select>
-                  {validationErrors.role && <p className="mt-1 text-sm text-error-500">{validationErrors.role}</p>}
+                  {validationErrors.role && (
+                    <p id="role-error" role="alert" className="mt-1 text-sm text-error-500">
+                      {validationErrors.role}
+                    </p>
+                  )}
+                  {/* "Other" was not an answer. The product recorded a
+                      professional role of literally "Other" — for a
+                      column the deed face and the admin console read. */}
+                  {formData.role === OTHER && (
+                    <div className="mt-2 space-y-1.5">
+                      <label htmlFor="roleOther" className="block text-sm font-medium text-gray-700">
+                        What is your role? <span className="text-error-500">*</span>
+                      </label>
+                      <input
+                        {...fieldProps("roleOther", validationErrors.roleOther, true)}
+                        type="text"
+                        value={formData.roleOther}
+                        onChange={handleChange}
+                        onBlur={() => blur("roleOther")}
+                        className={`${inputBase} ${
+                          validationErrors.roleOther ? "border-error-500" : "border-gray-200"}`}
+                        placeholder="Notary, Loan Officer, …"
+                      />
+                      {validationErrors.roleOther && (
+                        <p id="roleOther-error" role="alert" className="mt-1 text-sm text-error-500">
+                          {validationErrors.roleOther}
+                        </p>
+                      )}
+                    </div>
+                  )}
                 </div>
 
+                {/* ═══ THE STATE IS A FACT WE STATE, NOT A QUESTION ═══
+
+                    A dropdown asks. Asking implies the answer changes
+                    something, and it does not: every form, rate and
+                    county in this product is California. So the screen
+                    says what we serve, and does not pretend to take an
+                    order it cannot fill. */}
                 <div className="space-y-1.5">
-                  <label htmlFor="state" className="block text-sm font-semibold text-gray-900">
-                    State <span className="text-error-500">*</span>
-                  </label>
-                  <select
-                    id="state"
-                    name="state"
-                    value={formData.state}
-                    onChange={handleChange}
-                    className={`${inputBase} bg-white ${
-                      validationErrors.state ? "border-error-500" : "border-gray-200"
-                    }`}
-                  >
-                    <option value="">Select your state</option>
-                    {states.map((state) => (
-                      <option key={state.code} value={state.code}>
-                        {state.name}
-                      </option>
-                    ))}
-                  </select>
-                  {validationErrors.state && <p className="mt-1 text-sm text-error-500">{validationErrors.state}</p>}
+                  <p className="block text-sm font-semibold text-gray-900">State</p>
+                  <div className={`${inputBase} border-gray-200 bg-gray-50 text-gray-700`}>
+                    {SERVED_STATE_NAME}
+                  </div>
+                  <p className="text-xs text-gray-500">
+                    DeedPro serves California today. Our forms, transfer-tax
+                    rates and county requirements are California-specific.
+                  </p>
                 </div>
               </div>
 
@@ -455,15 +433,26 @@ export default function RegisterPage() {
                     Company name <span className="text-gray-400 text-xs font-normal">(Optional)</span>
                   </label>
                   <input
+                    {...fieldProps("companyName", validationErrors.companyName)}
                     type="text"
-                    id="companyName"
-                    name="companyName"
                     autoComplete="organization"
                     value={formData.companyName}
                     onChange={handleChange}
-                    className={`${inputBase} border-gray-200`}
+                    onBlur={() => blur("companyName")}
+                    className={`${inputBase} ${
+                      validationErrors.companyName ? "border-error-500" : "border-gray-200"}`}
                     placeholder="Your Company LLC"
                   />
+                  {/* The pair is checked BOTH ways: a type with no name
+                      is a company we cannot print on a deed face, a name
+                      with no type is one we cannot categorise, and each
+                      was separately optional so both halves could sit
+                      half-filled with the form happy. */}
+                  {validationErrors.companyName && (
+                    <p id="companyName-error" role="alert" className="mt-1 text-sm text-error-500">
+                      {validationErrors.companyName}
+                    </p>
+                  )}
                 </div>
 
                 <div className="space-y-1.5">
@@ -471,11 +460,12 @@ export default function RegisterPage() {
                     Company type <span className="text-gray-400 text-xs font-normal">(Optional)</span>
                   </label>
                   <select
-                    id="companyType"
-                    name="companyType"
+                    {...fieldProps("companyType", validationErrors.companyType)}
                     value={formData.companyType}
                     onChange={handleChange}
-                    className={`${inputBase} bg-white border-gray-200`}
+                    onBlur={() => blur("companyType")}
+                    className={`${inputBase} bg-white ${
+                      validationErrors.companyType ? "border-error-500" : "border-gray-200"}`}
                   >
                     <option value="">Select company type</option>
                     {companyTypes.map((type) => (
@@ -484,6 +474,33 @@ export default function RegisterPage() {
                       </option>
                     ))}
                   </select>
+                  {validationErrors.companyType && (
+                    <p id="companyType-error" role="alert" className="mt-1 text-sm text-error-500">
+                      {validationErrors.companyType}
+                    </p>
+                  )}
+                  {formData.companyType === OTHER && (
+                    <div className="mt-2 space-y-1.5">
+                      <label htmlFor="companyTypeOther" className="block text-sm font-medium text-gray-700">
+                        What kind of company? <span className="text-error-500">*</span>
+                      </label>
+                      <input
+                        {...fieldProps("companyTypeOther", validationErrors.companyTypeOther, true)}
+                        type="text"
+                        value={formData.companyTypeOther}
+                        onChange={handleChange}
+                        onBlur={() => blur("companyTypeOther")}
+                        className={`${inputBase} ${
+                          validationErrors.companyTypeOther ? "border-error-500" : "border-gray-200"}`}
+                        placeholder="Lender, Notary service, …"
+                      />
+                      {validationErrors.companyTypeOther && (
+                        <p id="companyTypeOther-error" role="alert" className="mt-1 text-sm text-error-500">
+                          {validationErrors.companyTypeOther}
+                        </p>
+                      )}
+                    </div>
+                  )}
                 </div>
               </div>
 
@@ -493,15 +510,63 @@ export default function RegisterPage() {
                   Phone number <span className="text-gray-400 text-xs font-normal">(Optional)</span>
                 </label>
                 <input
+                  {...fieldProps("phone", validationErrors.phone)}
                   type="tel"
-                  id="phone"
-                  name="phone"
+                  /* The number pad, on the device most people register
+                     on. `type="tel"` alone does not summon it reliably. */
+                  inputMode="tel"
                   autoComplete="tel"
                   value={formData.phone}
-                  onChange={handleChange}
-                  className={`${inputBase} border-gray-200`}
+                  /* Masked as she types, by the same lib the partner
+                     screens have used since PARTNER2. "not-a-phone!!" was
+                     accepted here, and production holds a nine-digit
+                     number nobody can call. */
+                  onChange={(e) =>
+                    setFormData({ ...formData, phone: maskUS(e.target.value) })}
+                  onBlur={() => blur("phone")}
+                  className={`${inputBase} ${
+                    validationErrors.phone ? "border-error-500" : "border-gray-200"}`}
                   placeholder="(555) 123-4567"
                 />
+                {validationErrors.phone && (
+                  <p id="phone-error" role="alert" className="mt-1 text-sm text-error-500">
+                    {validationErrors.phone}
+                  </p>
+                )}
+              </div>
+
+              {/* ═══ THE INTEREST SIGNAL, WHICH IS NOT A DROPDOWN ═══
+
+                  Owner-ruled. A free-text box records that somebody
+                  outside California wanted us; a dropdown would imply we
+                  would accept the answer.
+
+                  It is READABLE — it reaches the admin user list rather
+                  than sitting in a column nobody queries. LEGAL1 is the
+                  precedent: `subscribe` was collected, stored, and
+                  visible to nobody, which manufactured a record that
+                  looked like information and could not function as one.
+
+                  The copy promises nothing. A sentence like "we will let
+                  you know" would make this a consent, and a consent we
+                  cannot honour is the thing LEGAL1 deleted. */}
+              <div className="space-y-1.5">
+                <label htmlFor="interestState" className="block text-sm font-semibold text-gray-900">
+                  Working outside California?{" "}
+                  <span className="text-gray-400 text-xs font-normal">(Optional)</span>
+                </label>
+                <input
+                  {...fieldProps("interestState", undefined)}
+                  type="text"
+                  value={formData.interestState}
+                  onChange={handleChange}
+                  className={`${inputBase} border-gray-200`}
+                  placeholder="Which state?"
+                />
+                <p className="text-xs text-gray-500">
+                  Tell us where and we will record it. We are not taking
+                  orders outside California yet.
+                </p>
               </div>
 
               {/* Checkboxes */}

--- a/frontend/src/lib/registerForm.ts
+++ b/frontend/src/lib/registerForm.ts
@@ -1,0 +1,223 @@
+/**
+ * SIGNUP1 — what the registration form accepts, and how it says no.
+ *
+ * ═══ WHY THE RULES LEFT THE COMPONENT ═══
+ *
+ * They were a 40-line `validateForm` inside a 700-line page, called from
+ * one place, on submit. Nothing could ask them a question. "Does a
+ * company type without a company name fail?" was answerable only by
+ * filling in a form and pressing a button.
+ *
+ * Called, a test can ask.
+ *
+ * ═══ THE STATE IS A FACT, NOT A CHOICE ═══
+ *
+ * The form offered fifty states. The catalog, the chassis, the DTT rate
+ * registry and every county form in this product are CALIFORNIA by
+ * construction — 58 California counties, California code sections,
+ * California transfer tax. Fifty options is a promise the product breaks
+ * the moment somebody in Arizona registers and finds no Arizona forms.
+ *
+ * Owner-ruled: California, displayed rather than chosen. An optional
+ * free-text "which state are you in?" records an interest signal for
+ * later — but no dropdown, because a dropdown implies we would accept
+ * the answer.
+ *
+ * And the signal is READABLE (it reaches admin) rather than write-only.
+ * LEGAL1's ruling is the precedent: collecting something nobody can
+ * produce manufactures a record that looks like information and cannot
+ * function as one. That was `subscribe`, and it cost a ticket to undo.
+ */
+
+/** The one state this product serves. Not a default — the value. */
+export const SERVED_STATE = 'CA';
+export const SERVED_STATE_NAME = 'California';
+
+/** The literal a "pick one" list uses to mean "none of these". */
+export const OTHER = 'Other';
+
+export interface RegisterFields {
+  email: string;
+  password: string;
+  confirmPassword: string;
+  fullName: string;
+  role: string;
+  roleOther: string;
+  companyName: string;
+  companyType: string;
+  companyTypeOther: string;
+  phone: string;
+  interestState: string;
+  agreeTerms: boolean;
+}
+
+/** Field name → the sentence shown under it. Empty object = accepted. */
+export type FieldErrors = Partial<Record<keyof RegisterFields, string>>;
+
+/**
+ * Is this a plausible US phone number?
+ *
+ * Deliberately thin. It asks whether ten digits are present, and nothing
+ * about whether the line is assigned or reachable — `services/phone.py`
+ * makes the same refusal for the same reason. What it catches is the
+ * audited case: "not-a-phone!!" was accepted, and production holds a
+ * nine-digit number nobody can call.
+ *
+ * Optional stays optional: blank passes. A phone we do not have is not
+ * a phone we got wrong.
+ */
+export function phoneProblem(value: string): string | null {
+  const raw = (value || '').trim();
+  if (!raw) return null;
+  const digits = raw.replace(/\D/g, '');
+  if (!/\d/.test(raw)) return 'That does not look like a phone number.';
+  const national = digits.length === 11 && digits.startsWith('1')
+    ? digits.slice(1) : digits;
+  if (national.length !== 10) {
+    return `A US phone number has 10 digits — this one has ${national.length}.`;
+  }
+  return null;
+}
+
+/**
+ * The company pair, checked BOTH WAYS.
+ *
+ * A type without a name is a company we cannot print on a deed face; a
+ * name without a type is a company we cannot categorise. Each was
+ * separately optional and neither implied the other, so both halves of
+ * the pair could be half-filled and the form was happy.
+ */
+export function companyProblems(f: Pick<RegisterFields,
+  'companyName' | 'companyType' | 'companyTypeOther'>): FieldErrors {
+  const name = (f.companyName || '').trim();
+  const type = (f.companyType || '').trim();
+  const out: FieldErrors = {};
+  if (type && !name) {
+    out.companyName = 'Add the company name, or clear the company type.';
+  }
+  if (name && !type) {
+    out.companyType = 'Choose a company type, or clear the company name.';
+  }
+  if (type === OTHER && !(f.companyTypeOther || '').trim()) {
+    out.companyTypeOther = 'Tell us what kind of company it is.';
+  }
+  return out;
+}
+
+/**
+ * "Other" is not an answer.
+ *
+ * Both lists ended in it and neither asked what it meant, so the product
+ * recorded a professional role of literally "Other" — for a column the
+ * deed face and the admin console both read.
+ */
+export function otherProblems(f: Pick<RegisterFields, 'role' | 'roleOther'>): FieldErrors {
+  if (f.role === OTHER && !(f.roleOther || '').trim()) {
+    return { roleOther: 'Tell us your role.' };
+  }
+  return {};
+}
+
+const EMAIL = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+
+/** Every rule, in one callable place. */
+export function validate(f: RegisterFields): FieldErrors {
+  const out: FieldErrors = {};
+
+  if (!f.email) out.email = 'Email is required';
+  else if (!EMAIL.test(f.email)) out.email = 'Please enter a valid email address';
+
+  if (!f.password) out.password = 'Password is required';
+  else if (f.password.length < 8) out.password = 'Password must be at least 8 characters long';
+  else if (!/(?=.*[a-z])/.test(f.password)) out.password = 'Password must contain at least one lowercase letter';
+  else if (!/(?=.*[A-Z])/.test(f.password)) out.password = 'Password must contain at least one uppercase letter';
+  else if (!/(?=.*\d)/.test(f.password)) out.password = 'Password must contain at least one number';
+
+  if (!f.confirmPassword) out.confirmPassword = 'Please confirm your password';
+  else if (f.password !== f.confirmPassword) out.confirmPassword = 'Passwords do not match';
+
+  if (!f.fullName?.trim()) out.fullName = 'Full name is required';
+  if (!f.role) out.role = 'Role is required';
+  if (!f.agreeTerms) out.agreeTerms = 'You must agree to the terms and conditions';
+
+  const phone = phoneProblem(f.phone);
+  if (phone) out.phone = phone;
+
+  return { ...out, ...companyProblems(f), ...otherProblems(f) };
+}
+
+/**
+ * What actually goes to the server.
+ *
+ * `state` is not read from the form because the form does not ask. An
+ * "Other" role or company type resolves to what she typed — the free
+ * text IS the answer, and storing the literal "Other" beside it would be
+ * two columns disagreeing about one fact.
+ */
+export function registrationPayload(f: RegisterFields, normalizedPhone: string) {
+  const role = f.role === OTHER ? f.roleOther.trim() : f.role;
+  const companyType = f.companyType === OTHER
+    ? f.companyTypeOther.trim() : f.companyType;
+  return {
+    email: f.email,
+    password: f.password,
+    confirm_password: f.confirmPassword,
+    full_name: f.fullName,
+    role,
+    company_name: f.companyName || null,
+    company_type: companyType || null,
+    phone: normalizedPhone || null,
+    state: SERVED_STATE,
+    interest_state: f.interestState?.trim() || null,
+    agree_terms: f.agreeTerms,
+  };
+}
+
+/**
+ * The accessibility wiring for one field, in one place.
+ *
+ * The red asterisks were decoration: no `required`, no `aria-required`,
+ * no `aria-invalid`, no `aria-describedby`. A screen-reader user could
+ * not learn which fields were mandatory before submitting, and after
+ * submitting could not learn which one had failed — the error sentence
+ * was a coloured paragraph with no relationship to the input.
+ *
+ * Returned as props rather than written per field because eleven fields
+ * hand-wired is eleven chances to omit one, and the omitted one is
+ * invisible to everybody who can see.
+ */
+/**
+ * Fields that fail TOGETHER, so touching one surfaces both.
+ *
+ * The company pair is one fact in two inputs: leaving the type filled
+ * and the name empty raises an error on the NAME, which she has not
+ * touched. A "show errors for touched fields" filter hides it — she gets
+ * a silent form that refuses to submit, which is worse than the missing
+ * check was.
+ *
+ * A rule about a PAIR cannot be surfaced by a rule about one field.
+ */
+export const PAIRED: Record<string, string[]> = {
+  companyName: ['companyType', 'companyTypeOther'],
+  companyType: ['companyName', 'companyTypeOther'],
+  companyTypeOther: ['companyName', 'companyType'],
+  role: ['roleOther'],
+  roleOther: ['role'],
+};
+
+/** Which field names to reveal once `name` has been left. */
+export function revealedBy(name: string): string[] {
+  return [name, ...(PAIRED[name] || [])];
+}
+
+export function fieldProps(
+  name: string, error: string | undefined, required = false,
+): Record<string, string | boolean | undefined> {
+  return {
+    id: name,
+    name,
+    ...(required ? { required: true, 'aria-required': true } : {}),
+    'aria-invalid': error ? true : undefined,
+    'aria-describedby': error ? `${name}-error` : undefined,
+  };
+}


### PR DESCRIPTION
Ticket 2 of 5.

## Fifty options, one product

The catalog, the chassis, the DTT rate registry and every county form here are California by construction — 58 California counties, California code sections, California transfer tax. Fifty options is a promise broken the moment somebody in Arizona registers and finds no Arizona forms.

Owner-ruled: California, **displayed rather than chosen**, with an optional free-text interest signal and no dropdown implying we would accept the answer.

**And the refusal is the server's.** Removing the dropdown while the endpoint keeps accepting `AZ` is the cosmetic version — registration is public, so an API caller would still open an account this product cannot serve, and would find out by looking for forms that do not exist. The server refuses and names what we *do* serve rather than saying "invalid". The format check still runs first, pinned: `AAA` is a typo and `AZ` is a real state we do not serve, and collapsing them would tell somebody their typo was a business decision.

**The interest signal is readable.** It reaches the admin user view rather than sitting in a column nobody queries. LEGAL1 applied before the mistake instead of after: `subscribe` was collected, stored, and visible to nobody, manufacturing a record that looked like information and could not function as one. The copy promises nothing — "we will let you know" would make this a consent, and a consent we cannot honour is exactly what that ticket deleted. Pinned both ways.

## The phone, and the same bias as #192

`clean_profile_text` only collapses whitespace, so `"not-a-phone!!"` was stored verbatim and production holds a nine-digit number nobody can call.

**A full normalizer has existed in both languages since PARTNER2** — `services/phone.py`, `frontend/src/lib/phone.ts`, and a shared corpus (`phone_cases.json`) so the two are checked against one referee rather than each other's reputation. The partner screens have used it all along. **Registration never called it.**

That is the structural bias you named on #192, found again in the next ticket: the capability reached every surface where a customer could report a problem, and none where a stranger could not. Pinned as a finding rather than as a fix, so it reads that way later.

Masked as she types in the browser **and** normalized at the server write — a rule only the browser enforces is a rule the API does not have.

## The rest

The company pair is checked both directions; "Other" asks what it means and the free text **replaces** the literal (the product was recording a professional role of literally "Other", for a column the deed face and admin console both read); every field carries `required` / `aria-required` / `aria-invalid` / `aria-describedby` through one helper, because eleven fields hand-wired is eleven chances to omit one and the omitted one is invisible to everybody who can see; validation answers on blur rather than only at the end.

## Premises checked

All six **confirmed**, mechanisms verified. Two things I want on the record:

- **The free-text "Other" opens a new path into `users.role`** — the column `is_admin_role()` reads to gate the admin console, i.e. the #103 escalation. The guard sits on the resolved value and runs before the INSERT, so the box is not an escalation path; pinned, and `is_admin_role` confirmed case-insensitive. **This is a direct input to ROLE1**, which is next.
- **`is_admin_role` being case-insensitive** is a confirmation, not a fix — worth stating because ROLE1 will lean on it.

## Two findings the render test produced that a called rule could not

1. **`maskUS` strips non-digits as she types**, so `phoneProblem`'s "does not look like a phone number" branch is unreachable *by typing* — it guards the API and paste. The render test drives the reachable case (nine digits) instead. Testing the unreachable one would have tested the mask, not the rule.
2. **My blur filter hid the company-pair error.** "Show errors for touched fields" is correct for single fields and wrong for pairs: the complaint lands on the half she has *not* visited, so the form refused to submit and said nothing — worse than the missing check was. A rule about a pair cannot be surfaced by a rule about one field. Touching either half now reveals both.

## Self-review

**Pins changed:** none retargeted; all new.

**Least sure about:** storing the resolved "Other" free text directly in `users.role`. It is the honest answer — the free text *is* their role — but it widens the vocabulary of a column that is also the authorization gate. Safe today because the admin-role guard runs on the resolved value; ROLE1 may want it narrower.

**Would cut:** the blur-time validation. It is the largest change by line count and the least defect-driven — the reported bug was "validation fires only on submit", which is a quality complaint rather than a wrong answer. Cutting it costs the officer discovering every mistake at the end, all at once, after the work.

**Decided rather than flagged:** (1) the interest signal reaches the admin user view — the ruling said "records an interest signal" and left storage open, and a write-only column would have re-created `subscribe`; (2) `state` is no longer read from the form at all, rather than defaulted to CA — a default is a value somebody can override, and this is not one.

## Gates

| gate | result |
|---|---|
| pytest | 1310 passed |
| jest | 959 passed, 64 suites |
| tsc | 88 — baseline unchanged |
| six-flow | green |
| banned-claims | clean |
| next build | clean |
| mutation probes | 5 run, **5 caught** |

**Branch note, as standing practice:** fresh per-ticket branch off current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_