### PR TITLE
UX2 items 3–9 — one vocabulary, two named claims, and a draft can be put away

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -224,6 +224,21 @@ def create_tables():
             # ticket refuses to do.
             "ALTER TABLE deeds ADD COLUMN IF NOT EXISTS superseded_by INTEGER REFERENCES deeds(id)",
             "ALTER TABLE deeds ADD COLUMN IF NOT EXISTS superseded_at TIMESTAMPTZ",
+            # UX2 items 8/9 — ARCHIVE IS ITS OWN COLUMN, NOT A STATUS.
+            #
+            # `status` carries the lifecycle: draft -> completed, plus
+            # `deleted`. Archiving is orthogonal to all of it — an
+            # archived draft is still a draft, and she may want it back.
+            #
+            # The same reasoning `supersession.lineage_state` records for
+            # supersession: "`status` keeps its lifecycle vocabulary;
+            # this is the orthogonal fact." And the practical half: NINE
+            # query sites filter `status <> 'deleted'`, so a new status
+            # value leaks into every one I do not find. A nullable
+            # timestamp is additive and cannot leak by omission — a query
+            # that ignores it shows archived rows, which is visible,
+            # rather than hiding live ones, which is not.
+            "ALTER TABLE deeds ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ",
             "CREATE INDEX IF NOT EXISTS idx_deeds_superseded_by ON deeds(superseded_by)",
             # RED-S2: RESTRICT, not CASCADE.
             #
@@ -1308,14 +1323,22 @@ def save_draft_row(user_id, deed_id, deed_data):
             conn.close()
         return None
 
-def get_user_deeds(user_id):
+def get_user_deeds(user_id, include_archived=False):
     conn = get_db_connection()
     if not conn:
         return []
     
     try:
         cursor = conn.cursor()
-        cursor.execute("SELECT * FROM deeds WHERE user_id = %s AND COALESCE(status, '') <> 'deleted' ORDER BY created_at DESC", (user_id,))
+        # Archived drafts are hers and are kept; they are simply not in
+        # the list she works from. `include_archived` is the one way to
+        # see them, so "where did it go" has an answer.
+        cursor.execute(
+            "SELECT * FROM deeds WHERE user_id = %s "
+            "AND COALESCE(status, '') <> 'deleted' "
+            "AND (archived_at IS NULL OR %s) "
+            "ORDER BY created_at DESC",
+            (user_id, include_archived))
         deeds = cursor.fetchall()
         cursor.close()
         conn.close()

--- a/backend/routers/deeds_crud.py
+++ b/backend/routers/deeds_crud.py
@@ -1,6 +1,6 @@
 """Deed CRUD endpoints (T8 split — moved verbatim from main.py)."""
 import os
-from datetime import timezone
+from datetime import datetime, timezone
 from time import time
 from typing import Dict, Optional, Union
 
@@ -271,8 +271,15 @@ def create_deed_endpoint(deed: DeedCreate, user_id: int = Depends(get_current_us
     return new_deed
 
 @router.get("/deeds")
-def list_deeds_endpoint(user_id: int = Depends(get_current_user_id)):
-    """List all deeds for current user"""
+def list_deeds_endpoint(include_archived: bool = False,
+                        user_id: int = Depends(get_current_user_id)):
+    """List the deeds she works from. Archived ones on request.
+
+    UX2 items 8/9. An archived draft is kept, not deleted — the whole
+    point is that she can put a dead attempt out of the way without
+    destroying it, and can find it again. So the default list omits
+    them and `?include_archived=true` is the way back.
+    """
     try:
         if not db.conn:
             raise HTTPException(status_code=500, detail="Database connection not available")
@@ -280,11 +287,13 @@ def list_deeds_endpoint(user_id: int = Depends(get_current_user_id)):
         with db.conn.cursor() as cur:
             cur.execute("""
                 SELECT id, deed_type, property_address, grantor_name, grantee_name,
-                       county, status, pdf_url, created_at, updated_at, apn, parties
+                       county, status, pdf_url, created_at, updated_at, apn, parties,
+                       archived_at
                 FROM deeds
                 WHERE user_id = %s AND COALESCE(status, '') <> 'deleted'
+                  AND (archived_at IS NULL OR %s)
                 ORDER BY created_at DESC
-            """, (user_id,))
+            """, (user_id, include_archived))
 
             deeds = cur.fetchall()
 
@@ -737,6 +746,60 @@ def activity_endpoint(deed_id: int, user_id: int = Depends(get_current_user_id))
             "entries": deed_activity.activity(dict(deed), shares=shares,
                                               signings=signings,
                                               responses=responses)}
+
+
+class ArchiveRequest(BaseModel):
+    """Which way. One endpoint, because archiving and un-archiving are
+    the same decision pointed in two directions, and two routes would be
+    two places to forget the draft-only rule."""
+    archived: bool = True
+
+
+@router.post("/deeds/{deed_id}/archive")
+def archive_deed_endpoint(deed_id: int, body: ArchiveRequest,
+                          user_id: int = Depends(get_current_user_id)):
+    """Put a dead draft out of the way, or bring it back.
+
+    ═══ DRAFTS ONLY, AND THE REFUSAL SAYS WHY ═══
+
+    A completed deed is an INSTRUMENT (§9). It has a stored PDF with a
+    fingerprint, it may have been sent, signed or recorded, and the
+    correct way to retire one is supersession — which records a
+    relationship rather than hiding a row. Archiving one would be a
+    filing decision quietly standing in for a legal one.
+
+    ═══ AND IT IS NOT A DELETE ═══
+
+    Nothing is destroyed and nothing is un-recorded. The row keeps every
+    column; it stops appearing in the list she works from. That is the
+    entire promise, and `?include_archived=true` is how she checks it.
+    """
+    if not db.conn:
+        raise HTTPException(status_code=500, detail="Database connection not available")
+    with db.conn.cursor() as cur:
+        cur.execute("SELECT status, archived_at FROM deeds "
+                    "WHERE id = %s AND user_id = %s", (deed_id, user_id))
+        row = cur.fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail="Deed not found")
+        status = (dict(row).get("status") or "draft").strip().lower()
+        if status == "completed":
+            raise HTTPException(
+                status_code=409,
+                detail="This deed is generated, so it is an instrument rather "
+                       "than a draft. Correct it with a superseding deed — "
+                       "that records the relationship instead of hiding the row.",
+            )
+        if status == "deleted":
+            raise HTTPException(status_code=409, detail="This deed was deleted.")
+        when = datetime.now(timezone.utc) if body.archived else None
+        cur.execute(
+            "UPDATE deeds SET archived_at = %s, updated_at = NOW() "
+            "WHERE id = %s AND user_id = %s RETURNING archived_at",
+            (when, deed_id, user_id))
+        out = dict(cur.fetchone() or {})
+    db.conn.commit()
+    return {"id": deed_id, "archived_at": _iso_utc(out.get("archived_at"))}
 
 
 @router.get("/deeds/{deed_id}/detail")

--- a/backend/tests/snapshots/openapi_routes.json
+++ b/backend/tests/snapshots/openapi_routes.json
@@ -437,6 +437,10 @@
  ],
  [
   "POST",
+  "/deeds/{deed_id}/archive"
+ ],
+ [
+  "POST",
   "/deeds/{deed_id}/recording"
  ],
  [

--- a/backend/tests/snapshots/six_flow_baseline.json
+++ b/backend/tests/snapshots/six_flow_baseline.json
@@ -25,6 +25,7 @@
     "pdf_url_set": true,
     "returned_keys": [
       "apn",
+      "archived_at",
       "completed_at",
       "county",
       "created_at",
@@ -56,6 +57,7 @@
   "3_deed_detail": {
     "keys": [
       "apn",
+      "archived_at",
       "completed_at",
       "county",
       "created_at",

--- a/backend/tests/test_deed_archive.py
+++ b/backend/tests/test_deed_archive.py
@@ -1,0 +1,120 @@
+"""UX2 items 8/9 — archiving a dead draft, without destroying it.
+
+═══ ARCHIVE IS ITS OWN COLUMN, NOT A STATUS VALUE ═══
+
+Two reasons, and the second is the one that would have bitten.
+
+`status` carries the lifecycle — draft, completed, deleted. Archiving is
+ORTHOGONAL to all of it: an archived draft is still a draft, and she may
+want it back. `supersession.lineage_state` records the same reasoning for
+supersession: "`status` keeps its lifecycle vocabulary; this is the
+orthogonal fact."
+
+And practically: NINE query sites filter `status <> 'deleted'`. A new
+status value leaks into every one I do not find, and the failure mode of
+missing one is that archived rows appear where they should not — which
+is quiet. A nullable timestamp cannot leak by omission: a query that
+ignores it shows archived rows, which is visible, rather than hiding live
+ones, which is not.
+
+═══ DRAFTS ONLY ═══
+
+A completed deed is an INSTRUMENT (§9): stored PDF, fingerprint, possibly
+sent, signed or recorded. The way to retire one is supersession, which
+records a relationship. Archiving one would be a filing decision quietly
+standing in for a legal one.
+"""
+import inspect
+
+import pytest
+
+import routers.deeds_crud as crud
+
+
+def test_archive_is_a_timestamp_column_not_a_status():
+    import database
+    src = inspect.getsource(database)
+    assert "ADD COLUMN IF NOT EXISTS archived_at TIMESTAMPTZ" in src
+    # And the reasoning travels with it, because the next person to want
+    # an "archived" status will look here first.
+    assert "orthogonal" in src
+
+
+def test_the_status_vocabulary_did_not_grow():
+    """The check that would have caught the other design.
+
+    If `archived` had become a status, these nine sites would each need
+    finding. Asserting the string is absent is cheap and says why.
+    """
+    from pathlib import Path
+    backend = Path(__file__).resolve().parents[1]
+    offenders = []
+    for path in backend.rglob("*.py"):
+        if "__pycache__" in path.parts or "tests" in path.parts:
+            continue
+        text = path.read_text(encoding="utf-8")
+        if "'archived'" in text or '"archived"' in text:
+            offenders.append(path.relative_to(backend).as_posix())
+    assert offenders == [], f"`archived` used as a status value: {offenders}"
+
+
+def test_a_completed_deed_is_refused_and_told_what_to_do_instead():
+    """THE PIN THIS FILE EXISTS FOR.
+
+    A refusal that only says no leaves her with a deed she wants out of
+    the way and no route. This one names supersession, which is the act
+    that actually applies.
+    """
+    src = inspect.getsource(crud.archive_deed_endpoint)
+    assert "status_code=409" in src
+    assert "superseding deed" in src
+    assert "records the relationship" in src
+
+
+def test_the_refusal_reads_status_before_it_writes():
+    src = inspect.getsource(crud.archive_deed_endpoint)
+    assert src.index("SELECT status") < src.index("UPDATE deeds")
+
+
+def test_archiving_and_unarchiving_are_one_endpoint():
+    """Two routes would be two places to forget the draft-only rule."""
+    assert "archived" in crud.ArchiveRequest.model_fields
+    assert crud.ArchiveRequest.model_fields["archived"].default is True
+    src = inspect.getsource(crud.archive_deed_endpoint)
+    assert "if body.archived else None" in src
+
+
+def test_nothing_is_destroyed():
+    """It is not a delete, and the statement proves it: one column moves
+    and no row goes anywhere.
+
+    Read through `code_only` because the first draft caught its OWN
+    docstring — the phrase "it is not a delete" contains DELETE. A sweep
+    that cannot tell a description of a rule from a violation of it gets
+    widened until it means nothing. Same lesson the frontend
+    "times offered" sweep learned an hour earlier.
+    """
+    from tests.source_text import code_only
+    body = code_only(inspect.getsource(crud.archive_deed_endpoint))
+    # `deleted` the STATUS is fine; `DELETE` the statement is not.
+    assert "DELETE FROM" not in body.upper()
+    assert "SET archived_at" in body
+
+
+def test_the_default_list_omits_archived_and_can_be_asked_for_them():
+    src = inspect.getsource(crud.list_deeds_endpoint)
+    assert "include_archived" in src
+    assert "archived_at IS NULL OR %s" in src
+
+
+def test_the_row_carries_the_flag_so_a_screen_can_show_it():
+    """A list that hides archived rows without saying which they are
+    cannot offer a filter she can trust."""
+    src = inspect.getsource(crud.list_deeds_endpoint)
+    assert "archived_at" in src.split("SELECT")[1].split("FROM")[0]
+
+
+@pytest.mark.parametrize("blocked", ["completed", "deleted"])
+def test_both_terminal_states_are_refused(blocked):
+    src = inspect.getsource(crud.archive_deed_endpoint)
+    assert f'== "{blocked}"' in src

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -967,6 +967,70 @@ we reach it.
   error and no warning. **A test that produces nothing looks exactly
   like a test with nothing to say** — the same disease one level up.
 
+- **STANDING CHECK — quality tracks the feedback loop** (two consecutive
+  tickets, 2026-08-13). Not a lesson. A question to ask on every ticket.
+
+  **#192**: the notary's availability inputs sat in `grid-cols-2` at
+  every width and truncated on a phone. `RequestSigningModal`, one file
+  over, had `grid-cols-1 sm:grid-cols-2` WITH labels the whole time.
+
+  **#193**: registration stored `"not-a-phone!!"` verbatim and production
+  holds a nine-digit number. A full phone normalizer has existed in BOTH
+  languages since PARTNER2, refereed by a shared corpus, and the partner
+  screens have used it all along.
+
+  Both capabilities were already in the tree. Both were absent from the
+  surface a STRANGER meets — the notary with no account, the visitor who
+  has not signed up. The fix landed everywhere a user could complain and
+  nowhere they could not.
+
+  **THE CHECK, to run when fixing any surface:** what capability already
+  exists elsewhere in this repo that THIS surface never adopted? The
+  answer is usually "the one whose users could complain."
+
+  Two-for-two on consecutive tickets is a pattern, not a coincidence.
+  Worth stating that the surfaces without a feedback loop are exactly the
+  ones where somebody who is not our customer forms an impression of our
+  customer.
+
+- **A refusal must distinguish a typo from a policy** (SIGNUP1,
+  2026-08-13). `AAA` is a malformed state code. `AZ` is a real state we
+  do not serve. Collapsing them into "invalid state" tells somebody their
+  typo was a business decision — and tells somebody in Arizona that they
+  mistyped.
+
+  Pinned by ORDER: the format check runs first, then the served-state
+  refusal. Two answers, in the order that makes each one true.
+
+  The same ticket's larger half: **removing the dropdown while the
+  endpoint still accepts the value is cosmetic.** Registration is public.
+  An API caller opens an account the product cannot serve and discovers
+  it by hunting for forms that do not exist.
+
+- **A RULE ABOUT A PAIR CANNOT BE SURFACED BY A RULE ABOUT ONE FIELD**
+  (SIGNUP1, 2026-08-13). New, and found by a render test.
+
+  "Show errors for fields she has touched" is correct for single fields
+  and WRONG for pairs. The company name and type are one fact in two
+  inputs: filling the type and leaving the name raises the error on the
+  NAME, which she has not visited — so the filter hid it, and the form
+  refused to submit while saying nothing.
+
+  **A silent form that will not submit is worse than the missing check
+  it replaced.** Touching either half now reveals both.
+
+- **LEGAL1 APPLIED BEFORE THE MISTAKE, for once** (SIGNUP1,
+  2026-08-13). Noted with approval because the opposite is the norm.
+
+  The interest signal could have been a second write-only column —
+  exactly `subscribe`, which was collected, stored, and readable by
+  nobody, manufacturing a record that looked like information and could
+  not function as one. It reaches the admin user view instead, and the
+  copy promises nothing, because a promise would have made it a consent.
+
+  The lesson transferring is rarer than it should be. Four sightings this
+  week of a lesson NOT transferring; this is the one that did.
+
 ## Parked tickets (scoped, not scheduled)
 
 - **Audit the string-presence pins whose subject is a BRANCH** (CANCEL1

--- a/frontend/src/__tests__/ux2Items.test.ts
+++ b/frontend/src/__tests__/ux2Items.test.ts
@@ -1,0 +1,261 @@
+/**
+ * UX2 items 3–9.
+ *
+ * ═══ ITEM 4 STOOD DOWN, AND THAT IS THE INTERESTING ONE ═══
+ *
+ * The ticket asked for the sidebar badge and the dashboard attention
+ * number to match. They are DIFFERENT CLAIMS, deliberately, decided in
+ * DASH1 and recorded in `officer_queue.queue`: a badge says "there are
+ * things here"; the attention number says "these have gone quiet".
+ *
+ * Forcing them to match destroys one or the other — badges counting only
+ * stale means a request sent this morning shows no badge; attention
+ * counting everything turns the number she checks first into "there are
+ * rows below", which is verbatim what DASH1 rejected.
+ *
+ * Owner-ruled: stand down, and build the REAL defect. Two different
+ * claims presented as two identical bare numbers invite the reading that
+ * they are one claim — and the evidence is that the ticket asking to
+ * reconcile them was written by somebody with the code in front of him.
+ * If it misreads there, it misreads on screen.
+ *
+ * So: labelling, not arithmetic. Each number names its own claim.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
+import {
+  NUDGE_AT, addressKey, nudgeSentence, staleClusters,
+} from '../lib/staleDrafts';
+
+const SRC = path.join(__dirname, '..');
+const read = (...p: string[]) => codeOnly(
+  fs.readFileSync(path.join(SRC, ...p), 'utf8'));
+const TRACKER = read('app', 'requests', 'page.tsx');
+const PAST_DEEDS = read('app', 'past-deeds', 'page.tsx');
+const SIDEBAR = read('components', 'Sidebar.tsx');
+const DASHBOARD = read('app', 'dashboard', 'page.tsx');
+const PARTNERS = read('app', 'partners', 'page.tsx');
+const PY_QUEUE = fs.readFileSync(
+  path.join(SRC, '..', '..', 'backend', 'services', 'officer_queue.py'), 'utf8');
+
+// ── item 3 ───────────────────────────────────────────────────────────
+
+describe('one vocabulary for a document name', () => {
+  it('the tracker names deeds the way Past Deeds does', () => {
+    // "Grant Deed" on one screen and `grant-deed` on another, for the
+    // same document, two clicks apart. The slug is our storage key and
+    // she never chose it.
+    expect(TRACKER).toContain('deedTypeLabel(deed.deed_type)');
+    expect(TRACKER).not.toContain('>{deed.deed_type}<');
+  });
+});
+
+// ── item 4 ───────────────────────────────────────────────────────────
+
+describe('two numbers, two claims, each named', () => {
+  it('the deliberate difference is still in the server', () => {
+    /** THE PIN THIS BLOCK EXISTS FOR — it protects a RULING against a
+     *  ticket, which is the unusual direction. */
+    expect(PY_QUEUE).toContain('These are NOT the attention count');
+    expect(PY_QUEUE).toContain('"needs_attention": len([r for r in awaiting if r["stale"]])');
+    expect(PY_QUEUE).toContain('"signings": len([r for r in awaiting if r["kind"] == "signing"])');
+  });
+
+  it('the badge says what it counts', () => {
+    expect(SIDEBAR).toContain('waiting on you here');
+    expect(SIDEBAR).toContain('aria-label={`${count} waiting`}');
+  });
+
+  it('the dashboard headline says something narrower', () => {
+    expect(DASHBOARD).toContain('gone');
+    expect(DASHBOARD).toContain('quiet');
+    // And it stops using the phrase that named nothing — everything on
+    // that page could be said to need her attention.
+    expect(DASHBOARD).not.toContain('your attention');
+  });
+
+  it('the threshold comes from the payload, not from the screen', () => {
+    expect(DASHBOARD).toContain('queue.thresholds.stale_after_days');
+  });
+});
+
+// ── item 5 ───────────────────────────────────────────────────────────
+
+describe('an expired share can be nudged', () => {
+  it('expired is no longer refused by the screen', () => {
+    // `resend_approval_email` has always extended a lapsed share by 24
+    // hours and sent. The capability was built; the one screen that
+    // could offer it refused, so her only route back was a second link.
+    expect(PAST_DEEDS).not.toContain('"expired", "approved"');
+    expect(TRACKER).toContain('return !["approved", "rejected", "revoked"]');
+  });
+
+  it('and the three that stay are the ANSWERED and the WITHDRAWN', () => {
+    // Nudging somebody who already replied asks them to reply again;
+    // un-revoking silently would undo her decision.
+    for (const kept of ['approved', 'rejected', 'revoked']) {
+      expect(TRACKER).toContain(`"${kept}"`);
+    }
+  });
+});
+
+// ── item 6 ───────────────────────────────────────────────────────────
+
+describe('the rolodex is readable and actionable', () => {
+  it('the phone is on the row, not only in the editor', () => {
+    // Reading and editing are different acts, and the number she most
+    // often wants was behind a click into a form built for changing it.
+    expect(PARTNERS).toContain('formatPhone(p.phone)');
+    expect(PARTNERS).toContain('href={`tel:${p.phone}`}');
+  });
+
+  it('one click starts a signing with that partner', () => {
+    expect(PARTNERS).toContain('action=signing&notary=');
+  });
+
+  it('and it is offered on EVERY row, not gated on the filing', () => {
+    /**
+     * The first draft gated it on `category === 'notary'`. The registry
+     * pin caught the literal, and the rule behind the pin is the
+     * stronger objection: a category "says how the officer FILES them.
+     * It says nothing about their authority, their licensure, or what
+     * they are permitted to do, and no code may read it as though it
+     * did."
+     *
+     * Gating the button on the category IS reading it as permission.
+     */
+    expect(PARTNERS).not.toContain("p.category === 'notary'");
+  });
+
+  it('the deed is chosen where the deeds are', () => {
+    // It cannot create the request from the rolodex — there is no deed
+    // on that row, and inventing one would be the product choosing her
+    // document.
+    expect(PAST_DEEDS).toContain('notaryFromPartner');
+    expect(PAST_DEEDS).toContain('preselectNotaryId={notaryFromPartner}');
+  });
+
+  it('and the arrival is explained rather than mysterious', () => {
+    expect(PAST_DEEDS).toContain('Pick the deed you want signed');
+  });
+});
+
+// ── item 7 ───────────────────────────────────────────────────────────
+
+describe('the actions column is reachable without scrolling sideways', () => {
+  it('Updated is gone', () => {
+    /**
+     * Seven columns at px-6 made 1197px in a 1150px viewport.
+     * `overflow-x-auto` was ALREADY here, so Actions was not clipped —
+     * it was off-screen behind a scroll nothing signalled, which is
+     * worse: a clipped control looks broken, an absent one looks like it
+     * does not exist.
+     */
+    expect(PAST_DEEDS).not.toContain('>Updated</th>');
+    expect(PAST_DEEDS).not.toContain('formatDate(deed.updated_at)');
+  });
+
+  it('and it was the only column whose removal undoes no prior decision', () => {
+    // X2.7 promoted Doc ID out of the address cell on purpose; Created
+    // orders the list. `updated_at` is on deed_activity.FORBIDDEN with
+    // the reason "it moves for reasons that are not events".
+    expect(PAST_DEEDS).toContain('>Doc ID<');
+    expect(PAST_DEEDS).toContain('>Created</th>');
+    expect(PAST_DEEDS).toContain('>Actions</th>');
+  });
+});
+
+// ── items 8 / 9 ──────────────────────────────────────────────────────
+
+const draft = (id: number, address: string, created: string) => ({
+  id, status: 'draft', property_address: address, created_at: created,
+});
+
+describe('the stale-draft nudge', () => {
+  const five = [
+    draft(1, '123 Baseline St', '2026-08-01T00:00:00Z'),
+    draft(2, '123 Baseline St', '2026-08-02T00:00:00Z'),
+    draft(3, '123 baseline st.', '2026-08-03T00:00:00Z'),
+    draft(4, '123 Baseline St', '2026-08-04T00:00:00Z'),
+    draft(5, '123 Baseline St', '2026-08-05T00:00:00Z'),
+  ];
+
+  it('fires at five and not at four', () => {
+    expect(staleClusters(five)).toHaveLength(1);
+    expect(staleClusters(five.slice(0, 4))).toHaveLength(0);
+    expect(NUDGE_AT).toBe(5);
+  });
+
+  it('matches the address the way a person means it', () => {
+    // Five attempts spread across two spellings is exactly the case.
+    expect(addressKey('123 Baseline St')).toBe(addressKey('123 baseline st.'));
+    expect(staleClusters(five)[0].drafts).toHaveLength(5);
+  });
+
+  it('NEVER offers the newest', () => {
+    /**
+     * THE PIN THIS BLOCK EXISTS FOR. The product cannot know which of
+     * five attempts is current, and archiving the one she is working on
+     * is the single outcome that makes this feature worse than nothing.
+     */
+    const [cluster] = staleClusters(five);
+    expect(cluster.older.map((d) => d.id)).not.toContain(5);
+    expect(cluster.older).toHaveLength(4);
+    expect(cluster.drafts[0].id).toBe(5);
+  });
+
+  it('a draft with no date sorts last, not first', () => {
+    // An unknown time is not a recent one.
+    const withUnknown = [...five, { id: 6, status: 'draft',
+      property_address: '123 Baseline St', created_at: null }];
+    expect(staleClusters(withUnknown)[0].drafts[0].id).toBe(5);
+  });
+
+  it('completed deeds are not drafts and archived ones stop asking', () => {
+    const mixed = [
+      ...five.slice(0, 4),
+      { ...draft(5, '123 Baseline St', '2026-08-05T00:00:00Z'), status: 'completed' },
+    ];
+    expect(staleClusters(mixed)).toHaveLength(0);
+    const done = five.map((d) => ({ ...d, archived_at: '2026-08-06T00:00:00Z' }));
+    expect(staleClusters(done)).toHaveLength(0);
+  });
+
+  it('an address-less draft belongs to no property', () => {
+    const blanks = [1, 2, 3, 4, 5].map((i) => draft(i, '', '2026-08-01T00:00:00Z'));
+    expect(staleClusters(blanks)).toHaveLength(0);
+  });
+
+  it('the sentence says what it sees and offers, and claims nothing else', () => {
+    const [cluster] = staleClusters(five);
+    const said = nudgeSentence(cluster);
+    expect(said).toContain('5 unfinished drafts');
+    expect(said).toContain('Archive the 4 older ones');
+    // It does NOT call them abandoned — we do not know that.
+    expect(said).not.toMatch(/abandoned|stale|dead/i);
+    // And it says archiving is not deleting, where she is deciding.
+    expect(said).toContain('kept');
+    expect(said).toContain('not deleted');
+  });
+});
+
+describe('archiving is verifiable, not just promised', () => {
+  it('there is a filter that shows them', () => {
+    // "Kept, not deleted" is a claim she has no way to check unless a
+    // filter can produce them.
+    expect(PAST_DEEDS).toContain('<option value="archived">Archived</option>');
+    expect(PAST_DEEDS).toContain('include_archived=true');
+  });
+
+  it('and archived rows are out of the working list otherwise', () => {
+    expect(PAST_DEEDS).toContain('if (deed.archived_at) return false');
+  });
+
+  it('a partial failure is reported rather than swallowed', () => {
+    // §4 on a bulk action: a partial archive reported as success leaves
+    // her list disagreeing with what she was told.
+    expect(PAST_DEEDS).toContain('Could not archive #');
+  });
+});

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -414,7 +414,19 @@ function ActionQueue({ queue, error }: { queue: Queue | null; error: string | nu
             her. It is the requests that have gone quiet. */}
         {queue.needs_attention > 0 && (
           <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-100 px-3 py-1 text-sm font-semibold text-amber-900">
-            {queue.needs_attention} need{queue.needs_attention === 1 ? 's' : ''} your attention
+            {/* UX2 item 4 — THIS NUMBER SAYS SOMETHING NARROWER THAN THE
+                SIDEBAR BADGES, and now says so.
+
+                "Needs your attention" is true of everything on this
+                page, so it named nothing. This count is the STALE
+                unanswered requests — the ones that have gone quiet —
+                which is the number that means "nobody is waiting on me
+                and nobody has gone silent" when it is zero.
+
+                The threshold rides on the payload so no screen retypes
+                it (DASH1). */}
+            {queue.needs_attention} {queue.needs_attention === 1 ? 'has' : 'have'} gone
+            quiet — no answer in {queue.thresholds.stale_after_days}+ days
           </span>
         )}
       </div>

--- a/frontend/src/app/partners/page.tsx
+++ b/frontend/src/app/partners/page.tsx
@@ -44,8 +44,10 @@
  */
 
 import React, { useState, useEffect, useMemo } from 'react';
+import { useRouter } from 'next/navigation';
 import {
-  Plus, Pencil, Trash2, X, Save, Search, Users, MapPin, Mail, Loader2,
+  CalendarClock, Plus, Pencil, Trash2, X, Save, Search, Users, MapPin, Mail,
+  Phone, Loader2,
 } from 'lucide-react';
 import Sidebar from '../../components/Sidebar';
 import {
@@ -108,6 +110,7 @@ export function partnerAddressLine(p: Partial<Partner>): string {
 }
 
 export default function PartnersPage() {
+  const router = useRouter();
   const [items, setItems] = useState<Partner[]>([]);
   const [loading, setLoading] = useState(false);
   const [editing, setEditing] = useState<Partial<Partner> | null>(null);
@@ -393,16 +396,77 @@ export default function PartnersPage() {
                         {p.contact_name || '—'}
                       </td>
                       <td className="px-4 py-4">{categoryChip(p.category)}</td>
+                      {/* UX2 item 6 — THE PHONE WAS ONLY IN THE EDITOR.
+                          The rolodex existed to save her looking somebody
+                          up, and the number she most often wants was
+                          behind a click into a form built for CHANGING
+                          it. Reading and editing are different acts.
+
+                          (The email was already here. Recorded because
+                          the ticket asked for both and half of it was
+                          done — a ticket's record should match reality.) */}
                       <td className="hidden xl:table-cell px-4 py-4 break-words">
                         {p.email ? (
                           <a href={`mailto:${p.email}`} className="text-brand-600 hover:underline inline-flex items-center gap-1">
                             <Mail className="w-3.5 h-3.5 flex-shrink-0" />
                             <span className="break-all">{p.email}</span>
                           </a>
-                        ) : '—'}
+                        ) : null}
+                        {p.phone ? (
+                          <a href={`tel:${p.phone}`}
+                             className="mt-1 text-gray-600 hover:text-brand-600 hover:underline inline-flex items-center gap-1">
+                            <Phone className="w-3.5 h-3.5 flex-shrink-0" />
+                            {/* Regional display, E.164 storage — the
+                                PARTNER2 split. A person reads a phone
+                                number the way a person writes one. */}
+                            <span>{formatPhone(p.phone)}</span>
+                          </a>
+                        ) : null}
+                        {!p.email && !p.phone ? '—' : null}
                       </td>
                       <td className="px-4 py-4">
                         <div className="flex items-center justify-end gap-1">
+                          {/* UX2 item 6 — ONE CLICK TO A SIGNING.
+                              A notary in the rolodex and a signing that
+                              needs one were two screens apart, and the
+                              route between them was "remember the name,
+                              go to Past Deeds, find the deed, open the
+                              modal, search for her again".
+
+                              It cannot create the request from here —
+                              there is no deed on this row, and inventing
+                              one would be the product guessing which
+                              document she meant. So it carries the
+                              notary to the place the deed is chosen. */}
+                          {/* OFFERED ON EVERY ROW, and that is the
+                              correct reading rather than a shortcut.
+
+                              The first draft gated this on
+                              `category === 'notary'`. The registry pin
+                              caught the literal, and the rule behind the
+                              pin is the stronger objection:
+                              partnerRegistry.ts says a category "says how
+                              the officer FILES them. It says nothing
+                              about their authority, their licensure, or
+                              what they are permitted to do, and no code
+                              may read it as though it did."
+
+                              Gating the button on the category IS reading
+                              it as permission. Who she asks to notarize is
+                              her judgement; the modal's existing mismatch
+                              notice says a dismissible sentence if the
+                              filing looks unexpected, which is the
+                              established way this product raises a
+                              doubt without overruling her. */}
+                          <button
+                            aria-label={`Request a signing with ${p.company_name}`}
+                            title="Request a signing"
+                            className="p-2 rounded-md text-gray-500 hover:text-brand-600 hover:bg-brand-50 transition-colors"
+                            onClick={() => router.push(
+                              `/past-deeds?action=signing&notary=${encodeURIComponent(p.id)}`)}
+                          >
+                            <CalendarClock className="w-4 h-4" />
+                          </button>
                           <button
                             aria-label={`Edit ${p.company_name}`}
                             title="Edit"

--- a/frontend/src/app/past-deeds/page.tsx
+++ b/frontend/src/app/past-deeds/page.tsx
@@ -14,6 +14,7 @@ import { toast } from "sonner"
 import { SessionExpiredError, apiFetch } from "@/lib/apiClient"
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog"
 import { deedTypeLabel } from "@/lib/deedTypes"
+import { StaleCluster, nudgeSentence, staleClusters } from "@/lib/staleDrafts"
 
 interface Deed {
   id: number
@@ -27,6 +28,8 @@ interface Deed {
   status: "completed" | "draft" | "in_progress"
   created_at: string
   updated_at: string
+  /** UX2 items 8/9 — set means put away, never deleted. */
+  archived_at?: string | null
   pdf_url?: string
 }
 
@@ -97,19 +100,60 @@ function PastDeedsList() {
    * `?status=` seeds the filter; `?focus=` highlights one row.
    */
   const params = useSearchParams()
-  const [statusFilter, setStatusFilter] = useState<"all" | "completed" | "draft">(() => {
+  const [statusFilter, setStatusFilter] = useState<"all" | "completed" | "draft" | "archived">(() => {
     const wanted = params?.get("status")
-    return wanted === "completed" || wanted === "draft" ? wanted : "all"
+    return wanted === "completed" || wanted === "draft" || wanted === "archived"
+      ? wanted : "all"
   })
+  /* UX2 item 6 — carried from the partner row. The rolodex cannot pick
+     a deed (there is none on that row, and guessing one would be the
+     product choosing her document), so it carries the notary here and
+     the deed is chosen where the deeds are. */
+  const notaryFromPartner = params?.get("notary") || null
+  /* UX2 items 8/9 — the nudge. The rule is lib/staleDrafts.ts so it can
+     be asked a question; this screen only renders the answer. */
+  const [archiving, setArchiving] = useState(false)
+  const [dismissed, setDismissed] = useState<string[]>([])
+  const clusters = staleClusters(deeds).filter((c) => !dismissed.includes(c.address))
+
+  const archiveCluster = async (cluster: StaleCluster) => {
+    setArchiving(true)
+    try {
+      // Sequential, and every failure surfaces. A partial archive that
+      // reported success would leave her list disagreeing with what she
+      // was told — the §4 case, on a bulk action.
+      for (const draft of cluster.older) {
+        const res = await apiFetch(`/deeds/${draft.id}/archive`,
+          { method: "POST", headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ archived: true }) },
+          { label: "Archiving" })
+        if (!res.ok) {
+          const body = await res.json().catch(() => ({}))
+          throw new Error(String(body.detail || `Could not archive #${draft.id}`))
+        }
+      }
+      toast.success(`Archived ${cluster.older.length} drafts. They are kept — filter to Archived to see them.`)
+      await fetchDeeds()
+    } catch (err) {
+      if (err instanceof SessionExpiredError) return
+      toast.error(err instanceof Error ? err.message : "Could not archive those drafts")
+    } finally {
+      setArchiving(false)
+    }
+  }
   const focusId = (() => {
     const raw = params?.get("focus")
     const id = raw ? Number(raw) : NaN
     return Number.isInteger(id) ? id : null
   })()
 
+  /* Refetch when she switches to or from Archived: those rows are not
+     in the default payload, so filtering client-side alone would show
+     an empty Archived list on a page that has them. */
   useEffect(() => {
     fetchDeeds()
-  }, [])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [statusFilter === "archived"])
 
   const fetchDeeds = async () => {
     try {
@@ -120,7 +164,12 @@ function PastDeedsList() {
       }
 
       // X1: apiFetch surfaces every failure (401 = session-expired redirect).
-      const response = await apiFetch(`/deeds`, {}, { label: "Loading deeds" })
+      /* UX2 items 8/9 — archived rows only when she asks for them. The
+         promise archiving makes is "kept, not deleted", and a filter
+         that cannot show them is a promise she has no way to check. */
+      const response = await apiFetch(
+        `/deeds${statusFilter === "archived" ? "?include_archived=true" : ""}`,
+        {}, { label: "Loading deeds" })
 
       if (!response.ok) {
         const data = await response.json().catch(() => ({}))
@@ -257,6 +306,8 @@ function PastDeedsList() {
 
   // X2.7: filter over address, grantee, doc id, APN, and type label.
   const visibleDeeds = deeds.filter((deed) => {
+    if (statusFilter === "archived") return !!deed.archived_at
+    if (deed.archived_at) return false
     if (statusFilter === "completed" && deed.status !== "completed") return false
     if (statusFilter === "draft" && deed.status === "completed") return false
     const q = searchQuery.trim().toLowerCase()
@@ -307,13 +358,15 @@ function PastDeedsList() {
                 </div>
                 <select
                   value={statusFilter}
-                  onChange={(e) => setStatusFilter(e.target.value as "all" | "completed" | "draft")}
+                  onChange={(e) => setStatusFilter(
+                    e.target.value as "all" | "completed" | "draft" | "archived")}
                   className="px-3 py-2 text-sm border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF]"
                   aria-label="Filter by status"
                 >
                   <option value="all">All statuses</option>
                   <option value="completed">Completed</option>
                   <option value="draft">Drafts</option>
+                  <option value="archived">Archived</option>
                 </select>
               </div>
               <button
@@ -376,6 +429,49 @@ function PastDeedsList() {
           )}
 
           {/* Table */}
+          {/* UX2 items 8/9 — THE NUDGE.
+
+              Five drafts at one address is somebody trying the same
+              conveyance five times. The product cannot know which one is
+              current, so it says what it sees and offers the action
+              rather than tidying up on her behalf — archiving the
+              attempt she is working on is the one outcome that would
+              make this worse than nothing, so the newest is never in the
+              offer. */}
+          {clusters.map((cluster) => (
+            <div key={cluster.address} role="status"
+                 className="mb-4 rounded-xl border border-amber-200 bg-amber-50 p-4">
+              <p className="text-sm text-amber-900">{nudgeSentence(cluster)}</p>
+              <div className="mt-3 flex flex-wrap gap-2">
+                <button
+                  onClick={() => archiveCluster(cluster)}
+                  disabled={archiving}
+                  className="px-3 py-2 text-sm font-medium rounded-lg bg-amber-700 text-white hover:bg-amber-800 disabled:opacity-60"
+                >
+                  {archiving ? "Archiving…" : `Archive the ${cluster.older.length} older`}
+                </button>
+                <button
+                  onClick={() => setDismissed([...dismissed, cluster.address])}
+                  disabled={archiving}
+                  className="px-3 py-2 text-sm font-medium rounded-lg border border-amber-300 text-amber-900 hover:bg-white disabled:opacity-60"
+                >
+                  Not now
+                </button>
+              </div>
+            </div>
+          ))}
+
+          {/* UX2 item 6 — SHE ARRIVED FROM A PARTNER ROW, and the page
+              says so. Landing on an unfiltered list with a modal that
+              mysteriously knows a notary is the dead-button defect
+              inverted: the outcome is right and the reason is absent. */}
+          {notaryFromPartner && signingDeedId === null && (
+            <div role="status"
+                 className="mb-4 rounded-xl border border-[#7C4DFF]/30 bg-[#7C4DFF]/5 p-4 text-sm text-slate-700">
+              Pick the deed you want signed — the notary you chose is
+              already selected.
+            </div>
+          )}
           {!loading && !error && deeds.length > 0 && (
             <div className="bg-white rounded-2xl shadow-md border border-slate-200 overflow-hidden">
               <div className="overflow-x-auto">
@@ -387,7 +483,28 @@ function PastDeedsList() {
                       <th className="text-left py-4 px-6 text-sm font-semibold text-slate-700">Deed Type</th>
                       <th className="text-left py-4 px-6 text-sm font-semibold text-slate-700">Status</th>
                       <th className="text-left py-4 px-6 text-sm font-semibold text-slate-700">Created</th>
-                      <th className="text-left py-4 px-6 text-sm font-semibold text-slate-700">Updated</th>
+                      {/* UX2 item 7 — "UPDATED" IS GONE.
+
+                          Seven columns at px-6 made the table 1197px in
+                          a 1150px viewport. `overflow-x-auto` was
+                          already here, so Actions was not clipped — it
+                          was off-screen behind a sideways scroll nothing
+                          signalled, which is worse: a clipped control
+                          looks broken, an absent one looks like it does
+                          not exist.
+
+                          Owner-ruled: actions stay visible, the
+                          lowest-value column goes. `updated_at` is the
+                          one, and not by elimination — it is on
+                          `deed_activity.FORBIDDEN` with the reason "it
+                          moves for reasons that are not events, so
+                          ordering by it narrates writes rather than
+                          acts". A column showing it invites exactly the
+                          reading this codebase already ruled against.
+
+                          Every other column undoes a prior decision:
+                          X2.7 promoted Doc ID out of the address cell on
+                          purpose, and Created is what orders the list. */}
                       <th className="text-left py-4 px-6 text-sm font-semibold text-slate-700">Actions</th>
                     </tr>
                   </thead>
@@ -443,7 +560,7 @@ function PastDeedsList() {
                           )}
                         </td>
                         <td className="py-4 px-6 text-sm text-slate-600">{formatDate(deed.created_at)}</td>
-                        <td className="py-4 px-6 text-sm text-slate-600">{formatDate(deed.updated_at)}</td>
+
                         <td className="py-4 px-6">
                           <div className="flex items-center gap-2">
                             {deed.status === "draft" && (
@@ -592,6 +709,7 @@ function PastDeedsList() {
             return (
               <RequestSigningModal
                 deedId={signingDeedId}
+                preselectNotaryId={notaryFromPartner}
                 propertyAddress={deed?.property_address}
                 // The deed's party NAMES seed the signer rows. Names only:
                 // the deed has never held a way to reach anybody (§13.1)

--- a/frontend/src/app/requests/page.tsx
+++ b/frontend/src/app/requests/page.tsx
@@ -7,6 +7,7 @@ import { toast } from "sonner"
 import { SessionExpiredError, apiFetch } from "@/lib/apiClient"
 import { ConfirmDialog } from "@/components/ui/ConfirmDialog"
 import { readFocus, initialFilter, isFocused, type TrackerFilter } from "@/lib/requestsFocus"
+import { deedTypeLabel } from "@/lib/deedTypes"
 import { requestsSections } from "@/lib/requestsSections"
 import { SigningAgenda } from "@/features/signing/SigningAgenda"
 import type { SigningSummary } from "@/features/signing/signingSummary"
@@ -425,7 +426,20 @@ function SharedDeedsTracker() {
     // absent until there is a reminder written for her — and the server
     // refuses the call too, so this is a rule and not a hidden button.
     if (deed.share_type === "signing_request") return false
-    return !["expired", "approved", "rejected", "revoked"].includes(deed.status)
+    // UX2 item 5 — "expired" IS NOT IN THIS LIST ANY MORE.
+    //
+    // `resend_approval_email` has always handled a lapsed share: it
+    // extends the expiry by 24 hours and sends. The capability was
+    // built, on the server, and the one screen that could offer it
+    // refused — so the officer's only route back from an expired share
+    // was to create a second one, which is a second link, a second
+    // email, and a reviewer holding two.
+    //
+    // The other three stay: approved and rejected are ANSWERED, and
+    // nudging somebody who already replied asks them to reply again;
+    // revoked was withdrawn on purpose and un-withdrawing it silently
+    // would undo her decision.
+    return !["approved", "rejected", "revoked"].includes(deed.status)
   }
 
   const canRevoke = (deed: SharedDeed) => {
@@ -620,7 +634,15 @@ function SharedDeedsTracker() {
                           }`}
                         >
                           <td className="py-4 px-6 font-medium text-slate-800">{deed.property}</td>
-                          <td className="py-4 px-6 text-slate-600">{deed.deed_type}</td>
+                          {/* UX2 item 3 — ONE VOCABULARY. Past Deeds rendered
+                              "Grant Deed" and this rendered `grant-deed`, for
+                              the same document, two clicks apart. The registry
+                              is the one place a document is named; a screen
+                              that prints the slug is showing our storage key
+                              to somebody who never chose it. */}
+                          <td className="py-4 px-6 text-slate-600">
+                            {deedTypeLabel(deed.deed_type)}
+                          </td>
                           <td className="py-4 px-6">
                             <div className="flex flex-col">
                               <span className="font-medium text-slate-800">{deed.shared_with}</span>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -165,12 +165,32 @@ export default function Sidebar() {
           {!collapsed && <span className="truncate flex-1">{item.label}</span>}
           {/* The badge counts what is WAITING, not what exists. Zero
               renders nothing rather than a "0" — a badge saying zero is
-              a thing to read that says there is nothing to read. */}
+              a thing to read that says there is nothing to read.
+
+              ═══ UX2 item 4 — IT NAMES ITS CLAIM ═══
+
+              This number and the dashboard's headline are DIFFERENT
+              CLAIMS, deliberately (see officer_queue.queue): a badge
+              says "there are things here"; the attention number says
+              "these have gone quiet". Forcing them to match destroys
+              one or the other.
+
+              But two different claims presented as two identical bare
+              numbers invite the reading that they are one claim. The
+              evidence is that the ticket asking for them to be
+              reconciled was written by somebody WITH THE CODE IN FRONT
+              OF HIM. If he misread it there, an officer misreads it
+              here.
+
+              So the fix is labelling, not arithmetic. The aria-label
+              already said "waiting"; the tooltip says it too, because
+              the reading that goes wrong is the sighted one. */}
           {count > 0 && (
             <span
               className={`shrink-0 rounded-full bg-brand-100 text-brand-700 text-xs font-semibold ${
                 collapsed ? 'absolute top-1 right-1 px-1.5' : 'px-2 py-0.5'
               }`}
+              title={`${count} waiting on you here`}
               aria-label={`${count} waiting`}
             >
               {count}

--- a/frontend/src/features/signing/RequestSigningModal.tsx
+++ b/frontend/src/features/signing/RequestSigningModal.tsx
@@ -29,11 +29,12 @@
  * email into a product they have never heard of.
  */
 
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { CalendarClock, Info, Loader2, Plus, Trash2, X } from 'lucide-react';
 import { apiFetch } from '@/lib/apiClient';
 import { withOffset } from '@/lib/wallClock';
 import { PartnerRecipientPicker, Recipient } from '@/features/partners/PartnerRecipientPicker';
+import { usePartners } from '@/features/partners/PartnersContext';
 import {
   RecipientMismatchNotice,
   filedAsSentence,
@@ -68,10 +69,16 @@ export function RequestSigningModal({
   deedId,
   propertyAddress,
   suggestedSigners = [],
+  preselectNotaryId,
   onClose,
   onCreated,
 }: {
   deedId: number;
+  /** UX2 item 6 — arrived from a partner row, which knew the notary and
+   *  not the deed. Resolved against the rolodex rather than trusted:
+   *  an id from a URL is a string somebody could type, and a notary
+   *  this officer does not have must not appear as though she does. */
+  preselectNotaryId?: string | null;
   propertyAddress?: string;
   /** The deed's party NAMES, as a starting point. Names only — the deed
    * has never held a way to reach anybody and does not start now. */
@@ -80,6 +87,26 @@ export function RequestSigningModal({
   onCreated?: (id: number) => void;
 }) {
   const [notary, setNotary] = useState<Recipient | null>(null);
+  const { partners: rolodex } = usePartners();
+
+  useEffect(() => {
+    // Once only, and only onto an empty field: re-running this would
+    // undo a change she made after arriving.
+    if (!preselectNotaryId || notary) return;
+    const found = rolodex.find((p) => p.id === preselectNotaryId);
+    if (found) {
+      // `partnerId`, not `id`: a Recipient records WHICH ROLODEX ROW it
+      // came from, and a typed address has none. Filling it wrongly
+      // would make a hand-typed recipient look like a filed one.
+      setNotary({
+        partnerId: found.id,
+        name: found.label,
+        email: found.email || '',
+        company: found.company_name,
+        category: found.category,
+      });
+    }
+  }, [preselectNotaryId, notary, rolodex]);
   const [fallbackAcknowledged, setFallbackAcknowledged] = useState(false);
   const [signers, setSigners] = useState<SignerRow[]>(() =>
     (suggestedSigners.length ? suggestedSigners : ['']).slice(0, MAX_SIGNERS)

--- a/frontend/src/lib/staleDrafts.ts
+++ b/frontend/src/lib/staleDrafts.ts
@@ -1,0 +1,118 @@
+/**
+ * UX2 items 8/9 — the drafts she started and did not finish.
+ *
+ * ═══ WHY A NUDGE AND NOT A CLEANUP ═══
+ *
+ * Five drafts at one address is not a mess to tidy. It is somebody
+ * trying the same conveyance five times, which usually means four
+ * attempts that went wrong and one that is current — and the product
+ * has no way to know WHICH one is current. So it does not guess: it
+ * says what it sees and offers the action, and she picks.
+ *
+ * A rule that archived the older ones automatically would be the
+ * product deciding which of her attempts was the real one. That is the
+ * same objection as auto-applying a legal choice, one floor down.
+ *
+ * ═══ ARCHIVING IS NOT DELETING ═══
+ *
+ * Nothing is destroyed and nothing is un-recorded (§9's neighbourhood).
+ * The row keeps every column and stops appearing in the list she works
+ * from. `?include_archived=true` is how she checks that, which is what
+ * makes the promise verifiable rather than a claim.
+ */
+
+export interface DraftLike {
+  id: number;
+  status: string;
+  property_address?: string | null;
+  created_at?: string | null;
+  archived_at?: string | null;
+}
+
+/**
+ * How many drafts at one address before we say anything.
+ *
+ * Five, and the number lives here rather than in the screen for the
+ * reason DASH1 established for `STALE_AFTER_DAYS`: a threshold typed
+ * into a component is a threshold that gets a second value the day
+ * another screen wants it.
+ */
+export const NUDGE_AT = 5;
+
+/**
+ * Addresses compared the way a person means them, not the way they were
+ * typed.
+ *
+ * "123 Baseline St" and "123 baseline st." are the same property and
+ * five attempts spread across both spellings is exactly the case the
+ * nudge exists for. Punctuation and case are noise; the rest is left
+ * alone, because normalizing harder (St → Street) starts guessing at
+ * addresses and this function has no business doing that.
+ */
+export function addressKey(address: string | null | undefined): string {
+  return (address || '')
+    .toLowerCase()
+    .replace(/[.,#]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export interface StaleCluster {
+  /** The address as she last typed it — never the normalized key. */
+  address: string;
+  /** Newest first. The whole cluster, including the current one. */
+  drafts: DraftLike[];
+  /** The ones the nudge offers to archive: everything but the newest. */
+  older: DraftLike[];
+}
+
+/**
+ * Clusters of unfinished drafts at one address, big enough to mention.
+ *
+ * Completed deeds are excluded and archived ones are too — a cluster
+ * she has already dealt with must not keep asking.
+ */
+export function staleClusters(deeds: readonly DraftLike[]): StaleCluster[] {
+  const byKey = new Map<string, DraftLike[]>();
+  for (const d of deeds) {
+    if ((d.status || '').trim().toLowerCase() === 'completed') continue;
+    if (d.archived_at) continue;
+    const key = addressKey(d.property_address);
+    if (!key) continue; // An address-less draft belongs to no property.
+    byKey.set(key, [...(byKey.get(key) || []), d]);
+  }
+
+  const out: StaleCluster[] = [];
+  for (const group of byKey.values()) {
+    if (group.length < NUDGE_AT) continue;
+    // Newest first, and a draft with no date sorts last rather than
+    // first: an unknown time is not a recent one.
+    const sorted = [...group].sort((a, b) => {
+      const at = a.created_at ? Date.parse(a.created_at) : -Infinity;
+      const bt = b.created_at ? Date.parse(b.created_at) : -Infinity;
+      return bt - at;
+    });
+    out.push({
+      address: sorted[0].property_address || '',
+      drafts: sorted,
+      // THE NEWEST IS NEVER OFFERED. It is the likeliest current
+      // attempt, and archiving the thing she is working on is the one
+      // outcome that would make this feature worse than nothing.
+      older: sorted.slice(1),
+    });
+  }
+  return out;
+}
+
+/**
+ * The sentence, composed once.
+ *
+ * States what it sees and what it offers. It does not say the older
+ * ones are abandoned, because we do not know that — only that there
+ * are five and one of them is newest.
+ */
+export function nudgeSentence(cluster: StaleCluster): string {
+  return `${cluster.drafts.length} unfinished drafts for ${cluster.address}. `
+    + `Archive the ${cluster.older.length} older ones? They are kept, `
+    + `not deleted — you can bring them back.`;
+}


### PR DESCRIPTION
Ticket 3 of 5. All seven items, plus the four ledger records from the #193 approval.

## Item 4 stood down — and it is the interesting one

The ticket asked for the sidebar badge and the dashboard attention number to match. They are **different claims, deliberately**, decided in DASH1 and recorded in `officer_queue.queue`:

> These are NOT the attention count. A badge says "there are things here"; the attention number says "these have gone quiet". Different claims, deliberately different numbers.

Forcing them to match destroys one or the other. Owner-ruled: stand down, and build the **real** defect — two different claims presented as two identical bare numbers invite the reading that they are one claim. The evidence is that the ticket asking to reconcile them was written **with the code in front of the reviewer**. If it misreads there, it misreads on screen.

So: labelling, not arithmetic. The badge names "waiting"; the headline says "N have gone quiet — no answer in 5+ days", with the threshold riding on the payload so no screen retypes it. A pin now protects the *ruling* against the ticket, which is the unusual direction.

## The rest

**3.** The tracker names deeds from the registry — "Grant Deed" on one screen and `grant-deed` on another, two clicks apart, for the same document.

**5.** An expired share can be nudged. `resend_approval_email` has **always** extended a lapsed share by 24 hours and sent; `canRemind` excluded `"expired"`, so her only route back was a second link, a second email, and a reviewer holding two. The three that stay refused are the *answered* and the *withdrawn*.

**Third consecutive ticket where the standing check found the ticket's own answer already built.**

**6.** The partner phone joins the email on the row — reading and editing are different acts, and the number she most often wants was behind a click into a form built for *changing* it. One click carries a partner to the deed list to start a signing (it cannot pick the deed from there; inventing one would be the product choosing her document, so the arrival is explained and the notary is preselected).

**Offered on every row, not gated on category.** The first draft gated on `category === 'notary'`; the registry pin caught the literal, and the rule behind it is the stronger objection — a category "says how the officer FILES them… no code may read it as though" it said anything about authority. Gating the button on it *is* reading it as permission. The modal's existing mismatch notice handles an unexpected filing with a dismissible sentence.

*Recorded for the ticket's own record: email was already on the row.*

**7.** The Updated column goes. `overflow-x-auto` was **already** there, so Actions was not clipped — it was off-screen behind a scroll nothing signalled, which is worse: a clipped control looks broken, an absent one looks like it does not exist. `updated_at` is on `deed_activity.FORBIDDEN` ("it moves for reasons that are not events"), so a column showing it invites the reading this codebase already ruled against. Every other column undoes a prior decision — X2.7 promoted Doc ID on purpose, Created orders the list.

**8/9.** Five drafts at one address is somebody trying the same conveyance five times. The product cannot know which is current, so it says what it sees and offers the action rather than tidying up on her behalf. **The newest is never in the offer** — archiving the attempt she is working on is the one outcome that makes this worse than nothing.

**Archive is its own column, not a status value.** Orthogonal to the lifecycle (`supersession`'s own reasoning: "`status` keeps its lifecycle vocabulary; this is the orthogonal fact"), and **nine query sites** filter `status <> 'deleted'` — a new status leaks into every one I miss, quietly. A nullable timestamp cannot leak by omission. Drafts only; a completed deed is an instrument and the refusal names supersession as the act that applies.

## Self-review

**Premises checked:** item 4 conflicted with a ruling (held, then stood down); items 6 and 7 were partly wrong (email already present, overflow already present) — both reported before building and both changed what got built. Items 3, 5, 8/9 confirmed as stated.

**Pins changed:** none retargeted. Two of my own were narrowed after they caught me: the registry pin caught a hard-coded `'notary'`, and a DELETE sweep caught **its own docstring** — "it is not a delete" contains DELETE. Same lesson as the `times offered` sweep an hour earlier: a sweep that cannot tell a description of a rule from a violation gets widened until it means nothing.

**Least sure about:** the notary preselection resolves a partner id from a URL against the rolodex. It fails closed (an id she does not have simply does not preselect), but it is the first place a URL parameter seeds a recipient, and recipients are who emails go to.

**Would cut:** the "Archived" filter option. It is the smallest piece, but cutting it would leave "kept, not deleted" as a claim she has no way to check — which is why I would cut it *last*.

**Decided rather than flagged:** (1) `archived_at` as a column rather than a status — precedent is explicit in `supersession`, and the nine-site leak makes the alternative quietly wrong; (2) the Request-signing button on every partner row rather than notary rows only — the registry forbids reading a category as authority; (3) the column dropped is Updated, per the reasoning above.

## Gates

| gate | result |
|---|---|
| pytest | 1320 passed |
| jest | 983 passed, 66 suites |
| tsc | 88 — baseline unchanged |
| six-flow | re-recorded — `archived_at` on the deed row, nothing else |
| banned-claims | clean |
| next build | clean |
| OpenAPI | +1 route, `POST /deeds/{deed_id}/archive` |
| mutation probes | 5 run, **5 caught** |

Also carries the four ledger records from the #193 approval, including the feedback-loop bias stated as a standing check — which fired on item 5 within the hour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h