### PR TITLE
ROLE1 and VERIFY-CHECK — two investigations, no code changed

### DIFF
--- a/docs/ROLE1_INVESTIGATION.md
+++ b/docs/ROLE1_INVESTIGATION.md
@@ -1,0 +1,202 @@
+# ROLE1 — what `users.role` actually is
+
+**Investigation. No code changed.**
+
+---
+
+## The question, answered
+
+> Does `role` carry both job title and authorization in one column?
+
+**Yes.** And the codebase already says so, in its own words. From
+`tests/test_registration_privilege.py`, written when #103 was fixed:
+
+> `users.role` carries two meanings at once: the professional role that
+> prints on a profile (Escrow Officer, Title Agent, …) and the value
+> `is_admin_role()` reads to open the admin console.
+
+Registration writes a **job title** into it — the dropdown offers
+"Escrow Officer", "Title Agent", "Attorney", "Paralegal" — and
+`is_admin_role()` reads the same column to decide who may mint API keys.
+
+---
+
+## Correction to my own pre-finding
+
+In the `company_name` sweep I reported:
+
+> `users.role` is authorization, `user_profiles.role` is professional — a
+> name collision, not a duplicated fact, and merging them would be the
+> bug.
+
+**That was half right, and the wrong half matters.**
+
+`users.role` is authorization **and** job title. So the job-title half
+*is* duplicated across the two columns, in two spellings:
+
+| column | vocabulary | written by | read by |
+|---|---|---|---|
+| `users.role` | `Escrow Officer`, `Title Agent`, … (title case) | registration, admin edit | `/users/profile`, admin console, **the JWT** |
+| `users.role` | `admin`, `administrator`, `superadmin`, `super_admin` | admin edit only | `is_admin_role()` |
+| `user_profiles.role` | `escrow_officer`, `title_officer`, `notary` (snake) | `POST /users/profile/enhanced` | `suggest_defaults` |
+
+Rows 1 and 3 are **the same fact in two columns and two spellings**.
+Row 2 shares a column with row 1.
+
+So it is a collision *and* a duplicate. My earlier note under-reported it
+and should not be relied on.
+
+---
+
+## Three gates, three definitions of "admin"
+
+Executed against the same values rather than read:
+
+| `users.role` | `is_admin_role()` (JWT gate) | `admin_partners.py:31` | `deeds_crud.py:509` (SQL) |
+|---|---|---|---|
+| `admin` | ✅ | ✅ | ✅ |
+| `Admin` | ✅ | ❌ | ❌ |
+| `ADMIN` | ✅ | ❌ | ❌ |
+| `administrator` | ✅ | ❌ | ❌ |
+| `Administrator` | ✅ | ❌ | ❌ |
+| `superadmin` | ✅ | ❌ | ❌ |
+| `super_admin` | ✅ | ❌ | ❌ |
+| `Escrow Officer` | ❌ | ❌ | ❌ |
+
+- `auth.is_admin_role` — four spellings, case-insensitive.
+- `routers/admin_partners.py:31` — `user.get('role') == 'admin'`, exact.
+- `routers/deeds_crud.py:509` — `u.role = 'admin'` in SQL, exact.
+
+**Six of eight values diverge.** The divergence is *restrictive* — the
+JWT gate is the loosest — so this is **not** an escalation path. What it
+produces is a **partial admin**: somebody with role `Administrator`
+enters the admin console, and is then refused by the partner admin and by
+the owner-or-admin deed fetch. They would experience that as the console
+being broken.
+
+Which of the three is the intended authority is not recorded anywhere.
+
+---
+
+## Does the #103 fix depend on the current shape?
+
+**No.** It depends on the guard, not on the column's shape:
+
+```python
+if is_admin_role(user.role):
+    raise HTTPException(400, "That role cannot be selected at registration.")
+```
+
+- It runs on the **resolved** value (after SIGNUP1's "Other" free text
+  resolves), and **before** the INSERT — both verified by pin.
+- It covers all four spellings, case-insensitively — six spellings driven
+  end-to-end by `test_registration_privilege.py`, which also asserts no
+  row exists afterwards to be promoted later.
+
+Separating the columns would make the guard **unnecessary** rather than
+break it: if `users.role` accepted only a closed set, an admin spelling
+could not arrive from a public endpoint at all.
+
+### And SIGNUP1's free text — the named input
+
+Confirmed **not** an escalation path. The guard is on the resolved value,
+pre-INSERT, case-insensitive, and pinned.
+
+But the owner's framing is the right one: *safe because a guard catches
+it* is weaker than *safe because it cannot arrive*. The free text widened
+the vocabulary a public endpoint can put into the authorization column,
+and it is one deleted `if` from being a hole.
+
+---
+
+## The path that is genuinely unguarded
+
+`admin_api_v2.admin_update_user` — `allowed_fields` includes `'role'`,
+and there is **no validation of the value at all**:
+
+```python
+allowed_fields = ['full_name', 'email', 'role', 'plan', 'company_name',
+                  'phone', 'state', 'is_active', 'verified']
+```
+
+No closed set, no self-demotion guard, no confirmation. An admin may:
+
+- set any user's role to any string — legitimate authority, unvalidated;
+- create a **partial admin** by typing `Administrator` (console yes, two
+  gates no);
+- silently **fail** to grant admin by typing `adminn`, with no error;
+- **demote themselves** and lose console access with no warning.
+
+This is a bigger opening than the registration free text, and nothing
+pins it.
+
+---
+
+## Revocation — better than expected
+
+The JWT carries `role`, so a change is not instant. But
+`/users/refresh-token` **re-reads the role from the database** on every
+rotation:
+
+```python
+cur.execute("SELECT email, role FROM users WHERE id = %s", (user_id,))
+...
+create_access_token(data={"sub": ..., "email": email, "role": role or "user"})
+```
+
+Access tokens live 30 minutes, so **a revoked admin loses the console
+within 30 minutes without signing out**. Recorded as a confirmation
+because I expected to find it stale until re-login.
+
+---
+
+## A dead branch found on the way
+
+`user_profiles.role` is effectively unreachable:
+
+- **Only writer**: `POST /users/profile/enhanced` — no frontend caller.
+- **Only reader**: `suggest_defaults` — reached only by
+  `/ai/deed-suggestions`, which has no frontend caller.
+
+So `ai_assist`'s `role == 'escrow_officer'` / `'title_officer'` /
+`'notary'` branches never run in production. Whatever ROLE1 decides, that
+column is not carrying weight today.
+
+---
+
+## What separating them would cost
+
+**Shape:** `users.role` reduced to a closed set — `user` | `admin`.
+Job title moves to `users.job_title`.
+
+| step | size | risk |
+|---|---|---|
+| Add `users.job_title`, backfill from `role` where not an admin spelling | small, additive | none — same ALTER pattern as `interest_state` |
+| Set `role = 'user'` where it is a job title | **needs row counts first** | the company_name discipline: count before writing |
+| Registration writes `job_title`, leaves `role` alone | small | the #103 guard becomes redundant, not removed |
+| `/users/profile` returns both | small | one response key added |
+| Admin console: display + edit `job_title` freely; `role` becomes a two-value control | medium | the only real UI work |
+| Converge the three gates on `is_admin_role` | small | **behaviour change**: `Administrator` gains what it is currently denied, or loses the console. Needs a ruling. |
+
+**The load-bearing unknown:** how many production rows hold an admin
+spelling, and which spelling. If any hold `Administrator` or
+`superadmin`, converging the gates changes their access in one direction
+or the other. Same discipline as `company_name` — **count before
+deciding**, and the counting query is the deliverable, not the migration.
+
+---
+
+## What I would recommend, if asked
+
+1. **Close the set.** `users.role` ∈ {`user`, `admin`}; job title to its
+   own column. It converts "safe because a guard catches it" into "safe
+   because it cannot arrive", which was the owner's own framing.
+2. **One gate.** All three sites call `is_admin_role`. A second
+   definition of admin is a second answer to a security question.
+3. **Validate the admin edit** — a closed set, and a refusal when an
+   admin demotes themselves.
+4. **Count first.** Production row counts by role value, before any write.
+
+None of this is built. Steps 1, 2 and 4 are mechanical once the gate
+convergence is ruled; step 3 is the one I would do first regardless,
+because it is the unguarded path and it is small.

--- a/docs/VERIFY_CHECK_INVESTIGATION.md
+++ b/docs/VERIFY_CHECK_INVESTIGATION.md
@@ -1,0 +1,147 @@
+# VERIFY-CHECK — is email verification enforced, built-but-unused, or half-wired?
+
+**Investigation. No code changed.**
+
+---
+
+## The answer
+
+**Built-but-unused.** Both ends work. Nothing triggers it and nothing
+enforces it.
+
+The audit's observation — an account was immediately usable with no
+`verified` flag — is correct, and the reason is not a bug in either
+endpoint. It is that **no code path ever asks anybody to verify, and no
+code path ever cares whether they did.**
+
+---
+
+## What exists, and works
+
+| piece | state |
+|---|---|
+| `users.verified BOOLEAN DEFAULT FALSE` | exists, in the one schema authority |
+| `POST /users/verify-email/request` | works — mints a 24h token, emails the link |
+| `GET /users/verify-email?token=` | works — validates the `type: verify` claim, sets `verified = TRUE` |
+| `frontend/src/app/verify-email/page.tsx` | exists — reads `?token=` and calls the GET |
+
+So a link that arrives in somebody's inbox **does** verify them. The
+machinery is complete and correct.
+
+---
+
+## What is missing — both ends of it
+
+### 1. Nothing ever asks
+
+`POST /users/verify-email/request` has **no caller**. Not from
+registration, not from the frontend, not from any other endpoint. The
+only occurrences of its path in the repo are its own route decorator and
+a comment in a test.
+
+Registration does not send a verification email. It sends the admin
+notice and the welcome email; there is no
+`send_verify_email_with_reason` call anywhere in `users_auth.py`.
+
+So a new user is never given a link, and the frontend has no button to
+ask for one. The `/verify-email` page can only be reached by a link that
+nothing sends.
+
+### 2. Nothing ever checks
+
+`verified` is read in exactly **one** place: inside
+`/users/verify-email/request`, to answer "already verified".
+
+- Login does not check it (`SELECT id, password_hash, full_name, plan,
+  is_active, role` — `verified` is not even selected).
+- No endpoint gates on it.
+- No screen displays it.
+- It appears in the admin user list, and that is the only place a human
+  can see it.
+
+**A verified user and an unverified user are indistinguishable to every
+part of this product except one admin column.**
+
+---
+
+## So which of the three?
+
+Not *enforced* — nothing enforces.
+
+Not *half-wired* either, which is what I expected to find. Half-wired
+would mean a broken link in a working chain. This is the opposite: **the
+chain is intact and disconnected at both ends.** Both endpoints do
+exactly what they say; nobody calls one and nobody consults the result.
+
+That distinction matters for what to do next. There is no defect to fix
+here. There is a feature that was built and never turned on, and turning
+it on is a product decision with consequences.
+
+---
+
+## Why this is an owner decision, per the `/security` precedent
+
+`/security` was a page making claims the product could not support, and
+the ruling was **enforce or remove — not leave it looking real**. The
+same shape applies, with the same reasoning: a `verified` column that
+nobody sets and nobody reads is a record that looks like a control and is
+not one.
+
+The two directions are genuinely different products:
+
+### Enforce
+
+Registration sends the link; something is gated on `verified`.
+
+**What it costs:** the gate has to go somewhere, and every candidate has
+a real cost. Gating **login** locks out every existing account —
+`verified` defaults to FALSE and nobody has ever been asked, so *every
+current user is unverified*. Gating **deed generation** blocks the paid
+path. Gating **sharing** is the narrowest defensible choice: an
+unverified address should probably not be able to send a stranger a link
+with a property address on it.
+
+**Prerequisite:** a backfill decision for existing rows. Grandfather
+them, or send everybody a link at once.
+
+**And it depends on email working.** `send_verify_email_with_reason`
+returns a reason when it fails, and SendGrid is not configured in every
+environment — so a gate on verification is a gate on our email
+deliverability. That is a real availability coupling and it should be
+chosen deliberately, not inherited.
+
+### Remove
+
+Delete both endpoints and the frontend page; drop the column (Tier 3,
+after row counts).
+
+**What it costs:** nothing operational today. What it gives up is the
+groundwork, which is complete and would have to be rebuilt.
+
+---
+
+## What I would flag before either
+
+**If enforcing:** the honest order is (1) send the link at registration
+and display verification state to the user, (2) let it run and watch how
+many verify, (3) gate something. Gating first, on a population that has
+never been asked, locks out the whole customer base — which is the
+`subscribe` mistake in the other direction: acting on a signal nobody was
+given a chance to provide.
+
+**If removing:** the column has values only in the sense that they are
+all `FALSE`. Worth confirming with a row count before dropping, but there
+is nothing here that can be lost.
+
+**Either way:** the current state is the one option that should not
+persist, because an admin looking at a `verified` column reasonably
+reads it as meaning something.
+
+---
+
+## Not recommended without a ruling
+
+I have not built or removed anything. The `/security` precedent makes
+this an owner decision by construction, and the enforce path in
+particular has a lockout consequence that no amount of care in the
+implementation would soften.


### PR DESCRIPTION
Tickets 4 and 5. Both report-only, as specified. Docs only — nothing built, nothing removed.

---

# ROLE1

## The answer is yes, and the codebase already said so

`tests/test_registration_privilege.py`, written when #103 was fixed:

> `users.role` carries two meanings at once: the professional role that prints on a profile (Escrow Officer, Title Agent, …) and the value `is_admin_role()` reads to open the admin console.

## A correction to my own pre-finding

In the `company_name` sweep I reported `users.role` as authorization and `user_profiles.role` as professional — "a name collision, not a duplicated fact, and merging them would be the bug."

**Half right, and the wrong half matters.** `users.role` is authorization **and** job title, so the job title *is* duplicated across both columns in two spellings (`Escrow Officer` / `escrow_officer`). It is a collision *and* a duplicate. My earlier note under-reported it and should not be relied on.

## Three gates, three definitions — executed, not read

| `users.role` | `is_admin_role()` | `admin_partners.py:31` | `deeds_crud.py:509` |
|---|---|---|---|
| `admin` | ✅ | ✅ | ✅ |
| `Admin` / `ADMIN` | ✅ | ❌ | ❌ |
| `administrator` / `Administrator` | ✅ | ❌ | ❌ |
| `superadmin` / `super_admin` | ✅ | ❌ | ❌ |

**Six of eight diverge.** The divergence is *restrictive* — the JWT gate is loosest — so it is **not** an escalation path. It produces a **partial admin**: someone with role `Administrator` enters the console and is then refused by the partner admin and the owner-or-admin deed fetch. They would experience that as the console being broken. Which gate is the intended authority is recorded nowhere.

## The #103 question

**No dependency on the current shape.** The guard runs on the resolved value, before the INSERT, over all four spellings, case-insensitively — six spellings driven end-to-end. Separating the columns would make it **unnecessary rather than break it**: an admin spelling could not arrive from a public endpoint at all.

**SIGNUP1's free text (the named input):** confirmed not an escalation path. But your framing is the right one — *safe because a guard catches it* is weaker than *safe because it cannot arrive*, and the free text is one deleted `if` from being a hole.

## The genuinely unguarded path is elsewhere

`admin_update_user`'s `allowed_fields` includes `'role'` with **no value validation and no self-demotion guard**. An admin can create a partial admin by typing `Administrator`, silently fail to grant admin by typing `adminn`, or demote themselves with no warning. Bigger opening than the registration free text, and nothing pins it.

## Revocation — a confirmation

`/users/refresh-token` **re-reads the role from the database** on every rotation, so a revoked admin loses the console within the 30-minute access-token lifetime. Recorded because I expected to find it stale until re-login.

## A dead branch found on the way

`user_profiles.role` has one writer (`POST /users/profile/enhanced`, no frontend caller) and one reader (`suggest_defaults`, reached only via `/ai/deed-suggestions`, no frontend caller). Its role branches never run.

## Cost of separating

Full table in the doc. The load-bearing unknown is **how many production rows hold an admin spelling, and which** — converging the gates changes `Administrator`'s access in one direction or the other. Same discipline as `company_name`: **count before deciding**, and the counting query is the deliverable, not the migration.

Recommendation if asked: close the set (`user` | `admin`), one gate, validate the admin edit, count first. Step 3 is the one I would do first regardless — it is the unguarded path and it is small.

---

# VERIFY-CHECK

## Built-but-unused — and specifically *not* half-wired

That distinction is the finding. Half-wired would be a broken link in a working chain. This is the opposite: **the chain is intact and disconnected at both ends.**

**Both endpoints work.** `/users/verify-email/request` mints a 24h token and emails a link; `GET /users/verify-email` validates the claim and sets `verified = TRUE`; the frontend page at `/verify-email` calls it. A link that reaches an inbox verifies the person.

**Nothing ever asks.** `/users/verify-email/request` has no caller anywhere — registration does not send a link and no screen offers one. The only occurrences of its path are its own decorator and a test comment.

**Nothing ever checks.** `verified` is read in exactly one place: inside that same endpoint, to say "already verified". Login does not even select it. **A verified and an unverified user are indistinguishable to every part of this product except one admin column.**

So there is no defect to fix. There is a feature that was built and never turned on.

## Owner decision, per the `/security` precedent

Enforce or remove — not leave it looking real. A `verified` column nobody sets and nobody reads is a record that looks like a control and is not one.

**One thing to flag before choosing enforce:** `verified` defaults FALSE and nobody has ever been asked, so **every current account is unverified**. Gating login locks out the entire customer base. Gating generation blocks the paid path. Gating sharing is the narrowest defensible choice.

And enforcing couples availability to email deliverability — SendGrid is not configured in every environment, and a gate on verification becomes a gate on our sending. That should be chosen deliberately, not inherited.

The honest order if enforcing: send the link at registration and show the state, let it run, *then* gate. Gating first, on a population never asked, is the `subscribe` mistake in the other direction — acting on a signal nobody was given a chance to provide.

---

## Gates

| gate | result |
|---|---|
| pytest | 1320 passed |
| jest | 983 passed |
| tsc | 88 — baseline unchanged |
| six-flow | green |
| banned-claims | clean |

Docs only; no code, no schema, no gate moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_