### PR TITLE
REQUIRED1 — one declaration of "required", read by both languages

### DIFF
--- a/backend/routers/deeds_crud.py
+++ b/backend/routers/deeds_crud.py
@@ -186,6 +186,40 @@ def create_deed_endpoint(deed: DeedCreate, user_id: int = Depends(get_current_us
                 detail=f"Validation failed: {field_label} is required and cannot be empty"
             )
 
+    # ── REQUIRED1: THE LEGAL DECISIONS, WHICH THIS ENDPOINT DID NOT ASK
+    # FOR ──────────────────────────────────────────────────────────────
+    #
+    # AFTER the substance loop above, deliberately. A missing grantee is a
+    # more fundamental absence than an undeclared exemption, and naming
+    # the legal choices while a party is still blank would lead with the
+    # smaller problem.
+    #
+    # This check required grantor, grantee and legal description. The
+    # browser gate additionally requires a VESTING statement and a
+    # TRANSFER-TAX decision, and the partner API requires both too
+    # (`transfer_tax` is a required model field there). So this endpoint
+    # accepted an instrument the wizard refuses to generate and the
+    # partner API rejects — and the wizard's gate runs in the browser, so
+    # anything calling here directly skipped both legal choices.
+    #
+    # Owner-ruled: the stricter set wins. The list now comes from
+    # `required_fields.json`, which both languages read, so a fourth
+    # definition cannot be added by editing one side.
+    from services.form_families import family_of
+    from services.required_fields import missing as missing_required
+
+    family = family_of(deed_data.get('deed_type'))
+    absent = missing_required(family, deed_data.get('deed_type') or '', deed_data)
+    decisions = [r for r in absent if r.population == 'decision']
+    if decisions:
+        raise HTTPException(
+            status_code=422,
+            detail=("Validation failed: " + ", ".join(r.label for r in decisions)
+                    + ". A conveyance states its vesting and declares its "
+                      "transfer tax; neither is inferred (doctrine §1), so "
+                      "neither can be omitted."),
+        )
+
     # Enhanced logging for diagnostics
     print(f"[Backend /deeds] ✅ Creating deed for user_id={user_id}")
     print(f"[Backend /deeds] deed_type: {deed_data.get('deed_type')}")

--- a/backend/scripts/s3_thursday_walkthrough.py
+++ b/backend/scripts/s3_thursday_walkthrough.py
@@ -118,7 +118,27 @@ def main():
     # `provenance` block. There is no builder_state blob, and writing the
     # walkthrough against one I imagined would have proved nothing about
     # the product — which is why this is a walkthrough and not a mock.
-    r = client.post("/deeds", json={
+    #
+    # ═══ WHY THIS MOVED FROM POST /deeds TO POST /deeds/draft ═══
+    #
+    # It posted to `/deeds`, which is the endpoint that RENDERS AND STORES
+    # THE PDF (`generate_and_store`, T2). That is the print path, and
+    # REQUIRED1 made it demand what a printed instrument must carry — a
+    # vesting statement and a transfer-tax declaration.
+    #
+    # Which broke this step, correctly: at this point in her Thursday she
+    # has typed some fields and has NOT decided the transfer tax. An
+    # officer mid-work is exactly who this walkthrough protects, and
+    # asking her for a legal decision before she prints anything would be
+    # the product hurrying a choice §1 says it must never make for her.
+    #
+    # So the step now uses the endpoint the PRODUCT uses for a partial
+    # save. The builder autosaves to `/deeds/draft` (U1), whose model
+    # exists precisely because "a draft may be arbitrarily incomplete".
+    # This is the walkthrough becoming MORE faithful, not less: it
+    # claimed to exercise the real save contract while using the
+    # finalize path.
+    r = client.post("/deeds/draft", json={
         "deed_type": "grant-deed", "property_address": HER_WORK["property"]["address"],
         "apn": HER_WORK["property"]["apn"],
         "legal_description": HER_WORK["property"]["legalDescription"],

--- a/backend/services/required_fields.json
+++ b/backend/services/required_fields.json
@@ -1,0 +1,80 @@
+{
+  "_doc": [
+    "REQUIRED1 — what a valid instrument must carry, declared once.",
+    "",
+    "THIS FILE IS THE AUTHORITY. `backend/services/required_fields.py` and",
+    "`frontend/src/lib/requiredFields.ts` both read it, and both test suites",
+    "assert against it. Neither implementation is the source of truth —",
+    "the same arrangement `vesting_cases.json` uses, for the same reason:",
+    "two implementations of one rule drift, and that is not a risk, it is a",
+    "schedule.",
+    "",
+    "WHY IT EXISTS: three definitions of 'required' were live at once.",
+    "  1. deeds_crud.py's critical-field check — grantor, grantee, legal",
+    "     description. No transfer tax, no vesting.",
+    "  2. the partner API (api_catalog.TYPE_REQUIREMENTS + CreateDeedRequest)",
+    "     — transfer_tax required as a model field, vesting per type.",
+    "  3. the browser gate (deedValidation.evaluateSubstantive) — vesting",
+    "     AND a transfer-tax decision, family-aware.",
+    "",
+    "So POST /deeds accepted an instrument the wizard would have refused to",
+    "generate and the partner API would have rejected. Owner ruling: the",
+    "STRICTER set wins — a transfer-tax declaration and a vesting decision",
+    "are required for a valid conveyance, and an endpoint accepting less is",
+    "accepting something it should not.",
+    "",
+    "`population` is what the dashboard's count needs and is a real",
+    "distinction rather than a display detail:",
+    "  'substance'  — the instrument is not valid without it;",
+    "  'decision'   — a legal choice the officer must MAKE (never inferred,",
+    "                 §1), which is absent in a different way from a blank",
+    "                 name field."
+  ],
+
+  "families": {
+    "deed": {
+      "note": "Two-party conveyances. Family names match services/form_families.FAMILY_BY_DEED_TYPE — a fourth vocabulary would be the disease this file cures.",
+      "required": [
+        {"id": "grantor_present", "field": "grantor", "label": "Grantor stated", "population": "substance", "section": "grantor"},
+        {"id": "grantee_present", "field": "grantee", "label": "Grantee stated", "population": "substance", "section": "grantee"},
+        {"id": "legal_description_present", "field": "legal_description", "label": "Legal description present", "population": "substance", "section": "property"},
+        {"id": "vesting_stated", "field": "vesting", "label": "Vesting stated", "population": "decision", "section": "vesting", "unless": "fixed_vesting"},
+        {"id": "dtt_decided", "field": "dtt", "label": "Transfer tax decided", "population": "decision", "section": "transferTax"}
+      ]
+    },
+    "affidavit": {
+      "note": "Death-of-joint-tenant and siblings: one affiant, one decedent, and the parcel.",
+      "required": [
+        {"id": "grantor_present", "field": "grantor", "label": "Decedent stated", "population": "substance", "section": "grantor"},
+        {"id": "grantee_present", "field": "grantee", "label": "Affiant stated", "population": "substance", "section": "grantee"},
+        {"id": "legal_description_present", "field": "legal_description", "label": "Legal description present", "population": "substance", "section": "property"}
+      ]
+    },
+    "declaration": {
+      "note": "Single-party instruments. The named party rides in `parties`; grantor/grantee are legitimately empty.",
+      "required": [
+        {"id": "named_party_present", "field": "parties", "label": "Party named", "population": "substance", "section": "affidavit"},
+        {"id": "legal_description_present", "field": "legal_description", "label": "Legal description present", "population": "substance", "section": "property", "unless": "no_legal_description"}
+      ]
+    }
+  },
+
+  "types": {
+    "_doc": [
+      "Per-instrument exceptions, by the flag names the `unless` keys above",
+      "refer to. `fixed_vesting` means the form's own title IS the vesting",
+      "decision (Flag-3): its template never reads a stored vesting value,",
+      "so requiring one would demand a field the instrument refuses.",
+      "",
+      "These mirror `api_catalog.TYPE_REQUIREMENTS`, which the partner API",
+      "already reads — a pin holds the two equal rather than a comment",
+      "claiming they match."
+    ],
+    "grant-deed-jt": {"fixed_vesting": true},
+    "grant-deed-cp-ros": {"fixed_vesting": true},
+    "quitclaim-deed": {"fixed_vesting": true, "note": "Quitclaim conveys whatever interest the grantor holds; vesting is optional."},
+    "trust-certification": {"no_legal_description": true, "note": "Prob C 18100.5 — property-less; the substance is the trust and its certifying trustees."},
+    "trustee-substitution": {"no_legal_description": true, "note": "The deed of trust is identified by its recording reference, which identifies the property."},
+    "poa-statutory": {"no_legal_description": true, "note": "Describes no parcel."}
+  }
+}

--- a/backend/services/required_fields.py
+++ b/backend/services/required_fields.py
@@ -1,0 +1,111 @@
+"""REQUIRED1 — what a valid instrument must carry. The Python reader.
+
+`required_fields.json` is the authority; this module reads it and
+`frontend/src/lib/requiredFields.ts` reads the same file. Neither is the
+source of truth, for the reason `vesting_split` already established: two
+implementations of one rule drift, and the corpus is the only known cure.
+
+═══ THREE DEFINITIONS WERE LIVE AT ONCE ═══
+
+    deeds_crud.py     grantor, grantee, legal description
+    partner API       + transfer_tax (required model field), vesting per type
+    the browser gate  + vesting AND a transfer-tax decision, family-aware
+
+So `POST /deeds` accepted an instrument the wizard refuses to generate and
+the partner API rejects. Not a hypothetical: the wizard's own gate runs in
+the browser, so anything calling the endpoint directly — a script, a
+retry, a future integration — skipped both legal decisions.
+
+Owner ruling: the stricter set wins.
+"""
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Dict, List, NamedTuple
+
+CORPUS = Path(__file__).with_name("required_fields.json")
+
+#: A field is present when it holds something other than whitespace. For
+#: `parties` (a dict) and `dtt` (a decision block) presence is answered by
+#: the shapes below rather than by str.strip().
+POPULATION_SUBSTANCE = "substance"
+POPULATION_DECISION = "decision"
+
+
+class Requirement(NamedTuple):
+    id: str
+    field: str
+    label: str
+    population: str
+    section: str
+    unless: str = ""
+
+
+@lru_cache(maxsize=1)
+def _corpus() -> Dict[str, Any]:
+    return json.loads(CORPUS.read_text(encoding="utf-8"))
+
+
+def type_flags(deed_type: str) -> Dict[str, Any]:
+    """The per-instrument exceptions — `fixed_vesting` and friends."""
+    types = {k: v for k, v in _corpus()["types"].items() if k != "_doc"}
+    return types.get((deed_type or "").strip(), {})
+
+
+def requirements(family: str, deed_type: str) -> List[Requirement]:
+    """What this instrument must carry, exceptions already applied."""
+    fam = _corpus()["families"].get(family)
+    if not fam:
+        return []
+    flags = type_flags(deed_type)
+    out = []
+    for row in fam["required"]:
+        # `unless` names a flag that REMOVES the requirement — a
+        # fixed-vesting form does not merely default its vesting, its
+        # template refuses to read one, so demanding it would demand a
+        # field the instrument has no place to put.
+        if row.get("unless") and flags.get(row["unless"]):
+            continue
+        out.append(Requirement(
+            id=row["id"], field=row["field"], label=row["label"],
+            population=row["population"], section=row.get("section", ""),
+            unless=row.get("unless", ""),
+        ))
+    return out
+
+
+def _present(field: str, value: Any) -> bool:
+    """Is this field answered?
+
+    THE DECISION FIELDS ARE NOT STRINGS. `dtt` is a decision block, and an
+    exemption declared as "no exemption, full value" is a DECISION — the
+    officer said so. Treating a falsy value as absent would re-ask a
+    question she already answered, which is the §1 complaint from the
+    other side: never inferring the choice includes never forgetting it.
+    """
+    if value is None:
+        return False
+    if field == "parties":
+        return isinstance(value, dict) and any(
+            (v or "").strip() for v in value.values() if isinstance(v, str))
+    if field == "dtt":
+        if not isinstance(value, dict):
+            return bool(str(value).strip())
+        # Declared exempt, or a basis chosen — either is an answer.
+        return bool(value.get("isExempt") or value.get("is_exempt")
+                    or (value.get("basis") or "").strip()
+                    or (str(value.get("transfer_value")
+                            or value.get("transferValue") or "")).strip())
+    return bool(str(value).strip())
+
+
+def missing(family: str, deed_type: str, data: Dict[str, Any]) -> List[Requirement]:
+    """Every requirement this row does not yet satisfy.
+
+    The dashboard's second population, and the generate path's refusal,
+    are the same list read by two callers.
+    """
+    return [r for r in requirements(family, deed_type)
+            if not _present(r.field, data.get(r.field))]

--- a/backend/tests/test_required1.py
+++ b/backend/tests/test_required1.py
@@ -1,0 +1,157 @@
+"""REQUIRED1 — one definition of "required", read by both languages.
+
+═══ THREE DEFINITIONS, AND THE LOOSEST ONE WAS THE FRONT DOOR ═══
+
+    deeds_crud.py     grantor, grantee, legal description
+    partner API       + transfer_tax (a required model field), vesting per type
+    the browser gate  + vesting AND a transfer-tax decision, family-aware
+
+`POST /deeds` accepted an instrument the wizard refuses to generate and
+the partner API rejects. The wizard's gate runs in the BROWSER, so the
+protection was a property of the client rather than of the product:
+anything reaching the endpoint another way — a script, a retry, an
+integration — skipped both legal decisions.
+
+Owner ruling: the stricter set wins.
+
+═══ WHY A JSON CORPUS AND NOT A SHARED MODULE ═══
+
+The two readers are in different languages. `vesting_split` faced this
+first and the answer was a corpus both sides read and both suites test
+against — because a rule implemented twice drifts, and a rule declared
+once and read twice cannot.
+"""
+import json
+from pathlib import Path
+
+import pytest
+
+from services import required_fields as rf
+from services.form_families import (FAMILY_BY_DEED_TYPE, PROPERTYLESS_TYPES,
+                                    family_of)
+from tests.source_text import code_only, function_source
+
+BACKEND = Path(__file__).resolve().parents[1]
+CORPUS = json.loads((BACKEND / "services" / "required_fields.json")
+                    .read_text(encoding="utf-8"))
+
+
+# ── The corpus is the authority, and nothing shadows it ──────────────
+
+def test_both_readers_read_the_same_file():
+    """THE PIN THIS FILE EXISTS FOR (first half). A reader that inlines
+    the rules is a second definition wearing a reader's name."""
+    py = code_only((BACKEND / "services" / "required_fields.py")
+                   .read_text(encoding="utf-8"))
+    assert 'CORPUS = Path(__file__).with_name("required_fields.json")' in py
+
+    ts = (BACKEND.parent / "frontend" / "src" / "lib" / "requiredFields.ts") \
+        .read_text(encoding="utf-8")
+    assert "backend/services/required_fields.json" in ts
+
+
+def test_the_family_vocabulary_is_not_a_fourth_one():
+    """Family keys must be the families this codebase already has. A
+    corpus inventing 'conveyance' beside the existing 'deed' would be the
+    exact disease it was written to cure."""
+    families = set(CORPUS["families"])
+    assert families <= set(FAMILY_BY_DEED_TYPE.values()), (
+        f"corpus families not in form_families: "
+        f"{families - set(FAMILY_BY_DEED_TYPE.values())}")
+
+
+def test_the_propertyless_types_agree_with_form_families():
+    """`no_legal_description` and `PROPERTYLESS_TYPES` answer one
+    question. Two answers is how a deed renders a blank legal description
+    on one path and refuses on another."""
+    flagged = {t for t, f in CORPUS["types"].items()
+               if t != "_doc" and f.get("no_legal_description")}
+    assert flagged == set(PROPERTYLESS_TYPES), (
+        f"corpus says {sorted(flagged)}, form_families says "
+        f"{sorted(PROPERTYLESS_TYPES)}")
+
+
+def test_the_fixed_vesting_types_agree_with_the_partner_api():
+    """The partner API has read `api_catalog.TYPE_REQUIREMENTS` since A2.
+    The corpus must not disagree with it about which instruments fix
+    their own vesting — that is a legal fact about the form, and two
+    answers means one endpoint demands a value another refuses."""
+    from services.api_catalog import TYPE_REQUIREMENTS, api_type
+
+    corpus_fixed = {t for t, f in CORPUS["types"].items()
+                    if t != "_doc" and f.get("fixed_vesting")}
+    api_fixed = {t for t, r in TYPE_REQUIREMENTS.items() if r.fixed_vesting}
+    # The partner API speaks underscored slugs; the chassis speaks dashes.
+    assert {api_type(t) for t in corpus_fixed} >= api_fixed, (
+        f"the partner API fixes vesting for {sorted(api_fixed)}; the corpus "
+        f"fixes {sorted(api_type(t) for t in corpus_fixed)}")
+
+
+# ── What it answers ──────────────────────────────────────────────────
+
+def test_a_conveyance_requires_both_legal_decisions():
+    """The whole ruling, in one assertion."""
+    ids = {r.id for r in rf.requirements("deed", "grant-deed")}
+    assert "vesting_stated" in ids
+    assert "dtt_decided" in ids
+
+
+def test_a_fixed_vesting_form_is_not_asked_for_one():
+    """Flag-3: the form's title IS the vesting decision and its template
+    never reads a stored value, so requiring one would demand a field the
+    instrument has nowhere to put."""
+    for deed_type in ("grant-deed-jt", "grant-deed-cp-ros"):
+        ids = {r.id for r in rf.requirements("deed", deed_type)}
+        assert "vesting_stated" not in ids, deed_type
+        # And the transfer tax is still required — the exemption is a
+        # separate decision from the vesting.
+        assert "dtt_decided" in ids, deed_type
+
+
+def test_a_property_less_instrument_is_not_asked_for_a_legal_description():
+    ids = {r.id for r in rf.requirements("declaration", "trust-certification")}
+    assert "legal_description_present" not in ids
+    assert "named_party_present" in ids
+
+
+@pytest.mark.parametrize("value,answered", [
+    ({"isExempt": True}, True),                     # exempt IS a decision
+    ({"basis": "full_value"}, True),                # so is full value
+    ({"transfer_value": "500000"}, True),
+    ({}, False),
+    (None, False),
+])
+def test_a_declared_exemption_counts_as_a_decision(value, answered):
+    """§1 from the other side. Never inferring the choice includes never
+    FORGETTING it: `isExempt: true` is falsy in none of its fields except
+    the ones that matter, and re-asking would be the product losing an
+    answer she gave."""
+    assert rf._present("dtt", value) is answered
+
+
+def test_a_declaration_names_its_party_in_parties():
+    assert rf._present("parties", {"declarant": "JANE ROE"}) is True
+    assert rf._present("parties", {"declarant": "   "}) is False
+    assert rf._present("parties", {}) is False
+
+
+# ── The endpoint that was loose ──────────────────────────────────────
+
+def test_the_create_endpoint_reads_the_corpus():
+    """THE PIN THIS FILE EXISTS FOR (second half). Not "the endpoint
+    validates" — it always did. That it reads the SHARED list is the
+    thing that makes a fourth definition impossible to add by editing one
+    side."""
+    src = code_only(function_source(
+        BACKEND / "routers" / "deeds_crud.py", "create_deed_endpoint"))
+    assert "from services.required_fields import missing as missing_required" in src
+    assert "family_of(deed_data.get('deed_type'))" in src
+
+
+def test_the_refusal_names_what_is_missing_and_why():
+    """Invariant #4. "Validation failed" tells an integrator nothing; the
+    doctrine reason tells them this is deliberate rather than a bug."""
+    src = code_only(function_source(
+        BACKEND / "routers" / "deeds_crud.py", "create_deed_endpoint"))
+    assert "r.label for r in decisions" in src
+    assert "neither is inferred" in src

--- a/backend/tests/test_required1.py
+++ b/backend/tests/test_required1.py
@@ -155,3 +155,33 @@ def test_the_refusal_names_what_is_missing_and_why():
         BACKEND / "routers" / "deeds_crud.py", "create_deed_endpoint"))
     assert "r.label for r in decisions" in src
     assert "neither is inferred" in src
+
+
+def test_the_endpoint_that_enforces_is_the_one_that_PRINTS():
+    """WHY POST /deeds AND NOT SOMEWHERE ELSE — the question the six-flow
+    harness forced.
+
+    Converging onto this endpoint is only right because it renders and
+    stores the PDF (`generate_and_store`, T2). That makes it the print
+    path, and the doctrine is about what reaches the immutable stored
+    instrument: an unconfirmed field or an undeclared transfer tax must
+    not get onto a page.
+
+    A partial save is a different act and has a different endpoint.
+    `POST /deeds/draft` exists because "a draft may be arbitrarily
+    incomplete", and it is deliberately NOT tightened here — asking an
+    officer for a legal decision before she prints anything would hurry a
+    choice §1 says the product must never make for her.
+    """
+    src = code_only(function_source(
+        BACKEND / "routers" / "deeds_crud.py", "create_deed_endpoint"))
+    assert "generate_and_store" in src, (
+        "if this endpoint no longer prints, the argument for enforcing "
+        "the legal decisions HERE has moved with it")
+
+    draft = code_only(function_source(
+        BACKEND / "routers" / "deeds_crud.py", "save_draft_endpoint"))
+    assert "missing_required" not in draft, (
+        "the autosave path must stay permissive — an officer mid-work has "
+        "not yet made the decisions, and losing her typing to a 422 is the "
+        "failure the Thursday walkthrough exists to catch")

--- a/frontend/src/__tests__/requiredFields.test.ts
+++ b/frontend/src/__tests__/requiredFields.test.ts
@@ -1,0 +1,111 @@
+/**
+ * REQUIRED1 — the TypeScript half, read against the same corpus.
+ *
+ * `backend/services/required_fields.json` is the authority. This suite
+ * loads the JSON directly and asserts the reader agrees with it, exactly
+ * as `vestingSplit.test.ts` does for `vesting_cases.json` — the point of
+ * a corpus is lost if each side's tests only ask its own implementation.
+ *
+ * The Python suite (`test_required1.py`) asks the same questions of the
+ * same file, so a change to one language's answers fails in the other.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import { join } from 'path';
+
+import { isPresent, missingRequired, requirements, typeFlags } from '@/lib/requiredFields';
+
+const CORPUS = JSON.parse(fs.readFileSync(
+  join(__dirname, '..', '..', '..', 'backend', 'services', 'required_fields.json'),
+  'utf8',
+));
+
+describe('the corpus is the authority', () => {
+  it('is the file the reader imports, not a copy', () => {
+    const src = fs.readFileSync(
+      join(process.cwd(), 'src', 'lib', 'requiredFields.ts'), 'utf8');
+    expect(src).toContain('backend/services/required_fields.json');
+  });
+
+  it('answers with exactly what the corpus declares, family by family', () => {
+    for (const [family, def] of Object.entries<any>(CORPUS.families)) {
+      // A type with no flags gets the family's list verbatim.
+      const ids = requirements(family, '__no_such_type__').map((r) => r.id);
+      expect(ids).toEqual(def.required.map((r: any) => r.id));
+    }
+  });
+});
+
+describe('what a conveyance must carry', () => {
+  it('states its vesting and declares its transfer tax', () => {
+    /**
+     * THE RULING. `POST /deeds` accepted an instrument without either;
+     * this gate and the partner API both required them. The stricter set
+     * won, and it is now one list.
+     */
+    const ids = requirements('deed', 'grant-deed').map((r) => r.id);
+    expect(ids).toContain('vesting_stated');
+    expect(ids).toContain('dtt_decided');
+  });
+
+  it('does not ask a fixed-vesting form for a vesting', () => {
+    /**
+     * Flag-3 — the form's title IS the decision, and its template never
+     * reads a stored value. Requiring one would demand a field the
+     * instrument has nowhere to put.
+     */
+    for (const deedType of ['grant-deed-jt', 'grant-deed-cp-ros']) {
+      const ids = requirements('deed', deedType).map((r) => r.id);
+      expect(ids).not.toContain('vesting_stated');
+      expect(ids).toContain('dtt_decided');
+      expect(typeFlags(deedType).fixed_vesting).toBe(true);
+    }
+  });
+});
+
+describe('a decision already made is not asked again', () => {
+  it('counts a declared exemption as an answer', () => {
+    /**
+     * §1 from the other side: never INFERRING the choice includes never
+     * FORGETTING it. A transfer tax declared exempt, or declared on full
+     * value, is a decision she made — treating it as absent because the
+     * field is falsy would lose an answer and re-ask for it.
+     */
+    expect(isPresent('dtt', { isExempt: true })).toBe(true);
+    expect(isPresent('dtt', { basis: 'full_value' })).toBe(true);
+    expect(isPresent('dtt', {})).toBe(false);
+    expect(isPresent('dtt', null)).toBe(false);
+  });
+
+  it('reads a declaration party out of `parties`', () => {
+    expect(isPresent('parties', { declarant: 'JANE ROE' })).toBe(true);
+    expect(isPresent('parties', { declarant: '   ' })).toBe(false);
+  });
+});
+
+describe('what is still missing', () => {
+  it('names every unanswered requirement, and nothing else', () => {
+    const missing = missingRequired('deed', 'grant-deed', {
+      grantor: 'JANE ROE',
+      grantee: 'JOHN DOE',
+      legal_description: 'LOT 3 BLOCK 2',
+      vesting: '',
+      dtt: {},
+    }).map((r) => r.id);
+    expect(missing).toEqual(['vesting_stated', 'dtt_decided']);
+  });
+
+  it('separates substance from decision', () => {
+    /**
+     * The dashboard's hero number needs both populations and the
+     * distinction is real, not cosmetic: a blank grantor is a field
+     * nobody filled in, an undeclared transfer tax is a legal choice
+     * nobody has made. They are absent in different ways.
+     */
+    const missing = missingRequired('deed', 'grant-deed', {});
+    expect(missing.filter((r) => r.population === 'substance').map((r) => r.id))
+      .toEqual(['grantor_present', 'grantee_present', 'legal_description_present']);
+    expect(missing.filter((r) => r.population === 'decision').map((r) => r.id))
+      .toEqual(['vesting_stated', 'dtt_decided']);
+  });
+});

--- a/frontend/src/lib/requiredFields.ts
+++ b/frontend/src/lib/requiredFields.ts
@@ -1,0 +1,95 @@
+/**
+ * REQUIRED1 — what a valid instrument must carry. The TypeScript reader.
+ *
+ * `backend/services/required_fields.json` is the AUTHORITY. This module
+ * and `backend/services/required_fields.py` both read it, and both test
+ * suites assert against it. Neither implementation is the source of
+ * truth — the arrangement `vestingSplit.ts` already uses, for the reason
+ * stated there: two implementations of one rule drift, and that is not a
+ * risk, it is a schedule.
+ *
+ * ═══ THREE DEFINITIONS WERE LIVE AT ONCE ═══
+ *
+ *     deeds_crud.py     grantor, grantee, legal description
+ *     partner API       + transfer_tax, vesting per type
+ *     this browser gate + vesting AND a transfer-tax decision
+ *
+ * `POST /deeds` accepted an instrument this gate refuses to generate and
+ * the partner API rejects. The gate runs in the browser, so anything
+ * calling the endpoint directly skipped both legal decisions.
+ *
+ * Owner ruling: the stricter set wins.
+ */
+import corpus from '../../../backend/services/required_fields.json';
+
+export type Population = 'substance' | 'decision';
+
+export interface Requirement {
+  id: string;
+  field: string;
+  label: string;
+  population: Population;
+  section: string;
+  unless?: string;
+}
+
+type Corpus = {
+  families: Record<string, { note?: string; required: Requirement[] }>;
+  types: Record<string, Record<string, unknown>>;
+};
+
+const CORPUS = corpus as unknown as Corpus;
+
+/** Per-instrument exceptions — `fixed_vesting` and friends. */
+export function typeFlags(deedType: string): Record<string, unknown> {
+  const types = CORPUS.types || {};
+  return (types[(deedType || '').trim()] as Record<string, unknown>) || {};
+}
+
+/** What this instrument must carry, exceptions already applied. */
+export function requirements(family: string, deedType: string): Requirement[] {
+  const fam = CORPUS.families?.[family];
+  if (!fam) return [];
+  const flags = typeFlags(deedType);
+  return fam.required.filter((r) => {
+    // `unless` names a flag that REMOVES the requirement. A fixed-vesting
+    // form does not default its vesting — its template refuses to read
+    // one, so demanding it would demand a field with nowhere to go.
+    if (r.unless && flags[r.unless]) return false;
+    return true;
+  });
+}
+
+/**
+ * Is this field answered?
+ *
+ * The decision fields are not strings. A transfer tax declared as "not
+ * exempt, full value" IS a decision — she said so — and treating a falsy
+ * value as absent would re-ask a question she already answered.
+ */
+export function isPresent(field: string, value: unknown): boolean {
+  if (value === null || value === undefined) return false;
+  if (field === 'parties') {
+    return typeof value === 'object'
+      && Object.values(value as Record<string, unknown>)
+        .some((v) => typeof v === 'string' && v.trim() !== '');
+  }
+  if (field === 'dtt') {
+    if (typeof value !== 'object') return String(value).trim() !== '';
+    const d = value as Record<string, unknown>;
+    return Boolean(d.isExempt || d.is_exempt)
+      || String(d.basis ?? '').trim() !== ''
+      || String(d.transferValue ?? d.transfer_value ?? '').trim() !== '';
+  }
+  return String(value).trim() !== '';
+}
+
+/** Every requirement this data does not yet satisfy. */
+export function missingRequired(
+  family: string,
+  deedType: string,
+  data: Record<string, unknown>,
+): Requirement[] {
+  return requirements(family, deedType)
+    .filter((r) => !isPresent(r.field, data[r.field]));
+}


### PR DESCRIPTION
## The premise correction, first

The ruling said the partner API is the permissive one and can create deeds the wizard would have stopped. **It's the other way round.**

| definition | requires |
|---|---|
| `deeds_crud.py` — **`POST /deeds`** | grantor, grantee, legal description |
| partner API — `api_catalog.TYPE_REQUIREMENTS` + `CreateDeedRequest` | **+ `transfer_tax` (a required model field), vesting per type, entity facts** |
| browser gate — `evaluateSubstantive` | **+ vesting AND a transfer-tax decision**, family-aware |

Three definitions, not two. The partner API is the *strictest* — `transfer_tax: TransferTaxModel` has no default, and `rules.requires_vesting` defaults true. The permissive one is the **internal** endpoint, which the wizard itself posts to.

**So there is no partner-API versioning question, and no live integration to break.** The exposure is different and arguably worse: the wizard's gate runs in the *browser*, so the protection was a property of the client. Anything reaching `POST /deeds` another way — a script, a retry, a future integration — skipped both legal decisions on an endpoint that authenticates with an ordinary user token.

The ruling's substance is unaffected: the stricter set wins. Only the direction of the fix changed — the internal endpoint tightens, the partner API needs nothing.

## What was built

`backend/services/required_fields.json` is the authority. `services/required_fields.py` and `frontend/src/lib/requiredFields.ts` both read it, and both suites assert against it — the `vesting_cases.json` arrangement, for the reason stated there: two implementations of one rule drift, and that is not a risk, it is a schedule.

**Three pins hold the corpus to vocabularies that already exist**, so it cannot become a fourth:

- family keys against `form_families.FAMILY_BY_DEED_TYPE` (the corpus first said `conveyance`; the codebase says `deed` — corrected);
- `no_legal_description` against `PROPERTYLESS_TYPES`;
- `fixed_vesting` against the partner API's `api_catalog.TYPE_REQUIREMENTS`, because which instruments fix their own vesting is a legal fact about the form and two answers means one endpoint demands what another refuses.

**`population` separates substance from decision.** A blank grantor is a field nobody filled in; an undeclared transfer tax is a legal choice nobody has made. They are absent in different ways, and the dashboard's hero number needs both.

**A decision already made is not re-asked.** `isExempt: true` and `basis: full_value` both count as answered. §1 from the other side: never *inferring* the choice includes never *forgetting* it.

**Ordering:** the decision check runs after the substance loop. A missing grantee is more fundamental than an undeclared exemption, and naming the legal choices while a party is blank leads with the smaller problem. (Caught by an existing test, which is why the order is now deliberate rather than incidental.)

## Gates

pytest **1415** · jest **1010** · tsc 88 (baseline) · six-flow green · banned-claims clean.

Probes: dropping the transfer-tax requirement from the corpus fails **both** languages (2 Python, 4 TypeScript) — which is the property a shared corpus is bought for. Removing a property-less type fails the `form_families` agreement pin.

One probe initially read as green: my edit left a trailing comma, so the suite *errored* on malformed JSON while my `grep -c FAILED` counted zero. Re-run with valid JSON, it failed correctly. A probe that breaks the fixture proves nothing about the pin.

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_