### PR TITLE
ROLE1 — one definition of admin, and an admin form that cannot fail silently

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -241,12 +241,33 @@ class AuthUtils:
         }
         return state.upper() in valid_states
 
+#: Every spelling of "this person is an administrator". ONE tuple, and
+#: everything that asks the question reads it — including the SQL, which
+#: takes it as a bound parameter rather than repeating the literals.
+#:
+#: ROLE1 found three definitions of admin across three files:
+#: `is_admin_role` took these four case-insensitively, while
+#: `admin_partners.py` and the owner-or-admin deed fetch each took
+#: exactly 'admin'. Six of eight values diverged.
+#:
+#: The divergence was RESTRICTIVE, so it was never an escalation. What it
+#: produced was a PARTIAL ADMIN: somebody with role `Administrator`
+#: entered the console and was then refused by two gates inside it, which
+#: they would experience as the console being broken. Nothing recorded
+#: which of the three was authoritative.
+ADMIN_ROLES = ('admin', 'administrator', 'superadmin', 'super_admin')
+
+
 def is_admin_role(role: str) -> bool:
-    """Check if role string indicates admin access (case-insensitive)"""
+    """Check if role string indicates admin access (case-insensitive).
+
+    THE single definition. A second answer to "is this person an admin"
+    is a second answer to a security question, and the one that gets
+    missed is the one nobody knew existed.
+    """
     if not role:
         return False
-    r = role.strip().lower()
-    return r in ('admin', 'administrator', 'superadmin', 'super_admin')
+    return role.strip().lower() in ADMIN_ROLES
 
 async def get_current_admin(credentials: HTTPAuthorizationCredentials = Depends(security)) -> str:
     """Verify admin access from JWT token"""

--- a/backend/routers/admin_api_v2.py
+++ b/backend/routers/admin_api_v2.py
@@ -5,7 +5,7 @@ import os, csv, io
 
 # Import project-specific helpers (adjust if your module paths differ)
 try:
-    from auth import get_current_admin  # existing dependency
+    from auth import ADMIN_ROLES, get_current_admin, is_admin_role  # existing dependency
 except Exception:
     # If project uses package style imports
     from backend.auth import get_current_admin  # type: ignore
@@ -367,13 +367,94 @@ def admin_email_stats(days: int = Query(7, ge=1, le=90),
 # PHASE 12-3: USER CRUD OPERATIONS
 # ============================================================================
 
+#: What the admin console may ASSIGN to `users.role`.
+#:
+#: Every admin spelling, plus `user`. Deliberately NOT the job titles —
+#: and that is the interesting half of this ruling.
+#:
+#: `users.role` carries two meanings (ROLE1): a job title written by
+#: registration, and the authorization value the gates read. Registration
+#: legitimately writes free text there — SIGNUP1's "Other" resolves to
+#: whatever she typed — so a closed set covering BOTH meanings would
+#: reject values the product itself creates.
+#:
+#: But an admin editing this field is making an AUTHORIZATION decision.
+#: Job titles are the officer's own, entered where she enters them. So
+#: the console's assignable set is the authorization vocabulary, and the
+#: refusal says so rather than pretending the column is simpler than it
+#: is.
+#:
+#: When ROLE1 step 3 lands — job title to its own column, `role` reduced
+#: to a closed set — this becomes the whole vocabulary rather than a
+#: subset of it, and this comment can go.
+ASSIGNABLE_ROLES = frozenset({r.lower() for r in ADMIN_ROLES} | {'user'})
+
+
+def _validate_role_change(cur, target_user_id: int, admin_email: str,
+                          new_role) -> None:
+    """Refuse a role the product does not use, and refuse a self-lockout."""
+    value = (new_role or '').strip()
+    if not value:
+        raise HTTPException(
+            status_code=400,
+            detail="A role cannot be blank. Use 'user' for no special access.")
+
+    if value.lower() not in ASSIGNABLE_ROLES:
+        raise HTTPException(
+            status_code=400,
+            detail=(f"'{value}' would grant nothing. From here you can set "
+                    f"admin access ({', '.join(sorted(ADMIN_ROLES))}) or "
+                    f"'user'. A job title belongs to the person it describes "
+                    f"and is edited in their profile, not here."),
+        )
+
+    # ── THE SELF-LOCKOUT ─────────────────────────────────────────────
+    #
+    # Checked by EMAIL because that is what the admin dependency returns
+    # — `get_current_admin` yields `user_email` from the token, not an
+    # id. Comparing the target row's email to it is the comparison that
+    # is actually available, and it is the one that is true.
+    if is_admin_role(new_role):
+        return  # Promoting or keeping admin can never lock anybody out.
+    cur.execute("SELECT email, role FROM users WHERE id = %s", (target_user_id,))
+    row = cur.fetchone()
+    target = dict(row) if row else {}
+    if (target.get('email') or '').lower() == (admin_email or '').lower() \
+            and is_admin_role(target.get('role')):
+        raise HTTPException(
+            status_code=409,
+            detail=("You are removing your own admin access. Ask another "
+                    "admin to do it, so you are not locked out of the console "
+                    "you would need to undo it."),
+        )
+
+
 @router.put("/users/{user_id}")
 def admin_update_user(
     user_id: int, 
     updates: Dict[str, Any] = Body(...),
     admin=Depends(get_current_admin)
 ):
-    """Update user fields - Phase 12-3"""
+    """Update user fields - Phase 12-3.
+
+    ═══ ROLE1 — THE UNGUARDED PATH ═══
+
+    `role` was editable here with NO validation of the value and no
+    self-demotion guard. Three things followed, and none of them said
+    anything out loud:
+
+      - `Administrator` created a PARTIAL ADMIN — the console opened and
+        two gates inside it refused. (Fixed at the source: all three
+        gates now read `ADMIN_ROLES`.)
+      - `adminn` granted nothing, silently. An admin form that accepts a
+        typo and reports success is invariant #4 wearing a suit: the
+        product declined and did not say so.
+      - An admin could demote THEMSELVES and lose the console with no
+        warning. That is a lockout, not a decision.
+
+    The registration guard was the loud path and it was already closed.
+    This was the quiet one.
+    """
     with db_connection() as conn, conn.cursor() as cur:
         # Build dynamic UPDATE query
         set_clauses = []
@@ -382,7 +463,10 @@ def admin_update_user(
         # Allowed fields for update
         allowed_fields = ['full_name', 'email', 'role', 'plan', 'company_name', 
                          'phone', 'state', 'is_active', 'verified']
-        
+
+        if 'role' in updates:
+            _validate_role_change(cur, user_id, admin, updates['role'])
+
         for field in allowed_fields:
             if field in updates:
                 set_clauses.append(f"{field} = %s")

--- a/backend/routers/admin_partners.py
+++ b/backend/routers/admin_partners.py
@@ -5,7 +5,7 @@ Admin-only CRUD for all partners across all organizations
 
 from fastapi import APIRouter, HTTPException, Depends
 from typing import List, Dict
-from auth import get_current_user_id
+from auth import get_current_user_id, is_admin_role
 from database import get_db_connection
 from psycopg2.extras import RealDictCursor
 from services.partners import list_all_partners, get_partner, update_partner
@@ -27,8 +27,12 @@ def is_admin(user_id: int) -> bool:
         if not user:
             return False
         
-        # Check if user has admin role
-        return user.get('role') == 'admin'
+        # ROLE1 — ONE DEFINITION. This read `== 'admin'` exactly, so a
+        # user whose role was `Administrator` passed the JWT gate into
+        # the admin console and was refused here. Restrictive, so never
+        # an escalation — but a partial admin experiences the console as
+        # broken, and nothing recorded which gate was authoritative.
+        return is_admin_role(user.get('role'))
     except Exception as e:
         print(f"Error checking admin status: {e}")
         return False

--- a/backend/routers/deeds_crud.py
+++ b/backend/routers/deeds_crud.py
@@ -9,7 +9,7 @@ from psycopg2.extras import RealDictCursor
 from pydantic import BaseModel, Field
 
 import db
-from auth import get_current_user_id
+from auth import ADMIN_ROLES, get_current_user_id
 from database import create_deed
 from services import pcor_offer
 
@@ -506,8 +506,8 @@ def get_deed_endpoint(deed_id: int, user_id: int = Depends(get_current_user_id))
             SELECT d.*, u.role
             FROM deeds d
             LEFT JOIN users u ON u.id = %s
-            WHERE d.id = %s AND (d.user_id = %s OR u.role = 'admin')
-        """, (user_id, deed_id, user_id))
+            WHERE d.id = %s AND (d.user_id = %s OR LOWER(u.role) = ANY(%s))
+        """, (user_id, deed_id, user_id, list(ADMIN_ROLES)))
 
         deed = cursor.fetchone()
         cursor.close()
@@ -625,8 +625,8 @@ def _pcor_deed_row(deed_id: int, user_id: int) -> dict:
             SELECT d.*, u.role
             FROM deeds d
             LEFT JOIN users u ON u.id = %s
-            WHERE d.id = %s AND (d.user_id = %s OR u.role = 'admin')
-        """, (user_id, deed_id, user_id))
+            WHERE d.id = %s AND (d.user_id = %s OR LOWER(u.role) = ANY(%s))
+        """, (user_id, deed_id, user_id, list(ADMIN_ROLES)))
         deed = cur.fetchone()
     if not deed:
         raise HTTPException(status_code=404, detail="Deed not found")
@@ -1070,8 +1070,8 @@ def download_deed_endpoint(deed_id: int, user_id: int = Depends(get_current_user
             SELECT d.*, u.role
             FROM deeds d
             LEFT JOIN users u ON u.id = %s
-            WHERE d.id = %s AND (d.user_id = %s OR u.role = 'admin')
-        """, (user_id, deed_id, user_id))
+            WHERE d.id = %s AND (d.user_id = %s OR LOWER(u.role) = ANY(%s))
+        """, (user_id, deed_id, user_id, list(ADMIN_ROLES)))
         deed = cursor.fetchone()
         cursor.close()
 

--- a/backend/scripts/role_census.py
+++ b/backend/scripts/role_census.py
@@ -1,0 +1,117 @@
+"""Count what `users.role` actually holds, before anything is decided.
+
+═══ WHY THIS IS THE DELIVERABLE AND THE MIGRATION IS NOT ═══
+
+ROLE1 step 3 separates job title from authorization: job title to its own
+column, `users.role` reduced to a closed set. Every version of that
+migration rewrites somebody's access, and which somebody depends on
+values nobody has looked at.
+
+Specifically: `is_admin_role` accepts four spellings. If production holds
+`Administrator` or `superadmin`, converging the gates — which this same
+ticket just did — CHANGED that person's access. Not hypothetically:
+before, they entered the console and were refused by two gates inside it;
+now they are admitted by all three. That may be exactly right, and it is
+not a thing to discover from a support ticket.
+
+Same discipline as `company_name`: count first, and the count is a
+person's decision input rather than a step in a script.
+
+═══ WHAT IT DOES NOT DO ═══
+
+It writes nothing. There is no `--apply`, deliberately — a census that
+can mutate is a census somebody runs with the wrong flag.
+
+Usage (where DATABASE_URL points at the database being counted):
+
+    python scripts/role_census.py
+"""
+import os
+import sys
+
+import psycopg2
+from db_rows import ROW_FACTORY
+from services.db_identity import (WrongDatabase, assert_tables, describe,
+                                  expected_database)
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def main():
+    from auth import ADMIN_ROLES
+
+    db_url = os.getenv("DATABASE_URL")
+    if not db_url:
+        sys.exit("DATABASE_URL is required")
+
+    conn = psycopg2.connect(db_url, cursor_factory=ROW_FACTORY)
+
+    # WHICH DATABASE, BEFORE COUNTING ANYTHING OUT OF IT. A census from
+    # the wrong database looks exactly like the right one.
+    try:
+        with conn.cursor() as cur:
+            assert_tables(cur, ["users"], expect_database=expected_database())
+            print(describe(cur))
+    except WrongDatabase as e:
+        conn.close()
+        sys.exit(str(e))
+
+    admin = [r.lower() for r in ADMIN_ROLES]
+
+    with conn.cursor() as cur:
+        cur.execute("""
+            SELECT COALESCE(NULLIF(BTRIM(role), ''), '(blank)') AS value,
+                   COUNT(*) AS n
+              FROM users
+             GROUP BY 1
+             ORDER BY n DESC, 1
+        """)
+        rows = [dict(r) for r in cur.fetchall()]
+
+        cur.execute("""
+            SELECT COUNT(*) AS n FROM users
+             WHERE LOWER(BTRIM(role)) = ANY(%s)
+        """, (admin,))
+        admins = dict(cur.fetchone())["n"]
+
+        # The rows whose access the gate convergence CHANGED: an admin
+        # spelling that is not exactly 'admin' was previously refused by
+        # admin_partners and by the owner-or-admin deed fetch.
+        cur.execute("""
+            SELECT id, email, BTRIM(role) AS role FROM users
+             WHERE LOWER(BTRIM(role)) = ANY(%s)
+               AND BTRIM(role) <> 'admin'
+             ORDER BY id
+        """, (admin,))
+        widened = [dict(r) for r in cur.fetchall()]
+
+    print("\n── every value in users.role ────────────────────────────")
+    for row in rows:
+        mark = "  <- ADMIN" if row["value"].strip().lower() in admin else ""
+        print(f"  {row['n']:>6}  {row['value']!r}{mark}")
+
+    print(f"\n  admins by any spelling: {admins}")
+
+    print("\n── whose access the gate convergence CHANGED ────────────")
+    if not widened:
+        print("  none — every admin row is exactly 'admin', so converging")
+        print("  the three gates was a no-op for real users.")
+    else:
+        for row in widened:
+            print(f"  user {row['id']:>6}  {row['role']!r}  {row['email']}")
+        print("\n  These were PARTIAL admins: the console opened and two")
+        print("  gates inside it refused. They now pass all three. Confirm")
+        print("  that is intended for each one.")
+
+    print("\n── what step 3 needs from this ──────────────────────────")
+    print("  1. Which non-admin values are JOB TITLES (they move to")
+    print("     users.job_title) versus placeholders like 'user'.")
+    print("  2. Whether every admin row should keep admin.")
+    print("  3. Nothing is written by this script. Step 3 is a separate")
+    print("     decision, made by a person reading the numbers above.")
+
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_role1.py
+++ b/backend/tests/test_role1.py
@@ -1,0 +1,294 @@
+"""ROLE1 — one definition of admin, and an admin form that cannot fail
+silently.
+
+═══ THREE GATES, THREE ANSWERS ═══
+
+`is_admin_role` took four spellings case-insensitively.
+`admin_partners.py` and the owner-or-admin deed fetch each took exactly
+`'admin'`. Six of eight values diverged.
+
+The divergence was RESTRICTIVE, so it was never an escalation. What it
+produced was a PARTIAL ADMIN: somebody with role `Administrator` entered
+the console and was then refused by two gates inside it, which they would
+experience as the console being broken. Nothing recorded which of the
+three was authoritative.
+
+A second answer to "is this person an admin" is a second answer to a
+security question, and the one that gets missed is the one nobody knew
+existed.
+
+═══ AND THE PATH THAT WAS ACTUALLY UNGUARDED ═══
+
+Registration was the loud path and was closed by #103. The quiet one was
+`admin_update_user`, which accepted `role` with no value validation and
+no self-demotion guard:
+
+  - `Administrator` created a partial admin;
+  - `adminn` granted nothing, SILENTLY — invariant #4 in an admin form;
+  - an admin could demote themselves and lose the console with no warning.
+"""
+import inspect
+
+import pytest
+
+from auth import ADMIN_ROLES, is_admin_role
+
+
+# ── One definition ───────────────────────────────────────────────────
+
+def test_the_vocabulary_lives_in_exactly_one_place():
+    assert ADMIN_ROLES == ('admin', 'administrator', 'superadmin', 'super_admin')
+    src = inspect.getsource(is_admin_role)
+    assert "ADMIN_ROLES" in src
+
+
+@pytest.mark.parametrize("spelling", [
+    "admin", "Admin", "ADMIN", " administrator ", "Administrator",
+    "superadmin", "SUPER_ADMIN",
+])
+def test_every_spelling_is_admin_everywhere(spelling):
+    assert is_admin_role(spelling) is True
+
+
+@pytest.mark.parametrize("not_admin", [
+    "Escrow Officer", "user", "", None, "adminn", "administrater", "Notary",
+])
+def test_and_nothing_else_is(not_admin):
+    assert is_admin_role(not_admin) is False
+
+
+def test_the_partner_gate_asks_the_one_function():
+    """THE PIN THIS FILE EXISTS FOR (first half)."""
+    import routers.admin_partners as mod
+    src = inspect.getsource(mod)
+    assert "is_admin_role(user.get('role'))" in src
+    assert "user.get('role') == 'admin'" not in src
+
+
+def test_the_deed_fetch_shares_the_vocabulary_rather_than_copying_it():
+    """`is_admin_role` cannot run inside Postgres, so the shared thing is
+    the TUPLE: it travels as a bound parameter and the comparison is the
+    same case-insensitive one. A repeated literal would be a fourth place
+    for a spelling to be forgotten."""
+    import routers.deeds_crud as mod
+    src = inspect.getsource(mod)
+    assert "u.role = 'admin'" not in src
+    assert "LOWER(u.role) = ANY(%s)" in src
+    assert "list(ADMIN_ROLES)" in src
+
+
+def test_no_file_hard_codes_an_admin_spelling_any_more():
+    """The sweep that makes "one definition" mean something.
+
+    A comparison against a literal admin spelling anywhere is a fourth
+    gate waiting to diverge.
+    """
+    from pathlib import Path
+    backend = Path(__file__).resolve().parents[1]
+    offenders = []
+    for path in backend.rglob("*.py"):
+        if "__pycache__" in path.parts or "tests" in path.parts:
+            continue
+        if path.name == "admin_partners.py":
+            # Its only remaining hits are inside the COMMENT recording
+            # what it used to compare. Read through the stripper instead
+            # of exempting the file, so a real comparison still fails.
+            from tests.source_text import code_only
+            if any(lit in code_only(path.read_text(encoding="utf-8"))
+                   for lit in ("== 'admin'", '== "admin"')):
+                offenders.append(f"{path.relative_to(backend)} → comparison")
+            continue
+        if path.name in ("auth.py", "set_admin_role.py", "role_census.py"):
+            continue  # the definition itself, and two admin tools
+        if "migrations" in path.parts or path.name == "api_baseline.py":
+            # WRITES, not gates. `SET role = 'admin'` assigns the
+            # canonical spelling; it does not decide who is one. The
+            # rule is about a second ANSWER to the question, and these
+            # never ask it.
+            continue
+        text = path.read_text(encoding="utf-8")
+        for spelling in ADMIN_ROLES:
+            for literal in (f"== '{spelling}'", f'== "{spelling}"',
+                            f"= '{spelling}'"):
+                if literal in text:
+                    offenders.append(f"{path.relative_to(backend)} → {literal}")
+    assert offenders == [], f"a second definition of admin: {offenders}"
+
+
+# ── The admin form cannot fail silently ──────────────────────────────
+
+def test_a_role_that_grants_nothing_is_refused_by_name():
+    """`adminn` used to be accepted, stored, and reported as success —
+    the product declining and not saying so."""
+    import routers.admin_api_v2 as mod
+    src = inspect.getsource(mod._validate_role_change)
+    assert "ASSIGNABLE_ROLES" in src
+    assert "would grant nothing" in src
+    # And it names what WOULD work, or the admin retries the same typo.
+    assert "', '.join(sorted(ADMIN_ROLES))" in src
+
+
+def test_the_assignable_set_is_authorization_not_job_titles():
+    """The interesting half. `users.role` still carries both meanings, and
+    registration legitimately writes free text into it (SIGNUP1's
+    "Other"), so a closed set covering BOTH would reject values the
+    product itself creates.
+
+    An admin editing this field is making an AUTHORIZATION decision, so
+    that is the vocabulary offered — and the refusal says where a job
+    title is edited instead.
+    """
+    from routers.admin_api_v2 import ASSIGNABLE_ROLES
+    assert ASSIGNABLE_ROLES == frozenset({*ADMIN_ROLES, 'user'})
+    src = inspect.getsource(
+        __import__('routers.admin_api_v2', fromlist=['x'])._validate_role_change)
+    assert "job title" in src.lower()
+
+
+# ── CALLED, NOT READ ─────────────────────────────────────────────────
+#
+# The first draft of these three asserted that "status_code=409",
+# "locked out" and "Ask another" APPEAR IN THE SOURCE. A mutation probe
+# replaced the `if` with `if False:` — the raise block intact, the
+# guard gone — and all 29 tests passed.
+#
+# Same class as the frontend's `{false && (`, in Python. For a page the
+# fix is rendering; for a service it is CALLING. A string-presence pin
+# cannot tell REACHABLE from PRESENT, and knowing that does not stop
+# anybody writing one.
+
+def _cursor_for(row):
+    """A cursor that answers the one SELECT the guard makes."""
+    from unittest.mock import MagicMock
+    cur = MagicMock()
+    cur.fetchone.return_value = row
+    return cur
+
+
+def _check(target_row, admin_email, new_role):
+    from routers.admin_api_v2 import _validate_role_change
+    return _validate_role_change(_cursor_for(target_row), 7, admin_email, new_role)
+
+
+def test_self_demotion_is_refused_as_a_lockout():
+    """THE PIN THIS FILE EXISTS FOR (second half).
+
+    An admin removing their own last access is a lockout, not a decision:
+    undoing it needs the console they just left.
+    """
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as exc:
+        _check({"email": "boss@deedpro.com", "role": "admin"},
+               "boss@deedpro.com", "user")
+    assert exc.value.status_code == 409
+    assert "locked out" in exc.value.detail
+    # And it says who can undo it, or she is refused with nowhere to go.
+    assert "Ask another" in exc.value.detail
+
+
+def test_the_comparison_is_by_email_and_is_case_insensitive():
+    """`get_current_admin` returns an EMAIL, not an id — comparing ids
+    would need one it never receives. Addresses arrive in whatever case
+    the token carries."""
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException):
+        _check({"email": "Boss@DeedPro.com", "role": "admin"},
+               "boss@deedpro.com", "user")
+
+
+def test_demoting_SOMEBODY_ELSE_is_allowed():
+    """The guard is about a lockout, not about demotion. An admin
+    removing another admin is an ordinary decision."""
+    assert _check({"email": "other@deedpro.com", "role": "admin"},
+                  "boss@deedpro.com", "user") is None
+
+
+def test_demoting_a_non_admin_is_not_a_lockout():
+    """Nothing to lose. Firing here would refuse a no-op."""
+    assert _check({"email": "boss@deedpro.com", "role": "user"},
+                  "boss@deedpro.com", "user") is None
+
+
+def test_promotion_can_never_trip_the_lockout_check():
+    """Granting admin cannot lock anybody out — and a guard that fired on
+    promotion would make the console unable to add an admin, which is
+    worse than the defect it fixes.
+
+    Driven with a row that WOULD trip it if the early return were gone.
+    """
+    for spelling in ("admin", "Administrator", "super_admin"):
+        assert _check({"email": "boss@deedpro.com", "role": "admin"},
+                      "boss@deedpro.com", spelling) is None
+
+
+def test_an_unknown_role_is_refused_by_the_call_too():
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as exc:
+        _check({"email": "x@y.z", "role": "user"}, "boss@deedpro.com", "adminn")
+    assert exc.value.status_code == 400
+    assert "would grant nothing" in exc.value.detail
+
+
+def test_a_blank_role_is_refused_by_the_call_too():
+    from fastapi import HTTPException
+    with pytest.raises(HTTPException) as exc:
+        _check({"email": "x@y.z", "role": "user"}, "boss@deedpro.com", "   ")
+    assert exc.value.status_code == 400
+    assert "cannot be blank" in exc.value.detail
+
+
+def test_the_validation_runs_before_the_update_is_built():
+    import routers.admin_api_v2 as mod
+    src = inspect.getsource(mod.admin_update_user)
+    assert src.index("_validate_role_change") < src.index("cur.execute(query")
+
+
+# ── The census, which is the deliverable ─────────────────────────────
+
+def test_the_census_cannot_write():
+    """A census that can mutate is a census somebody runs with the wrong
+    flag. There is no `--apply`, deliberately."""
+    import scripts.role_census as census
+    src = inspect.getsource(census)
+    from tests.source_text import code_only
+    body = code_only(src)
+    # Read through the stripper: the docstring SAYS "there is no
+    # `--apply`", which is a description of the rule rather than a
+    # violation of it. Third time this week a sweep caught its own
+    # explanation.
+    assert "--apply" not in body
+    assert "UPDATE " not in body.upper()
+    assert "add_argument" not in body
+
+
+def test_the_census_reports_whose_access_the_convergence_changed():
+    """The number that matters. Converging the gates admitted every
+    non-'admin' admin spelling to two gates that previously refused
+    them — that is a real access change and it needs naming per row."""
+    import scripts.role_census as census
+    src = inspect.getsource(census)
+    assert "convergence CHANGED" in src
+    assert "BTRIM(role) <> 'admin'" in src
+
+
+def test_a_fourth_definition_was_found_and_deleted():
+    """`utils/roles.py` defined `is_admin` accepting `admin` and
+    `administrator` ONLY — missing `superadmin` and `super_admin` — and
+    NOTHING IMPORTED IT.
+
+    The investigation missed it; this sweep found it. Dead code carrying
+    a false explanation is worse than no code, and a false SECURITY
+    definition in a file named `roles.py` is worse still: it is not
+    wrong until somebody imports it as the obvious helper, and then it
+    is wrong quietly.
+    """
+    from pathlib import Path
+    backend = Path(__file__).resolve().parents[1]
+    assert not (backend / "utils" / "roles.py").exists()
+
+
+def test_the_census_names_which_database_it_read():
+    import scripts.role_census as census
+    src = inspect.getsource(census)
+    assert "assert_tables" in src
+    assert "expected_database()" in src

--- a/backend/utils/roles.py
+++ b/backend/utils/roles.py
@@ -1,5 +1,0 @@
-def is_admin(role: str) -> bool:
-    if not role:
-        return False
-    r = role.strip().lower()
-    return r == 'admin' or r == 'administrator'


### PR DESCRIPTION
Rulings 1, 2 and 4 built. Ruling 3 (job title to its own column) waits on the count, as ruled.

## One definition

`ADMIN_ROLES` is now the one vocabulary. The partner gate calls `is_admin_role`; the three SQL sites take the tuple as a **bound parameter** — `is_admin_role` cannot run inside Postgres, so what is shared is the vocabulary rather than a copied literal, and there is nowhere for a fourth spelling to be forgotten.

The partial-admin state ceases to exist: every spelling now passes all three gates or none.

## A fourth definition, found by the sweep and not by the investigation

`utils/roles.py` defined `is_admin` accepting `admin` and `administrator` **only** — missing `superadmin` and `super_admin` — and **nothing imported it**.

Deleted. Dead code carrying a false explanation is worse than no code, and a false *security* definition in a file named `roles.py` is worse still: it is not wrong until somebody imports it as the obvious helper, and then it is wrong quietly. My investigation missed it; the sweep I wrote to enforce the ruling found it.

## The admin form

- A value outside the assignable set is refused **by name**. `adminn` used to be accepted, stored, and reported as success — invariant #4 in an admin form.
- Self-demotion is a 409 that names the lockout and says who can undo it, because undoing it needs the console she just left.
- Promotion returns early, so the guard can never stop the console adding an admin — a guard that refused promotion would be worse than the defect.

**The assignable set is the authorization vocabulary, not job titles.** `users.role` still carries both meanings, and registration legitimately writes free text there (SIGNUP1's "Other"), so a closed set covering both would reject values the product itself creates. The refusal says where a job title is edited instead. When ruling 3 lands this becomes the whole vocabulary rather than a subset, and the comment saying so can go.

## The census is the deliverable

`scripts/role_census.py` counts every value in `users.role` and names, **per row**, whose access the gate convergence changed — a non-`admin` admin spelling was previously refused by two gates and now passes all three. That is a real access change and it should be confirmed per person, not discovered from a support ticket.

It cannot write. No `--apply`, deliberately: a census that can mutate is a census somebody runs with the wrong flag.

## Self-review

**Premises checked:** all confirmed from the investigation, plus one I had missed — the fourth definition. Worth stating plainly: **the investigation under-reported, and the enforcement sweep caught it.** That is the second time in two tickets that my own reporting needed correcting by my own later work.

**Pins changed:** three rewritten from source-reading to calling (see below). One sweep narrowed twice — it caught `admin_partners.py`'s own explanatory comment and the census docstring's `--apply`, both descriptions of the rule rather than violations. Migrations and `api_baseline.py` are exempted with a reason: `SET role = 'admin'` **assigns** the canonical spelling, it does not **decide** who is one, and the rule is about a second answer to the question.

**Least sure about:** the self-lockout check compares **emails**, because `get_current_admin` returns an email rather than an id. It is the comparison that is actually available, and it is case-insensitive — but it would be defeated by two accounts sharing an address, which the schema does not prevent as far as I checked.

**Would cut:** the blank-role refusal. It is the smallest of the three checks and a blank would have been caught by the assignable-set check anyway; it exists only to give a better sentence.

**Decided rather than flagged:** deleting `utils/roles.py` outright rather than reporting it. It had no importers, so deletion is reversible and inert — but it was a security definition and removing one is worth naming.

## Gates

| gate | result |
|---|---|
| pytest | 1352 passed |
| jest | 983 passed |
| tsc | 88 — baseline unchanged |
| six-flow | green |
| banned-claims | clean |
| mutation probes | 7 run, 6 caught, **1 came back green** |

**The green probe.** The self-lockout pins asserted `status_code=409`, `locked out` and `Ask another` **appear in the source**. Replacing the `if` with `if False:` left the raise block intact and passed all 29 tests. Same class as the frontend's `{false && (`, in Python — **for a page the fix is rendering; for a service it is calling.** Those pins now invoke `_validate_role_change` with a mock cursor and assert the raised exception. Re-running the probe: 2 failures where there were 0, plus two further probes (early return deleted, comparison made case-sensitive) that now fail where reading could not see them.

**And the §11.1 sweep caught my own new admin copy** — "in her profile", about a user whose pronouns we do not have. Second time this session, after citing the rule myself.

## Still outstanding

**Ruling 3** — job title to its own column, `users.role` reduced to a closed authorization set. Blocked on the census, as ruled. Jerry runs `python scripts/role_census.py` where `DATABASE_URL` points at production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_