### PR TITLE
Record the credential deferral, and §14 — records state what was executed

### DIFF
--- a/docs/DOCTRINE_CONFORMANCE.md
+++ b/docs/DOCTRINE_CONFORMANCE.md
@@ -1103,6 +1103,67 @@ connected at both ends and gated at neither.
 
 ---
 
+## §15 — The enforcement point is the endpoint that PRINTS, not the builder (2026-08-13, owner-ruled)
+
+**Statement.** Every rule this document states about what may reach a
+recorded instrument is enforced at the endpoint that renders and stores
+the PDF. **A rule enforced only by a screen is a rule the next screen
+does not have.**
+
+**How it was found, and why it is the most consequential instance.**
+REQUIRED1 set out to unify "required" and found the loosest definition
+was the front door:
+
+| where | required |
+|---|---|
+| `POST /deeds` — the endpoint that prints | grantor, grantee, legal description |
+| the partner API | + `transfer_tax` (required model field), vesting per type, entity recitals |
+| the browser gate | + vesting AND a transfer-tax decision, family-aware |
+
+So the wizard's protection was **a property of the client, not of the
+product**. Anything reaching that endpoint another way — a script, a
+retry, a replayed request, a future integration — created a deed and
+stored its PDF having skipped both legal decisions, holding nothing but
+an ordinary user token.
+
+Every finding in the sections above is a smaller version of this shape.
+This one landed on the legal decisions the whole document exists to
+protect: §1 says a vesting or transfer-tax choice is never auto-applied,
+and the endpoint that prints the instrument never asked whether one had
+been made.
+
+**The corrected premise, recorded because the ruling was made on the
+inverted one.** The partner API is the STRICTEST surface, not the
+loosest — `CreateDeedRequest.transfer_tax` has no default, and
+`api_catalog.TYPE_REQUIREMENTS` enforces vesting per instrument. There
+was no versioning question and no integration to break; the tightening
+was entirely internal.
+
+**And the line the proof harness drew.** Tightening the print path broke
+the Thursday walkthrough, correctly: its step 2 posted an officer's
+PARTIAL work to `POST /deeds`, and a partial save is a different act.
+
+> A legal decision is required before the product PRINTS. Requiring one
+> before it SAVES would be the product hurrying a choice §1 forbids it to
+> make.
+
+`POST /deeds/draft` therefore stays permissive, deliberately, and its own
+model says why: *a draft may be arbitrarily incomplete.* The walkthrough
+now posts to the endpoint the product actually uses for a partial save —
+which made it more faithful rather than more permissive, since its
+comment had claimed to exercise "the REAL save contract" while using the
+finalize path. **That distinction is what separates a legitimate harness
+change from making the instrument agree with the result.**
+
+**Enforced by.** `backend/tests/test_required1.py`, in particular
+`test_the_endpoint_that_enforces_is_the_one_that_PRINTS` — it fails if
+`generate_and_store` leaves that handler, because a refactor moving the
+render elsewhere would silently relocate this section's enforcement
+point — and its sibling asserting the autosave path never acquires the
+check.
+
+---
+
 ### §14.1 — A sweep matches the PROPERTY, not the spelling (2026-08-13)
 
 **Statement.** An enforcement sweep that enumerates syntax patterns is
@@ -1148,10 +1209,50 @@ the problem.
 
 ---
 
+### §14.2 — A control is checked before its result is believed (2026-08-13)
+
+**Statement.** Verification instruments fail in ways that look exactly
+like success. Before acting on what a check reports, establish that the
+check ran and measured what you think it measured.
+
+**Four in one week, and none of them looked wrong at the time.**
+
+1. **A probe that broke the fixture.** Removing an entry from
+   `required_fields.json` left a trailing comma; the suite ERRORED on
+   malformed JSON while `grep -c FAILED` counted zero. The probe was
+   read as "the pin holds". A probe that breaks the fixture proves
+   nothing about the pin, and "0 failures" reads identically either way.
+2. **A comparison against the wrong baseline.** Checking whether a change
+   broke a harness, `git stash` was a no-op because everything was
+   already committed — so the "does main break too?" run tested the very
+   branch under suspicion, and would have exonerated it.
+3. **A measurement counting the wrong things.** A regex over
+   `deedPayload.ts` matched every four-space-indented key and so counted
+   nested object contents as top-level, reporting 36 silently dropped
+   fields. Two were real. **The 33-name exemption list it produced looked
+   exactly like a considered decision.**
+4. **A sweep that could not see its subject.** `test_every_write_side_script_says_which_database`
+   asserted that each script CALLS `assert_tables`. Three callers had
+   never worked; presence of a call is not correctness of a call.
+
+**The rule.** A check gets a validity question of its own, separate from
+its result: *did it run, against the thing I meant, and would it have
+failed if the property were false?* The last clause is what a mutation
+probe answers, which is why probes are run — and why a probe needs the
+same question asked of it.
+
+**Why it belongs beside §14.** §14 is about records overstating what
+exists. This is the same failure in the instruments: a green tick and an
+unexecuted check are indistinguishable from the outside, and both are
+believed by default.
+
+---
+
 ## Change log
 
 | Date | Change |
 |---|---|
+| 2026-08-13 | §15 added (REQUIRED1) — the enforcement point is the endpoint that PRINTS, not the builder. Three definitions of "required" were live and the loosest was `POST /deeds`, which renders and stores the PDF: grantor, grantee and legal description, with no vesting statement and no transfer-tax declaration, while the browser gate demanded both and the partner API demanded both. The wizard's protection was a property of the CLIENT, not of the product — anything reaching that endpoint another way stored an instrument having skipped both legal decisions on an ordinary user token. Recorded with the corrected premise, since the ruling was made on the inverted one: the partner API is the strictest surface, not the loosest, so there was no versioning question and no integration to break. Also records the line the Thursday walkthrough drew: a legal decision is required before the product PRINTS, and requiring one before it SAVES would hurry a choice §1 forbids it to make — so `POST /deeds/draft` stays permissive and the walkthrough moved to it, which made the harness more faithful rather than more permissive. §14.2 added — a control is checked before its result is believed, from four instruments in one week that failed in ways indistinguishable from success: a probe that broke its fixture (the suite errored on malformed JSON while `grep -c FAILED` counted zero), a `git stash` no-op that made the "does main break too?" run test the branch under suspicion, a regex that counted nested keys as top-level and produced a 33-name exemption list that looked exactly like a considered decision, and a sweep asserting a mechanism is CALLED while three of its callers had never worked. |
 | 2026-08-13 | §14 and §14.1 added (VERIFY-CHECK, ROLE1 step 3). §14: a record of what we can do states what was EXECUTED, not what exists. Three sightings, all erring in the PERMISSIVE direction — `EMAIL_VERIFICATION_REQUIRED` was cited in the ledger as evidence that required verification was ready to switch on, and was defined in one file and read nowhere, so an operator could have set it on Render before a launch and had nothing change; the same entry described verification as "resend-only" when the resend endpoint had no caller and no button. The tsc baseline read 114 in the ledger while CI enforced 94. `role_census.py` and `company_name_consolidation.py` were both recorded as the count-first mechanism and neither had ever run successfully. A record that understates is found when somebody needs the thing; a record that overstates is found before a launch or during an incident. §14.1: an enforcement sweep matches the PROPERTY, not the spelling, because a list of syntax patterns is as wide as its author's imagination and fails SILENTLY — three sightings in three languages, most sharply a `job_title` gate sweep that walked past `user.get('job_title') == 'Administrator'` because a quote sat where the list expected a paren. Also recorded: `code_only()` strips comments and docstrings but NOT string contents, so a sweep for a word that also occurs in English belongs in the AST rather than in a better regex. |
 | 2026-08-12 | §13.3 added (UX2 item 1) — who chose the record the facts came from. An exact autocomplete pick returned 76 county candidates with the chosen address not ranked first; APN, legal description and vested owner all descend from whichever row is clicked, so a wrong row produces a confidently wrong deed out of a real source with a genuine confirmation on every field. `services/address_match.py` selects a parcel only when EXACTLY ONE candidate is unambiguously the chosen address, declines otherwise, and exposes no confidence score. Also recorded: the audit's proposed root cause — "we re-search by address string instead of passing the autocomplete's identifier" — was checked and is not fixable as framed. Google's `place_id` is not a SiteX key; SiteX takes an address or a FIPS+APN, and the FIPS+APN only exists once SiteX has answered. The defect was real and the diagnosis was not, which is a distinct outcome from DASH1's route rename, where neither was. |
 | 2026-08-11 | §13.2 added (FLOW1 item 7, DISPATCH) — `signing_responses.asserted_by`. See the section for the full reasoning; the short version is that convergence had to be able to count an officer-asserted signer answer without any surface being able to call it the signer's. Also: the §11.1 sweep was WIDENED after it missed two live habitats it should have caught — `services/signing_loop.state_label()` (the one function that turns a scheduling state into a sentence for every surface) and the `.ics` description that lands in the officer's own diary. Both said "she" about a notary. `services/vesting_split.py` exempted with a cited reason: it MATCHES recorded vesting language rather than writing prose about anybody. |

--- a/docs/DOCTRINE_CONFORMANCE.md
+++ b/docs/DOCTRINE_CONFORMANCE.md
@@ -1047,10 +1047,112 @@ miss the point of it.
 
 ---
 
+## §14 — A record of what we can do states what was EXECUTED, not what exists (2026-08-13)
+
+**Statement.** When the ledger, a doc, or a comment claims the product
+*can* do something, the claim names what was run and what it produced.
+"The plumbing exists" is not a capability claim; it is a description of
+files.
+
+**The three sightings.** All the same shape, all found by executing
+rather than reading:
+
+1. **`EMAIL_VERIFICATION_REQUIRED`** — the ledger cited it as evidence
+   that required verification was ready to switch on. It was defined in
+   `auth_extra.py` and **read nowhere**. An operator could have set it on
+   Render before a launch, believed verification was required, and
+   nothing whatsoever would have changed. The same entry said
+   verification "stays resend-only", describing a resend endpoint with no
+   caller and no button — a resend nobody could reach.
+2. **The tsc baseline** read 114 in the ledger while CI enforced 94.
+3. **`scripts/role_census.py` and `company_name_consolidation.py`** were
+   both recorded as the "count first" mechanism and **neither had ever
+   run successfully** — two import-order defects and a miscalled
+   `assert_tables`. A green sweep asserted the call existed; nothing
+   asserted the call worked.
+
+**Why the direction matters.** Every one of these erred PERMISSIVELY:
+the record claimed more capability than existed. A record that
+understates is discovered the moment somebody needs the thing. A record
+that overstates is discovered at the worst moment — before a launch, in
+an incident, or during the run that was supposed to inform a decision.
+
+**The rule, operationally.**
+
+- A capability claim in the ledger cites the command that was run and
+  what it printed, or it says "not executed".
+- A flag, env var or switch is not evidence of a capability unless
+  something **reads** it — and "reads it" means a test drives the
+  behaviour, not that the name appears twice.
+- An enforcement sweep that checks a mechanism is *called* is not a check
+  that the mechanism *works*. Presence of a call is not correctness of a
+  call.
+
+**Why this is §0 applied to our own records.** §0 is about the product
+declining to state more than it knows. This is the same refusal pointed
+at the documents we use to decide with — and the reason it needed
+writing down is that all three sightings were in records written
+carefully, by people who believed them.
+
+**Enforced by.** Nothing automatic, and that is stated rather than
+glossed: this is a rule about prose. What is mechanical is narrower and
+real — `backend/tests/test_db_identity.py` pins the call SHAPE of every
+`assert_tables` caller and the exact set of unparseable files;
+`backend/tests/test_verify_check.py` pins that the verification chain is
+connected at both ends and gated at neither.
+
+---
+
+### §14.1 — A sweep matches the PROPERTY, not the spelling (2026-08-13)
+
+**Statement.** An enforcement sweep that enumerates syntax patterns is
+only as wide as the imagination of whoever wrote the list, **and it fails
+silently**: the forbidden thing gets added, the suite stays green, and
+the pin reads as proof.
+
+**Three sightings, in three languages.**
+
+1. The `job_title` sweep listed six literal patterns and walked past
+   `user.get('job_title') == 'Administrator'` — a closing quote sat where
+   the list expected a paren.
+2. The `assert_tables` sweep checked that a call *existed*. Three callers
+   had never worked.
+3. The first `verified` sweep matched lines rather than expressions, and
+   flagged an error message about transfer-tax rates and a sentence about
+   signing keys — the English word inside a string.
+
+**The rule.** Ask what CHARACTERISES the thing being forbidden, then
+match that:
+
+- a gate is a value that **steers** — so parse, and look inside `If`,
+  `IfExp`, `While`, `Assert` tests and comprehension conditions;
+- a miscall is an **argument shape** — so parse, and inspect the arg
+  nodes;
+- "one definition" is a **second occurrence** — so count occurrences of
+  the definition, not spellings of the use.
+
+When the property is structural, use `ast`. A regex over source is the
+right tool for prose and the wrong tool for grammar.
+
+**And know what the stripper does.** `code_only()` removes comments and
+docstrings. It does **not** remove string contents, because they are
+code. A sweep for a word that also occurs in English must therefore go
+through the AST, not through `code_only` plus a better regex — no amount
+of refining a pattern teaches a matcher that a string is not a gate.
+
+**The related habit.** Sweeps have four times caught their own
+explanation — the comment describing the forbidden thing IS the
+forbidden thing, textually. Reading through `code_only()` is the fix
+where the property is textual; where it is structural, the AST never had
+the problem.
+
+---
+
 ## Change log
 
 | Date | Change |
 |---|---|
+| 2026-08-13 | §14 and §14.1 added (VERIFY-CHECK, ROLE1 step 3). §14: a record of what we can do states what was EXECUTED, not what exists. Three sightings, all erring in the PERMISSIVE direction — `EMAIL_VERIFICATION_REQUIRED` was cited in the ledger as evidence that required verification was ready to switch on, and was defined in one file and read nowhere, so an operator could have set it on Render before a launch and had nothing change; the same entry described verification as "resend-only" when the resend endpoint had no caller and no button. The tsc baseline read 114 in the ledger while CI enforced 94. `role_census.py` and `company_name_consolidation.py` were both recorded as the count-first mechanism and neither had ever run successfully. A record that understates is found when somebody needs the thing; a record that overstates is found before a launch or during an incident. §14.1: an enforcement sweep matches the PROPERTY, not the spelling, because a list of syntax patterns is as wide as its author's imagination and fails SILENTLY — three sightings in three languages, most sharply a `job_title` gate sweep that walked past `user.get('job_title') == 'Administrator'` because a quote sat where the list expected a paren. Also recorded: `code_only()` strips comments and docstrings but NOT string contents, so a sweep for a word that also occurs in English belongs in the AST rather than in a better regex. |
 | 2026-08-12 | §13.3 added (UX2 item 1) — who chose the record the facts came from. An exact autocomplete pick returned 76 county candidates with the chosen address not ranked first; APN, legal description and vested owner all descend from whichever row is clicked, so a wrong row produces a confidently wrong deed out of a real source with a genuine confirmation on every field. `services/address_match.py` selects a parcel only when EXACTLY ONE candidate is unambiguously the chosen address, declines otherwise, and exposes no confidence score. Also recorded: the audit's proposed root cause — "we re-search by address string instead of passing the autocomplete's identifier" — was checked and is not fixable as framed. Google's `place_id` is not a SiteX key; SiteX takes an address or a FIPS+APN, and the FIPS+APN only exists once SiteX has answered. The defect was real and the diagnosis was not, which is a distinct outcome from DASH1's route rename, where neither was. |
 | 2026-08-11 | §13.2 added (FLOW1 item 7, DISPATCH) — `signing_responses.asserted_by`. See the section for the full reasoning; the short version is that convergence had to be able to count an officer-asserted signer answer without any surface being able to call it the signer's. Also: the §11.1 sweep was WIDENED after it missed two live habitats it should have caught — `services/signing_loop.state_label()` (the one function that turns a scheduling state into a sentence for every surface) and the `.ics` description that lands in the officer's own diary. Both said "she" about a notary. `services/vesting_split.py` exempted with a cited reason: it MATCHES recorded vesting language rather than writing prose about anybody. |
 | 2026-08-11 | §11.1 added (FLOW1 items 3–4) — the product never infers a fact about a PERSON from their name or role. A live email told a notary that the officer "confirms the appointment with the signers herself", asserting an escrow officer's pronouns to her own professional contact on no information; the screen did the same about the notary. Ruled the same family as the "filed as" constraint, which forbids reading a partner's category as a statement about their authority — one direction infers what someone IS, the other what they MAY DO, and both put a claim in the record nobody made. Swept fail-closed across every template. Two habitats exempted with cited reasons and their own liveness test: the Civil Code §1189 all-purpose acknowledgement (prescribed certificate wording, names no party) and vesting terms of art. Also item 4: the Signings agenda's stuck age was reconstructed as `expires_at − 21 days`, duplicating `default_expiry()`'s constant into TypeScript as a bare number — the server sends `created_at` now. And its "soonest first" claim covered rows sorted by `COALESCE(booked_at, expires_at)`, two orthogonal facts under one sort key (T-5 one layer up); booked and being-arranged are now separated and each sorted by the fact it has. |

--- a/docs/EXECUTION_POLICY.md
+++ b/docs/EXECUTION_POLICY.md
@@ -194,6 +194,31 @@ one is useful, and the difference is four values Postgres gives away.
   against this page would have believed they had twenty errors of
   headroom they did not have.
 
+## Which gates to run is decided by the SHAPE of the change (2026-08-13)
+
+**Owner-ruled, from a failure.** REQUIRED1 tightened a write endpoint. I
+ran pytest, tsc, jest and banned-claims — and not the proof harnesses —
+then reported green. CI failed on `proof-harnesses`, and the harness was
+right: the tightened endpoint refused an officer's partial work in the
+Thursday walkthrough.
+
+**The generalisation, which is the useful part: the gates most likely to
+break are knowable in advance from the shape of the change.**
+
+| the change | the gate that will find it first |
+|---|---|
+| tightening or loosening a write endpoint | the end-to-end harnesses (six-flow, Thursday, API baseline) — unit tests hold fixtures the endpoint no longer accepts |
+| a page's markup, state or conditional rendering | `next build`, then a render test — jest and tsc both stay green while the deploy dies |
+| a shared vocabulary or a definition | the OTHER language's suite, and the cross-language pins |
+| a schema or persistence shape | the resume/round-trip pins, then the harnesses |
+| a refusal or a guard | a mutation probe, because a guard that never fires is invisible to every other check |
+
+Running four of six and reporting green is the failure to avoid, and it
+is worse than skipping arbitrary gates: **the skipped ones were the two
+most likely to break.** This does not replace running everything before a
+PR — it decides what to run FIRST, and what a "quick check" may never
+omit.
+
 ## Dead code and revived code
 
 **Reviving a dead file makes its violations live.** A file with no

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -212,6 +212,66 @@ when their trigger arrives.
   that audits the manifest against the code, which the new pin now does
   continuously.
 
+## Deferred by owner decision — credentials in git history (2026-08-13)
+
+**Status: DEFERRED BY DECISION, NOT OUTSTANDING, NOT FORGOTTEN.** The
+machine flagged this twice and asked for rotation; the owner has
+deliberately deferred it with the reasoning and trigger below. Recorded
+that way round so the record shows who decided what.
+
+**The finding.** Four backend files carry a `postgresql://user:password@host/db`
+literal — **two distinct credentials**, one repeated three times:
+
+| file | database | secret fingerprint |
+|---|---|---|
+| `backend/run_migration.py` | `deedpro` (Ohio) | `105f01e0` |
+| `backend/migrations/run_migration.py` | `deedpro` (Ohio) | `105f01e0` |
+| `backend/migrations/run_adminfix_migration.py` | `deedpro` (Ohio) | `105f01e0` |
+| `backend/set_admin_role.py` | `mr_staging_db` (Oregon) | `d6e6271a` |
+
+Fingerprints are `sha256(secret)[:8]`, so the owner can tell the two
+apart and confirm a rotation landed **without the value ever appearing in
+this file** — the standing rule that no credential value is written here
+holds, and a fingerprint is how the rule stays useful rather than merely
+observed. Found by an AST sweep written for an unrelated argument-shape
+bug.
+
+**Why deferring is defensible today.** Exposure requires clone access to
+a private repository with a single collaborator. Obscurity is not
+security, but access control is, and that is access control.
+
+**The two ways it actually bites — and neither is "an attacker finds us".**
+
+1. **The first outside clone makes the credential permanently theirs.**
+   A contractor, a design partner's engineer, an acquirer's diligence
+   team — the moment anyone else clones, it cannot be taken back, and
+   rotating afterwards does not un-give it.
+2. **Diligence will find it.** Live production credentials in git history
+   is a disclosure-schedule item, not a code smell. This is precisely
+   what RED0's reviewer #1 was simulating.
+
+**TRIGGER — rotate BEFORE any of, whichever comes first:**
+
+- a second person is granted access to the repository;
+- a design partner or contractor clones it;
+- acquisition or investment diligence begins.
+
+**Why the files stay unscrubbed until then.** Scrubbing the working tree
+while the secrets stay live in history is the appearance of a fix, and it
+**destroys the evidence of which credential needs rotating** — the table
+above stops being checkable against the code. Rotation first, then scrub
+to `os.getenv`, in that order. `run_migration.py` stays quarantined with
+them (it is also unparseable — a migration runner that has never parsed,
+so has never run a migration); deleting it is part of the same pass.
+
+**What is mechanical in the meantime.**
+`backend/tests/test_db_identity.py::test_no_new_file_hard_codes_a_database_password`
+holds the offender set at exactly these four. A fifth cannot arrive
+quietly, and a file cleaned up must be removed from the set — so the
+gate stops the next one without pretending to have fixed these.
+
+---
+
 ## Open — needs a ruling (found 2026-08-12, NOT fixed)
 
 - **CORS allows every origin, with credentials.** `backend/main.py:66-76`:


### PR DESCRIPTION
Documentation only. No code changes.

## The credential deferral, recorded as a decision

The four files carrying database credentials are now a **deferred-by-owner-decision** ledger entry rather than an outstanding finding — recorded that way round, because the machine flagged it and asked for rotation and the owner deferred it, and the record should show who decided what.

Carries the reasoning (exposure is bounded by access control, not by obscurity), the two ways it actually bites, and an explicit **trigger**: rotate before a second person is granted repository access, before a partner or contractor clones it, or before diligence begins.

Also records why the files stay unscrubbed: scrubbing before rotation is the appearance of a fix, and it destroys the evidence of which credential needs rotating.

**Secret fingerprints, not values.** `sha256(secret)[:8]` for each, so the two can be told apart and a rotation confirmed against the table without a credential ever appearing in the ledger. The standing rule is that no credential value is written here; a fingerprint is how that rule stays useful rather than merely observed.

## §14 — a record of what we can do states what was EXECUTED, not what exists

Three sightings, all found by running things rather than reading them, and **all erring in the permissive direction**:

- `EMAIL_VERIFICATION_REQUIRED`, cited in the ledger as evidence the plumbing was ready to switch on, defined in one file and read nowhere;
- the tsc baseline reading 114 in the ledger while CI enforced 94;
- `role_census.py` and `company_name_consolidation.py`, both recorded as the count-first mechanism, neither of which had ever run successfully.

A record that understates is discovered when somebody needs the thing. A record that overstates is discovered before a launch, in an incident, or during the run that was supposed to inform a decision.

The "enforced by" line says plainly that nothing automatic enforces a rule about prose, and names the narrower mechanical pins that do exist — rather than implying more coverage than there is, which would be the section committing its own offence.

## §14.1 — a sweep matches the property, not the spelling

Three sightings in three languages, most sharply the `job_title` sweep that walked past `user.get('job_title') == 'Administrator'` because a closing quote sat where the pattern list expected a paren. The rule: ask what *characterises* the forbidden thing, then match that — a gate is a value that steers, so parse and look inside test expressions.

Includes the limit that produced the most recent correction: **`code_only()` strips comments and docstrings but not string contents**, because they are code. A sweep for a word that also occurs in English belongs in the AST, not in a better regex.

## Gates

pytest 1397 · banned-claims clean (14 rules over 233 product-facing files). No source files touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_