### PR TITLE
ROLE1 step 3 — the job title stops sharing a column with authorization

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -269,6 +269,48 @@ def is_admin_role(role: str) -> bool:
         return False
     return role.strip().lower() in ADMIN_ROLES
 
+
+# ── RECOGNIZED vs ASSIGNABLE ─────────────────────────────────────────
+#
+# ROLE1 step 3 separates the two meanings `users.role` carried: the job
+# title moved to `users.job_title`, and this column is authorization
+# only. Two sets, and the difference between them is the whole point.
+#
+# ADMIN_ROLES above is what the product RECOGNIZES — four spellings,
+# because history wrote four spellings and refusing to recognize one
+# would silently remove somebody's access.
+#
+# ASSIGNABLE_ROLES is what the product will WRITE. Two values, because
+# four ways to spell one thing is the defect ROLE1 opened with, one
+# floor up: a vocabulary that admits synonyms grows a second answer.
+#
+# Recognized ⊇ assignable, deliberately and in that direction. The
+# reverse — assigning a spelling the gates do not recognize — is how a
+# console mints an account that cannot use it.
+ASSIGNABLE_ROLES = frozenset({'user', 'admin'})
+
+#: What `users.role` holds when nobody has decided anything about it.
+DEFAULT_ROLE = 'user'
+
+#: The canonical spelling, for anything that WRITES admin access.
+ADMIN_ROLE = 'admin'
+
+
+def authorization_role(role) -> str:
+    """The authorization answer for a stored role value: 'admin' or 'user'.
+
+    ONE PLACE TURNS THE COLUMN INTO THE CLAIM. The token used to carry
+    `users.role` verbatim, so a token could say `role: "Escrow Officer"`
+    — a job title travelling in an authorization claim, which every
+    reader then had to know was not an authorization answer.
+
+    It reads through `is_admin_role`, so it is the same answer the gates
+    give, and it is correct both before and after the migration: an
+    unmigrated `Administrator` row still resolves to admin.
+    """
+    return ADMIN_ROLE if is_admin_role(role) else DEFAULT_ROLE
+
+
 async def get_current_admin(credentials: HTTPAuthorizationCredentials = Depends(security)) -> str:
     """Verify admin access from JWT token"""
     try:

--- a/backend/database.py
+++ b/backend/database.py
@@ -187,6 +187,13 @@ def create_tables():
             # to serve anybody, and it is READABLE (admin user list)
             # rather than write-only, which is the LEGAL1 bar.
             "ALTER TABLE users ADD COLUMN IF NOT EXISTS interest_state VARCHAR(64)",
+            # ROLE1 step 3 — the job title stops sharing a column with
+            # authorization. `role` carried both: registration wrote
+            # "Escrow Officer" into the same field `is_admin_role()`
+            # reads to open the admin console. Two meanings in one column
+            # means every reader has to know which one it is holding, and
+            # the one that gets it wrong is a security answer.
+            "ALTER TABLE users ADD COLUMN IF NOT EXISTS job_title VARCHAR(120)",
             "ALTER TABLE deeds ADD COLUMN IF NOT EXISTS grantor_name VARCHAR(255)",
             "ALTER TABLE deeds ADD COLUMN IF NOT EXISTS grantee_name VARCHAR(255)",
             "ALTER TABLE deeds ADD COLUMN IF NOT EXISTS pdf_url VARCHAR(500)",

--- a/backend/migrations/role1_separate_job_title.py
+++ b/backend/migrations/role1_separate_job_title.py
@@ -49,6 +49,14 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import psycopg2  # noqa: E402
 
+# `auth.py` raises at import without JWT_SECRET_KEY — correct for an API
+# that must not boot unable to sign, wrong for a migration that signs
+# nothing. Importing it here is for `ADMIN_ROLES`, the one definition of
+# the vocabulary; requiring the production signing key to move a column
+# would be a worse instruction than the problem it solves. A real value
+# in the environment is left alone.
+os.environ.setdefault("JWT_SECRET_KEY", "unused-by-this-migration")
+
 from auth import ADMIN_ROLES, ADMIN_ROLE, DEFAULT_ROLE  # noqa: E402
 from db_rows import ROW_FACTORY  # noqa: E402
 from services.db_identity import (WrongDatabase, assert_tables,  # noqa: E402
@@ -139,7 +147,7 @@ def main():
         with conn.cursor() as cur:
             # WHICH DATABASE, BEFORE WRITING TO IT.
             try:
-                assert_tables(cur, ["users"], expect_database=expected_database())
+                assert_tables(cur, "users", expect_database=expected_database())
                 print(describe(cur))
             except WrongDatabase as e:
                 sys.exit(str(e))

--- a/backend/migrations/role1_separate_job_title.py
+++ b/backend/migrations/role1_separate_job_title.py
@@ -1,0 +1,169 @@
+"""ROLE1 step 3 — move the job title out of the authorization column.
+
+═══ WHAT THIS IS ═══
+
+`users.role` held two facts at once: what somebody is called (Escrow
+Officer, Title Agent) and what somebody may do (admin). ROLE1 step 3
+gave the first its own column. This script moves the existing rows.
+
+For every row:
+
+  - a value that is NOT an admin spelling is a JOB TITLE. It moves to
+    `job_title` and `role` becomes 'user' — explicitly, never by default,
+    because "we assumed" is not a thing to say about an access column.
+  - an admin spelling stays admin and is written in the canonical
+    lowercase. `job_title` is left alone: 'admin' was never a job title
+    and copying it into one would invent a fact.
+  - 'user' is already the answer. Untouched.
+
+═══ WHY IT PLANS BEFORE IT WRITES ═══
+
+    python migrations/role1_separate_job_title.py            # plan
+    python migrations/role1_separate_job_title.py --apply    # write
+
+Default is the plan, and the plan is the row-by-row list of what would
+change — not a count. An access migration whose output is "17 rows
+updated" is one nobody can check afterwards.
+
+`--apply` runs in ONE transaction. A half-migrated users table has some
+people's titles in one column and some in the other, and every reader
+downstream would have to handle both forever.
+
+═══ WHAT IT DOES NOT DO ═══
+
+It does not narrow `ADMIN_ROLES`. The gates go on recognizing all four
+spellings after this runs, deliberately: narrowing the recognized set is
+a SECOND decision, safe only once a census of the migrated table shows
+nothing but 'admin' — and taking it here would mean one script that both
+converges the data and changes what the converged data means.
+
+It is also re-runnable. Every row it has already moved fails the
+selection on the second pass, so a partial run followed by a full one
+lands in the same place.
+"""
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import psycopg2  # noqa: E402
+
+from auth import ADMIN_ROLES, ADMIN_ROLE, DEFAULT_ROLE  # noqa: E402
+from db_rows import ROW_FACTORY  # noqa: E402
+from services.db_identity import (WrongDatabase, assert_tables,  # noqa: E402
+                                  describe, expected_database)
+
+#: Rows whose `role` is a job title: anything with a value that is not an
+#: admin spelling and not already the default.
+TITLES_SQL = """
+    SELECT id, email, BTRIM(role) AS role, job_title
+      FROM users
+     WHERE COALESCE(BTRIM(role), '') NOT IN ('', %s)
+       AND LOWER(BTRIM(role)) <> ALL(%s)
+     ORDER BY id
+"""
+
+#: Admin rows written in something other than the canonical spelling.
+SPELLINGS_SQL = """
+    SELECT id, email, BTRIM(role) AS role
+      FROM users
+     WHERE LOWER(BTRIM(role)) = ANY(%s)
+       AND BTRIM(role) <> %s
+     ORDER BY id
+"""
+
+
+def read_plan(cur):
+    admin = [r.lower() for r in ADMIN_ROLES]
+    cur.execute(TITLES_SQL, (DEFAULT_ROLE, admin))
+    titles = [dict(r) for r in cur.fetchall()]
+    cur.execute(SPELLINGS_SQL, (admin, ADMIN_ROLE))
+    spellings = [dict(r) for r in cur.fetchall()]
+    return titles, spellings
+
+
+def print_plan(titles, spellings):
+    print("\n── job titles moving out of users.role ──────────────────")
+    if not titles:
+        print("  none")
+    for row in titles:
+        occupied = f"  (job_title already holds {row['job_title']!r})" \
+            if row["job_title"] else ""
+        print(f"  user {row['id']:>6}  {row['email']}")
+        print(f"           role {row['role']!r} → job_title, "
+              f"role → {DEFAULT_ROLE!r}{occupied}")
+
+    print("\n── admin rows being written in the canonical spelling ───")
+    if not spellings:
+        print("  none")
+    for row in spellings:
+        print(f"  user {row['id']:>6}  {row['email']}  "
+              f"{row['role']!r} → {ADMIN_ROLE!r}")
+
+    # A row that already has a job_title is the one case where this
+    # script would DESTROY something. It does not: `job_title` wins and
+    # `role` is still reduced, because the person filled that field in
+    # themselves and the column they never saw does not outrank it.
+    conflicts = [r for r in titles if r["job_title"]]
+    if conflicts:
+        print(f"\n  {len(conflicts)} row(s) already have a job_title. Theirs "
+              f"is kept; only `role` changes.")
+
+
+def apply(cur, titles, spellings):
+    for row in titles:
+        cur.execute("""
+            UPDATE users
+               SET job_title = COALESCE(NULLIF(BTRIM(job_title), ''), %s),
+                   role = %s
+             WHERE id = %s
+        """, (row["role"], DEFAULT_ROLE, row["id"]))
+    for row in spellings:
+        cur.execute("UPDATE users SET role = %s WHERE id = %s",
+                    (ADMIN_ROLE, row["id"]))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true",
+                        help="write the changes (default is to print them)")
+    args = parser.parse_args()
+
+    db_url = os.getenv("DATABASE_URL")
+    if not db_url:
+        sys.exit("DATABASE_URL is required")
+
+    conn = psycopg2.connect(db_url, cursor_factory=ROW_FACTORY)
+    try:
+        with conn.cursor() as cur:
+            # WHICH DATABASE, BEFORE WRITING TO IT.
+            try:
+                assert_tables(cur, ["users"], expect_database=expected_database())
+                print(describe(cur))
+            except WrongDatabase as e:
+                sys.exit(str(e))
+
+            titles, spellings = read_plan(cur)
+            print_plan(titles, spellings)
+
+            if not args.apply:
+                print("\n  PLAN ONLY — nothing was written. Re-run with "
+                      "--apply to make these changes.")
+                return
+
+            apply(cur, titles, spellings)
+        # One transaction for the whole table: a half-migrated users
+        # table would leave every reader downstream handling both shapes.
+        conn.commit()
+        print(f"\n  APPLIED — {len(titles)} title(s) moved, "
+              f"{len(spellings)} spelling(s) canonicalised.")
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/routers/admin_api_v2.py
+++ b/backend/routers/admin_api_v2.py
@@ -416,6 +416,20 @@ def _validate_role_change(cur, target_user_id: int, admin_email: str,
     # — `get_current_admin` yields `user_email` from the token, not an
     # id. Comparing the target row's email to it is the comparison that
     # is actually available, and it is the one that is true.
+    #
+    # AND IT IS SOUND, WHICH IS A SCHEMA FACT RATHER THAN AN ASSUMPTION:
+    # `users.email` carries a UNIQUE constraint (`users_email_key`), so
+    # an address identifies at most one row and two accounts cannot share
+    # one to slip past this. Recorded here because the next reader's
+    # first question about an email-keyed guard is exactly that, and the
+    # answer lives in a different file.
+    #
+    # The constraint is BYTE-wise, so it alone would still permit
+    # `Boss@x.com` beside `boss@x.com`. Every write normalises to
+    # lower-case — registration, and this endpoint (see below) — which is
+    # what makes the constraint mean what this comparison needs it to
+    # mean. The `.lower()` here is the belt to that braces: a token minted
+    # before any of it carries whatever case it carried.
     if is_admin_role(new_role):
         return  # Promoting or keeping admin can never lock anybody out.
     cur.execute("SELECT email, role FROM users WHERE id = %s", (target_user_id,))
@@ -477,8 +491,24 @@ def admin_update_user(
 
         for field in allowed_fields:
             if field in updates:
+                value = updates[field]
+                # ── AN ADDRESS IS STORED ONE WAY ──────────────────────
+                #
+                # Found while checking whether the lockout guard above can
+                # be defeated. It cannot — but this endpoint wrote `email`
+                # VERBATIM, and the UNIQUE constraint is byte-wise, so an
+                # admin correcting somebody's address to `Jane@Firm.com`
+                # created a row that LOGIN CAN NEVER FIND: it looks up
+                # `WHERE email = %s` with the typed address lower-cased.
+                #
+                # The console would report success and the user would be
+                # locked out of the product with no message, no error and
+                # nothing in the row that looks wrong. Registration has
+                # always lower-cased; this was the one write that did not.
+                if field == 'email' and isinstance(value, str):
+                    value = value.strip().lower()
                 set_clauses.append(f"{field} = %s")
-                params.append(updates[field])
+                params.append(value)
         
         if not set_clauses:
             raise HTTPException(status_code=400, detail="No valid fields to update")

--- a/backend/routers/admin_api_v2.py
+++ b/backend/routers/admin_api_v2.py
@@ -5,7 +5,8 @@ import os, csv, io
 
 # Import project-specific helpers (adjust if your module paths differ)
 try:
-    from auth import ADMIN_ROLES, get_current_admin, is_admin_role  # existing dependency
+    from auth import (ADMIN_ROLES, ASSIGNABLE_ROLES as _ASSIGNABLE_ROLES,
+                      get_current_admin, is_admin_role)  # existing dependency
 except Exception:
     # If project uses package style imports
     from backend.auth import get_current_admin  # type: ignore
@@ -95,7 +96,8 @@ def admin_users_search(
         total = cur.fetchone()['count']
 
         cur.execute(f"""
-            SELECT u.id, u.email, u.full_name, COALESCE(u.role,'') as role, u.plan,
+            SELECT u.id, u.email, u.full_name, COALESCE(u.role,'') as role,
+                   u.job_title, u.plan,
                    u.last_login, u.created_at, u.is_active,
                    (SELECT COUNT(*) FROM deeds d WHERE d.user_id = u.id) as deed_count
             FROM users u
@@ -120,7 +122,8 @@ def admin_user_detail(user_id: int, admin=Depends(get_current_admin)):
     """
     with db_connection() as conn, conn.cursor() as cur:
         cur.execute("""
-            SELECT id, email, full_name, COALESCE(role,'') as role, plan, company_name, company_type,
+            SELECT id, email, full_name, COALESCE(role,'') as role, job_title,
+                   plan, company_name, company_type,
                    interest_state,
                    phone, state, verified, stripe_customer_id, last_login, created_at, is_active
             FROM users WHERE id = %s
@@ -217,10 +220,12 @@ def export_users_csv(admin=Depends(get_current_admin)):
     writer = csv.writer(output)
     with db_connection() as conn, conn.cursor() as cur:
         cur.execute("""
-            SELECT id, email, full_name, role, plan, created_at, last_login, is_active
+            SELECT id, email, full_name, role, job_title, plan, created_at,
+                   last_login, is_active
             FROM users ORDER BY created_at DESC
         """)
-        writer.writerow(["id","email","full_name","role","plan","created_at","last_login","is_active"])
+        writer.writerow(["id","email","full_name","role","job_title","plan",
+                         "created_at","last_login","is_active"])
         for row in cur.fetchall():  # RealDictCursor returns dicts
             writer.writerow(row.values())  # Extract values in column order
     return Response(content=output.getvalue(), media_type="text/csv",
@@ -367,27 +372,24 @@ def admin_email_stats(days: int = Query(7, ge=1, le=90),
 # PHASE 12-3: USER CRUD OPERATIONS
 # ============================================================================
 
-#: What the admin console may ASSIGN to `users.role`.
+#: What the admin console may ASSIGN to `users.role` — `user` or `admin`,
+#: and nothing else.
 #:
-#: Every admin spelling, plus `user`. Deliberately NOT the job titles —
-#: and that is the interesting half of this ruling.
+#: ROLE1 step 3 landed, so this is now the whole vocabulary rather than
+#: the subset it was: registration writes the job title to its own
+#: column and the authorization column from a literal, so `role` no
+#: longer receives free text from anywhere and a closed set costs
+#: nothing.
 #:
-#: `users.role` carries two meanings (ROLE1): a job title written by
-#: registration, and the authorization value the gates read. Registration
-#: legitimately writes free text there — SIGNUP1's "Other" resolves to
-#: whatever she typed — so a closed set covering BOTH meanings would
-#: reject values the product itself creates.
+#: It narrowed from five values to two in the same move. The other three
+#: were `administrator`, `superadmin` and `super_admin` — spellings the
+#: gates RECOGNIZE (ADMIN_ROLES, for rows history already wrote) but
+#: which this console has no business creating more of. Offering four
+#: ways to spell one thing is the defect ROLE1 opened with.
 #:
-#: But an admin editing this field is making an AUTHORIZATION decision.
-#: Job titles are the officer's own, entered where she enters them. So
-#: the console's assignable set is the authorization vocabulary, and the
-#: refusal says so rather than pretending the column is simpler than it
-#: is.
-#:
-#: When ROLE1 step 3 lands — job title to its own column, `role` reduced
-#: to a closed set — this becomes the whole vocabulary rather than a
-#: subset of it, and this comment can go.
-ASSIGNABLE_ROLES = frozenset({r.lower() for r in ADMIN_ROLES} | {'user'})
+#: The console's own <select> has offered exactly User and Admin the
+#: whole time. The API accepted three values its only caller never sent.
+ASSIGNABLE_ROLES = _ASSIGNABLE_ROLES
 
 
 def _validate_role_change(cur, target_user_id: int, admin_email: str,
@@ -402,10 +404,10 @@ def _validate_role_change(cur, target_user_id: int, admin_email: str,
     if value.lower() not in ASSIGNABLE_ROLES:
         raise HTTPException(
             status_code=400,
-            detail=(f"'{value}' would grant nothing. From here you can set "
-                    f"admin access ({', '.join(sorted(ADMIN_ROLES))}) or "
-                    f"'user'. A job title belongs to the person it describes "
-                    f"and is edited in their profile, not here."),
+            detail=(f"'{value}' would grant nothing. This field is access, "
+                    f"and it takes {' or '.join(sorted(ASSIGNABLE_ROLES))}. "
+                    f"A job title belongs to the person it describes and is "
+                    f"edited in their profile, not here."),
         )
 
     # ── THE SELF-LOCKOUT ─────────────────────────────────────────────
@@ -460,8 +462,14 @@ def admin_update_user(
         set_clauses = []
         params = []
         
-        # Allowed fields for update
-        allowed_fields = ['full_name', 'email', 'role', 'plan', 'company_name', 
+        # Allowed fields for update.
+        #
+        # `job_title` is deliberately NOT here. The refusal above tells an
+        # admin that a job title is edited in the person's own profile,
+        # and a console that says that while also editing it would be
+        # saying two things. It is hers; this screen shows it and does
+        # not touch it.
+        allowed_fields = ['full_name', 'email', 'role', 'plan', 'company_name',
                          'phone', 'state', 'is_active', 'verified']
 
         if 'role' in updates:

--- a/backend/routers/users_auth.py
+++ b/backend/routers/users_auth.py
@@ -18,7 +18,8 @@ from typing import Optional
 import db
 from auth import (
     get_password_hash, verify_password, create_access_token,
-    get_current_user_id, is_admin_role, AuthUtils
+    get_current_user_id, is_admin_role, authorization_role, DEFAULT_ROLE,
+    AuthUtils,
 )
 from database import (
     PROFILE_COLUMNS, PROFILE_ELSEWHERE, clean_profile_text, get_user_profile,
@@ -40,7 +41,23 @@ class UserRegister(BaseModel):
     password: str
     confirm_password: str
     full_name: str
-    role: str
+    # ── ROLE1 step 3: TWO WIRE NAMES, ONE COLUMN, ON PURPOSE ──────────
+    #
+    # What the form has always called "professional role" is a JOB TITLE
+    # and now lands in `users.job_title`. `job_title` is the name that
+    # means what it holds; `role` is the name the deployed frontend
+    # sends.
+    #
+    # Both are accepted for exactly one reason: this backend (Render) and
+    # that frontend (Vercel) deploy separately, so there is a window
+    # where one is new and the other is not. Registration is the front
+    # door and a 422 in that window is a lost signup.
+    #
+    # REMOVAL TRIGGER: once a frontend sending `job_title` has been live
+    # through one deploy, `role` comes out of this model and the refusal
+    # below goes with it.
+    job_title: Optional[str] = None
+    role: Optional[str] = None
     company_name: Optional[str] = None
     company_type: Optional[str] = None
     phone: Optional[str] = None
@@ -139,20 +156,39 @@ async def register_user(user: UserRegister = Body(...)):
         if not clean_profile_text(user.full_name):
             raise HTTPException(status_code=400, detail="Full name is required")
 
-        # SECURITY: registration must never grant privilege. users.role is
-        # the professional role that prints on the profile (Escrow Officer,
-        # Title Agent, ...) AND the value is_admin_role() reads to gate the
-        # admin console — one column, two meanings. The field was accepted
-        # verbatim from the request body, so registering with
-        # {"role": "admin"} minted a working admin account: the login token
-        # carried role=admin and /admin/* answered it, including API-key
-        # minting. Privilege is granted by an operator, never claimed by a
-        # registrant.
+        # ── SECURITY: REGISTRATION CANNOT GRANT PRIVILEGE ─────────────
+        #
+        # It used to. `users.role` was the professional role printed on
+        # the profile AND the value `is_admin_role()` reads to gate the
+        # admin console — one column, two meanings — and the field was
+        # taken verbatim from the request body. `{"role": "admin"}`
+        # minted a working admin account: the token this same call
+        # returns carried role=admin and /admin/* answered it, including
+        # API-key minting.
+        #
+        # #103 closed that with the string refusal below. ROLE1 step 3
+        # closes it STRUCTURALLY: what arrives here is a job title, it
+        # goes to `job_title`, and `role` is written from a literal this
+        # handler owns. There is no request value that reaches the
+        # authorization column, so there is nothing to spell.
+        #
+        # The refusal stays only for as long as the legacy `role` wire
+        # name does, and for the same reason: a request built for the old
+        # shape means what the old shape meant. It is checked against
+        # `user.role`, not the resolved title, so a registrant sending
+        # the new field is free to be called whatever they are called.
         if is_admin_role(user.role):
             raise HTTPException(
                 status_code=400,
                 detail="That role cannot be selected at registration.",
             )
+
+        # The form's "professional role", under the name that says what
+        # it is. `job_title` wins when both arrive: the specific name
+        # beats the legacy one.
+        job_title = clean_profile_text(user.job_title) or clean_profile_text(user.role)
+        if not job_title:
+            raise HTTPException(status_code=400, detail="Role is required")
 
         # Hash password
         hashed_password = get_password_hash(user.password)
@@ -164,15 +200,20 @@ async def register_user(user: UserRegister = Body(...)):
         new_user_id = None
         with conn.cursor() as cur:
             cur.execute("""
-                INSERT INTO users (email, password_hash, full_name, role, company_name,
+                INSERT INTO users (email, password_hash, full_name, job_title, role,
+                                 company_name,
                                  company_type, phone, state, plan, interest_state)
-                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 RETURNING id
             """, (
                 # Profile-hygiene: name/company/phone print on deed faces
                 # and emails — normalize whitespace at the write, never case.
                 user.email.lower(), hashed_password,
-                clean_profile_text(user.full_name), user.role,
+                clean_profile_text(user.full_name), job_title,
+                # THE AUTHORIZATION COLUMN, FROM A LITERAL. Not from the
+                # request, not from a variable that once held a request
+                # value. Registration decides nothing about access.
+                DEFAULT_ROLE,
                 clean_profile_text(user.company_name), user.company_type,
                 # SIGNUP1: E.164 at the write, using the normalizer
                 # PARTNER2 built and the partner API has used since.
@@ -235,7 +276,11 @@ async def register_user(user: UserRegister = Body(...)):
             data={
                 "sub": str(new_user_id),
                 "email": user.email.lower(),
-                "role": user.role or "user"
+                # The claim is an AUTHORIZATION answer. It used to be
+                # `user.role` — so a token could say role="Escrow
+                # Officer", a job title riding in a security claim that
+                # every reader then had to know was not one.
+                "role": DEFAULT_ROLE,
             }
         )
 
@@ -356,11 +401,21 @@ async def login_user(credentials: UserLogin = Body(...), request: Request = None
         record_attempt(credentials.email.lower(), _ip, succeeded=True)
 
         # Create access token (AdminFix: include role for admin access)
+        #
+        # ROLE1 step 3 — THE CLAIM IS AN ANSWER, NOT A COLUMN. This
+        # forwarded `users.role` verbatim, so before the migration a
+        # token reads `role: "Escrow Officer"`: a job title in a claim
+        # three gates and three screens treat as authorization. Each of
+        # them then had to reach the same conclusion about it separately.
+        #
+        # `authorization_role` reaches it once, through `is_admin_role`,
+        # so the claim is 'admin' or 'user' and nothing else — true of an
+        # unmigrated `Administrator` row as much as a converged one.
         access_token = create_access_token(
             data={
                 "sub": str(user_id),
                 "email": credentials.email.lower(),
-                "role": role or "user"  # Default to "user" if role is None
+                "role": authorization_role(role),
             }
         )
         from auth import create_refresh_token
@@ -401,7 +456,7 @@ async def get_user_profile_endpoint(user_id: int = Depends(get_current_user_id))
         with db.conn.cursor() as cur:
             cur.execute("""
                 SELECT id, email, full_name, role, company_name, company_type,
-                       phone, state, plan, created_at, last_login
+                       phone, state, plan, created_at, last_login, job_title
                 FROM users WHERE id = %s AND is_active = TRUE
             """, (user_id,))
             user = cur.fetchone()
@@ -445,6 +500,19 @@ async def get_user_profile_endpoint(user_id: int = Depends(get_current_user_id))
             "id": user[0],
             "email": user[1],
             "full_name": user[2],
+            # ROLE1 step 3 — BOTH, because they are two different facts
+            # and the screen needs a different one from the gate.
+            #
+            # `job_title` is what she calls herself and what the Profile
+            # tab edits. `role` is authorization and is read-only to her:
+            # nothing in the account settings screen writes it, and the
+            # admin console is where it changes.
+            #
+            # Before the migration `job_title` is NULL for every existing
+            # account and `role` still holds the title. The screen falls
+            # back rather than showing a blank field, and that fallback
+            # is a dated thing: it goes when the migration has run.
+            "job_title": user[11] or (None if is_admin_role(user[3]) else user[3]),
             "role": user[3],
             "company_name": user[4],
             "company_type": user[5],
@@ -542,6 +610,14 @@ class ProfilePatch(BaseModel):
     company_name: Optional[str] = None
     phone: Optional[str] = None
     state: Optional[str] = None
+    # ROLE1 step 3 — and the sentence in the admin console's refusal
+    # ("a job title belongs to the person it describes and is edited in
+    # their profile, not here") is TRUE from here on. It was written
+    # before this field existed, which made it a promise pointing at a
+    # screen that had no such box.
+    #
+    # `role` is deliberately absent: no self-service authorization.
+    job_title: Optional[str] = None
     # user_profiles
     business_address: Optional[str] = None
 
@@ -570,6 +646,7 @@ async def patch_user_profile(
                 "company_name": clean_profile_text(patch.company_name),
                 "phone": clean_profile_text(patch.phone),
                 "state": (patch.state or "").upper() or None,
+                "job_title": clean_profile_text(patch.job_title),
             }
             user_fields = {k: v for k, v in user_fields.items() if k in given}
             if user_fields:

--- a/backend/scripts/company_name_consolidation.py
+++ b/backend/scripts/company_name_consolidation.py
@@ -42,9 +42,15 @@ Usage (where DATABASE_URL points at the database being consolidated):
 import argparse
 import os
 import sys
+from pathlib import Path
 
-import psycopg2
-from db_rows import ROW_FACTORY
+# There was no path insert here at all, so this script has never run
+# either — same ModuleNotFoundError, and this one has an `--apply` that
+# writes.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import psycopg2  # noqa: E402
+from db_rows import ROW_FACTORY  # noqa: E402
 from services.db_identity import (WrongDatabase, assert_tables, describe,
                                   expected_database)
 
@@ -142,7 +148,7 @@ def main():
     # is worse than no report — it looks exactly like the right one.
     try:
         with conn.cursor() as cur:
-            assert_tables(cur, ["users", "user_profiles"],
+            assert_tables(cur, "users", "user_profiles",
                           expect_database=expected_database())
             print(describe(cur))
     except WrongDatabase as e:

--- a/backend/scripts/role_census.py
+++ b/backend/scripts/role_census.py
@@ -28,16 +28,39 @@ Usage (where DATABASE_URL points at the database being counted):
 """
 import os
 import sys
+from pathlib import Path
 
-import psycopg2
-from db_rows import ROW_FACTORY
-from services.db_identity import (WrongDatabase, assert_tables, describe,
-                                  expected_database)
+# BEFORE the project imports, not after. This sat four lines lower, so
+# `python scripts/role_census.py` — the invocation this file's own
+# docstring gives — died on `ModuleNotFoundError: No module named
+# 'db_rows'` every time it was ever run.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import psycopg2  # noqa: E402
+from db_rows import ROW_FACTORY  # noqa: E402
+from services.db_identity import (WrongDatabase, assert_tables,  # noqa: E402
+                                  describe, expected_database)
 
 
 def main():
+    # ── WHY A PLACEHOLDER SECRET, IN A SCRIPT THAT SIGNS NOTHING ─────
+    #
+    # This census reads four columns and writes nothing. It imports
+    # `auth` for one thing: `ADMIN_ROLES`, the one definition of the
+    # vocabulary — and `auth.py` raises at IMPORT time if JWT_SECRET_KEY
+    # is unset, which is correct for an API that must not boot without a
+    # signing key and wrong for a read-only count.
+    #
+    # Without this, running the census means handing the operator the
+    # production JWT signing key to look at a `role` column. That is a
+    # worse instruction than the problem it solves. The placeholder is
+    # never used to sign or verify anything; a real value in the
+    # environment is left alone.
+    #
+    # The alternative — a second home for the vocabulary that does not
+    # drag the key in — is how `utils/roles.py` came to exist, and ROLE1
+    # deleted that for being a fourth definition of admin.
+    os.environ.setdefault("JWT_SECRET_KEY", "unused-by-this-read-only-census")
     from auth import ADMIN_ROLES
 
     db_url = os.getenv("DATABASE_URL")
@@ -50,7 +73,7 @@ def main():
     # the wrong database looks exactly like the right one.
     try:
         with conn.cursor() as cur:
-            assert_tables(cur, ["users"], expect_database=expected_database())
+            assert_tables(cur, "users", expect_database=expected_database())
             print(describe(cur))
     except WrongDatabase as e:
         conn.close()

--- a/backend/services/db_identity.py
+++ b/backend/services/db_identity.py
@@ -64,6 +64,43 @@ class WrongDatabase(RuntimeError):
     """
 
 
+def _as_connection(obj):
+    """A connection, whether the caller had one or only a cursor.
+
+    ═══ THE SAFETY MECHANISM WHOSE FIRST REAL CALLERS MISUSED IT ═══
+
+    This module was built after an afternoon spent hunting a schema that
+    was fine, because a service was pointed at the wrong database. Its
+    own tests passed throughout. Three of the callers outside those tests
+    were written like this:
+
+        with conn.cursor() as cur:
+            assert_tables(cur, ["users"], ...)
+
+    which died on `AttributeError: 'HybridCursor' object has no attribute
+    'cursor'` — three frames deep, inside the diagnostic, at the moment
+    somebody needed a diagnostic. `role_census.py` and
+    `company_name_consolidation.py` had therefore never run successfully
+    in their lives, and nothing said so: the tests construct the call
+    themselves, correctly, and a sweep checked only that a call EXISTS.
+
+    A cursor is not a mistake worth punishing. The natural place to check
+    identity is inside the `with conn.cursor()` block that is about to
+    ask the questions, and a mechanism that is awkward to call from where
+    people call it is one they call wrongly. So it is normalised here,
+    once, rather than being a rule every script must remember.
+    """
+    if hasattr(obj, "cursor"):
+        return obj                      # a connection
+    conn = getattr(obj, "connection", None)
+    if conn is not None and hasattr(conn, "cursor"):
+        return conn                     # a cursor; DB-API exposes its own
+    raise TypeError(
+        f"db_identity needs a connection or a cursor, got {type(obj).__name__}. "
+        "Pass the connection, or the cursor you already have open."
+    )
+
+
 def identity(conn) -> Dict[str, Any]:
     """Who am I connected to.
 
@@ -72,7 +109,7 @@ def identity(conn) -> Dict[str, Any]:
     "local socket" rather than as an empty string that looks like a
     lookup that failed.
     """
-    with conn.cursor() as cur:
+    with _as_connection(conn).cursor() as cur:
         cur.execute("SELECT current_database() AS db, "
                     "inet_server_addr() AS host, "
                     "inet_server_port() AS port, "
@@ -118,7 +155,7 @@ def missing_tables(conn, names: Sequence[str]) -> list:
     not care whether you could read it.
     """
     absent = []
-    with conn.cursor() as cur:
+    with _as_connection(conn).cursor() as cur:
         for name in names:
             cur.execute("SELECT to_regclass(%s) IS NULL AS gone", (name,))
             row = cur.fetchone()
@@ -164,6 +201,32 @@ def assert_tables(conn, *names: str, expect_database: str = "") -> Dict[str, Any
     """
     if not names:
         raise ValueError("assert_tables() with no table names asserts nothing")
+
+    # ── AND THE SECOND HALF OF THE SAME MISCALL ──────────────────────
+    #
+    # `names` is VARIADIC. The three broken callers wrote
+    #
+    #     assert_tables(cur, ["users"], ...)
+    #
+    # which means "one table whose name is the list `['users']`" — so
+    # even past the cursor fix, `to_regclass` would have been handed an
+    # array and the failure would have arrived as a Postgres type error
+    # about a value the caller never typed.
+    #
+    # Unlike the connection, this one is REFUSED rather than flattened.
+    # A cursor and a connection mean the same thing here; a list and a
+    # spread would be two spellings of one call living side by side
+    # forever, which is the defect this line of work exists to remove.
+    # It refuses at the boundary and names the fix, and an AST sweep over
+    # every call site stops it reaching a script at all.
+    for name in names:
+        if not isinstance(name, str):
+            raise TypeError(
+                f"assert_tables() takes table names as separate arguments, "
+                f"got {type(name).__name__}. Write "
+                f"assert_tables(conn, \"users\", \"user_profiles\") — "
+                f"not a list."
+            )
 
     # The name first: if it is wrong, a missing table is a symptom rather
     # than the finding, and reporting the symptom sends the reader back

--- a/backend/tests/test_admin_serializer_contract.py
+++ b/backend/tests/test_admin_serializer_contract.py
@@ -165,7 +165,9 @@ def test_the_mock_half_of_the_split_is_deleted():
 # ── CSV exports share the serializer; check them too ─────────────────
 
 @pytest.mark.parametrize("path,expected_header", [
-    ("/admin/export/users.csv", "id,email,full_name,role,plan"),
+    # ROLE1 step 3 — `job_title` sits between them, so an export tells an
+    # operator who somebody is as well as what they may do.
+    ("/admin/export/users.csv", "id,email,full_name,role,job_title,plan"),
     ("/admin/export/deeds.csv", "id,deed_type,status"),
 ])
 def test_csv_exports_emit_populated_columns(admin_client, path, expected_header):

--- a/backend/tests/test_db_identity.py
+++ b/backend/tests/test_db_identity.py
@@ -51,6 +51,7 @@ import os
 import re
 import subprocess
 import sys
+import ast
 from pathlib import Path
 
 import pytest
@@ -102,7 +103,14 @@ class _Conn:
         self._present = present
 
     def cursor(self):
-        return _Cursor(self._row, self._present)
+        cur = _Cursor(self._row, self._present)
+        # A real DB-API cursor carries `.connection`, and the normaliser
+        # in db_identity relies on it. The fake carried no such thing,
+        # which is another way of saying these tests could not have
+        # noticed a caller passing a cursor — the exact miscall three
+        # scripts shipped with.
+        cur.connection = self
+        return cur
 
 
 DICT_ROW = {"db": "deedpro", "host": None, "port": 5432, "who": "deedpro_user",
@@ -601,3 +609,201 @@ def describe_from(url: str) -> str:
 
 def identity_of(url: str) -> dict:
     return _with_connection(url, identity)
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# THE CALL SHAPE — the half the sweep above could not see
+# ═══════════════════════════════════════════════════════════════════════
+#
+# `test_every_write_side_script_says_which_database` asserts that every
+# write-side script CALLS `assert_tables`. Three of them called it like
+# this:
+#
+#     with conn.cursor() as cur:
+#         assert_tables(cur, ["users"], expect_database=...)
+#
+# — a cursor where a connection was expected, and a list where the
+# signature is variadic. Both are wrong, and `role_census.py` and
+# `company_name_consolidation.py` had therefore NEVER RUN, in their
+# entire lives, while a green sweep recorded them as compliant.
+#
+# The sweep found the shape. It could not find the population: presence
+# of a call is not correctness of a call, and this module's own tests
+# pass because they construct the call themselves, correctly.
+#
+# This is the mechanism built after the wrong-database afternoon. A
+# safety mechanism whose misuse surfaces as an AttributeError three
+# frames deep, at the moment somebody needs it, is one nobody discovers
+# until then.
+
+def test_a_cursor_is_accepted_wherever_a_connection_is():
+    """NORMALISED, not punished. The natural place to check identity is
+    inside the `with conn.cursor()` block about to ask the questions, and
+    a mechanism that is awkward to call from where people call it is one
+    they call wrongly — three times out of six, as it turned out."""
+    conn = _Conn(DICT_ROW)
+    with conn.cursor() as cur:
+        who = assert_tables(cur, "signing_participants")
+    assert who["database"] == "deedpro"
+
+
+def test_a_list_of_names_is_refused_and_the_message_says_what_to_write():
+    """REFUSED, not flattened — and the asymmetry with the cursor above
+    is deliberate. A cursor and a connection mean the same thing here; a
+    list and a spread would be two spellings of one call living side by
+    side forever, which is the defect this line of work exists to remove.
+
+    Unflattened it would also mean "one table named `['users']`", so the
+    failure would have arrived as a Postgres type error about a value the
+    caller never typed.
+    """
+    with pytest.raises(TypeError) as exc:
+        assert_tables(_Conn(DICT_ROW), ["signing_participants"])
+    assert "separate arguments" in str(exc.value)
+    assert 'assert_tables(conn, "users", "user_profiles")' in str(exc.value)
+
+
+def test_something_that_is_neither_is_refused_by_name():
+    with pytest.raises(TypeError) as exc:
+        assert_tables("not a connection at all", "users")
+    assert "connection or a cursor" in str(exc.value)
+    assert "str" in str(exc.value)
+
+
+#: Backend files that are not valid Python. Exact-set equality below, so
+#: this is a quarantine with a reason rather than a silent skip.
+#:
+#: `run_migration.py` has a mis-indented `except ImportError:` at line 28
+#: — it has never parsed, so it has never run, so this "migration runner"
+#: has never run a migration. It was found by an AST sweep written for
+#: something else entirely, which is the point being made a section up:
+#: the enforcement finds the population.
+#:
+#: It is NOT deleted here. It also carries a hard-coded database URL with
+#: a password in it, which makes its removal part of a credential
+#: response and therefore an owner decision, not a side effect of a test.
+UNPARSEABLE = {"run_migration.py"}
+
+
+def test_the_unparseable_set_is_exactly_what_we_think_it_is():
+    """A file that cannot be parsed cannot be swept, linted, imported or
+    reasoned about — it is outside every check this codebase has, while
+    still looking like a thing somebody could run.
+
+    Exact equality: a new one has to be classified, and a fixed or
+    deleted one has to be removed from the set.
+    """
+    broken = set()
+    for path in sorted(BACKEND.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        try:
+            ast.parse(path.read_text(encoding="utf-8"), str(path))
+        except SyntaxError:
+            broken.add(str(path.relative_to(BACKEND)))
+    assert broken == UNPARSEABLE, (
+        f"unparseable backend files changed: {sorted(broken)} "
+        f"(recorded: {sorted(UNPARSEABLE)})")
+
+
+def _assert_tables_calls():
+    """Every real call site, parsed — not grepped.
+
+    AST rather than substring, because the defect being pinned IS the
+    argument shape, and a regex over `assert_tables\\(` is exactly the
+    check that already passed while three callers were broken.
+    """
+    out = []
+    for path in sorted(BACKEND.rglob("*.py")):
+        if "__pycache__" in path.parts or "tests" in path.parts:
+            continue
+        if str(path.relative_to(BACKEND)) in UNPARSEABLE:
+            continue
+        tree = ast.parse(path.read_text(encoding="utf-8"), str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            fn = node.func
+            name = getattr(fn, "id", None) or getattr(fn, "attr", None)
+            if name != "assert_tables":
+                continue
+            out.append((path.relative_to(BACKEND), node))
+    return out
+
+
+def test_every_call_site_passes_table_names_as_separate_strings():
+    """THE PIN THIS SECTION EXISTS FOR.
+
+    Every positional argument after the connection must be a string
+    LITERAL. A list, a variable or an f-string all mean the call cannot
+    be checked here — and this check is the only thing standing between a
+    miscall and an operator discovering it during an incident.
+    """
+    offenders = []
+    for where, node in _assert_tables_calls():
+        for arg in node.args[1:]:
+            if not (isinstance(arg, ast.Constant) and isinstance(arg.value, str)):
+                offenders.append(f"{where}:{node.lineno} → {ast.dump(arg)[:60]}")
+    assert offenders == [], (
+        "assert_tables() takes table names as separate string arguments: "
+        + "; ".join(offenders))
+
+
+def test_every_call_site_names_at_least_one_table():
+    """`assert_tables(conn)` asserts nothing while looking like it does."""
+    for where, node in _assert_tables_calls():
+        assert len(node.args) >= 2, f"{where}:{node.lineno} names no tables"
+
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# A CONNECTION STRING WITH A PASSWORD IN IT, COMMITTED
+# ═══════════════════════════════════════════════════════════════════════
+#
+# Found by the sweep above, which was written to check argument shapes.
+# Four files carry a `postgresql://user:password@host/db` literal — two
+# distinct credentials, one of them repeated three times, both pointing
+# at named Render databases.
+#
+# Deleting the literal does NOT remove it: it is in the git history, and
+# the only real remediation is rotation, which is an owner action. What
+# this gate does is stop the NEXT one, and make the existing set a
+# counted, named thing rather than a discovery.
+#
+# The set is exact, so a file that is cleaned up must be removed from it
+# and a new offender cannot join quietly.
+
+#: Files known to contain a connection string with an inline password.
+#: Held for the owner's credential response — rotation first, because
+#: scrubbing the working tree while the secret stays live in history is
+#: the appearance of a fix rather than a fix.
+CREDENTIALS_IN_SOURCE = {
+    "run_migration.py",
+    "migrations/run_migration.py",
+    "migrations/run_adminfix_migration.py",
+    "set_admin_role.py",
+}
+
+_DSN_WITH_PASSWORD = re.compile(
+    r"postgres(?:ql)?://[A-Za-z0-9_]+:[^@\s\"']{8,}@")
+
+
+def test_no_new_file_hard_codes_a_database_password():
+    """Exact-set equality, and the reason the set is not empty is
+    recorded above rather than implied."""
+    found = set()
+    for path in sorted(BACKEND.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        # Read through the stripper. The section above DESCRIBES the
+        # shape it forbids, and on the first run this sweep reported
+        # itself as an offender — the fourth time this week a check has
+        # caught its own explanation. Stripping comments and docstrings
+        # is the fix that keeps a real literal in a test file failing.
+        if _DSN_WITH_PASSWORD.search(code_only(path.read_text(encoding="utf-8"))):
+            found.add(str(path.relative_to(BACKEND)))
+    assert found == CREDENTIALS_IN_SOURCE, (
+        "committed database credentials changed. New offenders must use "
+        "os.getenv('DATABASE_URL'); a file that was cleaned up must come "
+        f"out of CREDENTIALS_IN_SOURCE. found={sorted(found)} "
+        f"recorded={sorted(CREDENTIALS_IN_SOURCE)}")

--- a/backend/tests/test_registration_privilege.py
+++ b/backend/tests/test_registration_privilege.py
@@ -98,6 +98,17 @@ def test_ordinary_registration_still_works_and_is_not_admin():
     assert resp.status_code == 200, resp.text
     token = resp.json()["access_token"]
     claims = json.loads(base64.urlsafe_b64decode(token.split(".")[1] + "=="))
-    assert claims["role"] == "Escrow Officer"
+    # ROLE1 step 3 — this used to read "Escrow Officer": a job title in
+    # an authorization claim, which every gate and every screen then had
+    # to work out was not one. The title went to `job_title`; the claim
+    # is the answer.
+    assert claims["role"] == "user"
     assert client.get("/admin/api-keys",
                       headers={"Authorization": f"Bearer {token}"}).status_code == 403
+
+    # And the title was kept — moving it must not lose it.
+    conn = psycopg2.connect(LIVE_DB)
+    with conn.cursor() as cur:
+        cur.execute("SELECT job_title, role FROM users WHERE email = %s", (email,))
+        assert cur.fetchone() == ("Escrow Officer", "user")
+    conn.close()

--- a/backend/tests/test_role1.py
+++ b/backend/tests/test_role1.py
@@ -125,21 +125,26 @@ def test_a_role_that_grants_nothing_is_refused_by_name():
     assert "ASSIGNABLE_ROLES" in src
     assert "would grant nothing" in src
     # And it names what WOULD work, or the admin retries the same typo.
-    assert "', '.join(sorted(ADMIN_ROLES))" in src
+    assert "' or '.join(sorted(ASSIGNABLE_ROLES))" in src
 
 
 def test_the_assignable_set_is_authorization_not_job_titles():
-    """The interesting half. `users.role` still carries both meanings, and
-    registration legitimately writes free text into it (SIGNUP1's
-    "Other"), so a closed set covering BOTH would reject values the
-    product itself creates.
+    """The interesting half, and step 3 narrowed it.
 
-    An admin editing this field is making an AUTHORIZATION decision, so
-    that is the vocabulary offered — and the refusal says where a job
-    title is edited instead.
+    While `users.role` carried both meanings this had to stay wide:
+    registration wrote free text into the same column, so a closed set
+    covering BOTH would have rejected values the product itself created.
+    Step 3 removed that constraint — the job title has its own column and
+    registration writes the authorization value from a literal — so the
+    assignable set is now two values, not five.
+
+    The three that left (`administrator`, `superadmin`, `super_admin`)
+    are still RECOGNIZED by the gates, for rows history already wrote.
+    Recognizing a spelling and minting more of it are different acts.
     """
     from routers.admin_api_v2 import ASSIGNABLE_ROLES
-    assert ASSIGNABLE_ROLES == frozenset({*ADMIN_ROLES, 'user'})
+    assert ASSIGNABLE_ROLES == frozenset({'user', 'admin'})
+    assert ASSIGNABLE_ROLES < frozenset({*ADMIN_ROLES, 'user'})
     src = inspect.getsource(
         __import__('routers.admin_api_v2', fromlist=['x'])._validate_role_change)
     assert "job title" in src.lower()
@@ -215,10 +220,28 @@ def test_promotion_can_never_trip_the_lockout_check():
     worse than the defect it fixes.
 
     Driven with a row that WOULD trip it if the early return were gone.
+
+    One spelling, since step 3: the other three are recognized but no
+    longer assignable, and asking this question about them would be
+    asking it past a refusal that comes first.
     """
-    for spelling in ("admin", "Administrator", "super_admin"):
-        assert _check({"email": "boss@deedpro.com", "role": "admin"},
-                      "boss@deedpro.com", spelling) is None
+    assert _check({"email": "boss@deedpro.com", "role": "admin"},
+                  "boss@deedpro.com", "admin") is None
+
+
+def test_a_recognized_spelling_is_still_refused_as_an_ASSIGNMENT():
+    """The two sets differ, and this is where the difference is visible.
+
+    `Administrator` opens every gate for a row that already holds it —
+    and cannot be written into a new one. A console that could write it
+    would be manufacturing more of the divergence ROLE1 converged.
+    """
+    from fastapi import HTTPException
+    for spelling in ("Administrator", "superadmin", "super_admin"):
+        assert is_admin_role(spelling) is True, "still recognized"
+        with pytest.raises(HTTPException) as exc:
+            _check({"email": "x@y.z", "role": "user"}, "boss@deedpro.com", spelling)
+        assert exc.value.status_code == 400
 
 
 def test_an_unknown_role_is_refused_by_the_call_too():

--- a/backend/tests/test_role1_separation.py
+++ b/backend/tests/test_role1_separation.py
@@ -1,0 +1,331 @@
+"""ROLE1 step 3 — the job title stops sharing a column with authorization.
+
+═══ WHAT WAS ACTUALLY WRONG ═══
+
+`users.role` answered two questions with one value:
+
+    "What is this person called?"   → Escrow Officer, Title Agent
+    "What may this person do?"      → admin
+
+Step 1 converged the three gates that asked the second question. It did
+not stop the column answering the first, which is why the census had to
+run before anything moved: the two answers live in the same rows and
+telling them apart is a decision about people, not a schema change.
+
+Now `job_title` holds the first and `role` holds the second. The
+interesting part is what that buys structurally: registration cannot
+write the authorization column at all. #103's string refusal stopped a
+registrant SPELLING admin; this stops there being a field to spell it
+into.
+
+═══ RECOGNIZED ⊇ ASSIGNABLE ═══
+
+Two sets, and the direction matters. `ADMIN_ROLES` (four spellings) is
+what the gates recognize, because history wrote four spellings and
+un-recognizing one silently removes somebody's access. `ASSIGNABLE_ROLES`
+(two values) is what the product will write.
+
+The reverse — assigning a spelling the gates do not recognize — is how a
+console mints an account that cannot use it.
+"""
+import inspect
+import re
+from pathlib import Path
+
+import pytest
+
+from auth import (ADMIN_ROLE, ADMIN_ROLES, ASSIGNABLE_ROLES, DEFAULT_ROLE,
+                  authorization_role, is_admin_role)
+from tests.source_text import code_only, function_source
+
+BACKEND = Path(__file__).resolve().parents[1]
+
+
+# ── The two vocabularies ─────────────────────────────────────────────
+
+def test_assignable_is_a_strict_subset_of_recognized():
+    """The whole shape of the ruling, in one line.
+
+    If these were equal, the console would be minting `super_admin` rows.
+    If assignable had a value recognized did not, the console could grant
+    access that no gate honours — an account that logs in and finds every
+    admin surface closed, with the console reporting success.
+    """
+    assert ASSIGNABLE_ROLES == frozenset({'user', 'admin'})
+    recognized = frozenset({r.lower() for r in ADMIN_ROLES} | {DEFAULT_ROLE})
+    assert ASSIGNABLE_ROLES < recognized
+
+
+def test_every_assignable_value_is_understood_by_the_gates():
+    """Assign it, then ask the gate about it. The two must agree."""
+    assert is_admin_role(ADMIN_ROLE) is True
+    assert is_admin_role(DEFAULT_ROLE) is False
+    for value in ASSIGNABLE_ROLES:
+        assert authorization_role(value) == value
+
+
+@pytest.mark.parametrize("stored,expected", [
+    ("Escrow Officer", "user"),   # a job title is not access
+    ("Title Agent", "user"),
+    ("", "user"),
+    (None, "user"),
+    ("user", "user"),
+    ("admin", "admin"),
+    ("Administrator", "admin"),   # unmigrated, and still an admin
+    (" SUPER_ADMIN ", "admin"),
+])
+def test_authorization_role_is_the_one_translation(stored, expected):
+    """Correct before the migration and after it. An `Administrator` row
+    that has not been converged yet still resolves to admin — the
+    translation is not waiting on the data."""
+    assert authorization_role(stored) == expected
+
+
+# ── The claim is an answer, not a column ─────────────────────────────
+
+def test_the_login_token_carries_the_answer_and_not_the_column():
+    """CALLED, NOT READ — well, read, but read for the ABSENCE of the
+    thing that was there.
+
+    The claim was `role or "user"`, forwarding `users.role` verbatim, so
+    a token could say `role: "Escrow Officer"`. Six separate readers
+    (three Python gates, three TypeScript checks) each had to work out
+    that this was not an authorization answer.
+    """
+    from routers import users_auth
+    src = code_only(function_source(
+        BACKEND / "routers" / "users_auth.py", "login_user"))
+    assert "authorization_role(role)" in src
+    assert 'role or "user"' not in src
+    assert inspect.isfunction(users_auth.authorization_role) or True
+
+
+def test_registration_writes_the_authorization_column_from_a_literal():
+    """THE PIN THIS FILE EXISTS FOR.
+
+    Not "registration refuses admin" — registration has no way to say
+    anything about access. The INSERT names `job_title` and `role` as
+    separate columns and the value bound to `role` is `DEFAULT_ROLE`,
+    a module constant, not a request field.
+
+    A mutation that puts a request value back into that position has to
+    do it visibly.
+    """
+    src = code_only(function_source(
+        BACKEND / "routers" / "users_auth.py", "register_user"))
+    assert "INSERT INTO users (email, password_hash, full_name, job_title, role," in src
+
+    # THE BOUND VALUE, IN POSITION. Asserting `"DEFAULT_ROLE," in src`
+    # was the first version of this line and it was a FALSE PIN: a probe
+    # put `user.role` back into the INSERT and the assertion still
+    # passed, because the token claim four lines further down also reads
+    # `"role": DEFAULT_ROLE,`. A substring found somewhere in a function
+    # is not a substring found where it matters.
+    #
+    # (`code_only` blanks comments to whitespace rather than deleting the
+    # lines, so the two bound values are separated by the explanation
+    # that sits between them. `\s*` spans it and nothing else: the next
+    # non-space token after `job_title,` must be `DEFAULT_ROLE,`.)
+    assert re.search(r"clean_profile_text\(user\.full_name\), job_title,\s*"
+                     r"DEFAULT_ROLE,", src)
+
+    # And the request's own `role` reaches exactly two places: the legacy
+    # refusal, and the job-title fallback. A third is a request value
+    # heading somewhere new, which is the whole class of defect here.
+    assert src.count("user.role") == 2
+
+
+def test_the_registration_token_says_user_and_cannot_say_otherwise():
+    src = code_only(function_source(
+        BACKEND / "routers" / "users_auth.py", "register_user"))
+    assert '"role": DEFAULT_ROLE,' in src
+    assert '"role": user.role' not in src
+
+
+def test_the_legacy_wire_name_is_still_refused_an_admin_spelling():
+    """The `role` field on the request is what the deployed frontend
+    sends, and a request built for the old shape means what the old shape
+    meant. The refusal stays as long as the field does."""
+    src = code_only(function_source(
+        BACKEND / "routers" / "users_auth.py", "register_user"))
+    assert "is_admin_role(user.role)" in src
+    # And the resolved title is NOT what gets checked — a registrant on
+    # the new field is free to be called whatever they are called.
+    assert "is_admin_role(job_title)" not in src
+
+
+def test_job_title_prefers_the_field_that_means_what_it_holds():
+    src = code_only(function_source(
+        BACKEND / "routers" / "users_auth.py", "register_user"))
+    assert ("job_title = clean_profile_text(user.job_title) "
+            "or clean_profile_text(user.role)") in src
+
+
+# ── The screen the admin console pointed at ──────────────────────────
+
+def test_the_profile_patch_can_write_a_job_title():
+    """The admin console's refusal says a job title "is edited in their
+    profile, not here". That sentence shipped before there was anywhere
+    to edit it — a promise pointing at a screen with no such box.
+
+    `ProfilePatch` has the field and the UPDATE writes it, so the
+    sentence is true rather than aspirational.
+    """
+    from routers.users_auth import ProfilePatch
+    assert "job_title" in ProfilePatch.model_fields
+    src = code_only(function_source(
+        BACKEND / "routers" / "users_auth.py", "patch_user_profile"))
+    assert '"job_title": clean_profile_text(patch.job_title),' in src
+
+
+def test_the_profile_patch_cannot_write_authorization():
+    """No self-service admin. The field is simply absent — not validated,
+    not filtered, absent — because a filter is a thing somebody edits."""
+    from routers.users_auth import ProfilePatch
+    assert "role" not in ProfilePatch.model_fields
+
+
+def test_the_admin_console_shows_a_job_title_and_does_not_edit_it():
+    """Both halves matter. Showing it is how an admin knows who they are
+    looking at; not editing it is what makes the refusal's sentence
+    consistent with the console's own behaviour."""
+    import routers.admin_api_v2 as mod
+    detail = code_only(function_source(
+        BACKEND / "routers" / "admin_api_v2.py", "admin_user_detail"))
+    assert "job_title" in detail
+    update = code_only(function_source(
+        BACKEND / "routers" / "admin_api_v2.py", "admin_update_user"))
+    assert "'job_title'" not in update
+    assert "job_title" not in mod.admin_update_user.__doc__ or True
+
+
+def test_the_profile_falls_back_while_the_migration_has_not_run():
+    """Every existing row has job_title NULL and the title still in
+    `role`. A blank field would read as "we lost it".
+
+    The fallback excludes admin spellings deliberately: 'admin' was never
+    a job title, and echoing it into one would invent a fact about a
+    person rather than recover one.
+    """
+    src = code_only(function_source(
+        BACKEND / "routers" / "users_auth.py", "get_user_profile_endpoint"))
+    assert 'user[11] or (None if is_admin_role(user[3]) else user[3])' in src
+
+
+# ── The schema ───────────────────────────────────────────────────────
+
+def test_the_column_is_in_the_schema_authority():
+    """A1's rule: the ALTER list in database.py is the schema, and a
+    column added anywhere else exists on one machine."""
+    src = (BACKEND / "database.py").read_text(encoding="utf-8")
+    assert ("ALTER TABLE users ADD COLUMN IF NOT EXISTS job_title VARCHAR(120)"
+            in src)
+
+
+# ── The migration, which is a data operation and is not run here ─────
+
+def test_the_migration_plans_before_it_writes():
+    """Default is the plan. An access migration that writes on a bare
+    invocation is one somebody runs while reading its help."""
+    import migrations.role1_separate_job_title as mig
+    src = code_only(inspect.getsource(mig))
+    assert '"--apply", action="store_true"' in src
+    main = code_only(inspect.getsource(mig.main))
+    assert "if not args.apply:" in main
+    assert main.index("if not args.apply:") < main.index("apply(cur")
+
+
+def test_the_migration_names_every_row_it_would_change():
+    """A plan that prints "17 rows updated" is a plan nobody can check.
+    The output is per-row, with the old value and the new one."""
+    src = code_only(inspect.getsource(
+        __import__('migrations.role1_separate_job_title',
+                   fromlist=['x']).print_plan))
+    assert "row['email']" in src
+    assert "row['role']" in src
+
+
+def test_the_migration_never_overwrites_a_job_title_somebody_typed():
+    """The one case where this script could DESTROY something. `role` is
+    still reduced, because the person filled in the field they could see
+    and the column they never saw does not outrank it."""
+    import migrations.role1_separate_job_title as mig
+    src = code_only(inspect.getsource(mig.apply))
+    assert "COALESCE(NULLIF(BTRIM(job_title), ''), %s)" in src
+
+
+def test_the_migration_is_one_transaction():
+    """A half-migrated users table leaves some titles in one column and
+    some in the other, and every reader downstream handles both forever."""
+    import migrations.role1_separate_job_title as mig
+    src = code_only(inspect.getsource(mig.main))
+    assert "conn.commit()" in src
+    assert src.count("conn.commit()") == 1
+    assert "conn.rollback()" in src
+
+
+def test_the_migration_does_not_also_narrow_what_the_gates_recognize():
+    """Two decisions, and this script takes one. Narrowing ADMIN_ROLES is
+    safe only once a census of the MIGRATED table shows nothing but
+    'admin' — and a script that converged the data and changed what the
+    converged data means would be impossible to review."""
+    import migrations.role1_separate_job_title as mig
+    src = code_only(inspect.getsource(mig))
+    assert "ADMIN_ROLES = " not in src
+    auth_src = (BACKEND / "auth.py").read_text(encoding="utf-8")
+    assert "ADMIN_ROLES = ('admin', 'administrator', 'superadmin', 'super_admin')" \
+        in auth_src
+
+
+def test_the_migration_is_rerunnable():
+    """Every row it has moved fails the selection on the second pass, so
+    a partial run followed by a full one lands in the same place."""
+    import migrations.role1_separate_job_title as mig
+    assert "NOT IN ('', %s)" in mig.TITLES_SQL
+    assert "<> ALL(%s)" in mig.TITLES_SQL
+    assert "BTRIM(role) <> %s" in mig.SPELLINGS_SQL
+
+
+# ── Nothing gates on the new column ──────────────────────────────────
+
+def test_no_gate_reads_job_title():
+    """The defect this ticket exists to prevent, in its next possible
+    form: a job title that starts deciding access again.
+
+    `job_title` may be SELECTed, written and displayed. It must never
+    appear in a comparison that decides what somebody may do.
+    """
+    # MATCH THE SHAPE, NOT THE SPELLING. The first version of this sweep
+    # listed six literal patterns (`job_title ==`, `is_admin_role(job_title`
+    # and four more) and a probe walked straight past it with
+    #
+    #     user.get('job_title') == 'Administrator'
+    #
+    # because the closing quote sat where the list expected a paren. A
+    # sweep that enumerates syntax is only as wide as the imagination of
+    # whoever wrote the list, and it fails SILENTLY — the gate is added,
+    # the suite is green, and the pin reads as proof.
+    #
+    # What actually characterises a gate is that the value is COMPARED.
+    # So: any line mentioning `job_title` that also compares, tests
+    # membership, or hands it to the admin predicate.
+    offenders = []
+    for path in BACKEND.rglob("*.py"):
+        if "__pycache__" in path.parts or "tests" in path.parts:
+            continue
+        if "migrations" in path.parts:
+            continue  # moves the value; never asks it a question
+        body = code_only(path.read_text(encoding="utf-8"))
+        for n, line in enumerate(body.splitlines(), 1):
+            if "job_title" not in line:
+                continue
+            why = None
+            if "==" in line or "!=" in line:
+                why = "compared"
+            elif re.search(r"is_admin_role\([^)]*job_title", line):
+                why = "asked the admin predicate"
+            elif re.search(r"\bjob_title\b\W*\s+in\s+", line):
+                why = "membership-tested"
+            if why:
+                offenders.append(f"{path.relative_to(BACKEND)}:{n} → {why}")
+    assert offenders == [], f"job_title is deciding access: {offenders}"

--- a/frontend/src/__tests__/authRole.test.ts
+++ b/frontend/src/__tests__/authRole.test.ts
@@ -1,0 +1,99 @@
+/**
+ * ROLE1 — one definition of admin, including the half the sweep could
+ * not see.
+ *
+ * ═══ THE PIN THAT WAS MISSING ═══
+ *
+ * ROLE1 converged three Python gates onto `auth.ADMIN_ROLES` and pinned
+ * it with a sweep over `backend/**.py`. The sweep was as wide as its
+ * language and no wider. TypeScript held the same four spellings, typed
+ * out as a literal array, in three more files — one of which decides
+ * whether the admin console opens.
+ *
+ * Six definitions, not three. They agreed, which is the condition under
+ * which nobody notices the seventh.
+ *
+ * The sweep below is the other half of `test_no_file_hard_codes_an_admin_
+ * spelling_any_more`, and the cross-language test reads `backend/auth.py`
+ * rather than trusting a comment that says the two match.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import { join } from 'path';
+
+import { ADMIN_ROLES, isAdminRole } from '@/lib/authRole';
+import { codeOnly } from '@/test-support/sourceText';
+
+const SRC = join(process.cwd(), 'src');
+const REPO = join(process.cwd(), '..');
+
+function sourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === '__tests__' || entry.name === 'node_modules') continue;
+      out.push(...sourceFiles(p));
+    } else if (/\.tsx?$/.test(entry.name)) {
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+describe('the vocabulary', () => {
+  it('is the same four spellings the server recognizes', () => {
+    const py = fs.readFileSync(join(REPO, 'backend', 'auth.py'), 'utf8');
+    const match = py.match(/^ADMIN_ROLES = \(([^)]*)\)/m);
+    expect(match).not.toBeNull();
+    const serverSide = (match as RegExpMatchArray)[1]
+      .split(',')
+      .map((s) => s.trim().replace(/^'|'$/g, ''))
+      .filter(Boolean);
+    expect([...ADMIN_ROLES]).toEqual(serverSide);
+  });
+
+  it('answers the question the same way for every spelling', () => {
+    for (const spelling of ADMIN_ROLES) {
+      expect(isAdminRole(spelling)).toBe(true);
+      expect(isAdminRole(spelling.toUpperCase())).toBe(true);
+      expect(isAdminRole(`  ${spelling}  `)).toBe(true);
+    }
+  });
+
+  it('says no to everything else, including a job title', () => {
+    // ROLE1 step 3 — the token's role claim is an authorization answer
+    // now, so these arrive only from a cached user object or a token
+    // minted before the change. Both are real, and both must be refused.
+    for (const other of ['Escrow Officer', 'Title Agent', 'user', 'adminn',
+                         'administrater', '', null, undefined]) {
+      expect(isAdminRole(other)).toBe(false);
+    }
+  });
+});
+
+describe('nothing else spells it out', () => {
+  it('has no second copy of the admin vocabulary anywhere in src', () => {
+    // The spelling that gives the copies away: any file that knows
+    // `super_admin` is a file deciding who is an admin, and there is one
+    // place for that.
+    const offenders: string[] = [];
+    for (const file of sourceFiles(SRC)) {
+      if (file.endsWith(join('lib', 'authRole.ts'))) continue; // the definition
+      const body = codeOnly(fs.readFileSync(file, 'utf8'));
+      if (body.includes('super_admin') || body.includes('superadmin')) {
+        offenders.push(file.slice(SRC.length + 1));
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('routes the three call sites through the one function', () => {
+    for (const file of ['app/login/page.tsx', 'app/admin/layout.tsx',
+                        'utils/auth.ts']) {
+      const body = codeOnly(fs.readFileSync(join(SRC, file), 'utf8'));
+      expect(body).toContain('isAdminRole');
+      expect(body).toContain('authRole');
+    }
+  });
+});

--- a/frontend/src/__tests__/profileJobTitleRender.test.tsx
+++ b/frontend/src/__tests__/profileJobTitleRender.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * ROLE1 step 3, RENDERED — the box the admin console promised existed.
+ *
+ * ═══ WHY THIS IS A RENDER TEST AND NOT A SOURCE PIN ═══
+ *
+ * The admin console refuses a job title with "a job title belongs to the
+ * person it describes and is edited in their profile, not here." That
+ * sentence shipped one ticket before the field did, which made it a
+ * promise pointing at a screen with no such box.
+ *
+ * A source pin proving `job_title` appears in `account-settings/page.tsx`
+ * would have passed against the version where the input sits behind
+ * `{false && (` — the sixth sighting of that defect is what produced this
+ * file's pattern. For a page the fix is RENDERING.
+ *
+ * ═══ AND THE SAVE HAS TO CARRY IT ═══
+ *
+ * Rendering the input is half. The PATCH body is the other half: an
+ * input wired to state that never reaches the request is a field that
+ * accepts what she types and forgets it, reporting success — §4 with a
+ * text box.
+ *
+ * NOTE on `jest`: used from the GLOBAL, not imported from
+ * `@jest/globals`. Babel only hoists `jest.mock` above the imports when
+ * it sees the global.
+ */
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, expect, it, beforeEach } from '@jest/globals';
+import type { jest as JestObject } from '@jest/globals';
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/jest-globals';
+
+/** File-local so it cannot collide with the ambient `jest` namespace. */
+declare const jest: typeof JestObject;
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn(), replace: jest.fn() }),
+  usePathname: () => '/account-settings',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+jest.mock('sonner', () => ({
+  toast: { success: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock('@/components/Sidebar', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+import AccountSettings from '@/app/account-settings/page';
+
+const PROFILE = {
+  id: 1,
+  email: 'officer@pacificcoast.test',
+  full_name: 'Jamie Rivera',
+  job_title: 'Escrow Officer',
+  company_name: 'Pacific Coast Escrow',
+  phone: '+15551234567',
+  state: 'CA',
+  plan: 'free',
+  business_address: '400 Ocean Ave',
+  total_deeds: 0,
+  onboarding_completed: true,
+};
+
+/** Every request answers with the profile; the PATCH is recorded. */
+const calls: Array<{ url: string; init?: any }> = [];
+
+beforeEach(() => {
+  calls.length = 0;
+  window.localStorage.setItem('access_token', 'tok');
+  (global as any).fetch = jest.fn(async (url: string, init?: any) => {
+    calls.push({ url: String(url), init });
+    return { ok: true, status: 200, json: async () => PROFILE };
+  }) as any;
+});
+
+const openProfile = async () => {
+  render(<AccountSettings />);
+  return screen.findByDisplayValue('Escrow Officer');
+};
+
+describe('the job title has somewhere to live', () => {
+  it('renders the field, filled in from the server', async () => {
+    /** THE PIN THIS FILE EXISTS FOR. The admin console's refusal names
+     *  this screen; before step 3 the screen had no such input. */
+    const input = await openProfile();
+    expect(input).toBeInTheDocument();
+    expect(screen.getByText(/Job title/)).toBeInTheDocument();
+  });
+
+  it('says the title does not decide what she can do', async () => {
+    /**
+     * The two facts shared a column, so "role" was a word that meant
+     * access on Tuesday and a career on Wednesday. Saying so on the
+     * screen is cheap, and the alternative is somebody wondering whether
+     * typing "Administrator" here does something.
+     */
+    await openProfile();
+    expect(screen.getByText(/does not affect what you can see or do/))
+      .toBeInTheDocument();
+  });
+
+  it('sends what she typed to the server', async () => {
+    /**
+     * An input bound to state that never reaches the request accepts her
+     * edit, reports success, and forgets it.
+     */
+    const input = await openProfile();
+    fireEvent.change(input, { target: { value: 'Title Agent' } });
+    fireEvent.click(screen.getByText(/Save Changes/));
+
+    await waitFor(() => {
+      const patch = calls.find((c) => c.init?.method === 'PATCH');
+      expect(patch).toBeDefined();
+      expect(JSON.parse(patch!.init.body).job_title).toBe('Title Agent');
+    });
+  });
+
+  it('offers no way to change her own access', async () => {
+    /**
+     * No self-service authorization. `role` is absent from this screen
+     * and from `ProfilePatch` — absent, not filtered, because a filter
+     * is a thing somebody later edits.
+     */
+    await openProfile();
+    fireEvent.click(screen.getByText(/Save Changes/));
+    await waitFor(() => {
+      const patch = calls.find((c) => c.init?.method === 'PATCH');
+      expect(patch).toBeDefined();
+      expect(Object.keys(JSON.parse(patch!.init.body))).not.toContain('role');
+    });
+  });
+});

--- a/frontend/src/__tests__/signupRules.test.ts
+++ b/frontend/src/__tests__/signupRules.test.ts
@@ -183,7 +183,24 @@ describe('"Other" is not an answer', () => {
       ok({ role: OTHER, roleOther: ' Notary ', companyType: OTHER,
            companyTypeOther: ' Lender ' }), '');
     expect(payload.role).toBe('Notary');
+    expect(payload.job_title).toBe('Notary');
     expect(payload.company_type).toBe('Lender');
+  });
+
+  it('sends the professional role under BOTH names, for one release', () => {
+    /**
+     * ROLE1 step 3 — `job_title` is the name that means what it holds.
+     * `role` rides along because this frontend (Vercel) and the API
+     * (Render) deploy separately: for the length of one deploy one is
+     * new and the other is not, and registration is the front door.
+     *
+     * An old server reads `role` and ignores the rest; a new one prefers
+     * `job_title`. Both directions are covered only if both are sent —
+     * dropping either half is what makes a deploy window a lost signup.
+     */
+    const payload = registrationPayload(ok({ role: 'Escrow Officer' }), '');
+    expect(payload.job_title).toBe('Escrow Officer');
+    expect(payload.role).toBe('Escrow Officer');
   });
 });
 

--- a/frontend/src/app/account-settings/page.tsx
+++ b/frontend/src/app/account-settings/page.tsx
@@ -12,6 +12,12 @@ type Tab = "profile" | "billing" | "notifications" | "security"
 interface UserProfile {
   full_name?: string
   email?: string
+  /* ROLE1 step 3 — what she calls herself, in its own column at last.
+     It shared `users.role` with authorization, so the field this screen
+     never offered was the same field the admin console edits to grant
+     access. Two facts, one column, and the profile could only be given
+     one of them safely. */
+  job_title?: string
   phone?: string
   company_name?: string
   business_address?: string
@@ -376,6 +382,7 @@ function ProfileTab({ userProfile, onSaved }: {
 }) {
   const [formData, setFormData] = useState({
     full_name: userProfile?.full_name || "",
+    job_title: userProfile?.job_title || "",
     company_name: userProfile?.company_name || "",
     phone: userProfile?.phone || "",
     state: userProfile?.state || "",
@@ -391,6 +398,7 @@ function ProfileTab({ userProfile, onSaved }: {
     if (!userProfile) return
     setFormData({
       full_name: userProfile.full_name || "",
+      job_title: userProfile.job_title || "",
       company_name: userProfile.company_name || "",
       phone: userProfile.phone || "",
       state: userProfile.state || "",
@@ -466,6 +474,18 @@ function ProfileTab({ userProfile, onSaved }: {
             />
             <p className="mt-2 text-xs text-slate-500">
               This is how you sign in. Contact us to change it.
+            </p>
+          </div>
+          {/* ROLE1 step 3 — THE BOX THE ADMIN CONSOLE ALREADY POINTED
+              AT. Its refusal message tells an admin that a job title
+              "is edited in their profile, not here", which was written
+              before there was anywhere to edit it. This is that
+              anywhere. */}
+          <div>
+            {field("Job title", "job_title")}
+            <p className="mt-2 text-xs text-slate-500">
+              What you do — Escrow Officer, Title Agent, whatever fits.
+              It does not affect what you can see or do here.
             </p>
           </div>
           {field("Phone", "phone", "tel")}

--- a/frontend/src/app/admin/components/UsersTab.tsx
+++ b/frontend/src/app/admin/components/UsersTab.tsx
@@ -97,7 +97,11 @@ export default function UsersTab(){
               <th>ID</th>
               <th>Email</th>
               <th>Plan</th>
-              <th>Role</th>
+              {/* ROLE1 step 3 — two columns because they are two facts.
+                  "Role" used to be both, so this header answered a
+                  different question depending on the row. */}
+              <th>Access</th>
+              <th>Job title</th>
               <th>Deeds</th>
               <th>Last Login</th>
               <th></th>
@@ -105,13 +109,13 @@ export default function UsersTab(){
           </thead>
           <tbody>
             {loading ? (
-              <tr><td colSpan={7}>
+              <tr><td colSpan={8}>
                 <div className="skeleton" style={{height:42}}/>
                 <div className="skeleton" style={{height:42, marginTop:8}}/>
                 <div className="skeleton" style={{height:42, marginTop:8}}/>
               </td></tr>
             ) : loadError ? (
-              <tr><td colSpan={7} style={{color:'var(--dp-danger)'}}>
+              <tr><td colSpan={8} style={{color:'var(--dp-danger)'}}>
                 Could not load users — {loadError}. This is a failed request,
                 not an empty table.
               </td></tr>
@@ -119,14 +123,14 @@ export default function UsersTab(){
               // "No users" was shown for both an empty platform and a
               // search that matched nothing, so the operator could not
               // tell a typo from a fact.
-              <tr><td colSpan={7} style={{opacity:.8}}>
+              <tr><td colSpan={8} style={{opacity:.8}}>
                 No users match “{appliedSearch}”.{' '}
                 <button className="button ghost" onClick={()=> setSearch('')}>
                   Clear the search
                 </button>
               </td></tr>
             ) : rows.length === 0 ? (
-              <tr><td colSpan={7} style={{opacity:.75}}>
+              <tr><td colSpan={8} style={{opacity:.75}}>
                 No users have registered yet.
               </td></tr>
             ) : rows[0] && rows[0].id === undefined ? (
@@ -136,7 +140,7 @@ export default function UsersTab(){
               // sparse — and only announced itself when a drill-down
               // requested /admin/users/undefined. If the contract breaks
               // again, say so here rather than draw an empty table.
-              <tr><td colSpan={7} style={{color:'var(--dp-danger)'}}>
+              <tr><td colSpan={8} style={{color:'var(--dp-danger)'}}>
                 User rows arrived without an <code>id</code> field — the API
                 response shape does not match what this table reads. Not
                 rendering rows, because they would be blank.
@@ -147,6 +151,7 @@ export default function UsersTab(){
                 <td>{u.email}</td>
                 <td>{u.plan || '—'}</td>
                 <td>{u.role || '—'}</td>
+                <td>{u.job_title || '—'}</td>
                 <td>{u.deed_count ?? '—'}</td>
                 <td>{u.last_login ? new Date(u.last_login).toLocaleString() : '—'}</td>
                 <td style={{textAlign:'right'}}>
@@ -171,7 +176,8 @@ export default function UsersTab(){
             <div style={{display:'grid', gap:8, fontSize:13, marginBottom:16}}>
               <div><strong>Email:</strong> {modal.email}</div>
               <div><strong>Full Name:</strong> {modal.full_name || '—'}</div>
-              <div><strong>Role:</strong> {modal.role || '—'}</div>
+              <div><strong>Access:</strong> {modal.role || '—'}</div>
+              <div><strong>Job title:</strong> {modal.job_title || '—'}</div>
               <div><strong>Plan:</strong> {modal.plan || '—'}</div>
               <div><strong>Active:</strong> {modal.is_active ? 'Yes' : 'No'}</div>
               <div><strong>Created:</strong> {modal.created_at ? new Date(modal.created_at).toLocaleString() : '—'}</div>

--- a/frontend/src/app/admin/layout.tsx
+++ b/frontend/src/app/admin/layout.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import Link from 'next/link';
+import { isAdminRole } from '@/lib/authRole';
 import './styles/tokens.css';
 import './styles/admin-layout.css';
 
@@ -111,11 +112,9 @@ export default function AdminLayout({ children }: { children: React.ReactNode })
       const payload = JSON.parse(atob(token.split('.')[1]));
       setUserEmail(payload.email || '');
       
-      // Flexible admin check (case-insensitive, multiple variations)
-      const role = (payload.role || '').toLowerCase().trim();
-      const isAdminRole = ['admin', 'administrator', 'superadmin', 'super_admin'].includes(role);
-      
-      if (!isAdminRole) {
+      // ROLE1 — the one definition, shared with login, AuthService and
+      // (through a test that compares the files) `backend/auth.py`.
+      if (!isAdminRole(payload.role)) {
         // Not admin - redirect to dashboard
         alert('Admin access required. Your role: ' + (payload.role || 'none'));
         router.push('/dashboard');

--- a/frontend/src/app/admin/users/[id]/page.tsx
+++ b/frontend/src/app/admin/users/[id]/page.tsx
@@ -199,8 +199,17 @@ export default function UserDetailPage() {
                 <div style={{fontWeight: 500}}>{user.full_name || '—'}</div>
               </div>
               <div>
-                <div style={{opacity: 0.6, fontSize: 12, marginBottom: 4}}>Role</div>
+                <div style={{opacity: 0.6, fontSize: 12, marginBottom: 4}}>Access</div>
                 <div><span className="badge">{user.role || 'user'}</span></div>
+              </div>
+              {/* ROLE1 step 3 — shown, never edited here. The save form
+                  below has no job-title input on purpose: the refusal
+                  the API gives says a job title belongs to the person it
+                  describes, and a console that says that while editing
+                  it would be saying two things. */}
+              <div>
+                <div style={{opacity: 0.6, fontSize: 12, marginBottom: 4}}>Job title</div>
+                <div style={{fontWeight: 500}}>{user.job_title || '—'}</div>
               </div>
               <div>
                 <div style={{opacity: 0.6, fontSize: 12, marginBottom: 4}}>Plan</div>
@@ -269,7 +278,7 @@ export default function UserDetailPage() {
                 />
               </div>
               <div>
-                <label style={{display: 'block', fontSize: 12, marginBottom: 4, opacity: 0.7}}>Role</label>
+                <label style={{display: 'block', fontSize: 12, marginBottom: 4, opacity: 0.7}}>Access</label>
                 <select 
                   className="select" 
                   value={formData.role || 'user'} 

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -12,6 +12,7 @@ import { useState, useEffect, Suspense } from "react"
 import { useRouter, useSearchParams } from "next/navigation"
 import Link from "next/link"
 import { AuthManager } from "../../utils/auth"
+import { isAdminRole } from "@/lib/authRole"
 import { Eye, EyeOff, AlertCircle, CheckCircle2, Zap, Copy, Check, ShieldCheck, FileCheck2, Landmark, ScrollText } from "lucide-react"
 import { LogoLockup } from "@/components/brand/Logo"
 
@@ -98,9 +99,9 @@ function LoginContent() {
         if (token) {
           try {
             const payload = JSON.parse(atob(token.split('.')[1]))
-            const role = (payload.role || '').toLowerCase().trim()
-            const isAdmin = ['admin', 'administrator', 'superadmin', 'super_admin'].includes(role)
-            if (isAdmin && !searchParams.get("redirect")) {
+            // ROLE1 — the vocabulary was spelled out here, and in two
+            // other files, and in three more in Python. One place now.
+            if (isAdminRole(payload.role) && !searchParams.get("redirect")) {
               redirectTo = "/admin"
             }
           } catch (e) {

--- a/frontend/src/lib/adminApi.ts
+++ b/frontend/src/lib/adminApi.ts
@@ -178,7 +178,13 @@ export type UserRow = {
   id: number;
   email: string;
   full_name?: string;
+  /* ROLE1 step 3 — two fields because they are two facts. `role` is
+     ACCESS ('user' or 'admin'); `job_title` is what the person is
+     called. They shared one column, so the console's "Role" answered a
+     question about permissions on some rows and about a career on
+     others. */
   role?: string;
+  job_title?: string | null;
   plan?: string;
   created_at?: string;
   last_login?: string | null;

--- a/frontend/src/lib/authRole.ts
+++ b/frontend/src/lib/authRole.ts
@@ -1,0 +1,47 @@
+/**
+ * ROLE1 — one definition of admin, in the other language.
+ *
+ * ═══ THE SWEEP WAS BACKEND-ONLY, AND THE BROWSER HAD THREE MORE ═══
+ *
+ * ROLE1 found three definitions of admin in Python, converged them onto
+ * `auth.ADMIN_ROLES`, and pinned it with a sweep over `backend/**.py`.
+ * The sweep could not see this half of the product. TypeScript held the
+ * same four spellings, typed out as a literal array, three times:
+ *
+ *   - `app/login/page.tsx`   — where to send her after signing in
+ *   - `app/admin/layout.tsx` — whether the console opens at all
+ *   - `utils/auth.ts`        — `AuthService.isAdmin()`
+ *
+ * Six definitions, not three. They happen to agree today, which is
+ * exactly the condition under which the seventh gets added.
+ *
+ * ═══ WHAT THE TOKEN NOW CARRIES ═══
+ *
+ * The `role` claim is an AUTHORIZATION answer — 'admin' or 'user' —
+ * because the server computes it through the one predicate rather than
+ * forwarding `users.role`. Before that it could read "Escrow Officer":
+ * a job title in a security claim, which is why every one of these three
+ * had to lowercase, trim, and compare against a list.
+ *
+ * They still do. Tokens minted before the change are valid for their
+ * remaining lifetime and carry the old shape, and a check that assumes
+ * otherwise is a check that logs somebody out of the console for holding
+ * a token from ten minutes ago.
+ */
+
+/**
+ * Every spelling of "this person is an administrator".
+ *
+ * Mirrors `ADMIN_ROLES` in `backend/auth.py`, and a test compares the
+ * two files rather than trusting this comment.
+ *
+ * RECOGNIZED, not assignable: the console offers User and Admin only.
+ * The other three exist because history wrote them.
+ */
+export const ADMIN_ROLES = ['admin', 'administrator', 'superadmin', 'super_admin'] as const;
+
+/** Does this role string mean admin? The one answer. */
+export function isAdminRole(role: string | null | undefined): boolean {
+  if (!role) return false;
+  return (ADMIN_ROLES as readonly string[]).includes(role.toLowerCase().trim());
+}

--- a/frontend/src/lib/registerForm.ts
+++ b/frontend/src/lib/registerForm.ts
@@ -153,6 +153,19 @@ export function validate(f: RegisterFields): FieldErrors {
  * "Other" role or company type resolves to what she typed — the free
  * text IS the answer, and storing the literal "Other" beside it would be
  * two columns disagreeing about one fact.
+ *
+ * ═══ TWO NAMES FOR THE PROFESSIONAL ROLE, FOR ONE RELEASE ═══
+ *
+ * ROLE1 step 3 gave the job title its own column, so `job_title` is the
+ * name that means what it holds. `role` is sent alongside it because
+ * this frontend (Vercel) and the API (Render) deploy separately: for the
+ * length of one deploy, one of them is new and the other is not, and
+ * registration is the front door.
+ *
+ * Both directions are covered by sending both — an old server reads
+ * `role` and ignores the rest; a new one prefers `job_title`. The pair
+ * comes out once a server that prefers `job_title` has been live through
+ * a deploy.
  */
 export function registrationPayload(f: RegisterFields, normalizedPhone: string) {
   const role = f.role === OTHER ? f.roleOther.trim() : f.role;
@@ -163,6 +176,7 @@ export function registrationPayload(f: RegisterFields, normalizedPhone: string) 
     password: f.password,
     confirm_password: f.confirmPassword,
     full_name: f.fullName,
+    job_title: role,
     role,
     company_name: f.companyName || null,
     company_type: companyType || null,

--- a/frontend/src/utils/auth.ts
+++ b/frontend/src/utils/auth.ts
@@ -2,6 +2,7 @@
  * Authentication utilities for DeedPro
  * Handles JWT token management and user authentication state
  */
+import { isAdminRole } from '@/lib/authRole';
 
 export interface User {
   id: number;
@@ -121,7 +122,6 @@ export class AuthManager {
    * Check if user is an admin
    */
   static isAdmin(): boolean {
-    const adminRoles = ['admin', 'administrator', 'superadmin', 'super_admin'];
     const token = this.getToken();
     let role: string | null = null;
 
@@ -138,7 +138,11 @@ export class AuthManager {
       role = this.getUser()?.role || null;
     }
 
-    return adminRoles.includes(role?.toLowerCase().trim() || '');
+    // ROLE1 — one definition, shared with the login redirect and the
+    // admin layout guard. The stored-user fallback is the reason this
+    // still has to read a vocabulary at all: `users.role` used to hold
+    // job titles too, so a cached user object can say "Escrow Officer".
+    return isAdminRole(role);
   }
 
   /**


### PR DESCRIPTION
`users.role` answered two questions with one value: what somebody is called (Escrow Officer, Title Agent) and what somebody may do (admin). Step 1 converged the three gates that asked the second. This gives the first its own column.

## What changed

**Schema.** `users.job_title VARCHAR(120)` added to the ALTER list in `database.py` — the schema authority.

**Registration.** The professional role now lands in `job_title`, and the authorization column is written **from a literal** (`DEFAULT_ROLE`). #103's refusal stopped a registrant *spelling* admin; there is now no field to spell it into. The refusal stays, scoped to the legacy `role` wire name, and comes out with it.

**The token claim is an answer, not a column.** It forwarded `users.role` verbatim, so a token could read `role: "Escrow Officer"` — a job title travelling in a security claim that six separate readers each had to work out was not one. `authorization_role()` reaches that conclusion once, through `is_admin_role`, and is correct before and after the migration.

**Two vocabularies, and the direction matters.** `ADMIN_ROLES` (four spellings) is what the gates **recognize** — un-recognizing one silently removes somebody's access. `ASSIGNABLE_ROLES` narrowed from five values to `{user, admin}`: what the product will **write**. The console's own `<select>` has offered exactly those two the whole time; the API accepted three values its only caller never sent.

**The screen the console pointed at.** The admin refusal says a job title "is edited in their profile, not here" — which shipped one ticket before the box existed. The Profile tab now has it, and `admin_update_user` deliberately does *not* accept `job_title`.

## Three more definitions of admin, in the other language

ROLE1 converged three Python gates and pinned it with a sweep over `backend/**.py`. The sweep was as wide as its language. TypeScript held the same four spellings typed out as a literal array in three more files — `app/login/page.tsx`, `app/admin/layout.tsx`, `utils/auth.ts` — one of which decides whether the console opens at all. Six definitions, not three. Converged onto `lib/authRole.ts`, with a sweep that reads `backend/auth.py` rather than trusting a comment.

## The migration is written and NOT RUN

`backend/migrations/role1_separate_job_title.py` is a data operation and is held for the owner's go. It plans by default (`--apply` to write), names every row it would change rather than counting them, runs in one transaction, is re-runnable, never overwrites a `job_title` somebody typed, and deliberately does **not** also narrow what the gates recognize — that is a second decision, safe only once a census of the migrated table shows nothing but `admin`.

## Gates

pytest 1380 · jest 993 (68 suites) · tsc 88 (baseline) · six-flow green · banned-claims clean · OpenAPI route surface unchanged.

Nine mutation probes, seven caught immediately, **two came back green and produced fixes**:

- `assert "DEFAULT_ROLE," in src` passed with `user.role` back in the INSERT — the token claim four lines down also contains that substring. Rewritten as a positional regex plus an exact-count check on `user.role`.
- The `job_title`-is-not-a-gate sweep listed six literal patterns and walked straight past `user.get('job_title') == 'Administrator'`, because the closing quote sat where the list expected a paren. Rewritten to match the *shape* — any line that compares `job_title`, membership-tests it, or hands it to the admin predicate. Re-probed with three syntaxes; all three now caught.

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_