### PR TITLE
The hero number, counted honestly — and a dormant check in REQUIRED1

### DIFF
--- a/backend/routers/dashboard.py
+++ b/backend/routers/dashboard.py
@@ -17,6 +17,7 @@ from fastapi import APIRouter, Depends, HTTPException
 
 import db
 from auth import get_current_user_id
+from services import deed_accuracy as accuracy
 from services import officer_queue as q
 from services import signing_loop as loop
 
@@ -137,6 +138,44 @@ def officer_queue(user_id: int = Depends(get_current_user_id)) -> Dict[str, Any]
                             else "Sent, not opened yet"),
             })
 
+        # ── What stands between her documents and being ready ─────────
+        #
+        # THE HERO NUMBER. Every unfinished document, not just the idle
+        # ones: "7 fields still need your eyes, across 4 documents" is
+        # the product's own promise made countable, and a promise counted
+        # over a subset is a smaller promise.
+        #
+        # One pass, server-side, because the two populations come from
+        # `required_fields.json` and a stored provenance block — neither
+        # of which the screen holds.
+        cur.execute("""
+            SELECT id, deed_type, property_address, grantor_name, grantee_name,
+                   legal_description, apn, vesting, parties, metadata
+              FROM deeds
+             WHERE user_id = %s
+               AND COALESCE(status, 'draft') NOT IN ('completed', 'deleted')
+               AND archived_at IS NULL
+             ORDER BY COALESCE(updated_at, created_at) DESC
+        """, (user_id,))
+        accuracy_items: List[Dict[str, Any]] = []
+        total_fields = 0
+        for row in _rows(cur):
+            meta = row.get("metadata") or {}
+            checks = accuracy.outstanding(
+                {**row,
+                 "dtt": meta.get("dtt"),
+                 "current_owner": meta.get("current_owner")},
+                provenance=meta.get("provenance"))
+            if not checks:
+                continue
+            total_fields += len(checks)
+            accuracy_items.append({
+                "deed_id": row["id"],
+                "deed_type": row.get("deed_type"),
+                "property": row.get("property_address"),
+                "checks": checks,
+            })
+
         # ── Her own drafts, untouched ─────────────────────────────────
         cur.execute("""
             SELECT id, deed_type, property_address, updated_at, created_at
@@ -162,4 +201,7 @@ def officer_queue(user_id: int = Depends(get_current_user_id)) -> Dict[str, Any]
     # last rather than first — an unknown age is not evidence of urgency.
     awaiting.sort(key=lambda r: (r["days_waiting"] is None,
                                  -(r["days_waiting"] or 0)))
-    return q.queue(upcoming=upcoming, awaiting=awaiting, idle_drafts=idle)
+    return q.queue(upcoming=upcoming, awaiting=awaiting, idle_drafts=idle,
+                   accuracy={"fields": total_fields,
+                             "documents": len(accuracy_items),
+                             "items": accuracy_items})

--- a/backend/services/deed_accuracy.py
+++ b/backend/services/deed_accuracy.py
@@ -1,0 +1,177 @@
+"""What still stands between a document and being ready.
+
+═══ THE PROMISE, MADE COUNTABLE ═══
+
+The product's claim is "every field confirmed by you before it prints",
+and nothing in it reported on that claim. This is the report.
+
+═══ TWO POPULATIONS, AND WHY THE FIRST ALONE WOULD LIE ═══
+
+The obvious count is unconfirmed candidates — county-record values the
+officer has not yet confirmed. Counted alone it is worse than no number
+at all:
+
+  - a draft where she typed an address and left has NOTHING confirmed and
+    NOTHING unconfirmed, because a field with no value has nothing to
+    confirm. It reports ZERO.
+  - a draft one click from done reports its last remaining candidate.
+
+So the number would read zero for the documents furthest from ready and
+peak on the ones nearly finished — a hero figure that is not merely
+imprecise but inverted, in the most prominent slot on the page.
+
+Owner-ruled: count what stands between this document and being ready,
+which is two populations.
+
+  UNCONFIRMED   present, `confirmed_at` is null, source is not 'user'.
+                County-record values she has not yet vouched for.
+
+  REQUIRED      what `required_fields.json` says a valid instrument must
+                carry and this row does not. Sourced from the corpus the
+                print path itself reads (REQUIRED1) — a second definition
+                of "required" here would be the disease that ticket cured.
+
+═══ AND A THIRD THING, WHICH IS NOT A COUNT ═══
+
+`names_disagree` is a FACT, not an inference: the grantor she typed and
+the owner the county record carries are different strings. It reports the
+difference and never says which is right — deciding that is hers, and a
+rule that picked one would be inventing an answer §0 forbids.
+"""
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional
+
+from services.form_families import family_of
+from services.required_fields import missing as missing_required
+
+#: The county-record fields that carry provenance. Mirrors
+#: `MATERIAL_FIELD_LABELS` in `frontend/src/lib/provenance.ts`; a pin
+#: holds the two equal.
+MATERIAL_FIELDS = {
+    "apn": "APN",
+    "legalDescription": "Legal description",
+    "owner": "Current owner (per county records)",
+    "grantor": "Grantor name",
+}
+
+#: Where a material field's value lives on the deed row, so "present" can
+#: be answered. A provenance stamp for a field the row does not hold is
+#: not a thing to confirm.
+VALUE_COLUMN = {
+    "apn": "apn",
+    "legalDescription": "legal_description",
+    "owner": "current_owner",
+    "grantor": "grantor_name",
+}
+
+
+def unconfirmed(provenance: Optional[Dict[str, Any]],
+                row: Dict[str, Any]) -> List[Dict[str, str]]:
+    """County-record values she has not yet confirmed.
+
+    THE DERIVATION RULE, owner-approved:
+
+        present AND confirmed_at IS NULL AND source != 'user'
+
+    The stored shape is `{field: {source, confirmed_at}}` — `status` is
+    not persisted. `confirmed_at` is stamped at entry for anything typed,
+    so a null timestamp means unconfirmed for every value the current
+    builder wrote. The `source != 'user'` clause covers the one exception:
+    a grantor stamped before provenance existed persists as
+    `{'user', null}` while the browser treats it as confirmed on entry.
+    Counting it would ask her to re-confirm something she typed herself.
+    """
+    prov = provenance or {}
+    out = []
+    for key, label in MATERIAL_FIELDS.items():
+        stamp = prov.get(key) or {}
+        value = row.get(VALUE_COLUMN[key])
+        if not (value or "").strip():
+            continue                      # nothing there to confirm
+        if stamp.get("confirmed_at"):
+            continue                      # she confirmed it
+        if (stamp.get("source") or "").strip().lower() == "user":
+            continue                      # she typed it; that IS confirming
+        if not stamp and key == "grantor":
+            # MIRRORS `grantorFieldProvenance` IN THE BROWSER, and the two
+            # must agree or the dashboard counts a field the builder shows
+            # as settled.
+            #
+            # An unstamped grantor only predates stamping. If it equals the
+            # county's owner it arrived by the SiteX prefill and is a
+            # candidate; anything else she typed, and typing is confirming.
+            if (value or "").strip().lower() != \
+                    (row.get("current_owner") or "").strip().lower():
+                continue
+        out.append({"field": key, "label": label, "population": "unconfirmed"})
+    return out
+
+
+def _tokens(name: str) -> frozenset:
+    """A name reduced to its parts, for comparing two spellings of one.
+
+    ═══ WHY TOKENS AND NOT THE STRING ═══
+
+    County records write `SMITH, JANE`; an officer types `JANE SMITH`.
+    Comparing the strings would flag every deed in the product, and a
+    warning that fires always is a warning nobody reads.
+
+    Reordering the parts of a full name is a SPELLING difference in §0's
+    sense — `5TH ST` and `5th Street` — not an identity decision. Two
+    different people do not share a token set. What this deliberately does
+    NOT do is treat `MARIA L. RUIZ` and `MARIA LUCIA RUIZ` as one name:
+    they differ, she should look, and guessing that an initial stands for
+    a particular name is exactly the invention §0 declines.
+    """
+    cleaned = re.sub(r"[.,]", " ", (name or "").lower())
+    return frozenset(t for t in cleaned.split() if t)
+
+
+def names_disagree(row: Dict[str, Any]) -> Optional[Dict[str, str]]:
+    """The typed grantor and the county's vested owner are different.
+
+    A FACT, reported as one. It does not say which is correct, because
+    both are legitimate: she may be conveying from a name the record does
+    not carry, or the record may be stale, or one of them is a typo. The
+    product cannot tell, and a rule that picked would be inventing an
+    answer about a person's identity on a recorded instrument.
+
+    Named for what it compares, too. The mockup said "escrow instructions
+    say X" — the product has never ingested an escrow instruction, so the
+    sentence would have described a document it does not hold.
+    """
+    typed = (row.get("grantor_name") or "").strip()
+    record = (row.get("current_owner") or "").strip()
+    if not typed or not record:
+        return None                       # nothing to compare
+    if _tokens(typed) == _tokens(record):
+        return None
+    return {
+        "field": "grantor",
+        "label": "Names differ",
+        "population": "disagreement",
+        "typed": typed,
+        "record": record,
+    }
+
+
+def outstanding(row: Dict[str, Any],
+                provenance: Optional[Dict[str, Any]] = None) -> List[Dict[str, str]]:
+    """Everything standing between this document and being ready.
+
+    One list, in the order she would work through it: what the instrument
+    is missing, then what she has not vouched for, then the disagreement
+    that needs her judgement rather than her typing.
+    """
+    deed_type = row.get("deed_type") or ""
+    required = [
+        {"field": r.field, "label": r.label, "population": r.population}
+        for r in missing_required(family_of(deed_type), deed_type, row)
+    ]
+    items = required + unconfirmed(provenance, row)
+    disagreement = names_disagree(row)
+    if disagreement:
+        items.append(disagreement)
+    return items

--- a/backend/services/officer_queue.py
+++ b/backend/services/officer_queue.py
@@ -111,7 +111,15 @@ QUEUE_KEYS = frozenset({
     "needs_attention", # ONE number, and it is the stale ones
     "thresholds",      # the numbers above, so no screen retypes them
     "badges",          # per-page waiting counts for the sidebar
+    "accuracy",        # what stands between her documents and being ready
 })
+
+#: The hero number and the list under it, in ONE block from ONE pass —
+#: the same reason `needs_attention` is computed here. A screen deriving
+#: "7 fields across 4 documents" from a list it also renders would be a
+#: second opinion about the product's own promise.
+ACCURACY_KEYS = frozenset({"fields", "documents", "items"})
+ACCURACY_ITEM_KEYS = frozenset({"deed_id", "deed_type", "property", "checks"})
 
 UPCOMING_KEYS = frozenset({"kind", "id", "deed_id", "property", "when",
                            "who", "summary"})
@@ -122,7 +130,8 @@ IDLE_KEYS = frozenset({"kind", "id", "deed_type", "property", "days_idle"})
 
 def queue(*, upcoming: Sequence[Dict[str, Any]],
           awaiting: Sequence[Dict[str, Any]],
-          idle_drafts: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+          idle_drafts: Sequence[Dict[str, Any]],
+          accuracy: Dict[str, Any]) -> Dict[str, Any]:
     """Assemble the payload and assert its shape.
 
     `needs_attention` is computed HERE rather than by the screen, and it
@@ -140,7 +149,14 @@ def queue(*, upcoming: Sequence[Dict[str, Any]],
     for row in idle_drafts:
         assert set(row) == IDLE_KEYS, f"idle row drifted: {sorted(row)}"
 
+    assert set(accuracy) == ACCURACY_KEYS, \
+        f"accuracy block drifted: {sorted(accuracy)}"
+    for row in accuracy["items"]:
+        assert set(row) == ACCURACY_ITEM_KEYS, \
+            f"accuracy row drifted: {sorted(row)}"
+
     payload = {
+        "accuracy": accuracy,
         "upcoming": list(upcoming),
         "awaiting": list(awaiting),
         "idle_drafts": list(idle_drafts),

--- a/backend/services/required_fields.py
+++ b/backend/services/required_fields.py
@@ -76,6 +76,33 @@ def requirements(family: str, deed_type: str) -> List[Requirement]:
     return out
 
 
+#: The corpus names a field once; the two shapes that carry it spell two
+#: of them differently.
+#:
+#: FOUND BY THE DASHBOARD, and it was dormant rather than harmless. The
+#: builder's state says `grantor`; a deed ROW says `grantor_name`. The
+#: create path passes a row, so `missing()` reported grantor and grantee
+#: absent on every call — and nothing showed, because that path raises
+#: only on the `decision` population. A substance check that never
+#: matches is a check that would not have failed if the property were
+#: false (§14.2).
+#:
+#: The alias belongs here rather than in the corpus: which column a shape
+#: uses is a fact about the shape, not about what an instrument requires.
+ROW_ALIASES = {
+    "grantor": ("grantor", "grantor_name"),
+    "grantee": ("grantee", "grantee_name"),
+}
+
+
+def _read(field: str, data: Dict[str, Any]) -> Any:
+    """The field's value, under whichever name this shape uses."""
+    for name in ROW_ALIASES.get(field, (field,)):
+        if name in data:
+            return data[name]
+    return None
+
+
 def _present(field: str, value: Any) -> bool:
     """Is this field answered?
 
@@ -108,4 +135,4 @@ def missing(family: str, deed_type: str, data: Dict[str, Any]) -> List[Requireme
     are the same list read by two callers.
     """
     return [r for r in requirements(family, deed_type)
-            if not _present(r.field, data.get(r.field))]
+            if not _present(r.field, _read(r.field, data))]

--- a/backend/tests/test_dash1_officer_queue.py
+++ b/backend/tests/test_dash1_officer_queue.py
@@ -55,6 +55,13 @@ dbonly = pytest.mark.skipif(not os.getenv("DATABASE_URL"), reason="needs a datab
 # The rules, without a database
 # ══════════════════════════════════════════════════════════════════════
 
+#: An empty accuracy block, stated rather than defaulted. `queue()` takes
+#: it as a required keyword for the reason the key sets exist: a caller
+#: that omits the hero number would get "nothing outstanding", which is
+#: exactly the reading the two-population design exists to prevent.
+NOTHING_OUTSTANDING = {"fields": 0, "documents": 0, "items": []}
+
+
 def test_an_unknown_age_is_unknown_rather_than_today():
     """Zero reads as "asked today", which is a claim. None reads as "we
     do not know", which is true."""
@@ -92,6 +99,7 @@ def test_the_attention_count_is_stale_requests_and_nothing_else():
         awaiting=[_awaiting(True), _awaiting(False)],
         idle_drafts=[{"kind": "draft", "id": 5, "deed_type": "grant_deed",
                       "property": "z", "days_idle": 30}],
+        accuracy=NOTHING_OUTSTANDING,
     )
     assert payload["needs_attention"] == 1
 
@@ -111,6 +119,7 @@ def test_a_badge_counts_presence_and_the_attention_number_counts_silence():
             dict(_awaiting(False), kind="review"),
         ],
         idle_drafts=[],
+        accuracy=NOTHING_OUTSTANDING,
     )
     assert payload["badges"] == {"signings": 1, "shared_deeds": 2}
     assert payload["needs_attention"] == 1
@@ -119,7 +128,7 @@ def test_a_badge_counts_presence_and_the_attention_number_counts_silence():
 def test_the_payload_shape_is_asserted_by_equality():
     from services.officer_queue import QUEUE_KEYS
 
-    payload = q.queue(upcoming=[], awaiting=[], idle_drafts=[])
+    payload = q.queue(upcoming=[], awaiting=[], idle_drafts=[], accuracy=NOTHING_OUTSTANDING)
     assert set(payload) == QUEUE_KEYS
     assert payload["needs_attention"] == 0
     # And the thresholds travel WITH it, so no screen retypes them.
@@ -132,7 +141,7 @@ def test_a_row_that_grew_a_field_is_refused():
     bad = _awaiting(True)
     bad["extra"] = 1
     with pytest.raises(AssertionError):
-        q.queue(upcoming=[], awaiting=[bad], idle_drafts=[])
+        q.queue(upcoming=[], awaiting=[bad], idle_drafts=[], accuracy=NOTHING_OUTSTANDING)
 
 
 def test_only_one_place_decides_what_stale_means():

--- a/backend/tests/test_dash_accuracy.py
+++ b/backend/tests/test_dash_accuracy.py
@@ -1,0 +1,177 @@
+"""The hero number, and why counting one population would have lied.
+
+═══ THE FINDING THAT CHANGED THE NUMBER ═══
+
+The mockup's hero figure is "N fields still need your eyes, across M
+documents" — the product's own promise made countable. Built from
+unconfirmed candidates alone it would report ZERO for a draft where the
+officer typed an address and left, because a field with no value has
+nothing to confirm, and its largest values would come from drafts one
+click from done.
+
+Inverted, in the most prominent slot on the page. Owner ruling: change
+the number to match the promise, not the wording to match the data.
+"""
+from pathlib import Path
+
+import pytest
+
+from services import deed_accuracy as acc
+from tests.source_text import code_only
+
+BACKEND = Path(__file__).resolve().parents[1]
+
+CONFIRMED = {"source": "sitex", "confirmed_at": "2026-08-01T00:00:00Z"}
+#: Every material field vouched for, so a test can vary ONE of them.
+#: Leaving the others unstamped made the first draft of this suite fail
+#: on fields it was not testing — an unstamped present value IS a
+#: candidate, which is the browser's own backfill rule.
+ALL_CONFIRMED = {k: CONFIRMED for k in
+                 ("apn", "legalDescription", "owner", "grantor")}
+CANDIDATE = {"source": "sitex", "confirmed_at": None}
+TYPED_LEGACY = {"source": "user", "confirmed_at": None}
+
+
+def deed(**over):
+    row = {"deed_type": "grant-deed", "grantor_name": "JANE ROE",
+           "grantee_name": "JOHN DOE", "legal_description": "LOT 3",
+           "apn": "1111-222-333", "current_owner": "ROE, JANE",
+           "vesting": "a single woman", "dtt": {"basis": "full_value"}}
+    row.update(over)
+    return row
+
+
+# ── The empty draft: the case that made the first design wrong ───────
+
+def test_a_barely_started_draft_reports_a_LARGE_number_not_zero():
+    """THE PIN THIS FILE EXISTS FOR.
+
+    She typed an address and left. Nothing is confirmed and nothing is
+    unconfirmed — there are no values to confirm — so a candidates-only
+    count says zero, and the number she checks first would tell her the
+    document furthest from ready needs nothing.
+    """
+    started = {"deed_type": "grant-deed", "property_address": "123 Baseline St"}
+    items = acc.outstanding(started, provenance=None)
+    assert len(items) >= 4, items
+    assert {i["field"] for i in items} >= {"grantor", "grantee",
+                                           "legal_description", "dtt"}
+
+
+def test_a_nearly_finished_draft_reports_a_SMALL_number():
+    """The other end of the inversion. One unconfirmed APN and nothing
+    else outstanding."""
+    items = acc.outstanding(deed(), provenance={**ALL_CONFIRMED,
+                                                "apn": CANDIDATE})
+    assert [i["field"] for i in items] == ["apn"]
+
+
+# ── The derivation rule, exactly as ruled ────────────────────────────
+
+def test_a_confirmed_field_is_not_counted():
+    assert acc.unconfirmed(ALL_CONFIRMED, deed()) == []
+
+
+def test_an_unconfirmed_county_value_is_counted():
+    out = acc.unconfirmed({**ALL_CONFIRMED, "apn": CANDIDATE}, deed())
+    assert [i["field"] for i in out] == ["apn"]
+
+
+def test_a_field_she_typed_is_already_confirmed_even_with_no_timestamp():
+    """The backfill branch. A grantor stamped before provenance existed
+    persists as `{'user', null}` and the browser treats it as confirmed
+    on entry — asking her to re-confirm her own typing would be the
+    product forgetting an answer she gave."""
+    assert acc.unconfirmed({**ALL_CONFIRMED, "grantor": TYPED_LEGACY}, deed()) == []
+
+
+def test_a_stamp_for_a_field_the_row_does_not_hold_is_not_counted():
+    """A provenance entry without a value is not a thing to confirm —
+    the same rule the browser gate applies to empty fields (U0)."""
+    row = deed(apn="")
+    assert acc.unconfirmed({**ALL_CONFIRMED, "apn": CANDIDATE}, row) == []
+
+
+# ── Required-and-empty comes from the corpus, not a second list ──────
+
+def test_the_required_half_reads_the_shared_corpus():
+    """REQUIRED1's whole point. A second definition of "required" here
+    would be the disease that ticket cured, one screen further out."""
+    src = code_only((BACKEND / "services" / "deed_accuracy.py")
+                    .read_text(encoding="utf-8"))
+    assert "from services.required_fields import missing as missing_required" in src
+    # And nothing local re-states what a deed needs.
+    assert "grantee_name" not in src.replace('"grantor_name"', "")
+
+
+def test_an_undeclared_transfer_tax_is_outstanding():
+    items = acc.outstanding(deed(dtt=None), provenance={})
+    assert "dtt" in {i["field"] for i in items}
+
+
+def test_a_fixed_vesting_form_is_not_asked_for_a_vesting():
+    """Flag-3 travels with the corpus, so the count inherits it."""
+    row = deed(deed_type="grant-deed-jt", vesting="")
+    assert "vesting" not in {i["field"] for i in acc.outstanding(row, {})}
+
+
+# ── The disagreement: a fact, not a guess ────────────────────────────
+
+def test_a_reordered_name_is_not_a_disagreement():
+    """County records write `SMITH, JANE`; she types `JANE SMITH`.
+    Comparing strings would flag every deed in the product, and a warning
+    that always fires is one nobody reads."""
+    assert acc.names_disagree(deed(grantor_name="JANE ROE",
+                                   current_owner="ROE, JANE")) is None
+
+
+def test_a_different_middle_name_IS_a_disagreement():
+    """The mockup's own example, and the one worth stopping for: a deed
+    rejects over exactly this."""
+    found = acc.names_disagree(deed(grantor_name="MARIA L. RUIZ",
+                                    current_owner="RUIZ, MARIA LUCIA"))
+    assert found is not None
+    assert found["typed"] == "MARIA L. RUIZ"
+    assert found["record"] == "RUIZ, MARIA LUCIA"
+
+
+def test_it_never_says_which_name_is_right():
+    """§0. Both are legitimate — the record may be stale, she may be
+    conveying from a name it does not carry, or one is a typo. A rule
+    that picked would invent an answer about a person's identity on a
+    recorded instrument."""
+    found = acc.names_disagree(deed(grantor_name="MARIA L. RUIZ",
+                                    current_owner="RUIZ, MARIA LUCIA"))
+    text = " ".join(str(v) for v in found.values()).lower()
+    for claim in ("should be", "correct", "incorrect", "wrong", "instead"):
+        assert claim not in text
+
+
+def test_a_missing_side_is_not_a_disagreement():
+    """Nothing to compare. An absent county owner is a gap in the record
+    (`OWNER_ABSENT_FROM_RECORD`), not a conflict with her typing."""
+    assert acc.names_disagree(deed(current_owner="")) is None
+    assert acc.names_disagree(deed(grantor_name="")) is None
+
+
+def test_it_does_not_describe_a_document_the_product_has_never_held():
+    """The mockup said "escrow instructions say X". The product has never
+    ingested an escrow instruction — zero occurrences in the codebase —
+    so that sentence would have named a source it does not hold."""
+    src = (BACKEND / "services" / "deed_accuracy.py").read_text(encoding="utf-8")
+    body = code_only(src)
+    assert "escrow instruction" not in body.lower()
+
+
+def test_an_unstamped_grantor_she_typed_is_not_re_asked():
+    """MIRRORS the browser's `grantorFieldProvenance`. An unstamped
+    grantor only predates stamping: equal to the county owner it arrived
+    by prefill and is a candidate; anything else she typed, and typing is
+    confirming. The two languages must agree, or the dashboard counts a
+    field the builder shows as settled."""
+    prov = {k: CONFIRMED for k in ("apn", "legalDescription", "owner")}
+    typed = deed(grantor_name="JANE ROE", current_owner="SOMEBODY ELSE")
+    assert acc.unconfirmed(prov, typed) == []
+
+    prefilled = deed(grantor_name="ROE, JANE", current_owner="ROE, JANE")
+    assert [i["field"] for i in acc.unconfirmed(prov, prefilled)] == ["grantor"]

--- a/backend/tests/test_required1.py
+++ b/backend/tests/test_required1.py
@@ -185,3 +185,32 @@ def test_the_endpoint_that_enforces_is_the_one_that_PRINTS():
         "the autosave path must stay permissive — an officer mid-work has "
         "not yet made the decisions, and losing her typing to a 422 is the "
         "failure the Thursday walkthrough exists to catch")
+
+
+def test_every_required_field_is_readable_from_a_DEED_ROW():
+    """§14.2 — would this check have failed if the property were false?
+
+    It would not have. The corpus names `grantor`; a deed row carries
+    `grantor_name`, so `missing()` reported grantor and grantee absent on
+    every create — silently, because that path raises only on the
+    `decision` population. A substance check that never matches is a
+    check nobody would notice was broken.
+
+    Driven with a COMPLETE row: nothing may be reported missing.
+    """
+    row = {"deed_type": "grant-deed", "grantor_name": "JANE ROE",
+           "grantee_name": "JOHN DOE", "legal_description": "LOT 3",
+           "vesting": "a single woman", "dtt": {"basis": "full_value"}}
+    absent = rf.missing("deed", "grant-deed", row)
+    assert absent == [], f"complete row reported missing: {[r.id for r in absent]}"
+
+
+def test_the_alias_map_matches_the_typescript_reader():
+    """Two shapes, one corpus — and the alias tables must agree or the
+    dashboard counts a field the builder shows as filled in."""
+    ts = (BACKEND.parent / "frontend" / "src" / "lib" / "requiredFields.ts") \
+        .read_text(encoding="utf-8")
+    for field, names in rf.ROW_ALIASES.items():
+        assert f"{field}: [" in ts, f"{field} missing from the TS alias map"
+        for name in names:
+            assert f"'{name}'" in ts, f"{field} → {name} missing in TS"

--- a/frontend/src/lib/requiredFields.ts
+++ b/frontend/src/lib/requiredFields.ts
@@ -84,6 +84,24 @@ export function isPresent(field: string, value: unknown): boolean {
   return String(value).trim() !== '';
 }
 
+/**
+ * The corpus names a field once; the two shapes that carry it spell two
+ * of them differently. Builder state says `grantor`; a deed row says
+ * `grantor_name`. Mirrors `ROW_ALIASES` in `required_fields.py`, and a
+ * pin holds the two equal.
+ */
+const ROW_ALIASES: Record<string, string[]> = {
+  grantor: ['grantor', 'grantor_name'],
+  grantee: ['grantee', 'grantee_name'],
+};
+
+function read(field: string, data: Record<string, unknown>): unknown {
+  for (const name of ROW_ALIASES[field] ?? [field]) {
+    if (name in data) return data[name];
+  }
+  return undefined;
+}
+
 /** Every requirement this data does not yet satisfy. */
 export function missingRequired(
   family: string,
@@ -91,5 +109,5 @@ export function missingRequired(
   data: Record<string, unknown>,
 ): Requirement[] {
   return requirements(family, deedType)
-    .filter((r) => !isPresent(r.field, data[r.field]));
+    .filter((r) => !isPresent(r.field, read(r.field, data)));
 }


### PR DESCRIPTION
The dashboard's accuracy engine, server-side. This is the half the hero number rests on; the page itself follows.

## Two populations, because one would have inverted the number

`services/deed_accuracy.py` answers *what stands between this document and being ready*:

- **unconfirmed** — present, `confirmed_at` null, `source != 'user'`, exactly as ruled;
- **required** — from `required_fields.json`, the corpus the print path itself reads (REQUIRED1). A second list here would be that ticket's disease one screen further out.

Plus the browser's own grantor rule, mirrored: an unstamped grantor is confirmed *unless* it equals the county owner. Without that, the dashboard counts a field the builder shows as settled — the two languages have to agree about what "confirmed" means.

## The names check, worded for what it actually compares

`names_disagree` reports a **fact** — the typed grantor and the county's vested owner are different strings — and never says which is right. Both are legitimate: the record may be stale, she may be conveying from a name it doesn't carry, or one is a typo.

It compares name **tokens**, and that choice needed an argument. County records write `SMITH, JANE`; officers type `JANE SMITH`. String comparison would flag every deed in the product, and a warning that always fires is one nobody reads. Reordering a full name's parts is a *spelling* difference in §0's sense — two different people don't share a token set.

What it deliberately does **not** do is treat `MARIA L. RUIZ` and `MARIA LUCIA RUIZ` as one name. They differ, she should look, and guessing what an initial stands for is the invention §0 declines. That's the mockup's own example and the case a deed rejects over.

Named for the source it has: the product has never ingested an escrow instruction, so nothing here says one.

## A dormant check in REQUIRED1, found by building on it

**The corpus names `grantor`; a deed row carries `grantor_name`.** So `missing()` reported grantor and grantee absent on *every* create — invisibly, because that path raises only on the `decision` population.

A substance check that never matched: precisely §14.2's third question — *would it have failed if the property were false?* It would not. Fixed with an alias map in both readers, pinned from both sides plus a complete-row test that fails if anything is reported missing.

## Contract

`accuracy` joins the queue's asserted key set, and `queue()` takes it as a **required** keyword rather than a defaulted one — a caller that omitted it would get "nothing outstanding", which is the inverted count wearing a different costume. Every existing caller now states its block.

Computed over every unfinished document, not just idle ones: a promise counted over a subset is a smaller promise.

## Gates

Run in the order the change's shape calls for — a write-adjacent endpoint, so harnesses first.

pytest **1433** · six-flow ✔ · Thursday ✔ · API baseline ✔ · jest 1010 (71 suites) · tsc 88 · banned-claims clean.

Two probes: removing the alias map fails both the complete-row pin and the accuracy suite.

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_