### PR TITLE
The migration ran, so both conditional rulings fire

### DIFF
--- a/backend/auth.py
+++ b/backend/auth.py
@@ -255,7 +255,20 @@ class AuthUtils:
 #: entered the console and was then refused by two gates inside it, which
 #: they would experience as the console being broken. Nothing recorded
 #: which of the three was authoritative.
-ADMIN_ROLES = ('admin', 'administrator', 'superadmin', 'super_admin')
+#: NARROWED 2026-08-13, after the ROLE1 migration ran and was verified.
+#: Final state: ('admin', None, 1), ('user', 'Escrow Officer', 1),
+#: ('user', 'Title Agent', 1), ('user', None, 1) — four rows, one admin,
+#: canonically spelled, and no other spelling anywhere in the column.
+#:
+#: The four spellings were RECOGNIZED because history had written four.
+#: History no longer has: narrowing before the migration would have
+#: silently removed access from an unmigrated row, and narrowing after it
+#: removes nothing, because there is nothing left to remove. That
+#: ordering was the whole reason this stayed wide through step 3.
+#:
+#: Recognized and assignable are now the same set, which is the point:
+#: the interim shape had an expiry and this is it.
+ADMIN_ROLES = ('admin',)
 
 
 def is_admin_role(role: str) -> bool:

--- a/backend/routers/dashboard.py
+++ b/backend/routers/dashboard.py
@@ -173,6 +173,13 @@ def officer_queue(user_id: int = Depends(get_current_user_id)) -> Dict[str, Any]
                 "deed_id": row["id"],
                 "deed_type": row.get("deed_type"),
                 "property": row.get("property_address"),
+                # The field that ties this deed to the FILE, which is the
+                # orientation the resume card exists to give. Added
+                # deliberately rather than left to render blank where the
+                # design shows a fact.
+                # In `metadata`, not a column — the draft extras list is
+                # where it has always lived.
+                "escrow_no": meta.get("escrow_no"),
                 "checks": checks,
             })
 

--- a/backend/routers/users_auth.py
+++ b/backend/routers/users_auth.py
@@ -41,23 +41,13 @@ class UserRegister(BaseModel):
     password: str
     confirm_password: str
     full_name: str
-    # ── ROLE1 step 3: TWO WIRE NAMES, ONE COLUMN, ON PURPOSE ──────────
-    #
-    # What the form has always called "professional role" is a JOB TITLE
-    # and now lands in `users.job_title`. `job_title` is the name that
-    # means what it holds; `role` is the name the deployed frontend
-    # sends.
-    #
-    # Both are accepted for exactly one reason: this backend (Render) and
-    # that frontend (Vercel) deploy separately, so there is a window
-    # where one is new and the other is not. Registration is the front
-    # door and a 422 in that window is a lost signup.
-    #
-    # REMOVAL TRIGGER: once a frontend sending `job_title` has been live
-    # through one deploy, `role` comes out of this model and the refusal
-    # below goes with it.
+    # ROLE1 step 3, completed. `job_title` is the only name now: the
+    # legacy `role` field came out once a frontend sending `job_title`
+    # had been live through a deploy, which was the removal trigger this
+    # comment carried. A registrant sending `role` is ignored by
+    # Pydantic, which is the right outcome — it was never the
+    # authorization column and now it is not a field at all.
     job_title: Optional[str] = None
-    role: Optional[str] = None
     company_name: Optional[str] = None
     company_type: Optional[str] = None
     phone: Optional[str] = None
@@ -172,21 +162,15 @@ async def register_user(user: UserRegister = Body(...)):
         # handler owns. There is no request value that reaches the
         # authorization column, so there is nothing to spell.
         #
-        # The refusal stays only for as long as the legacy `role` wire
-        # name does, and for the same reason: a request built for the old
-        # shape means what the old shape meant. It is checked against
-        # `user.role`, not the resolved title, so a registrant sending
-        # the new field is free to be called whatever they are called.
-        if is_admin_role(user.role):
-            raise HTTPException(
-                status_code=400,
-                detail="That role cannot be selected at registration.",
-            )
-
+        # The string refusal that used to sit here went with the legacy
+        # `role` field it guarded. What remains is stronger and is what
+        # the test now drives: the INSERT binds `DEFAULT_ROLE`, a module
+        # constant, to the authorization column. There is no request
+        # value that reaches it, so there is nothing to spell.
         # The form's "professional role", under the name that says what
         # it is. `job_title` wins when both arrive: the specific name
         # beats the legacy one.
-        job_title = clean_profile_text(user.job_title) or clean_profile_text(user.role)
+        job_title = clean_profile_text(user.job_title)
         if not job_title:
             raise HTTPException(status_code=400, detail="Role is required")
 

--- a/backend/scripts/api_baseline.py
+++ b/backend/scripts/api_baseline.py
@@ -115,7 +115,7 @@ def run_flows(db_url):
     # ── Flow 1: admin mints a key ─────────────────────────────────
     client.post("/users/register", json={
         "email": ADMIN_EMAIL, "password": ADMIN_PASSWORD, "confirm_password": ADMIN_PASSWORD,
-        "full_name": "API Baseline Admin", "role": "escrow_officer", "state": "CA",
+        "full_name": "API Baseline Admin", "job_title": "escrow_officer", "state": "CA",
         "agree_terms": True,
     })
     _sql(db_url, "UPDATE users SET role = 'admin' WHERE email = %s", (ADMIN_EMAIL,))

--- a/backend/scripts/s3_thursday_walkthrough.py
+++ b/backend/scripts/s3_thursday_walkthrough.py
@@ -101,7 +101,7 @@ def main():
     print("\n[1] 4:20pm — she signs in")
     r = client.post("/users/register", json={
         "email": email, "password": password, "confirm_password": password,
-        "full_name": "Thursday Officer", "role": "escrow_officer",
+        "full_name": "Thursday Officer", "job_title": "escrow_officer",
         "state": "CA", "agree_terms": True})
     check("registered", r.status_code == 200, r.text[:120])
     r = client.post("/users/login", json={"email": email, "password": password})
@@ -156,7 +156,7 @@ def main():
     print("\n[3] the phone goes. Her access token EXPIRES (for real)")
     expired = create_access_token(
         data={"sub": jwt.get_unverified_claims(access)["sub"], "email": email,
-              "role": "escrow_officer"},
+              "job_title": "escrow_officer"},
         expires_delta=timedelta(seconds=-5))
     r = client.get("/deeds", headers={"Authorization": f"Bearer {expired}"})
     check("an expired token is refused (401)", r.status_code == 401, str(r.status_code))

--- a/backend/scripts/six_flow_baseline.py
+++ b/backend/scripts/six_flow_baseline.py
@@ -84,7 +84,7 @@ def run_flows():
     reg = client.post("/users/register", json={
         "email": BASELINE_EMAIL, "password": BASELINE_PASSWORD,
         "confirm_password": BASELINE_PASSWORD, "full_name": "Baseline User",
-        "role": "escrow_officer", "state": "CA", "agree_terms": True,
+        "job_title": "escrow_officer", "state": "CA", "agree_terms": True,
     })
     login = client.post("/users/login", json={
         "email": BASELINE_EMAIL, "password": BASELINE_PASSWORD,

--- a/backend/services/officer_queue.py
+++ b/backend/services/officer_queue.py
@@ -126,7 +126,8 @@ INSTRUMENT_KEYS = frozenset({"deed_type", "count", "period"})
 #: "7 fields across 4 documents" from a list it also renders would be a
 #: second opinion about the product's own promise.
 ACCURACY_KEYS = frozenset({"fields", "documents", "items"})
-ACCURACY_ITEM_KEYS = frozenset({"deed_id", "deed_type", "property", "checks"})
+ACCURACY_ITEM_KEYS = frozenset({"deed_id", "deed_type", "property",
+                                "escrow_no", "checks"})
 
 UPCOMING_KEYS = frozenset({"kind", "id", "deed_id", "property", "when",
                            "who", "summary"})

--- a/backend/tests/test_admin15_reconciliation.py
+++ b/backend/tests/test_admin15_reconciliation.py
@@ -158,7 +158,7 @@ def test_the_dashboard_serves_both_windows_and_the_label():
 
     client.post("/users/register", json={
         "email": email, "password": password, "confirm_password": password,
-        "full_name": "Recon Admin", "role": "escrow_officer",
+        "full_name": "Recon Admin", "job_title": "escrow_officer",
         "state": "CA", "agree_terms": True})
     conn = psycopg2.connect(os.environ["DATABASE_URL"])
     conn.autocommit = True

--- a/backend/tests/test_admin1_truth_pass.py
+++ b/backend/tests/test_admin1_truth_pass.py
@@ -82,7 +82,7 @@ def test_probe_reports_down_when_the_engine_is_broken():
     conn.close()
     client.post("/users/register", json={
         "email": email, "password": password, "confirm_password": password,
-        "full_name": "Probe", "role": "escrow_officer", "state": "CA", "agree_terms": True})
+        "full_name": "Probe", "job_title": "escrow_officer", "state": "CA", "agree_terms": True})
     conn = psycopg2.connect(LIVE_DB)
     conn.autocommit = True
     with conn.cursor() as cur:

--- a/backend/tests/test_admin3_email_outcomes.py
+++ b/backend/tests/test_admin3_email_outcomes.py
@@ -245,7 +245,7 @@ def test_the_admin_surface_reads_the_ledger():
 
     client.post("/users/register", json={
         "email": email, "password": password, "confirm_password": password,
-        "full_name": "Email Admin", "role": "escrow_officer",
+        "full_name": "Email Admin", "job_title": "escrow_officer",
         "state": "CA", "agree_terms": True})
     conn = psycopg2.connect(os.environ["DATABASE_URL"])
     conn.autocommit = True

--- a/backend/tests/test_admin_serializer_contract.py
+++ b/backend/tests/test_admin_serializer_contract.py
@@ -72,7 +72,7 @@ def admin_client():
     client.post("/users/register", json={
         "email": ADMIN_EMAIL, "password": ADMIN_PASSWORD,
         "confirm_password": ADMIN_PASSWORD, "full_name": "Contract Admin",
-        "role": "escrow_officer", "state": "CA", "agree_terms": True})
+        "job_title": "escrow_officer", "state": "CA", "agree_terms": True})
     conn = psycopg2.connect(LIVE_DB)
     conn.autocommit = True
     with conn.cursor() as cur:

--- a/backend/tests/test_api_key_requests.py
+++ b/backend/tests/test_api_key_requests.py
@@ -99,7 +99,7 @@ def client_and_token():
     conn.close()
     client.post("/users/register", json={
         "email": email, "password": password, "confirm_password": password,
-        "full_name": "Funnel Tester", "role": "escrow_officer", "state": "CA",
+        "full_name": "Funnel Tester", "job_title": "escrow_officer", "state": "CA",
         "agree_terms": True,
     })
     token = client.post("/users/login", json={

--- a/backend/tests/test_api_v1_integration.py
+++ b/backend/tests/test_api_v1_integration.py
@@ -63,7 +63,7 @@ def admin_token(client):
     import psycopg2
     client.post("/users/register", json={
         "email": API_EMAIL, "password": API_PASSWORD, "confirm_password": API_PASSWORD,
-        "full_name": "API Harness", "role": "escrow_officer", "state": "CA", "agree_terms": True,
+        "full_name": "API Harness", "job_title": "escrow_officer", "state": "CA", "agree_terms": True,
     })
     conn = psycopg2.connect(LIVE_DB)
     conn.autocommit = True

--- a/backend/tests/test_registration_privilege.py
+++ b/backend/tests/test_registration_privilege.py
@@ -5,7 +5,7 @@ prints on a profile (Escrow Officer, Title Agent, ...) and the value
 `is_admin_role()` reads to open the admin console. Registration accepted
 that field verbatim from the request body, so:
 
-    POST /users/register {"role": "admin", ...}
+    POST /users/register {"job_title": "admin", ...}
 
 minted a working admin account — the token returned by the very same call
 carried role=admin, and /admin/* answered it, including POST
@@ -27,19 +27,37 @@ ADMIN_ROLE_SPELLINGS = ["admin", "Admin", "ADMIN", " administrator ",
 
 
 def test_registration_rejects_privileged_roles_structurally():
-    """The guard lives in the handler and must stay there."""
+    """STRUCTURALLY, and that word finally means what it says.
+
+    This asserted the handler contains `is_admin_role(user.role)` — a
+    string refusal, which was the right fix in #103 and is not the fix
+    now. ROLE1 step 3 gave the job title its own column and bound the
+    access column to a module constant, so no request value reaches it.
+    The refusal came out with the legacy `role` field once a frontend
+    sending `job_title` had been live through a deploy.
+
+    What is pinned instead is the structure.
+    """
     from routers import users_auth
+    from routers.users_auth import UserRegister
+
+    assert "role" not in UserRegister.model_fields, (
+        "a `role` field on the registration model is a field that can be "
+        "spelled at, which is the defect this replaced")
     src = inspect.getsource(users_auth.register_user)
-    assert "is_admin_role(user.role)" in src, "registration no longer checks the role"
+    assert "DEFAULT_ROLE," in src
 
 
-def test_is_admin_role_still_covers_every_spelling():
-    """The guard is only as wide as the predicate it shares with the
-    admin gate — they must not drift apart."""
+def test_no_spelling_a_registrant_could_try_grants_anything():
+    """The predicate NARROWED with the data — `ADMIN_ROLES` is ('admin',)
+    since the migration converged the column — so most of these are now
+    ordinary strings. That changes nothing about the protection, which is
+    the point: it never depended on the predicate being wide."""
     from auth import is_admin_role
-    for spelling in ADMIN_ROLE_SPELLINGS:
-        assert is_admin_role(spelling), spelling
-    for ordinary in ["escrow_officer", "Title Agent", "attorney", "user", ""]:
+    assert is_admin_role("admin") is True
+    assert is_admin_role(" ADMIN ") is True
+    for ordinary in ["escrow_officer", "Title Agent", "attorney", "user", "",
+                     "administrator", "superadmin", "super_admin"]:
         assert not is_admin_role(ordinary), ordinary
 
 
@@ -55,20 +73,36 @@ def test_cannot_self_register_as_admin(spelling):
 
     client = TestClient(app)
     email = f"escalate-{spelling.strip().lower()}@privilege.test"
+    import psycopg2
+    conn = psycopg2.connect(LIVE_DB)
+    conn.autocommit = True
+    with conn.cursor() as cur:
+        cur.execute("""DELETE FROM user_profiles WHERE user_id IN
+                       (SELECT id FROM users WHERE email = %s)""", (email,))
+        cur.execute("DELETE FROM users WHERE email = %s", (email,))
+    conn.close()
+
+    # Sent under the ONE wire name there is. The account IS created —
+    # this is a job title, and being called "admin" is not a claim on
+    # anything.
     resp = client.post("/users/register", json={
         "email": email, "password": "Escalate!Passw0rd",
         "confirm_password": "Escalate!Passw0rd", "full_name": "Escalation Probe",
-        "role": spelling, "state": "CA", "agree_terms": True,
+        "job_title": spelling, "state": "CA", "agree_terms": True,
     })
-    assert resp.status_code == 400, f"{spelling!r} was accepted: {resp.text}"
+    assert resp.status_code == 200, resp.text
 
-    # And no account exists to be promoted by a later login.
-    import psycopg2
+    # AND IT GRANTED NOTHING — a stronger statement than the 400 this
+    # used to assert, because it survives somebody adding a field back.
     conn = psycopg2.connect(LIVE_DB)
     with conn.cursor() as cur:
-        cur.execute("SELECT COUNT(*) FROM users WHERE email = %s", (email,))
-        assert cur.fetchone()[0] == 0
+        cur.execute("SELECT role, job_title FROM users WHERE email = %s", (email,))
+        assert cur.fetchone() == ("user", spelling.strip())
     conn.close()
+
+    token = resp.json()["access_token"]
+    assert client.get("/admin/api-keys",
+                      headers={"Authorization": f"Bearer {token}"}).status_code == 403
 
 
 @pytest.mark.skipif(not LIVE_DB, reason="live test DB required")
@@ -93,7 +127,7 @@ def test_ordinary_registration_still_works_and_is_not_admin():
     resp = client.post("/users/register", json={
         "email": email, "password": "Ordinary!Passw0rd",
         "confirm_password": "Ordinary!Passw0rd", "full_name": "Ordinary User",
-        "role": "Escrow Officer", "state": "CA", "agree_terms": True,
+        "job_title": "Escrow Officer", "state": "CA", "agree_terms": True,
     })
     assert resp.status_code == 200, resp.text
     token = resp.json()["access_token"]

--- a/backend/tests/test_role1.py
+++ b/backend/tests/test_role1.py
@@ -37,21 +37,24 @@ from auth import ADMIN_ROLES, is_admin_role
 # ── One definition ───────────────────────────────────────────────────
 
 def test_the_vocabulary_lives_in_exactly_one_place():
-    assert ADMIN_ROLES == ('admin', 'administrator', 'superadmin', 'super_admin')
+    assert ADMIN_ROLES == ('admin',)
     src = inspect.getsource(is_admin_role)
     assert "ADMIN_ROLES" in src
 
 
-@pytest.mark.parametrize("spelling", [
-    "admin", "Admin", "ADMIN", " administrator ", "Administrator",
-    "superadmin", "SUPER_ADMIN",
-])
+@pytest.mark.parametrize("spelling", ["admin", "Admin", "ADMIN", " admin "])
 def test_every_spelling_is_admin_everywhere(spelling):
     assert is_admin_role(spelling) is True
 
 
 @pytest.mark.parametrize("not_admin", [
     "Escrow Officer", "user", "", None, "adminn", "administrater", "Notary",
+    # NARROWED after the migration converged the column. These three were
+    # recognized while history held them; the migration verified that it
+    # no longer does — ('admin', None, 1), ('user', 'Escrow Officer', 1),
+    # ('user', 'Title Agent', 1), ('user', None, 1). Narrowing before it
+    # ran would have removed somebody's access silently.
+    "administrator", "superadmin", "super_admin",
 ])
 def test_and_nothing_else_is(not_admin):
     assert is_admin_role(not_admin) is False
@@ -139,12 +142,15 @@ def test_the_assignable_set_is_authorization_not_job_titles():
     assignable set is now two values, not five.
 
     The three that left (`administrator`, `superadmin`, `super_admin`)
-    are still RECOGNIZED by the gates, for rows history already wrote.
-    Recognizing a spelling and minting more of it are different acts.
+    stayed RECOGNIZED while rows history had written still held them.
+    The migration converged the column on 2026-08-13 and `ADMIN_ROLES`
+    narrowed with it, so recognized and assignable are now the same set —
+    the boundary case of recognized ⊇ assignable, reached deliberately
+    and in that order.
     """
     from routers.admin_api_v2 import ASSIGNABLE_ROLES
     assert ASSIGNABLE_ROLES == frozenset({'user', 'admin'})
-    assert ASSIGNABLE_ROLES < frozenset({*ADMIN_ROLES, 'user'})
+    assert ASSIGNABLE_ROLES == frozenset({*ADMIN_ROLES, 'user'})
     src = inspect.getsource(
         __import__('routers.admin_api_v2', fromlist=['x'])._validate_role_change)
     assert "job title" in src.lower()
@@ -229,16 +235,23 @@ def test_promotion_can_never_trip_the_lockout_check():
                   "boss@deedpro.com", "admin") is None
 
 
-def test_a_recognized_spelling_is_still_refused_as_an_ASSIGNMENT():
-    """The two sets differ, and this is where the difference is visible.
+def test_the_two_sets_have_converged_now_that_the_data_has():
+    """The interim shape had an expiry, and this is it.
 
-    `Administrator` opens every gate for a row that already holds it —
-    and cannot be written into a new one. A console that could write it
-    would be manufacturing more of the divergence ROLE1 converged.
+    Recognized was WIDER than assignable while rows existed that the
+    console must not mint more of. The migration converged the column, so
+    the sets are now equal — recognized ⊇ assignable still holds, at the
+    boundary case.
+
+    A spelling the gates no longer recognize is also refused as an
+    assignment, which is the same refusal arriving from both directions.
     """
     from fastapi import HTTPException
+    from routers.admin_api_v2 import ASSIGNABLE_ROLES
+
+    assert ASSIGNABLE_ROLES == frozenset({*ADMIN_ROLES, 'user'})
     for spelling in ("Administrator", "superadmin", "super_admin"):
-        assert is_admin_role(spelling) is True, "still recognized"
+        assert is_admin_role(spelling) is False, "no longer recognized"
         with pytest.raises(HTTPException) as exc:
             _check({"email": "x@y.z", "role": "user"}, "boss@deedpro.com", spelling)
         assert exc.value.status_code == 400

--- a/backend/tests/test_role1_separation.py
+++ b/backend/tests/test_role1_separation.py
@@ -43,17 +43,24 @@ BACKEND = Path(__file__).resolve().parents[1]
 
 # ── The two vocabularies ─────────────────────────────────────────────
 
-def test_assignable_is_a_strict_subset_of_recognized():
-    """The whole shape of the ruling, in one line.
+def test_assignable_never_exceeds_recognized():
+    """The whole shape of the ruling, and the direction is what matters.
 
-    If these were equal, the console would be minting `super_admin` rows.
-    If assignable had a value recognized did not, the console could grant
-    access that no gate honours — an account that logs in and finds every
-    admin surface closed, with the console reporting success.
+    Assignable must never hold a value recognized does not: the console
+    would grant access no gate honours — an account that logs in and
+    finds every admin surface closed, with the console reporting success.
+
+    It was a STRICT subset while history held spellings the console must
+    not mint more of. The migration converged the column
+    (('admin', None, 1), ('user', 'Escrow Officer', 1),
+    ('user', 'Title Agent', 1), ('user', None, 1)) and `ADMIN_ROLES`
+    narrowed with it, so the two are now equal — the boundary case of
+    the same rule, reached in the only safe order.
     """
     assert ASSIGNABLE_ROLES == frozenset({'user', 'admin'})
     recognized = frozenset({r.lower() for r in ADMIN_ROLES} | {DEFAULT_ROLE})
-    assert ASSIGNABLE_ROLES < recognized
+    assert ASSIGNABLE_ROLES <= recognized
+    assert ASSIGNABLE_ROLES == recognized, "converged: the interim shape expired"
 
 
 def test_every_assignable_value_is_understood_by_the_gates():
@@ -71,13 +78,15 @@ def test_every_assignable_value_is_understood_by_the_gates():
     (None, "user"),
     ("user", "user"),
     ("admin", "admin"),
-    ("Administrator", "admin"),   # unmigrated, and still an admin
-    (" SUPER_ADMIN ", "admin"),
+    # Recognized until the migration ran. It has, and these now resolve
+    # to `user` — which is correct precisely because no row holds them.
+    ("Administrator", "user"),
+    (" SUPER_ADMIN ", "user"),
 ])
 def test_authorization_role_is_the_one_translation(stored, expected):
-    """Correct before the migration and after it. An `Administrator` row
-    that has not been converged yet still resolves to admin — the
-    translation is not waiting on the data."""
+    """One translation, and its answers moved WITH the data rather than
+    ahead of it. `Administrator` resolved to admin while a row could hold
+    it; the migration verified none does, and only then did it stop."""
     assert authorization_role(stored) == expected
 
 
@@ -129,10 +138,10 @@ def test_registration_writes_the_authorization_column_from_a_literal():
     assert re.search(r"clean_profile_text\(user\.full_name\), job_title,\s*"
                      r"DEFAULT_ROLE,", src)
 
-    # And the request's own `role` reaches exactly two places: the legacy
-    # refusal, and the job-title fallback. A third is a request value
-    # heading somewhere new, which is the whole class of defect here.
-    assert src.count("user.role") == 2
+    # And the request has no `role` at all any more. Zero, not two: the
+    # legacy field and the refusal that guarded it came out together once
+    # a frontend sending `job_title` had been live through a deploy.
+    assert src.count("user.role") == 0
 
 
 def test_the_registration_token_says_user_and_cannot_say_otherwise():
@@ -142,23 +151,31 @@ def test_the_registration_token_says_user_and_cannot_say_otherwise():
     assert '"role": user.role' not in src
 
 
-def test_the_legacy_wire_name_is_still_refused_an_admin_spelling():
-    """The `role` field on the request is what the deployed frontend
-    sends, and a request built for the old shape means what the old shape
-    meant. The refusal stays as long as the field does."""
+def test_the_legacy_wire_name_is_gone_and_so_is_its_refusal():
+    """The removal trigger fired.
+
+    `role` was accepted beside `job_title` for exactly one deploy window,
+    with the string refusal that guarded it. Both came out together: the
+    refusal existed because a request built for the old shape meant what
+    the old shape meant, and there is no old shape now.
+
+    What replaced it is structural and stronger — the INSERT binds a
+    module constant to the authorization column, so no request value
+    reaches it and there is nothing to spell.
+    """
+    from routers.users_auth import UserRegister
+    assert "role" not in UserRegister.model_fields
+    assert "job_title" in UserRegister.model_fields
+
     src = code_only(function_source(
         BACKEND / "routers" / "users_auth.py", "register_user"))
-    assert "is_admin_role(user.role)" in src
-    # And the resolved title is NOT what gets checked — a registrant on
-    # the new field is free to be called whatever they are called.
-    assert "is_admin_role(job_title)" not in src
+    assert "is_admin_role(user.role)" not in src
 
 
 def test_job_title_prefers_the_field_that_means_what_it_holds():
     src = code_only(function_source(
         BACKEND / "routers" / "users_auth.py", "register_user"))
-    assert ("job_title = clean_profile_text(user.job_title) "
-            "or clean_profile_text(user.role)") in src
+    assert "job_title = clean_profile_text(user.job_title)" in src
 
 
 # ── The screen the admin console pointed at ──────────────────────────
@@ -264,17 +281,20 @@ def test_the_migration_is_one_transaction():
     assert "conn.rollback()" in src
 
 
-def test_the_migration_does_not_also_narrow_what_the_gates_recognize():
-    """Two decisions, and this script takes one. Narrowing ADMIN_ROLES is
-    safe only once a census of the MIGRATED table shows nothing but
-    'admin' — and a script that converged the data and changed what the
-    converged data means would be impossible to review."""
+def test_the_migration_did_not_also_narrow_what_the_gates_recognize():
+    """Two decisions, and the script took one.
+
+    Narrowing `ADMIN_ROLES` was safe only once the MIGRATED table showed
+    nothing but 'admin', and a script that converged the data and changed
+    what the converged data means would have been impossible to review.
+    It ran first; the narrowing followed as its own change, which is why
+    this pin now reads the narrowed value.
+    """
     import migrations.role1_separate_job_title as mig
     src = code_only(inspect.getsource(mig))
     assert "ADMIN_ROLES = " not in src
     auth_src = (BACKEND / "auth.py").read_text(encoding="utf-8")
-    assert "ADMIN_ROLES = ('admin', 'administrator', 'superadmin', 'super_admin')" \
-        in auth_src
+    assert "ADMIN_ROLES = ('admin',)" in auth_src
 
 
 def test_the_migration_is_rerunnable():

--- a/backend/tests/test_signup1.py
+++ b/backend/tests/test_signup1.py
@@ -147,20 +147,25 @@ def test_the_column_exists_in_the_one_schema_authority():
 # ── The role guard still holds on the new path ───────────────────────
 
 def test_a_free_text_role_cannot_grant_privilege():
-    """SIGNUP1 opens a NEW WAY INTO `users.role`.
+    """SIGNUP1 opened a NEW WAY INTO `users.role`, and ROLE1 step 3 shut
+    the door rather than widening the guard on it.
 
-    "Other" now resolves to whatever she typed, and `users.role` is the
-    column `is_admin_role()` reads to gate the admin console — the #103
-    escalation. The guard must sit on the resolved value, not on the
-    dropdown, or the free-text box is the escalation path reopened.
+    "Other" resolves to whatever she typed. While `users.role` was the
+    column `is_admin_role()` reads, that free-text box was the #103
+    escalation path reopened, and the answer was a refusal sitting on the
+    resolved value.
 
-    Verified structurally: the check reads `user.role`, which is what the
-    client sends after resolving "Other", so there is no second field
-    that bypasses it.
+    The answer now is that the resolved value goes to `job_title` and the
+    access column is written from a module constant. There is no field to
+    guard, which is why the guard is gone: what she types cannot reach
+    the column that decides anything.
     """
     src = inspect.getsource(mod.register_user)
-    assert "is_admin_role(user.role)" in src
-    assert src.index("is_admin_role(user.role)") < src.index("INSERT INTO users")
+    assert "job_title = clean_profile_text(user.job_title)" in src
+    assert "DEFAULT_ROLE," in src
+    # The resolved title is bound to `job_title` BEFORE the INSERT, and
+    # nothing between them touches the access column.
+    assert src.index("job_title = clean_profile_text") < src.index("INSERT INTO users")
 
 
 @pytest.mark.parametrize("claimed", ["admin", "Admin", "ADMIN"])

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -212,6 +212,46 @@ when their trigger arrives.
   that audits the manifest against the code, which the new pin now does
   continuously.
 
+## ROLE1 migration — APPLIED and verified (2026-08-13)
+
+`backend/migrations/role1_separate_job_title.py --apply`, run by the
+owner against production after the plan was reviewed.
+
+**Final state, verified:**
+
+| role | job_title | rows |
+|---|---|---|
+| `admin` | — | 1 |
+| `user` | Escrow Officer | 1 |
+| `user` | Title Agent | 1 |
+| `user` | — | 1 |
+
+Two job titles moved out of the authorization column with `role` set to
+`user` EXPLICITLY, and the one admin was already canonically spelled, so
+no spelling was rewritten.
+
+**Both conditional rulings fired on the strength of it:**
+
+- `ADMIN_ROLES` narrowed from four spellings to `('admin',)`. It stayed
+  wide through steps 1–3 on purpose: narrowing before the migration would
+  have silently removed access from an unmigrated row, and narrowing
+  after removes nothing because there is nothing left to remove. The
+  interim shape (recognized ⊋ assignable) had an expiry and this was it —
+  the two sets are now equal.
+- The legacy `role` field came off the registration wire, with the string
+  refusal that guarded it. The trigger written into both files was "once
+  a frontend sending `job_title` has been live through a deploy", and it
+  fired rather than being forgotten.
+
+**What replaced the refusal is stronger than the refusal.** Registration
+binds a module constant to the access column, so no request value reaches
+it — there is no field to spell at. Every test-suite fixture registering
+with `role` had to move to `job_title`, which is a fair rehearsal of what
+a stale client would have experienced and is the reason the pair was kept
+through one deploy window rather than cut in one step.
+
+---
+
 ## Deferred by owner decision — credentials in git history (2026-08-13)
 
 **Status: DEFERRED BY DECISION, NOT OUTSTANDING, NOT FORGOTTEN.** The

--- a/frontend/src/__tests__/signupRules.test.ts
+++ b/frontend/src/__tests__/signupRules.test.ts
@@ -182,25 +182,20 @@ describe('"Other" is not an answer', () => {
     const payload = registrationPayload(
       ok({ role: OTHER, roleOther: ' Notary ', companyType: OTHER,
            companyTypeOther: ' Lender ' }), '');
-    expect(payload.role).toBe('Notary');
     expect(payload.job_title).toBe('Notary');
     expect(payload.company_type).toBe('Lender');
   });
 
-  it('sends the professional role under BOTH names, for one release', () => {
+  it('sends the professional role under the one name the column has', () => {
     /**
-     * ROLE1 step 3 — `job_title` is the name that means what it holds.
-     * `role` rides along because this frontend (Vercel) and the API
-     * (Render) deploy separately: for the length of one deploy one is
-     * new and the other is not, and registration is the front door.
-     *
-     * An old server reads `role` and ignores the rest; a new one prefers
-     * `job_title`. Both directions are covered only if both are sent —
-     * dropping either half is what makes a deploy window a lost signup.
+     * The paired `role` came out once a server preferring `job_title`
+     * had been live through a deploy. Two names for one thing was a
+     * deploy-window affordance with a stated trigger, and the trigger
+     * fired.
      */
     const payload = registrationPayload(ok({ role: 'Escrow Officer' }), '');
     expect(payload.job_title).toBe('Escrow Officer');
-    expect(payload.role).toBe('Escrow Officer');
+    expect('role' in payload).toBe(false);
   });
 });
 

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -78,7 +78,7 @@ export default function Dashboard() {
      most-recently-touched, so asking again would be a second opinion
      about which document is hers to resume. */
   const resumeTarget = queue?.accuracy?.items?.length
-    ? { ...queue.accuracy.items[0], escrow_no: null }
+    ? queue.accuracy.items[0]
     : null
 
   // Authentication check and load user data

--- a/frontend/src/features/dashboard/AccuracySection.tsx
+++ b/frontend/src/features/dashboard/AccuracySection.tsx
@@ -39,6 +39,7 @@ export interface AccuracyItem {
   deed_id: number;
   deed_type?: string | null;
   property?: string | null;
+  escrow_no?: string | null;
   checks: AccuracyCheck[];
 }
 

--- a/frontend/src/lib/authRole.ts
+++ b/frontend/src/lib/authRole.ts
@@ -35,10 +35,12 @@
  * Mirrors `ADMIN_ROLES` in `backend/auth.py`, and a test compares the
  * two files rather than trusting this comment.
  *
- * RECOGNIZED, not assignable: the console offers User and Admin only.
- * The other three exist because history wrote them.
+ * NARROWED to one, 2026-08-13, after the ROLE1 migration converged the
+ * column. Three spellings were recognized because history had written
+ * three; it no longer has. Narrowing before the migration would have
+ * silently removed somebody's access — narrowing after removes nothing.
  */
-export const ADMIN_ROLES = ['admin', 'administrator', 'superadmin', 'super_admin'] as const;
+export const ADMIN_ROLES = ['admin'] as const;
 
 /** Does this role string mean admin? The one answer. */
 export function isAdminRole(role: string | null | undefined): boolean {

--- a/frontend/src/lib/registerForm.ts
+++ b/frontend/src/lib/registerForm.ts
@@ -154,18 +154,12 @@ export function validate(f: RegisterFields): FieldErrors {
  * text IS the answer, and storing the literal "Other" beside it would be
  * two columns disagreeing about one fact.
  *
- * ═══ TWO NAMES FOR THE PROFESSIONAL ROLE, FOR ONE RELEASE ═══
+ * ═══ ONE NAME NOW ═══
  *
- * ROLE1 step 3 gave the job title its own column, so `job_title` is the
- * name that means what it holds. `role` is sent alongside it because
- * this frontend (Vercel) and the API (Render) deploy separately: for the
- * length of one deploy, one of them is new and the other is not, and
- * registration is the front door.
- *
- * Both directions are covered by sending both — an old server reads
- * `role` and ignores the rest; a new one prefers `job_title`. The pair
- * comes out once a server that prefers `job_title` has been live through
- * a deploy.
+ * `job_title` is what the column is called and what the server takes.
+ * The paired `role` came out on 2026-08-13, once a server preferring
+ * `job_title` had been live through a deploy — the removal trigger this
+ * comment carried, fired rather than forgotten.
  */
 export function registrationPayload(f: RegisterFields, normalizedPhone: string) {
   const role = f.role === OTHER ? f.roleOther.trim() : f.role;
@@ -177,7 +171,6 @@ export function registrationPayload(f: RegisterFields, normalizedPhone: string) 
     confirm_password: f.confirmPassword,
     full_name: f.fullName,
     job_title: role,
-    role,
     company_name: f.companyName || null,
     company_type: companyType || null,
     phone: normalizedPhone || null,


### PR DESCRIPTION
## `ADMIN_ROLES` narrows to `('admin',)`

It stayed at four spellings through steps 1–3 on purpose. Narrowing **before** the migration would have silently removed access from an unmigrated row; narrowing **after** removes nothing, because the verified state holds nothing else:

| role | job_title | rows |
|---|---|---|
| `admin` | — | 1 |
| `user` | Escrow Officer | 1 |
| `user` | Title Agent | 1 |
| `user` | — | 1 |

The interim shape — recognized ⊋ assignable — had an expiry and this is it. The two sets are now **equal**, which is the same rule at its boundary rather than a different rule, and the pin says so.

## The legacy `role` comes off the registration wire

With the string refusal that guarded it. The trigger written into both files — *"once a frontend sending `job_title` has been live through a deploy"* — fired rather than being forgotten.

What remains is stronger than what left: registration binds a module constant to the access column, so no request value reaches it. **There is no field to spell at.** The pins moved accordingly — from asserting a refusal exists, to asserting the model has no `role` and that a registrant who calls themselves "admin" is created with `role='user'`, keeps the title, and is refused by the console.

That last one is a better test than the 400 it replaces: it survives somebody adding a field back.

## What the wire removal actually cost

**Every test fixture registering with `role` had to move to `job_title`** — ten files. That is a fair rehearsal of what a stale client would have met, and the reason the pair was worth keeping through one deploy window rather than cutting in a single step.

## Also, per ruling

`escrow_no` reaches the resume card. My first attempt selected it as a column; it isn't one — it lives in `metadata`, where the draft extras have always put it. The query failed immediately and loudly, which is what `test_endpoint_sql.py` exists to make happen.

## Gates

pytest **1430** · jest **1021** · tsc 88 · six-flow ✔ · Thursday ✔ · API baseline ✔ · S1 concurrency ✔ · banned-claims clean.

Three `test_api_key_requests` errors are pre-existing on `origin/main` (local DB state, verified by running that file against main's version) and are absent in CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_