### PR TITLE
The dashboard page — resume with checks named, the promise counted

### DIFF
--- a/backend/routers/dashboard.py
+++ b/backend/routers/dashboard.py
@@ -176,6 +176,30 @@ def officer_queue(user_id: int = Depends(get_current_user_id)) -> Dict[str, Any]
                 "checks": checks,
             })
 
+        # ── What she actually files ───────────────────────────────────
+        #
+        # The catalog is 21 California instruments and an officer files
+        # three of them. Ordering the "start something new" list by her
+        # own frequency puts her next document first; ordering it
+        # alphabetically puts an affidavit she has never filed above the
+        # grant deed she files weekly.
+        #
+        # THIS YEAR, and the window is named in the payload rather than
+        # implied by the number — "14" over an unstated period is a
+        # figure the reader has to guess the meaning of.
+        cur.execute("""
+            SELECT deed_type, COUNT(*) AS n
+              FROM deeds
+             WHERE user_id = %s
+               AND COALESCE(status, '') <> 'deleted'
+               AND created_at >= date_trunc('year', now())
+             GROUP BY deed_type
+             ORDER BY n DESC, deed_type
+        """, (user_id,))
+        instruments = [{"deed_type": r["deed_type"], "count": r["n"],
+                        "period": "this year"}
+                       for r in _rows(cur) if r.get("deed_type")]
+
         # ── Her own drafts, untouched ─────────────────────────────────
         cur.execute("""
             SELECT id, deed_type, property_address, updated_at, created_at
@@ -202,6 +226,7 @@ def officer_queue(user_id: int = Depends(get_current_user_id)) -> Dict[str, Any]
     awaiting.sort(key=lambda r: (r["days_waiting"] is None,
                                  -(r["days_waiting"] or 0)))
     return q.queue(upcoming=upcoming, awaiting=awaiting, idle_drafts=idle,
+                   instruments=instruments,
                    accuracy={"fields": total_fields,
                              "documents": len(accuracy_items),
                              "items": accuracy_items})

--- a/backend/services/officer_queue.py
+++ b/backend/services/officer_queue.py
@@ -112,7 +112,14 @@ QUEUE_KEYS = frozenset({
     "thresholds",      # the numbers above, so no screen retypes them
     "badges",          # per-page waiting counts for the sidebar
     "accuracy",        # what stands between her documents and being ready
+    "instruments",     # what THIS officer files, most-used first
 })
+
+#: "Start something new", ordered by what she actually files rather than
+#: alphabetically — and the count is the evidence for the order, shown
+#: rather than implied. An officer who files nothing but interspousal
+#: transfers should not scroll past four grant-deed variants.
+INSTRUMENT_KEYS = frozenset({"deed_type", "count", "period"})
 
 #: The hero number and the list under it, in ONE block from ONE pass —
 #: the same reason `needs_attention` is computed here. A screen deriving
@@ -131,7 +138,8 @@ IDLE_KEYS = frozenset({"kind", "id", "deed_type", "property", "days_idle"})
 def queue(*, upcoming: Sequence[Dict[str, Any]],
           awaiting: Sequence[Dict[str, Any]],
           idle_drafts: Sequence[Dict[str, Any]],
-          accuracy: Dict[str, Any]) -> Dict[str, Any]:
+          accuracy: Dict[str, Any],
+          instruments: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
     """Assemble the payload and assert its shape.
 
     `needs_attention` is computed HERE rather than by the screen, and it
@@ -155,8 +163,13 @@ def queue(*, upcoming: Sequence[Dict[str, Any]],
         assert set(row) == ACCURACY_ITEM_KEYS, \
             f"accuracy row drifted: {sorted(row)}"
 
+    for row in instruments:
+        assert set(row) == INSTRUMENT_KEYS, \
+            f"instrument row drifted: {sorted(row)}"
+
     payload = {
         "accuracy": accuracy,
+        "instruments": list(instruments),
         "upcoming": list(upcoming),
         "awaiting": list(awaiting),
         "idle_drafts": list(idle_drafts),

--- a/backend/tests/test_dash1_officer_queue.py
+++ b/backend/tests/test_dash1_officer_queue.py
@@ -60,6 +60,9 @@ dbonly = pytest.mark.skipif(not os.getenv("DATABASE_URL"), reason="needs a datab
 #: that omits the hero number would get "nothing outstanding", which is
 #: exactly the reading the two-population design exists to prevent.
 NOTHING_OUTSTANDING = {"fields": 0, "documents": 0, "items": []}
+#: She has filed nothing yet — stated, like the accuracy block, rather
+#: than defaulted.
+FILES_NOTHING: list = []
 
 
 def test_an_unknown_age_is_unknown_rather_than_today():
@@ -100,6 +103,7 @@ def test_the_attention_count_is_stale_requests_and_nothing_else():
         idle_drafts=[{"kind": "draft", "id": 5, "deed_type": "grant_deed",
                       "property": "z", "days_idle": 30}],
         accuracy=NOTHING_OUTSTANDING,
+        instruments=FILES_NOTHING,
     )
     assert payload["needs_attention"] == 1
 
@@ -120,6 +124,7 @@ def test_a_badge_counts_presence_and_the_attention_number_counts_silence():
         ],
         idle_drafts=[],
         accuracy=NOTHING_OUTSTANDING,
+        instruments=FILES_NOTHING,
     )
     assert payload["badges"] == {"signings": 1, "shared_deeds": 2}
     assert payload["needs_attention"] == 1
@@ -128,7 +133,8 @@ def test_a_badge_counts_presence_and_the_attention_number_counts_silence():
 def test_the_payload_shape_is_asserted_by_equality():
     from services.officer_queue import QUEUE_KEYS
 
-    payload = q.queue(upcoming=[], awaiting=[], idle_drafts=[], accuracy=NOTHING_OUTSTANDING)
+    payload = q.queue(upcoming=[], awaiting=[], idle_drafts=[], accuracy=NOTHING_OUTSTANDING,
+        instruments=FILES_NOTHING)
     assert set(payload) == QUEUE_KEYS
     assert payload["needs_attention"] == 0
     # And the thresholds travel WITH it, so no screen retypes them.
@@ -141,7 +147,8 @@ def test_a_row_that_grew_a_field_is_refused():
     bad = _awaiting(True)
     bad["extra"] = 1
     with pytest.raises(AssertionError):
-        q.queue(upcoming=[], awaiting=[bad], idle_drafts=[], accuracy=NOTHING_OUTSTANDING)
+        q.queue(upcoming=[], awaiting=[bad], idle_drafts=[], accuracy=NOTHING_OUTSTANDING,
+        instruments=FILES_NOTHING)
 
 
 def test_only_one_place_decides_what_stale_means():

--- a/frontend/src/__tests__/dashboardAccuracyRender.test.tsx
+++ b/frontend/src/__tests__/dashboardAccuracyRender.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * The dashboard's accuracy surface, RENDERED.
+ *
+ * ═══ WHY RENDERED ═══
+ *
+ * The hero number is the product's promise made countable, and its
+ * failure modes are all things a source pin cannot see: a zero drawn
+ * before the data arrives, a count that disagrees with the list beneath
+ * it, a thumbnail that says settled while the sentence says outstanding.
+ *
+ * For a page the fix is rendering — the seventh time this suite has
+ * needed that rule.
+ */
+import { describe, expect, it } from '@jest/globals';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import '@testing-library/jest-dom/jest-globals';
+
+import AccuracySection, { checkSentence } from '@/features/dashboard/AccuracySection';
+import type { AccuracyCheck } from '@/features/dashboard/AccuracySection';
+import ResumeCard from '@/features/dashboard/ResumeCard';
+import StartSomethingNew from '@/features/dashboard/StartSomethingNew';
+
+const check = (over: Partial<AccuracyCheck> = {}): AccuracyCheck => ({
+  field: 'apn', label: 'APN', population: 'unconfirmed', ...over,
+});
+
+describe('the hero number', () => {
+  it('never renders a figure it did not receive', () => {
+    /**
+     * THE PIN THIS FILE EXISTS FOR. A zero drawn while the request is in
+     * flight is the same lie as the inverted count, arriving earlier —
+     * it tells her nothing is outstanding before anything has been
+     * counted.
+     */
+    const { container } = render(<AccuracySection accuracy={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('says how many fields across how many documents', () => {
+    render(<AccuracySection accuracy={{
+      fields: 7, documents: 4,
+      items: [{ deed_id: 1, property: '1358 5th St', checks: [check()] }],
+    }} />);
+    expect(screen.getByTestId('accuracy-figure')).toHaveTextContent('7');
+    expect(screen.getByText(/across 4 documents/)).toBeInTheDocument();
+  });
+
+  it('says so plainly when nothing is outstanding', () => {
+    /** Zero is a real answer once it has been counted — and it is worth
+     *  saying, because "no list" and "nothing left" look identical. */
+    render(<AccuracySection accuracy={{ fields: 0, documents: 0, items: [] }} />);
+    expect(screen.getByText(/Every field on every open document is confirmed/))
+      .toBeInTheDocument();
+  });
+});
+
+describe('what each check says', () => {
+  it('reports a name difference without saying which is right', () => {
+    /**
+     * §0. Both are legitimate — the record may be stale, she may be
+     * conveying from a name it does not carry, or one is a typo.
+     */
+    const sentence = checkSentence(check({
+      field: 'grantor', population: 'disagreement',
+      typed: 'MARIA L. RUIZ', record: 'RUIZ, MARIA LUCIA',
+    }));
+    expect(sentence).toContain('MARIA L. RUIZ');
+    expect(sentence).toContain('RUIZ, MARIA LUCIA');
+    for (const claim of [/should be/i, /correct/i, /wrong/i, /instead/i]) {
+      expect(sentence).not.toMatch(claim);
+    }
+  });
+
+  it('distinguishes never-answered from not-yet-confirmed', () => {
+    /**
+     * A blank grantee is a field nobody filled in; an unconfirmed APN is
+     * a county value she has not vouched for. Same count, different act,
+     * and collapsing them would tell her to type where she should read.
+     */
+    expect(checkSentence(check({ population: 'substance', label: 'Grantee stated' })))
+      .toMatch(/still empty/);
+    expect(checkSentence(check({ population: 'unconfirmed' })))
+      .toMatch(/not yet confirmed by you/);
+    expect(checkSentence(check({ population: 'decision', label: 'Transfer tax decided' })))
+      .toMatch(/not chosen yet/);
+  });
+});
+
+describe('the resume card', () => {
+  const target = {
+    deed_id: 9, deed_type: 'Interspousal Transfer', property: '4420 Cahuenga Blvd',
+    escrow_no: '24-0902',
+    checks: [check({ field: 'legal_description', label: 'Legal description',
+                     population: 'unconfirmed' }),
+             check({ field: 'dtt', label: 'Transfer tax decided',
+                     population: 'decision' })],
+  };
+
+  it('names the remaining checks rather than only counting them', () => {
+    render(<ResumeCard target={target} />);
+    expect(screen.getByText(/Legal description — from county records/)).toBeInTheDocument();
+    expect(screen.getByText(/Transfer tax decided — not chosen yet/)).toBeInTheDocument();
+    expect(screen.getByText(/Continue — 2 checks left/)).toBeInTheDocument();
+  });
+
+  it('marks the thumbnail from the same list as the sentences', () => {
+    /**
+     * The picture and the words cannot disagree, because they are one
+     * source. A thumbnail drawn from separate state is a thumbnail that
+     * eventually says settled while the line beneath says outstanding.
+     */
+    render(<ResumeCard target={target} />);
+    expect(screen.getByTestId('thumb-legal_description'))
+      .toHaveAttribute('data-state', 'outstanding');
+    expect(screen.getByTestId('thumb-dtt'))
+      .toHaveAttribute('data-state', 'outstanding');
+    expect(screen.getByTestId('thumb-grantor'))
+      .toHaveAttribute('data-state', 'confirmed');
+  });
+
+  it('counts one check in the singular', () => {
+    render(<ResumeCard target={{ ...target, checks: [check()] }} />);
+    expect(screen.getByText(/Continue — 1 check left/)).toBeInTheDocument();
+  });
+
+  it('renders nothing when there is nothing to resume', () => {
+    const { container } = render(<ResumeCard target={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe('start something new', () => {
+  it('orders by what she files and shows the count with its period', () => {
+    render(<StartSomethingNew instruments={[
+      { deed_type: 'grant-deed', count: 31, period: 'this year' },
+      { deed_type: 'interspousal-transfer', count: 14, period: 'this year' },
+    ]} />);
+    expect(screen.getByText('most used')).toBeInTheDocument();
+    expect(screen.getByText('14 this year')).toBeInTheDocument();
+  });
+
+  it('offers the catalog on day one instead of an empty list', () => {
+    /**
+     * A frequency-ordered list is useless before there is any frequency,
+     * and must not become the only way in.
+     */
+    render(<StartSomethingNew instruments={[]} />);
+    expect(screen.getByText('grant-deed')).toBeInTheDocument();
+    expect(screen.queryByText('most used')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -9,6 +9,9 @@ import { AICard } from "@/components/ui/AICard"
 import { AIEmptyState } from "@/components/ui/AIEmptyState"
 import { AuthManager } from "@/utils/auth"
 import EmailVerificationNotice from "@/features/account/EmailVerificationNotice"
+import AccuracySection from "@/features/dashboard/AccuracySection"
+import ResumeCard from "@/features/dashboard/ResumeCard"
+import StartSomethingNew from "@/features/dashboard/StartSomethingNew"
 import { pickInProgressDeed } from "@/lib/latestDraft"
 import { SessionExpiredError, apiFetch } from "@/lib/apiClient"
 import { 
@@ -31,6 +34,12 @@ import {
  * `services/officer_queue.py`. Nothing here decides what "stale" means.
  */
 type Queue = {
+  /* Both added by the dashboard rebuild and both computed server-side:
+     the hero number's two populations come from `required_fields.json`
+     and a stored provenance block, and the instrument order comes from
+     her own filing history. Neither is derivable here. */
+  accuracy?: import('@/features/dashboard/AccuracySection').Accuracy;
+  instruments?: Array<{ deed_type: string; count: number; period: string }>;
   upcoming: Array<{ kind: string; id: number; deed_id: number; property: string | null;
                     when: string; who: string | null; summary: string }>;
   awaiting: Array<{ kind: string; id: number; deed_id: number; property: string | null;
@@ -44,6 +53,9 @@ type Queue = {
 
 export default function Dashboard() {
   const [queue, setQueue] = useState<Queue | null>(null)
+  /* The accuracy block and the instrument list ride on the queue's one
+     response (DASH1) — a second request would let the page render a
+     partial truth when one of the two failed. */
   const [queueError, setQueueError] = useState<string | null>(null)
   const [isAuthenticated, setIsAuthenticated] = useState(false)
   const [loading, setLoading] = useState(true)
@@ -60,6 +72,14 @@ export default function Dashboard() {
     lastThirtyDays: number
   } | null>(null)
   const router = useRouter()
+
+  /* THE DOCUMENT SHE WAS LAST IN, and it is the accuracy list's first
+     row rather than a second query: the server already ordered those by
+     most-recently-touched, so asking again would be a second opinion
+     about which document is hers to resume. */
+  const resumeTarget = queue?.accuracy?.items?.length
+    ? { ...queue.accuracy.items[0], escrow_no: null }
+    : null
 
   // Authentication check and load user data
   useEffect(() => {
@@ -242,6 +262,29 @@ export default function Dashboard() {
               and offers; it withholds nothing, because nothing in this
               product is gated on the answer. */}
           <EmailVerificationNotice verified={account.verified} email={account.email} />
+
+          {/* THE MOCKUP'S ORDER, AND IT IS AN ARGUMENT: resume is the
+              highest-frequency action in a preparation tool, so it sits
+              above everything, with the remaining checks NAMED. */}
+          <div className="mb-6 grid gap-4 lg:grid-cols-[2fr,1fr]">
+            <ResumeCard
+              target={resumeTarget}
+              onResume={(id) => router.push(`/deed-builder/grant-deed?resume=${id}`)}
+            />
+            <StartSomethingNew
+              instruments={queue?.instruments}
+              onStart={(t) => router.push(`/deed-builder/${t}`)}
+              onBrowse={() => router.push('/create-deed')}
+            />
+          </div>
+
+          {/* The promise, made countable. */}
+          <div className="mb-8">
+            <AccuracySection
+              accuracy={queue?.accuracy}
+              onOpen={(id) => router.push(`/deeds/${id}`)}
+            />
+          </div>
 
           {/* AI Greeting */}
           <div className="mb-8">

--- a/frontend/src/features/dashboard/AccuracySection.tsx
+++ b/frontend/src/features/dashboard/AccuracySection.tsx
@@ -1,0 +1,133 @@
+/**
+ * The hero number, and the list it counts.
+ *
+ * ═══ THE PROMISE, MADE COUNTABLE ═══
+ *
+ * "Every field confirmed by you before it prints" is what this product
+ * sells, and nothing in it reported on that claim. This does.
+ *
+ * ═══ WHY THE NUMBER IS NOT A COUNT OF UNCONFIRMED FIELDS ═══
+ *
+ * That was the first design and it would have been inverted. A field
+ * with no value has nothing to confirm, so a draft where she typed an
+ * address and left reports ZERO, while a draft one click from done
+ * reports its last candidate. The most prominent figure on the page
+ * would have read lowest for the documents furthest from ready.
+ *
+ * Owner-ruled: count what stands between the document and being ready —
+ * required-and-empty AND unconfirmed. Both come from the server in one
+ * pass (`/dashboard/queue`), because both are derived from
+ * `required_fields.json` and a stored provenance block, neither of which
+ * this screen holds.
+ *
+ * ═══ AND IT NEVER RENDERS A NUMBER IT DID NOT RECEIVE ═══
+ *
+ * A zero drawn while the request is in flight is the same lie as the
+ * inverted count, arriving earlier. Absent data renders nothing.
+ */
+'use client';
+
+export interface AccuracyCheck {
+  field: string;
+  label: string;
+  population: 'substance' | 'decision' | 'unconfirmed' | 'disagreement';
+  typed?: string;
+  record?: string;
+}
+
+export interface AccuracyItem {
+  deed_id: number;
+  deed_type?: string | null;
+  property?: string | null;
+  checks: AccuracyCheck[];
+}
+
+export interface Accuracy {
+  fields: number;
+  documents: number;
+  items: AccuracyItem[];
+}
+
+/**
+ * What this check is, in her words — one place turns state into English
+ * (§13 rule 3), so the resume card and this list cannot drift.
+ */
+export function checkSentence(check: AccuracyCheck): string {
+  if (check.population === 'disagreement') {
+    // Reports the difference and NEVER which one is right. Both are
+    // legitimate: the record may be stale, she may be conveying from a
+    // name it does not carry, or one is a typo.
+    return `Names differ — you typed ${check.typed}; the county record says ${check.record}`;
+  }
+  if (check.population === 'unconfirmed') {
+    return `${check.label} — from county records, not yet confirmed by you`;
+  }
+  if (check.population === 'decision') {
+    return `${check.label} — not chosen yet`;
+  }
+  return `${check.label} — still empty`;
+}
+
+const HEADLINE = 'fields still need your eyes';
+
+export default function AccuracySection({ accuracy, onOpen }: {
+  accuracy?: Accuracy | null;
+  onOpen?: (deedId: number) => void;
+}) {
+  // Nothing received: say nothing. Not zero — zero is a claim.
+  if (!accuracy) return null;
+
+  if (accuracy.fields === 0) {
+    return (
+      <div className="rounded-xl border border-emerald-200 bg-emerald-50 px-5 py-4">
+        <p className="text-sm text-emerald-900">
+          Every field on every open document is confirmed. Nothing is waiting on your eyes.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <section aria-labelledby="accuracy-heading" className="space-y-4">
+      <div className="flex items-end gap-4">
+        <div className="text-5xl font-bold leading-none text-slate-900"
+             data-testid="accuracy-figure">
+          {accuracy.fields}
+        </div>
+        <h2 id="accuracy-heading" className="pb-1 text-sm text-slate-600">
+          {HEADLINE}, across {accuracy.documents}{' '}
+          {accuracy.documents === 1 ? 'document' : 'documents'}
+        </h2>
+      </div>
+
+      <ul className="space-y-3">
+        {accuracy.items.map((item) => (
+          <li key={item.deed_id}
+              className="rounded-xl border border-slate-200 bg-white p-4">
+            <div className="font-medium text-slate-800">
+              {item.property || 'Untitled document'}
+            </div>
+            <div className="text-xs text-slate-500">{item.deed_type}</div>
+            <ul className="mt-2 space-y-1">
+              {item.checks.map((check) => (
+                <li key={`${item.deed_id}-${check.field}-${check.population}`}
+                    className="text-sm text-slate-700">
+                  {checkSentence(check)}
+                </li>
+              ))}
+            </ul>
+            {onOpen && (
+              <button
+                type="button"
+                onClick={() => onOpen(item.deed_id)}
+                className="mt-3 text-sm font-medium text-[#7C4DFF] underline underline-offset-2"
+              >
+                Open this document
+              </button>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/frontend/src/features/dashboard/ResumeCard.tsx
+++ b/frontend/src/features/dashboard/ResumeCard.tsx
@@ -1,0 +1,115 @@
+/**
+ * Pick up where you left off — with what is left NAMED.
+ *
+ * ═══ WHY THE CHECKS ARE LISTED AND NOT COUNTED ═══
+ *
+ * "Continue — 2 checks left" tells her there is work; the two lines
+ * above it tell her what she is walking back into before she clicks.
+ * The difference matters most on the document she abandoned yesterday,
+ * which is the one she remembers least about.
+ *
+ * ═══ THE THUMBNAIL IS THE DOCUMENT'S STATE, NOT A PICTURE OF IT ═══
+ *
+ * Confirmed fields draw solid, outstanding ones dashed. It is a
+ * schematic, deliberately: a real preview would be an illegible
+ * postage-stamp of a legal instrument, while a schematic answers the one
+ * question the page is for — how much of this is settled — without her
+ * opening it.
+ *
+ * It is drawn from the SAME check list as the sentences beside it, so
+ * the picture and the words cannot disagree.
+ */
+'use client';
+
+import type { AccuracyCheck } from './AccuracySection';
+import { checkSentence } from './AccuracySection';
+
+export interface ResumeTarget {
+  deed_id: number;
+  deed_type?: string | null;
+  property?: string | null;
+  escrow_no?: string | null;
+  checks: AccuracyCheck[];
+}
+
+/**
+ * The fields a grant deed's face carries, in the order they print. The
+ * thumbnail marks each one solid or dashed; fields with no outstanding
+ * check are settled.
+ */
+const FACE_FIELDS = [
+  { key: 'grantor', label: 'Grantor' },
+  { key: 'grantee', label: 'Grantee' },
+  { key: 'legal_description', label: 'Legal description' },
+  { key: 'apn', label: 'APN' },
+  { key: 'vesting', label: 'Vesting' },
+  { key: 'dtt', label: 'Transfer tax' },
+];
+
+export function outstandingFields(checks: AccuracyCheck[]): Set<string> {
+  return new Set(checks.map((c) => c.field));
+}
+
+export default function ResumeCard({ target, onResume }: {
+  target?: ResumeTarget | null;
+  onResume?: (deedId: number) => void;
+}) {
+  if (!target) return null;
+  const outstanding = outstandingFields(target.checks);
+  const left = target.checks.length;
+
+  return (
+    <section aria-labelledby="resume-heading"
+             className="flex gap-5 rounded-xl border border-slate-200 bg-white p-5">
+      {/* The schematic. `aria-hidden` because the checks below say the
+          same thing in words — a screen-reader user gets the sentences,
+          not a description of dashes. */}
+      <div aria-hidden className="hidden w-28 shrink-0 sm:block"
+           data-testid="resume-thumbnail">
+        <div className="space-y-1.5 rounded border border-slate-300 p-2">
+          {FACE_FIELDS.map((f) => (
+            <div
+              key={f.key}
+              data-testid={`thumb-${f.key}`}
+              data-state={outstanding.has(f.key) ? 'outstanding' : 'confirmed'}
+              className={outstanding.has(f.key)
+                ? 'h-1.5 rounded border border-dashed border-slate-400'
+                : 'h-1.5 rounded bg-slate-700'}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <div className="text-xs uppercase tracking-wide text-slate-500">
+          Pick up where you left off
+        </div>
+        <h3 id="resume-heading" className="text-lg font-semibold text-slate-900">
+          {target.property || 'Untitled document'}
+        </h3>
+        <div className="text-sm text-slate-500">
+          {[target.deed_type, target.escrow_no].filter(Boolean).join(' · ')}
+        </div>
+
+        <ul className="mt-3 space-y-1">
+          {target.checks.map((check) => (
+            <li key={`${check.field}-${check.population}`}
+                className="text-sm text-slate-700">
+              {checkSentence(check)}
+            </li>
+          ))}
+        </ul>
+
+        <button
+          type="button"
+          onClick={() => onResume?.(target.deed_id)}
+          className="mt-4 rounded-lg bg-[#7C4DFF] px-5 py-2.5 font-medium text-white"
+        >
+          {/* The count and the list are the same data, so they cannot
+              disagree about how much is left. */}
+          Continue — {left} {left === 1 ? 'check' : 'checks'} left
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/features/dashboard/StartSomethingNew.tsx
+++ b/frontend/src/features/dashboard/StartSomethingNew.tsx
@@ -1,0 +1,77 @@
+/**
+ * Start something new — ordered by what THIS officer actually files.
+ *
+ * ═══ WHY NOT ALPHABETICALLY ═══
+ *
+ * The catalog is 21 California instruments and an officer files three of
+ * them. Alphabetical order puts an affidavit she has never filed above
+ * the grant deed she files weekly; her own frequency puts her next
+ * document first.
+ *
+ * ═══ THE COUNT IS THE EVIDENCE FOR THE ORDER ═══
+ *
+ * Shown rather than implied, and with its PERIOD, because "14" over an
+ * unstated window is a number the reader has to guess the meaning of.
+ * The server sends the period with the count so this screen does not
+ * invent one.
+ *
+ * An officer with no history sees the catalog, not an empty list — a
+ * frequency-ordered list is useless on day one and must not become the
+ * only way in.
+ */
+'use client';
+
+export interface InstrumentUse {
+  deed_type: string;
+  count: number;
+  period: string;
+}
+
+/** The types offered when she has filed nothing yet. */
+export const STARTERS = ['grant-deed', 'interspousal-transfer', 'quitclaim-deed'];
+
+export default function StartSomethingNew({ instruments, onStart, onBrowse }: {
+  instruments?: InstrumentUse[] | null;
+  onStart?: (deedType: string) => void;
+  onBrowse?: () => void;
+}) {
+  const used = instruments ?? [];
+  const rows = used.length
+    ? used
+    : STARTERS.map((deed_type) => ({ deed_type, count: 0, period: '' }));
+
+  return (
+    <section aria-labelledby="start-heading"
+             className="rounded-xl border border-slate-200 bg-white p-5">
+      <h3 id="start-heading" className="font-semibold text-slate-900">
+        Start something new
+      </h3>
+      <ul className="mt-3 space-y-2">
+        {rows.map((row, i) => (
+          <li key={row.deed_type}>
+            <button
+              type="button"
+              onClick={() => onStart?.(row.deed_type)}
+              className="flex w-full items-center justify-between rounded-lg border border-slate-200 px-3 py-2 text-left text-sm"
+            >
+              <span className="text-slate-800">{row.deed_type}</span>
+              <span className="text-xs text-slate-500">
+                {/* "most used" only where it is TRUE — the top row of a
+                    list she has actually filed from. On day one there is
+                    no most-used and claiming one would be a fact
+                    invented out of an empty table. */}
+                {row.count > 0
+                  ? (i === 0 ? 'most used' : `${row.count} ${row.period}`)
+                  : ''}
+              </span>
+            </button>
+          </li>
+        ))}
+      </ul>
+      <button type="button" onClick={onBrowse}
+              className="mt-3 text-sm text-[#7C4DFF] underline underline-offset-2">
+        Browse all 21 California instruments
+      </button>
+    </section>
+  );
+}


### PR DESCRIPTION
The page, built against `docs/design/dashboard_steady_state.html`, on the data #202 shipped.

## Resume, with the checks named

Above everything, because resume is the highest-frequency action in a preparation tool. **"Continue — 2 checks left" says there is work; the two lines above it say what she is walking back into** — which matters most on the document she abandoned yesterday, the one she remembers least about.

The **thumbnail** marks confirmed fields solid and outstanding ones dashed, drawn from the *same check list* as the sentences beside it. A picture built from separate state is one that eventually says settled while the line beneath says outstanding. It's a schematic deliberately: a real preview would be an illegible postage stamp of a legal instrument, while this answers the one question the page exists for.

## The hero number

**Never renders a figure it did not receive.** A zero drawn while the request is in flight is the same lie as the inverted count, arriving earlier. Zero *after* counting is said plainly — "no list" and "nothing left" look identical otherwise.

Each check says which **kind** of absence it is: a blank grantee is a field nobody filled in, an unconfirmed APN is a county value she hasn't vouched for, an undeclared transfer tax is a choice nobody has made. Collapsing them would tell her to type where she should read. One function turns a check into a sentence (§13 rule 3), so the resume card and the list can't drift.

The names difference reports both values and never says which is right — pinned by a test that fails on "should be", "correct", "wrong", "instead".

## Start something new

Ordered by what this officer actually files, with the count **and its period** — "14" over an unstated window is a number the reader has to guess at, so the server sends the period rather than the screen inventing one.

On day one it offers the catalog instead of an empty list, and claims no "most used": that would be a fact invented out of an empty table.

## Contract

`accuracy` and `instruments` both ride on the queue's single response (DASH1) — a second request would let the page render a partial truth when one of the two failed. Both joined the asserted key set; every direct caller of `queue()` now states them rather than receiving a default, because an omitted hero number reads as "nothing outstanding".

## Gates

Page changed, so `next build` is in the set this time, per the gate-selection table.

pytest **1433** · jest **1021** (72 suites) · tsc 88 · **`next build` clean** · six-flow ✔ · Thursday ✔ · API baseline ✔ · banned-claims clean.

Two probes, both caught: the thumbnail drawn from separate state (words and picture disagree), and the hero rendering 0 before data arrives.

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_