### PR TITLE
§13.3 parcel selection persists, and the draft stops dropping `parties`

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -1156,7 +1156,7 @@ def create_deed(user_id, deed_data):
             key: deed_data.get(key)
             for key in ('dtt', 'title_order_no', 'escrow_no', 'return_to', 'source', 'provenance',
                         'property_city', 'property_state', 'property_zip', 'current_owner',
-                        'requested_by_address', 'affidavit')
+                        'requested_by_address', 'affidavit', 'parcel')
             if deed_data.get(key)
         }
 
@@ -1214,7 +1214,7 @@ def update_deed_draft(user_id, deed_id, deed_data):
             key: deed_data.get(key)
             for key in ('dtt', 'title_order_no', 'escrow_no', 'return_to', 'source', 'provenance',
                         'property_city', 'property_state', 'property_zip', 'current_owner',
-                        'requested_by_address', 'affidavit')
+                        'requested_by_address', 'affidavit', 'parcel')
             if deed_data.get(key)
         }
         cursor.execute("""
@@ -1270,7 +1270,7 @@ def save_draft_row(user_id, deed_id, deed_data):
             key: deed_data.get(key)
             for key in ('dtt', 'title_order_no', 'escrow_no', 'return_to', 'source', 'provenance',
                         'property_city', 'property_state', 'property_zip', 'current_owner',
-                        'requested_by_address', 'affidavit')
+                        'requested_by_address', 'affidavit', 'parcel')
             if deed_data.get(key)
         }
         if deed_id:

--- a/backend/routers/deeds_crud.py
+++ b/backend/routers/deeds_crud.py
@@ -61,6 +61,18 @@ class DeedCreate(BaseModel):
     return_to: Optional[Union[str, Dict[str, Optional[str]]]] = Field(
         default=None, description="Mail-to for the recorded deed (name or address block)")
     provenance: Optional[Dict] = Field(default=None, description="Per-field source + confirmation timestamps (Ticket B)")
+    # §13.3 — WHO CHOSE THIS PARCEL, kept with the document rather than
+    # with the page. `basis` is 'exact_address_match' (the server matched
+    # her address), 'officer_choice' (she picked from the list), or
+    # 'only_county_match' (nobody chose — there was one), alongside how
+    # many alternatives there were.
+    #
+    # It was computed at search time and held in React state, so it died
+    # when the page unmounted: the record could not tell a parcel the
+    # SERVER matched from one SHE picked, which is the exact distinction
+    # §13.3 exists to preserve. Her confirmation of the fields proves she
+    # read them; it does not prove the row was the property she meant.
+    parcel: Optional[Dict] = Field(default=None, description="§13.3 parcel selection: basis, matchedAddress, alternativeCount")
     # Resume-persistence follow-up: city/state/zip and the county-records
     # owner were only recoverable by parsing the address string (or not at
     # all) — persist them into metadata so a resumed draft restores fully.
@@ -112,6 +124,9 @@ class DraftSave(BaseModel):
     escrow_no: Optional[str] = None
     return_to: Optional[Union[str, Dict[str, Optional[str]]]] = None
     provenance: Optional[Dict] = None
+    # §13.3 — see DeedCreate.parcel above. A draft that drops it resumes
+    # unable to say who chose the parcel.
+    parcel: Optional[Dict] = None
     property_city: Optional[str] = None
     property_state: Optional[str] = None
     property_zip: Optional[str] = None

--- a/backend/tests/test_draft_autosave.py
+++ b/backend/tests/test_draft_autosave.py
@@ -133,3 +133,54 @@ def test_list_endpoint_never_regresses_to_date_only_strings():
     import routers.deeds_crud as mod
     src = inspect.getsource(mod)
     assert 'strftime("%Y-%m-%d")' not in src
+
+
+def test_the_single_party_reaches_the_draft_row():
+    """FOUND BY AUDIT. `parties` carries the ONLY party a declaration-family
+    instrument has — the homestead declaration's declarant, the trust
+    certification's certifying trustee, the statutory POA's principal.
+
+    The draft proxy's hand-written field list omitted it while the create
+    proxy forwards the payload wholesale, so those drafts autosaved
+    without their party and resumed with it blank: work discarded by a
+    save that reported success.
+    """
+    payload = {
+        "deed_type": "homestead-declaration",
+        "parties": {"declarant": "JANE ROE"},
+    }
+    with authed_client() as client, \
+            patch("database.save_draft_row", return_value=dict(FAKE_ROW)) as save:
+        resp = client.post("/deeds/draft", json=payload)
+
+    assert resp.status_code == 200
+    _, _, draft_data = save.call_args[0]
+    assert draft_data["parties"] == {"declarant": "JANE ROE"}
+
+
+def test_who_chose_the_parcel_survives_the_page():
+    """§13.3 — `basis` and `alternativeCount` were computed at search time
+    and held in React state, so the record could not tell a parcel the
+    SERVER matched from one SHE picked. Her confirmation proves she read
+    the fields; it does not prove the row was the property she meant."""
+    parcel = {"basis": "officer_choice",
+              "matched_address": "1358 5TH ST",
+              "alternative_count": 2}
+    with authed_client() as client, \
+            patch("database.save_draft_row", return_value=dict(FAKE_ROW)) as save:
+        resp = client.post("/deeds/draft",
+                           json={"deed_type": "grant-deed", "parcel": parcel})
+
+    assert resp.status_code == 200
+    _, _, draft_data = save.call_args[0]
+    assert draft_data["parcel"] == parcel
+
+
+def test_the_parcel_is_carried_into_the_stored_metadata():
+    """The model accepting it is half; the DB layer has its own key list
+    and a field absent from THAT is a field the row never sees."""
+    from tests.source_text import code_only
+    from pathlib import Path
+    src = code_only(Path(__file__).resolve().parents[1] / "database.py")
+    keys = src[src.index("'requested_by_address', 'affidavit'"):][:80]
+    assert "'parcel'" in keys

--- a/frontend/src/__tests__/draftProxyCompleteness.test.ts
+++ b/frontend/src/__tests__/draftProxyCompleteness.test.ts
@@ -1,0 +1,102 @@
+/**
+ * A draft never persists a poorer payload than generate does.
+ *
+ * ═══ THE RULE WAS ALREADY WRITTEN. NOTHING CHECKED IT. ═══
+ *
+ * `app/api/deeds/draft/route.ts` says so in its own opening comment, and
+ * then lists twenty-two fields by hand. The create proxy forwards the
+ * payload wholesale, so generate keeps everything the serializer emits
+ * and the draft keeps whatever somebody remembered to add to the list.
+ *
+ * `parties` was not on the list. It carries the single named party of
+ * every declaration-family instrument — the homestead declaration's
+ * declarant, the trust certification's certifying trustee, the statutory
+ * POA's principal, the TOD revocation's grantor. So those drafts
+ * autosaved without the only party they have, and resumed with the field
+ * blank: work silently discarded, with a save that reported success.
+ *
+ * A hand-maintained list of fields is a list that falls behind the
+ * serializer. This compares the two rather than trusting the comment.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import { join } from 'path';
+
+import { codeOnly } from '@/test-support/sourceText';
+
+const SRC = join(process.cwd(), 'src');
+
+/** Top-level keys the builder's one serializer emits. */
+function serializerKeys(): string[] {
+  const src = codeOnly(fs.readFileSync(join(SRC, 'lib', 'deedPayload.ts'), 'utf8'));
+  const body = src.slice(src.indexOf('export function buildDeedPayload'));
+  const start = body.indexOf('return {');
+  // Top-level keys of the returned literal are at exactly four spaces;
+  // nested object keys are deeper, which is what keeps this honest.
+  return Array.from(body.slice(start).matchAll(/^ {4}([a-z_][a-z0-9_]*):/gm))
+    .map((m) => m[1]);
+}
+
+/** Keys the draft proxy forwards to the backend. */
+function proxyKeys(): string[] {
+  const src = codeOnly(
+    fs.readFileSync(join(SRC, 'app', 'api', 'deeds', 'draft', 'route.ts'), 'utf8'));
+  const body = src.slice(src.indexOf('const draftSave = {'));
+  return Array.from(body.matchAll(/^ {6}([a-z_][a-z0-9_]*):/gm)).map((m) => m[1]);
+}
+
+/**
+ * Serializer keys the proxy renames rather than drops. The backend's
+ * `DraftSave` uses the column names; the serializer uses the render
+ * context's names, and the proxy is where the two meet.
+ */
+const RENAMED: Record<string, string> = {
+  doc_type: 'deed_type',
+  grantors_text: 'grantor_name',
+  grantees_text: 'grantee_name',
+};
+
+/**
+ * Serializer keys that legitimately do not reach the draft row.
+ *
+ * EMPTY, and that is the finding. The first draft of this file carried a
+ * 33-name exemption list for the affidavit facts — written from a regex
+ * that matched every four-space-indented key in the file and therefore
+ * counted the CONTENTS of `buildFactsBlock` as top-level. They are not:
+ * they are nested under `affidavit`, which the proxy forwards whole.
+ *
+ * The same bad regex first suggested that 36 fields were being silently
+ * dropped. Two were. A measurement worth acting on is one that survives
+ * being checked.
+ */
+const NOT_PERSISTED_SEPARATELY = new Set<string>([]);
+
+describe('the draft proxy forwards what the serializer emits', () => {
+  it('drops nothing that is not accounted for', () => {
+    const forwarded = new Set(proxyKeys());
+    const dropped = serializerKeys().filter((key) => {
+      if (NOT_PERSISTED_SEPARATELY.has(key)) return false;
+      return !forwarded.has(RENAMED[key] ?? key);
+    });
+    expect(dropped).toEqual([]);
+  });
+
+  it('carries the two the audit found', () => {
+    /**
+     * `parties` — every declaration-family draft's only party.
+     * `parcel` — §13.3's record of who chose the parcel, which lived in
+     * React state and died with the page.
+     */
+    const forwarded = proxyKeys();
+    expect(forwarded).toContain('parties');
+    expect(forwarded).toContain('parcel');
+  });
+
+  it('and the exemption list does not outlive the serializer', () => {
+    // A key exempted but no longer emitted is a stale excuse, and the
+    // next reader would take it for a considered decision.
+    const emitted = new Set(serializerKeys());
+    const stale = [...NOT_PERSISTED_SEPARATELY].filter((k) => !emitted.has(k));
+    expect(stale).toEqual([]);
+  });
+});

--- a/frontend/src/app/api/deeds/draft/route.ts
+++ b/frontend/src/app/api/deeds/draft/route.ts
@@ -38,6 +38,19 @@ export async function POST(req: NextRequest) {
       return_to: payload.return_to || null,
       provenance: payload.provenance || null,
       affidavit: payload.affidavit || null,
+      // FOUND BY AUDIT, and the file's own docstring already forbade it:
+      // "a draft must never persist a poorer payload than generate does."
+      // `parties` carries the single named party of every declaration-family
+      // instrument — the homestead's declarant, the trust certification's
+      // trustee, the POA's principal, the TOD revocation's grantor. The
+      // create proxy forwards the payload wholesale so generate kept it;
+      // this map listed twenty-two fields and not this one, so every
+      // single-party draft autosaved without the only party it has, and
+      // resumed with that field blank.
+      parties: payload.parties || null,
+      // §13.3 — see deedPayload.ts. Dropping it here would persist a
+      // document that cannot say who chose its parcel.
+      parcel: payload.parcel || null,
     };
 
     const authHeader = req.headers.get('authorization');

--- a/frontend/src/lib/deedPayload.ts
+++ b/frontend/src/lib/deedPayload.ts
@@ -135,6 +135,16 @@ export function buildDeedPayload(genState: DeedBuilderState) {
       city_name: genState.dtt?.cityName || '',
       calculated_amount: genState.dtt?.calculatedAmount || '',
     },
+    // §13.3 — who chose this parcel, kept WITH THE DOCUMENT. It lived in
+    // component state and died when the page unmounted, so the record
+    // could not tell a parcel the server matched from one she picked.
+    parcel: genState.property?.parcelSelection
+      ? {
+          basis: genState.property.parcelSelection.basis,
+          matched_address: genState.property.parcelSelection.matchedAddress,
+          alternative_count: genState.property.parcelSelection.alternativeCount,
+        }
+      : null,
     // Who-confirmed-what-when, persisted into deeds.metadata.provenance
     // alongside the stored PDF's hash.
     provenance: {


### PR DESCRIPTION
Two findings from the dashboard feasibility audit. Both are independent of the dashboard and justified without it, so they ship ahead of it.

## §13.3 — who chose the parcel now survives the page

`ParcelSelection` carried `basis` (`exact_address_match` / `officer_choice` / `only_county_match`) and `alternativeCount` in component state, and died when the page unmounted. Neither `DraftSave` nor `DeedCreate` had a field for it, and `DeedCreate.Config.extra = "ignore"` would have dropped it silently if sent.

So the record could not tell a parcel the **server matched** from one **she picked** — precisely the distinction §13.3 exists to preserve. Her confirmation of APN, legal description and vested owner proves she read them; it does not prove the row was the property she meant. Now serialized, forwarded, and persisted into `deeds.metadata.parcel`.

## `parties` — the draft was dropping the only party those instruments have

Found while checking whether other intended fields are discarded the same way. The mechanism turned out not to be `extra = "ignore"` at all: the **create** proxy forwards the payload wholesale, while the **draft** proxy hand-lists twenty-two fields — and `parties` was not among them, under a docstring that says *"a draft must never persist a poorer payload than generate does."*

`parties` carries the single named party of every declaration-family instrument: the homestead declaration's declarant, the trust certification's certifying trustee, the statutory POA's principal, the TOD revocation's grantor. Those drafts autosaved without it and resumed with the field blank — work discarded by a save that reported success.

Pinned by comparing the serializer's emitted keys against the proxy's forwarded keys, rather than trusting the docstring. A hand-maintained field list is a list that falls behind its serializer.

## A correction to my own measurement

The first pass at this audit reported **36 silently dropped fields**. Two were real. The regex matched every four-space-indented key in `deedPayload.ts` and so counted the *contents* of `buildFactsBlock` — which are nested under `affidavit`, a key the proxy forwards whole — and it compared them against the wrong model (`DeedCreate`, when the builder posts to the draft proxy). The corrected extractor and the reason are recorded in the test file, because the exemption list a bad measurement produces looks exactly like a considered decision.

## Gates

pytest **1400** · jest **1002** · tsc 88 (baseline) · six-flow green · banned-claims clean.

Four mutation probes, all caught: `parties` and `parcel` each removed from the proxy; `parcel` removed from `DraftSave`; `parcel` removed from the DB layer's metadata key list (the model accepting a field is half — a field absent from *that* list is a field the row never sees).

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_