### PR TITLE
Record the deploy window, and git stash as a destructive read

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -350,6 +350,16 @@ def create_tables():
             # what we actually know. The one exception is backfilled
             # below because it is a recorded fact rather than a guess.
             "ALTER TABLE deed_shares ADD COLUMN IF NOT EXISTS recipient_name TEXT",
+            # EMAIL2 — the fee THE OFFICER TYPED, carried to the notary
+            # who is deciding whether to accept. Optional, free text,
+            # never computed: NOTARY0b's no-fee-handling ruling stands,
+            # and passing on a figure one person set for another is
+            # carrying information rather than brokering between them.
+            #
+            # TEXT rather than numeric, deliberately. It is a thing she
+            # wrote — "85", "$85 + travel" — not an amount this product
+            # owns, and a numeric column would invite arithmetic on it.
+            "ALTER TABLE signing_requests ADD COLUMN IF NOT EXISTS offered_fee TEXT",
             "ALTER TABLE deed_shares ADD COLUMN IF NOT EXISTS responded_at TIMESTAMPTZ",
             # `feedback_at` is stamped in exactly one place — the reject
             # branch of POST /approve/{token} — so for a rejected share it

--- a/backend/database.py
+++ b/backend/database.py
@@ -350,16 +350,6 @@ def create_tables():
             # what we actually know. The one exception is backfilled
             # below because it is a recorded fact rather than a guess.
             "ALTER TABLE deed_shares ADD COLUMN IF NOT EXISTS recipient_name TEXT",
-            # EMAIL2 — the fee THE OFFICER TYPED, carried to the notary
-            # who is deciding whether to accept. Optional, free text,
-            # never computed: NOTARY0b's no-fee-handling ruling stands,
-            # and passing on a figure one person set for another is
-            # carrying information rather than brokering between them.
-            #
-            # TEXT rather than numeric, deliberately. It is a thing she
-            # wrote — "85", "$85 + travel" — not an amount this product
-            # owns, and a numeric column would invite arithmetic on it.
-            "ALTER TABLE signing_requests ADD COLUMN IF NOT EXISTS offered_fee TEXT",
             "ALTER TABLE deed_shares ADD COLUMN IF NOT EXISTS responded_at TIMESTAMPTZ",
             # `feedback_at` is stamped in exactly one place — the reject
             # branch of POST /approve/{token} — so for a rejected share it
@@ -429,6 +419,26 @@ def create_tables():
                 created_at TIMESTAMPTZ DEFAULT now(),
                 updated_at TIMESTAMPTZ DEFAULT now()
             )""",
+            # EMAIL2 — the fee THE OFFICER TYPED, carried to the notary
+            # who is deciding whether to accept. Optional, free text,
+            # never computed: NOTARY0b's no-fee-handling ruling stands,
+            # and passing on a figure one person set for another is
+            # carrying information rather than brokering between them.
+            #
+            # TEXT rather than numeric, deliberately. It is a thing she
+            # wrote — "85", "$85 + travel" — not an amount this product
+            # owns, and a numeric column would invite arithmetic on it.
+            #
+            # AND IT SITS HERE, AFTER THE CREATE, FOR A REASON THAT COST
+            # A RED CI RUN. It was first written thirty lines above, among
+            # the deed_shares ALTERs. Against a database that already had
+            # `signing_requests` — every developer's, and production's —
+            # it worked. Against an EMPTY one it raises UndefinedTable,
+            # and because this whole list runs in ONE transaction with a
+            # single commit at the end, that one failure rolls back the
+            # entire schema: not a missing column, NO TABLES AT ALL.
+            # `test_schema_statement_order.py` now holds the ordering.
+            "ALTER TABLE signing_requests ADD COLUMN IF NOT EXISTS offered_fee TEXT",
             # SIGNER CONTACT LIVES HERE AND NOWHERE ELSE (§13.1). One
             # table, one row per participant, a purge stamp beside it, and
             # a fail-closed sweep in the suite asserting no other table

--- a/backend/routers/users_auth.py
+++ b/backend/routers/users_auth.py
@@ -47,6 +47,13 @@ class UserRegister(BaseModel):
     # comment carried. A registrant sending `role` is ignored by
     # Pydantic, which is the right outcome — it was never the
     # authorization column and now it is not a field at all.
+    #
+    # AND THE DEPLOY WINDOW WAS REAL, which is worth recording because
+    # the pair looked like fussiness when it was written. Removing the
+    # field broke TEN test fixtures at once — every one registering with
+    # `role`, every one failing with no access token. Those fixtures are
+    # exactly what a browser holding the previous bundle would have been.
+    # The caution was the deploy topology made visible, not timidity.
     job_title: Optional[str] = None
     company_name: Optional[str] = None
     company_type: Optional[str] = None

--- a/backend/tests/test_email2.py
+++ b/backend/tests/test_email2.py
@@ -173,9 +173,45 @@ def test_dispatch_is_the_primary_path_and_asks_its_own_question():
 def test_availability_is_the_fallback_and_keeps_the_designs_ask():
     _, html, _ = T.notary_invited(
         "Jerry", "John Doe", "Acme", "Grant Deed", "1358 5th St, Santa Monica",
-        "Los Angeles", "https://app.test/s/ABC", "Sep 1, 2026", fee="85")
+        "Los Angeles", "https://app.test/s/ABC", "Sep 1, 2026")
     assert "Post the times you are free" in html
     assert "Accept this signing" not in html
+
+
+def test_the_availability_path_carries_no_fee_at_all():
+    """OWNER-RULED, and the reason is the shape of the two paths.
+
+    On dispatch a fee attaches to a SPECIFIC job at a SPECIFIC time. Here
+    she is posting windows before anything is agreed, so a figure shown
+    now reads as an offer that survives whatever time gets picked — the
+    product implying a term nobody agreed to.
+
+    Pinned at the SIGNATURE, not just the output: a `fee` parameter that
+    exists is a fee somebody wires up later.
+    """
+    import inspect
+    assert "fee" not in inspect.signature(T.notary_invited).parameters
+    assert "fee" not in inspect.signature(
+        __import__("utils.notifications", fromlist=["x"]).send_notary_invited
+    ).parameters
+    _, html, text = T.notary_invited(
+        "J", "O", "C", "Grant Deed", "1 A St", "LA", "https://l", "Sep 1")
+    assert "$" not in html and "$" not in text
+
+
+def test_the_decision_block_holds_exactly_the_three_decisions():
+    """`signer_count` was in the first build and came out, owner-ruled:
+    context, not a decision input. The block's strength is that every
+    element in it is something she decides on, and a fourth cell that is
+    merely useful dilutes the three that are not.
+
+    It still reaches her — in the quieter facts table below.
+    """
+    _, html, _ = dispatched(fee="85", signer_count="1 signer")
+    start = html.lower().index("when</div>")
+    block = html[start:start + 1400]
+    assert "1 signer" not in block, "the block took on a fourth, non-decision cell"
+    assert "1 signer" in html, "and it must still reach her somewhere"
 
 
 def test_neither_variant_says_anything_is_booked():

--- a/backend/tests/test_email2.py
+++ b/backend/tests/test_email2.py
@@ -1,0 +1,261 @@
+"""EMAIL2 — the signing-request email, from the owner's design.
+
+`docs/design/email_signing_request.html` is the reference implementation.
+What was adopted, and the two things that were not, are pinned here.
+
+═══ THE DESIGN'S CENTRAL IDEA ═══
+
+WHEN / FEE / WHERE, in that order, above everything else — the three
+things a notary decides on. The design's own comment says so, and it is
+right: she decides can I be there then, is it worth the trip, and where
+am I going. Any of the three buried in a facts table is a thing she has
+to hunt for while deciding.
+
+═══ AND THE TWO REFUSALS ═══
+
+The design says "Reply to this email — it goes to our signing team."
+There is no signing team.
+
+The design shows "~6 mi from you". This product holds a notary's city and
+postal code, not a geocoded point, so a mileage would be arithmetic on
+data we do not have.
+
+Both are the same shape: a sentence that reads as service and is not
+true. §0 declines the second for the same reason it declines every
+heuristic — it would be roughly right often enough that nobody checked.
+"""
+from pathlib import Path
+
+import pytest
+
+from tests.source_text import code_only
+from utils import email_templates as T
+
+BACKEND = Path(__file__).resolve().parents[1]
+DESIGN = BACKEND.parent / "docs" / "design" / "email_signing_request.html"
+
+DISPATCH = dict(
+    notary_name="Jerry", officer_name="John Doe", officer_company="Acme Escrow",
+    deed_type="Affidavit of Death of Joint Tenant",
+    property_address="1358 5th St, Santa Monica, CA 90401",
+    county="Los Angeles", when_text="Fri, Aug 15 at 2:00 PM",
+    location="Santa Monica", link="https://app.test/s/ABC/accept",
+    expires_at="Sep 1, 2026",
+)
+
+
+def dispatched(**over):
+    return T.notary_dispatched(**{**DISPATCH, **over})
+
+
+# ── The design is the reference, and it is in the repo ───────────────
+
+def test_the_design_is_committed_and_is_what_this_was_built_against():
+    assert DESIGN.exists(), "the reference implementation must travel with the code"
+    src = DESIGN.read_text(encoding="utf-8")
+    assert "three things a notary decides on" in src
+
+
+# ── WHEN / FEE / WHERE ───────────────────────────────────────────────
+
+def test_the_three_decisions_lead_and_are_in_the_ruled_order():
+    """THE PIN THIS FILE EXISTS FOR (first half)."""
+    _, html, _ = dispatched(fee="85")
+    # WITHIN THE BLOCK, not first-occurrence in the document: the address
+    # legitimately appears earlier (subject line, preheader), and an
+    # index-of test over the whole page measures the wrong thing — which
+    # it did, on the first run.
+    block = html[html.index("WHEN") if "WHEN" in html else 0:]
+    start = html.lower().index("when</div>") if "when</div>" in html.lower() else None
+    assert start is not None, "the decision block did not render"
+    block = html[start:start + 1400]
+    when = block.index("Fri, Aug 15 at 2:00 PM")
+    fee = block.index("$85")
+    where = block.index("Santa Monica")
+    assert when < fee < where, "WHEN / FEE / WHERE is the order she decides in"
+    # And the block leads: it comes before the quieter facts table.
+    assert start < html.index("Los Angeles")
+
+
+def test_the_fee_block_renders_only_when_she_set_one():
+    _, with_fee, _ = dispatched(fee="85")
+    assert "$85" in with_fee
+    for absent in (None, "", "   "):
+        _, without, text = dispatched(fee=absent)
+        assert "Fee" not in without.replace("Fee&nbsp;", ""), absent
+        assert "$" not in text.split("Accept:")[0], absent
+
+
+def test_nothing_anywhere_computes_defaults_or_suggests_a_fee():
+    """THE PIN THIS FILE EXISTS FOR (second half), and the one that keeps
+    NOTARY0b intact.
+
+    That ruling was no fee HANDLING: never quote, process, split, or
+    suggest. Displaying a figure the officer typed is passing information
+    between two people, not brokering between them — and the difference
+    is entirely that no code here has an opinion about the number.
+
+    A default would be a suggestion. Arithmetic would be a quote.
+    """
+    for path in (BACKEND / "utils" / "email_templates.py",
+                 BACKEND / "utils" / "notifications.py"):
+        body = code_only(path.read_text(encoding="utf-8"))
+        for line in body.splitlines():
+            if "fee" not in line.lower():
+                continue
+            # No arithmetic on it, and no default other than "absent".
+            assert not any(op in line for op in ("fee *", "fee +", "fee /",
+                                                 "fee -", "* fee", "+ fee")), line
+            assert "fee=0" not in line.replace(" ", ""), line
+            assert not any(w in line.lower() for w in
+                           ("typical", "suggested", "recommend", "average",
+                            "market rate", "going rate")), line
+    # ═══ AND THE DEFAULT, CHECKED STRUCTURALLY ═══
+    #
+    # The word-list above missed the obvious mutation on its first probe:
+    # `fee: Optional[str] = "75"` in a signature is a SUGGESTED fee, and
+    # no list of suspicious words contains "75". §14.1 — match the
+    # property, not the spelling. The property is that a fee parameter
+    # defaults to absent and to nothing else.
+    import ast
+    for path in (BACKEND / "utils" / "email_templates.py",
+                 BACKEND / "utils" / "notifications.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            args = node.args.args + node.args.kwonlyargs
+            defaults = ([None] * (len(node.args.args) - len(node.args.defaults))
+                        + list(node.args.defaults) + list(node.args.kw_defaults))
+            for arg, default in zip(args, defaults):
+                if "fee" not in arg.arg.lower() or default is None:
+                    continue
+                assert isinstance(default, ast.Constant) and default.value is None, (
+                    f"{path.name}:{node.name} defaults {arg.arg} to "
+                    f"{ast.unparse(default)} — a default fee is a suggested fee")
+
+
+def test_the_fee_is_text_because_it_is_a_thing_she_wrote():
+    """`$85 + travel` is a real answer. A numeric column would refuse it
+    and would invite arithmetic on a number this product does not own."""
+    src = (BACKEND / "database.py").read_text(encoding="utf-8")
+    assert ("ALTER TABLE signing_requests ADD COLUMN IF NOT EXISTS "
+            "offered_fee TEXT") in src
+
+
+# ── The preheader, so she can triage from the inbox ──────────────────
+
+def test_the_preheader_carries_document_fee_and_respond_by():
+    """The design's idea and a good one: a notary scanning ten requests
+    decides which to open on exactly these three."""
+    _, html, _ = dispatched(fee="85", respond_by="Thu, Aug 14 at 5:00 PM PT")
+    head = html[:1200]
+    assert "Affidavit of Death of Joint Tenant" in head
+    assert "$85" in head
+    assert "respond by Thu, Aug 14 at 5:00 PM PT" in head
+
+
+def test_the_preheader_omits_what_is_not_set_rather_than_showing_a_gap():
+    _, html, _ = dispatched()
+    head = html[:1200]
+    assert "$" not in head
+    assert "respond by" not in head
+
+
+# ── Two variants, because the flow was re-ruled after the drawing ────
+
+def test_dispatch_is_the_primary_path_and_asks_its_own_question():
+    subject, html, text = dispatched()
+    assert "Accept this signing" in html
+    assert "at a set time" in text
+
+
+def test_availability_is_the_fallback_and_keeps_the_designs_ask():
+    _, html, _ = T.notary_invited(
+        "Jerry", "John Doe", "Acme", "Grant Deed", "1358 5th St, Santa Monica",
+        "Los Angeles", "https://app.test/s/ABC", "Sep 1, 2026", fee="85")
+    assert "Post the times you are free" in html
+    assert "Accept this signing" not in html
+
+
+def test_neither_variant_says_anything_is_booked():
+    """§13 reaching the email most tempted to break it. She is the party
+    who has not answered; nothing is arranged until she does."""
+    for _, html, text in (dispatched(), T.notary_invited(
+            "J", "O", "C", "Grant Deed", "1 A St", "LA", "https://l", "Sep 1")):
+        for body in (html.lower(), text.lower()):
+            # ═══ A TEXTUAL PROXY FOR A SEMANTIC PROPERTY, SAID SO ═══
+            #
+            # What must be true is that the email never asserts the
+            # signing IS arranged. That is not decidable by matching:
+            # "Nothing is booked until you accept" and "when you and they
+            # land on the same one, it is booked" are both correct copy
+            # and both contain the forbidden substring. The first version
+            # of this pin failed on both.
+            #
+            # So it checks the narrower thing it CAN check — every
+            # occurrence sits in a clause that qualifies it — and this
+            # comment is the record that the wider property is held by
+            # the templates' own reasoning rather than by this assertion.
+            QUALIFIERS = ("nothing", "until", "when", "once")
+            for claim in ("is booked", "is confirmed", "has been scheduled"):
+                at = 0
+                while (at := body.find(claim, at)) != -1:
+                    window = body[max(0, at - 70):at + 40]
+                    assert any(q in window for q in QUALIFIERS), (
+                        f"an unqualified {claim!r}: ...{window}...")
+                    at += 1
+
+
+# ── The escape hatch ─────────────────────────────────────────────────
+
+def test_cannot_take_this_one_is_a_real_link():
+    """A notary who cannot take it is the most useful early answer the
+    officer can get. Making that the hard path is how a request sits
+    unanswered for three days."""
+    _, html, text = dispatched(decline_link="https://app.test/s/ABC/decline")
+    assert "https://app.test/s/ABC/decline" in html
+    assert "take this one" in html
+    assert "https://app.test/s/ABC/decline" in text
+
+
+# ── The two refusals ─────────────────────────────────────────────────
+
+def test_there_is_no_signing_team_so_the_email_does_not_mention_one():
+    """The design's line was "Reply to this email — it goes to our
+    signing team". It does not; there is no such team. A support channel
+    that does not exist is worse than no sentence, because she waits for
+    an answer from nobody."""
+    for _, html, text in (dispatched(), T.notary_invited(
+            "J", "O", "C", "Grant Deed", "1 A St", "LA", "https://l", "Sep 1")):
+        assert "signing team" not in html.lower()
+        assert "signing team" not in text.lower()
+    # And it says where a reply DOES go, naming the person.
+    _, html, _ = dispatched()
+    assert "reaches John Doe directly" in html
+
+
+def test_no_distance_is_ever_rendered():
+    """The design shows "~6 mi from you". Partners carry a city, state
+    and postal code — NOT a geocoded point — so any mileage would be
+    arithmetic on data this product does not hold.
+
+    §0: it would be roughly right often enough that nobody checked.
+    """
+    _, html, text = dispatched(fee="85")
+    for unit in (" mi ", " mi<", "miles from", "mi from you"):
+        assert unit not in html
+        assert unit not in text
+    body = code_only((BACKEND / "utils" / "email_templates.py")
+                     .read_text(encoding="utf-8"))
+    assert "miles_from" not in body
+    assert "distance" not in body.lower()
+
+
+def test_the_footer_says_what_the_product_does_and_what_it_is_not():
+    """Adopted verbatim from the design, and it belongs on anything sent
+    to somebody who is not our customer."""
+    _, html, text = dispatched()
+    assert ("DeedPro prepares recorder-formatted documents at your direction. "
+            "Nothing in this email is legal advice.") in html
+    assert "Nothing in this email is legal advice." in text

--- a/backend/tests/test_schema_statement_order.py
+++ b/backend/tests/test_schema_statement_order.py
@@ -1,0 +1,175 @@
+"""The schema authority must be runnable against an EMPTY database.
+
+═══ WHAT THIS EXISTS TO CATCH ═══
+
+`create_tables()` is a single transaction with one commit at the very
+end. Every statement in it either succeeds or the whole thing rolls
+back — so a statement that references a table created LATER in the same
+list does not produce a missing column. It produces NO SCHEMA AT ALL.
+
+That is exactly what EMAIL2 shipped to CI: an
+`ALTER TABLE signing_requests ADD COLUMN IF NOT EXISTS offered_fee TEXT`
+placed thirty lines above the CREATE for `signing_requests`. Sixty-odd
+tests failed with `relation "users" does not exist` — users, a table
+created nine hundred lines earlier and entirely innocent.
+
+═══ AND WHY IT WAS INVISIBLE UNTIL CI ═══
+
+§14.2, again, and in its purest form. Every database a human runs this
+against ALREADY HAS the tables, because it ran successfully once before
+the mistake was made. Production has them. My local database had them.
+The statement is correct on every database except a new one — and a new
+one is the only kind CI ever sees, and the only kind the next
+deployment will be.
+
+So the property is checked STATICALLY, from the source order, because
+the only environment that can observe it dynamically is one nobody
+develops against.
+"""
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+from tests.source_text import code_only
+
+BACKEND = Path(__file__).resolve().parents[1]
+DATABASE = BACKEND / "database.py"
+
+
+def _code():
+    """`database.py` with comments and docstrings blanked.
+
+    Not a formality. The fix for the bug this file pins added a fifteen-
+    line comment to `database.py` explaining the ordering rule — and two
+    of the tests below work by substring position. A raw read would let
+    that comment satisfy a pin about the statement it describes, which is
+    the precise trip `code_only` was built to end. Positions are
+    preserved, so the ordering comparisons still mean what they say.
+    """
+    return code_only(DATABASE)
+
+# `CREATE TABLE IF NOT EXISTS x` / `CREATE TABLE x`
+CREATES = re.compile(r"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?([a-z_][a-z0-9_]*)", re.I)
+# Everything that RESOLVES a table name and therefore needs it to exist.
+NEEDS = (
+    ("ALTER TABLE", re.compile(r"ALTER\s+TABLE\s+(?:IF\s+EXISTS\s+)?([a-z_][a-z0-9_]*)", re.I)),
+    ("CREATE INDEX", re.compile(r"CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:CONCURRENTLY\s+)?"
+                                r"(?:IF\s+NOT\s+EXISTS\s+)?\S+\s+ON\s+([a-z_][a-z0-9_]*)", re.I)),
+    ("UPDATE", re.compile(r"^\s*UPDATE\s+([a-z_][a-z0-9_]*)", re.I)),
+    ("INSERT INTO", re.compile(r"^\s*INSERT\s+INTO\s+([a-z_][a-z0-9_]*)", re.I)),
+    ("REFERENCES", re.compile(r"REFERENCES\s+([a-z_][a-z0-9_]*)\s*\(", re.I)),
+)
+
+
+def _statements():
+    """Every SQL literal inside create_tables(), IN SOURCE ORDER.
+
+    ast.walk() is unordered and would defeat the entire point of this
+    file, so the nodes are sorted by position. The list-driven loop and
+    the older inline cursor.execute() calls are both just string
+    constants in that function, which is why this reaches both without
+    knowing how either is dispatched.
+    """
+    tree = ast.parse(_code(), str(DATABASE))
+    fn = next(n for n in ast.walk(tree)
+              if isinstance(n, ast.FunctionDef) and n.name == "create_tables")
+    doc = ast.get_docstring(fn, clean=False)
+    nodes = [n for n in ast.walk(fn)
+             if isinstance(n, ast.Constant) and isinstance(n.value, str)
+             and n.value != doc]
+    nodes.sort(key=lambda n: (n.lineno, n.col_offset))
+    return [n.value for n in nodes]
+
+
+def test_the_function_is_one_transaction_which_is_why_order_matters():
+    """The premise this whole file rests on, pinned so it cannot quietly
+    stop being true. If create_tables() ever commits per statement, a
+    mis-ordered ALTER costs one column instead of the schema — still a
+    bug, but a different one, and this file's reasoning would need
+    rewriting rather than just passing."""
+    src = _code()
+    body = src[src.index("def create_tables"):]
+    body = body[:body.index("\ndef ", 1)]
+    assert body.count("conn.commit()") == 1, (
+        "create_tables no longer has exactly one commit — re-read this file's "
+        "docstring before changing the assertion")
+
+
+def test_nothing_touches_a_table_before_the_statement_that_creates_it():
+    """THE PIN THIS FILE EXISTS FOR."""
+    created = set()
+    problems = []
+    for sql in _statements():
+        if not any(k in sql.upper() for k in
+                   ("CREATE", "ALTER", "UPDATE ", "INSERT ", "DROP")):
+            continue
+        # A DO $$ ... $$ block is a guarded conditional — its ALTER runs
+        # only when a catalogue query says the column is there, so it
+        # cannot fail on an absent table. Excluded deliberately, not
+        # because it was awkward.
+        guarded = sql.lstrip().upper().startswith("DO $$")
+        # WITHIN a statement, its own CREATEs count as already done —
+        # `superseded_by UUID REFERENCES document_authenticity(id)` inside
+        # the CREATE for document_authenticity is a self-referencing key,
+        # which is legal and which the first version of this pin called a
+        # defect. Registering before checking fixes that without weakening
+        # the cross-statement ordering this file is actually about.
+        for m in CREATES.finditer(sql):
+            created.add(m.group(1).lower())
+        for kind, pattern in NEEDS:
+            if guarded:
+                continue
+            for m in pattern.finditer(sql):
+                table = m.group(1).lower()
+                if table in created:
+                    continue
+                # Only tables THIS FUNCTION creates are in scope. A name
+                # it never creates is a different defect (or a catalogue
+                # view) and is caught by the test below.
+                if not any(table == c.group(1).lower()
+                           for s in _statements() for c in CREATES.finditer(s)):
+                    continue
+                problems.append(f"{kind} {table} — before its CREATE: {sql.strip()[:90]}")
+
+    assert not problems, (
+        "create_tables() runs in ONE transaction, so each of these rolls back "
+        "the ENTIRE schema on a fresh database:\n  " + "\n  ".join(problems))
+
+
+def test_every_table_it_alters_is_a_table_it_also_creates():
+    """The other half of the same property: an ALTER against a table no
+    statement here creates depends on a migration that lives somewhere
+    else, and on a new database there is no somewhere else."""
+    all_sql = _statements()
+    created = {m.group(1).lower() for s in all_sql for m in CREATES.finditer(s)}
+    altered = set()
+    for sql in all_sql:
+        if sql.lstrip().upper().startswith("DO $$"):
+            continue
+        for m in NEEDS[0][1].finditer(sql):
+            altered.add(m.group(1).lower())
+    assert not (altered - created), (
+        f"altered but never created here: {sorted(altered - created)}")
+
+
+def test_the_email2_column_is_ordered_correctly_and_would_be_caught_if_it_moved():
+    """A mutation probe on the pin above, kept because the pin's whole
+    claim is that it catches THIS mistake — the one that shipped."""
+    src = _code()
+    alter = src.index("ALTER TABLE signing_requests ADD COLUMN IF NOT EXISTS offered_fee")
+    create = src.index("CREATE TABLE IF NOT EXISTS signing_requests")
+    assert create < alter, "the column is added before the table exists again"
+
+
+@pytest.mark.parametrize("table", ["signing_requests", "signing_participants",
+                                   "signing_windows", "signing_responses",
+                                   "deed_shares", "deed_pdfs", "users", "deeds"])
+def test_the_tables_ci_reported_missing_are_all_created_here(table):
+    """The failure named sixty tests and eleven tables. It was one
+    statement — but the reason it LOOKED like a schema-wide collapse is
+    that it was one, so this pins that the authority does hold all of
+    them and the collapse was the transaction, not absent DDL."""
+    assert any(m.group(1).lower() == table
+               for s in _statements() for m in CREATES.finditer(s)), table

--- a/backend/utils/email_templates.py
+++ b/backend/utils/email_templates.py
@@ -368,8 +368,7 @@ def admin_api_key_request(company_name, contact_email, business_type,
 # in a commit message nobody reads next year.
 
 
-def _decision_block(when_text: str, fee: Optional[str], where: str,
-                    signer_count: Optional[str] = None) -> str:
+def _decision_block(when_text: str, fee: Optional[str], where: str) -> str:
     """WHEN / FEE / WHERE — the three things a notary decides on.
 
     THE DESIGN'S CENTRAL IDEA, and its own comment gives the reason: a
@@ -389,13 +388,15 @@ def _decision_block(when_text: str, fee: Optional[str], where: str,
     suggestion, no "typical", and no arithmetic anywhere in this file. A
     pin holds that.
     """
-    cells = []
-    cells.append(("When", when_text))
+    # OWNER-RULED: exactly three. `signer_count` was in the first build
+    # and came out — it is CONTEXT, not a decision input, and the block's
+    # whole strength is that every element in it is something she decides
+    # on. A fourth cell that is merely useful dilutes the three that are
+    # not. It still reaches her, in the facts table below.
+    cells = [("When", when_text)]
     if (fee or "").strip():
         cells.append(("Fee", f"${_esc(fee)}"))
     cells.append(("Where", where))
-    if (signer_count or "").strip():
-        cells.append(("Signers", signer_count))
 
     tds = "".join(
         f'<td valign="top" style="padding:0 14px 0 0;'
@@ -480,7 +481,7 @@ SIGNING_FOOTER = (
 
 
 def notary_invited(notary_name, officer_name, officer_company, deed_type,
-                   property_address, county, link, expires_at, fee=None,
+                   property_address, county, link, expires_at,
                    signer_count=None, decline_link="", respond_by="",
                    window_text="") -> Rendered:
     """NOTARY2 — officer → notary: post the times you are free.
@@ -498,14 +499,24 @@ def notary_invited(notary_name, officer_name, officer_company, deed_type,
     that document; what they do NOT get is any way to reach the signers,
     because they have no reason to and the officer does.
 
-    No distance: see `notary_dispatched`. We hold a city, not a point.
+    ═══ AND NO FEE ON THIS PATH ═══
+
+    OWNER-RULED, and the reason is the shape of the two paths rather than
+    squeamishness about the number. On dispatch a fee attaches to a
+    SPECIFIC job at a SPECIFIC time — unambiguous. Here she is posting
+    windows before anything is agreed, so a figure shown now reads as an
+    offer that survives whatever time is eventually picked. That is the
+    product implying a term nobody agreed to, which is the same family as
+    every other invented-fact ruling in this codebase.
+
+    No distance either: see `notary_dispatched`. We hold a city, not a
+    point.
     """
     addr = _short_addr(property_address)
     subject = f"Signing request — {addr}" if addr else "Notary signing request"
 
     preheader = " · ".join(x for x in [
         _esc(deed_type) or "Signing request",
-        f"${_esc(fee)}" if (fee or "").strip() else "",
         f"respond by {_esc(respond_by)}" if (respond_by or "").strip() else "",
     ] if x)
 
@@ -517,8 +528,8 @@ def notary_invited(notary_name, officer_name, officer_company, deed_type,
         # The three decisions, with WHEN as the window she is being asked
         # about rather than a time anybody has agreed — nothing is
         # proposed on this path, so it says so.
-        + _decision_block(window_text or "You post the times", fee,
-                          addr or (county or ""), signer_count)
+        + _decision_block(window_text or "You post the times", None,
+                          addr or (county or ""))
         + _facts([("Document", deed_type), ("Address", property_address),
                   ("County", county), ("Link expires", expires_at or "")])
         + _respond_by(respond_by)
@@ -532,7 +543,6 @@ def notary_invited(notary_name, officer_name, officer_company, deed_type,
     )
     text = (
         f"{officer_name} is asking whether you can notarize a signing.\n\n"
-        + (f"Fee: ${fee}\n" if (fee or "").strip() else "")
         + f"Document: {deed_type}\nProperty: {addr}\nCounty: {county}\n"
         f"Link expires: {expires_at or ''}\n"
         + (f"Please respond by: {respond_by}\n" if (respond_by or "").strip() else "")
@@ -553,8 +563,7 @@ def notary_invited(notary_name, officer_name, officer_company, deed_type,
 # in a commit message nobody reads next year.
 
 
-def _decision_block(when_text: str, fee: Optional[str], where: str,
-                    signer_count: Optional[str] = None) -> str:
+def _decision_block(when_text: str, fee: Optional[str], where: str) -> str:
     """WHEN / FEE / WHERE — the three things a notary decides on.
 
     THE DESIGN'S CENTRAL IDEA, and its own comment gives the reason: a
@@ -574,13 +583,15 @@ def _decision_block(when_text: str, fee: Optional[str], where: str,
     suggestion, no "typical", and no arithmetic anywhere in this file. A
     pin holds that.
     """
-    cells = []
-    cells.append(("When", when_text))
+    # OWNER-RULED: exactly three. `signer_count` was in the first build
+    # and came out — it is CONTEXT, not a decision input, and the block's
+    # whole strength is that every element in it is something she decides
+    # on. A fourth cell that is merely useful dilutes the three that are
+    # not. It still reaches her, in the facts table below.
+    cells = [("When", when_text)]
     if (fee or "").strip():
         cells.append(("Fee", f"${_esc(fee)}"))
     cells.append(("Where", where))
-    if (signer_count or "").strip():
-        cells.append(("Signers", signer_count))
 
     tds = "".join(
         f'<td valign="top" style="padding:0 14px 0 0;'
@@ -727,9 +738,10 @@ def notary_dispatched(notary_name, officer_name, officer_company, deed_type,
         + _p(f"<strong>{_esc(officer_name)}</strong>"
              + (f" at {_esc(officer_company)}" if officer_company else "")
              + " is asking whether you can take a signing at a set time.")
-        + _decision_block(when_text, fee, where, signer_count)
+        + _decision_block(when_text, fee, where)
         + _facts([("Document", deed_type), ("Address", property_address),
-                  ("County", county), ("Link expires", expires_at or "")])
+                  ("County", county), ("Signers", signer_count or ""),
+                  ("Link expires", expires_at or "")])
         + _respond_by(respond_by)
         + _button(link, "Accept this signing")
         + _escape_hatch(decline_link)

--- a/backend/utils/email_templates.py
+++ b/backend/utils/email_templates.py
@@ -361,43 +361,324 @@ def admin_api_key_request(company_name, contact_email, business_type,
 # test_admin3_email_outcomes.py is what caught it.
 
 
+# ── EMAIL2: the signing-request email, from the owner's design ────────
+#
+# `docs/design/email_signing_request.html` is the reference. What is
+# adopted from it, and what is not, is recorded at each site rather than
+# in a commit message nobody reads next year.
+
+
+def _decision_block(when_text: str, fee: Optional[str], where: str,
+                    signer_count: Optional[str] = None) -> str:
+    """WHEN / FEE / WHERE — the three things a notary decides on.
+
+    THE DESIGN'S CENTRAL IDEA, and its own comment gives the reason: a
+    notary reading an assignment decides in that order — can I be there
+    then, is it worth the trip, and where is it. Burying any of the three
+    in a facts table makes her hunt for the thing she is deciding on.
+
+    ═══ THE FEE IS DISPLAYED, NEVER COMPUTED ═══
+    ═══
+    NOTARY0b ruled no fee handling and that ruling stands: this product
+    does not quote, process, split, or suggest a fee. What it does here is
+    pass on a figure THE OFFICER TYPED, to the person deciding whether to
+    accept — which is carrying information between two people, not
+    brokering between them.
+    ═══
+    So the block renders only when she set one. There is no default, no
+    suggestion, no "typical", and no arithmetic anywhere in this file. A
+    pin holds that.
+    """
+    cells = []
+    cells.append(("When", when_text))
+    if (fee or "").strip():
+        cells.append(("Fee", f"${_esc(fee)}"))
+    cells.append(("Where", where))
+    if (signer_count or "").strip():
+        cells.append(("Signers", signer_count))
+
+    tds = "".join(
+        f'<td valign="top" style="padding:0 14px 0 0;'
+        f'font-family:-apple-system,\'Segoe UI\',Roboto,Helvetica,Arial,sans-serif;">'
+        f'<div style="font-size:11px;letter-spacing:0.6px;text-transform:uppercase;'
+        f'color:#5C6370;padding-bottom:4px;">{_esc(label)}</div>'
+        f'<div style="font-size:16px;line-height:22px;font-weight:700;color:{INK};">'
+        f'{_esc(value)}</div></td>'
+        for label, value in cells if value
+    )
+    return (
+        '<table role="presentation" cellpadding="0" cellspacing="0" border="0" '
+        'width="100%" style="background-color:#F7F6FB;border:1px solid #E7E3F5;'
+        'border-radius:10px;margin:20px 0 0;">'
+        f'<tr><td style="padding:18px 20px 16px;"><table role="presentation" '
+        f'cellpadding="0" cellspacing="0" border="0" width="100%"><tr>{tds}</tr>'
+        "</table></td></tr></table>"
+    )
+
+
+def _respond_by(respond_by: Optional[str]) -> str:
+    """The deadline, as its own chip rather than a row in a table.
+
+    A response deadline that reads like another fact is a deadline she
+    finds after deciding. Renders only when there is one — an invented
+    urgency would be the product hurrying somebody on no information.
+    """
+    if not (respond_by or "").strip():
+        return ""
+    return (
+        '<table role="presentation" cellpadding="0" cellspacing="0" border="0" '
+        'style="margin:22px 0 0;"><tr><td style="background-color:#F3EEFF;'
+        'border:1px solid #DDD1FA;border-radius:6px;padding:8px 12px;'
+        "font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;"
+        'font-size:13px;line-height:18px;font-weight:600;color:#4C1D95;">'
+        f"Please respond by {_esc(respond_by)}</td></tr></table>"
+    )
+
+
+def _escape_hatch(decline_link: str) -> str:
+    """"Can't take this one" as a REAL link, not a sentence asking her to
+    reply.
+
+    A notary who cannot take an assignment is the most useful early
+    answer the officer can get, and making that the hard path is how a
+    request sits unanswered for three days. The design made it an
+    explicit escape hatch and it is adopted as such.
+    """
+    if not decline_link:
+        return ""
+    return _p(
+        f'<a href="{_esc(decline_link)}" style="color:#5B21B6;font-weight:600;'
+        'text-decoration:underline;">Can\u2019t take this one</a>'
+        '<span style="color:#6E7480;">&nbsp;&mdash;&nbsp;lets the officer '
+        "reassign it right away</span>"
+    )
+
+
+def _reply_line(officer_name: str) -> str:
+    """WHERE A REPLY ACTUALLY GOES.
+
+    The design said "Reply to this email — it goes to our signing team."
+    There is no signing team. Owner-ruled out: a support channel that
+    does not exist is worse than no sentence, because she waits for an
+    answer from nobody.
+
+    Replies reach the officer, and the officer is named.
+    """
+    who = _esc(officer_name) or "the officer who sent it"
+    return _p(
+        f'<span style="font-size:13px;color:#8a94a0;">Questions about this '
+        f"signing? Replying to this email reaches {who} directly.</span>"
+    )
+
+
+#: The one legal footer for anything sent to somebody who is not our
+#: customer. Adopted verbatim from the design.
+SIGNING_FOOTER = (
+    "DeedPro prepares recorder-formatted documents at your direction. "
+    "Nothing in this email is legal advice."
+)
+
+
 def notary_invited(notary_name, officer_name, officer_company, deed_type,
-                   property_address, county, link, expires_at) -> Rendered:
+                   property_address, county, link, expires_at, fee=None,
+                   signer_count=None, decline_link="", respond_by="",
+                   window_text="") -> Rendered:
     """NOTARY2 — officer → notary: post the times you are free.
+
+    ═══ THE FALLBACK VARIANT (EMAIL2) ═══
+
+    The owner's design was drawn for exactly this case — its primary
+    button is "Post my availability" — and the flow was re-ruled after
+    the drawing: dispatch became the primary path, this the fallback. So
+    the design's structure lands on BOTH, and the question stays
+    different, because these two emails want different answers.
 
     Professional-to-professional. The notary gets the address, the
     instrument and the county because they are going there to notarise
     that document; what they do NOT get is any way to reach the signers,
     because they have no reason to and the officer does.
+
+    No distance: see `notary_dispatched`. We hold a city, not a point.
     """
     addr = _short_addr(property_address)
     subject = f"Signing request — {addr}" if addr else "Notary signing request"
+
+    preheader = " · ".join(x for x in [
+        _esc(deed_type) or "Signing request",
+        f"${_esc(fee)}" if (fee or "").strip() else "",
+        f"respond by {_esc(respond_by)}" if (respond_by or "").strip() else "",
+    ] if x)
+
     content = (
         _p(f"Hi {_esc(notary_name) or 'there'},")
         + _p(f"<strong>{_esc(officer_name)}</strong>"
              + (f" at {_esc(officer_company)}" if officer_company else "")
              + " is asking whether you can notarize a signing.")
-        + _facts([("Document", deed_type), ("Property", addr),
+        # The three decisions, with WHEN as the window she is being asked
+        # about rather than a time anybody has agreed — nothing is
+        # proposed on this path, so it says so.
+        + _decision_block(window_text or "You post the times", fee,
+                          addr or (county or ""), signer_count)
+        + _facts([("Document", deed_type), ("Address", property_address),
                   ("County", county), ("Link expires", expires_at or "")])
+        + _respond_by(respond_by)
         + _button(link, "Post the times you are free")
+        + _escape_hatch(decline_link)
         + _p('<span style="font-size:13px;color:#8a94a0;">The signers pick from the '
              "times you post. When you and they land on the same one, it is booked and "
              "everybody is told.</span>")
+        + _reply_line(officer_name)
+        + _p(f'<span style="font-size:12px;color:#8a94a0;">{SIGNING_FOOTER}</span>')
     )
     text = (
         f"{officer_name} is asking whether you can notarize a signing.\n\n"
-        f"Document: {deed_type}\nProperty: {addr}\nCounty: {county}\n"
-        f"Link expires: {expires_at or ''}\n\n"
-        f"Post the times you are free: {link}\n\n"
-        "The signers pick from the times you post."
+        + (f"Fee: ${fee}\n" if (fee or "").strip() else "")
+        + f"Document: {deed_type}\nProperty: {addr}\nCounty: {county}\n"
+        f"Link expires: {expires_at or ''}\n"
+        + (f"Please respond by: {respond_by}\n" if (respond_by or "").strip() else "")
+        + f"\nPost the times you are free: {link}\n"
+        + (f"Can't take this one: {decline_link}\n" if decline_link else "")
+        + "\nThe signers pick from the times you post.\n\n"
+        f"Questions? Replying to this email reaches {officer_name} directly.\n\n"
+        f"{SIGNING_FOOTER}"
     )
-    return subject, _base(f"{officer_name} asked about your availability", content, True), text
+    return subject, _base(preheader, content, True), text
+
+
+
+# ── EMAIL2: the signing-request email, from the owner's design ────────
+#
+# `docs/design/email_signing_request.html` is the reference. What is
+# adopted from it, and what is not, is recorded at each site rather than
+# in a commit message nobody reads next year.
+
+
+def _decision_block(when_text: str, fee: Optional[str], where: str,
+                    signer_count: Optional[str] = None) -> str:
+    """WHEN / FEE / WHERE — the three things a notary decides on.
+
+    THE DESIGN'S CENTRAL IDEA, and its own comment gives the reason: a
+    notary reading an assignment decides in that order — can I be there
+    then, is it worth the trip, and where is it. Burying any of the three
+    in a facts table makes her hunt for the thing she is deciding on.
+
+    ═══ THE FEE IS DISPLAYED, NEVER COMPUTED ═══
+    ═══
+    NOTARY0b ruled no fee handling and that ruling stands: this product
+    does not quote, process, split, or suggest a fee. What it does here is
+    pass on a figure THE OFFICER TYPED, to the person deciding whether to
+    accept — which is carrying information between two people, not
+    brokering between them.
+    ═══
+    So the block renders only when she set one. There is no default, no
+    suggestion, no "typical", and no arithmetic anywhere in this file. A
+    pin holds that.
+    """
+    cells = []
+    cells.append(("When", when_text))
+    if (fee or "").strip():
+        cells.append(("Fee", f"${_esc(fee)}"))
+    cells.append(("Where", where))
+    if (signer_count or "").strip():
+        cells.append(("Signers", signer_count))
+
+    tds = "".join(
+        f'<td valign="top" style="padding:0 14px 0 0;'
+        f'font-family:-apple-system,\'Segoe UI\',Roboto,Helvetica,Arial,sans-serif;">'
+        f'<div style="font-size:11px;letter-spacing:0.6px;text-transform:uppercase;'
+        f'color:#5C6370;padding-bottom:4px;">{_esc(label)}</div>'
+        f'<div style="font-size:16px;line-height:22px;font-weight:700;color:{INK};">'
+        f'{_esc(value)}</div></td>'
+        for label, value in cells if value
+    )
+    return (
+        '<table role="presentation" cellpadding="0" cellspacing="0" border="0" '
+        'width="100%" style="background-color:#F7F6FB;border:1px solid #E7E3F5;'
+        'border-radius:10px;margin:20px 0 0;">'
+        f'<tr><td style="padding:18px 20px 16px;"><table role="presentation" '
+        f'cellpadding="0" cellspacing="0" border="0" width="100%"><tr>{tds}</tr>'
+        "</table></td></tr></table>"
+    )
+
+
+def _respond_by(respond_by: Optional[str]) -> str:
+    """The deadline, as its own chip rather than a row in a table.
+
+    A response deadline that reads like another fact is a deadline she
+    finds after deciding. Renders only when there is one — an invented
+    urgency would be the product hurrying somebody on no information.
+    """
+    if not (respond_by or "").strip():
+        return ""
+    return (
+        '<table role="presentation" cellpadding="0" cellspacing="0" border="0" '
+        'style="margin:22px 0 0;"><tr><td style="background-color:#F3EEFF;'
+        'border:1px solid #DDD1FA;border-radius:6px;padding:8px 12px;'
+        "font-family:-apple-system,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;"
+        'font-size:13px;line-height:18px;font-weight:600;color:#4C1D95;">'
+        f"Please respond by {_esc(respond_by)}</td></tr></table>"
+    )
+
+
+def _escape_hatch(decline_link: str) -> str:
+    """"Can't take this one" as a REAL link, not a sentence asking her to
+    reply.
+
+    A notary who cannot take an assignment is the most useful early
+    answer the officer can get, and making that the hard path is how a
+    request sits unanswered for three days. The design made it an
+    explicit escape hatch and it is adopted as such.
+    """
+    if not decline_link:
+        return ""
+    return _p(
+        f'<a href="{_esc(decline_link)}" style="color:#5B21B6;font-weight:600;'
+        'text-decoration:underline;">Can\u2019t take this one</a>'
+        '<span style="color:#6E7480;">&nbsp;&mdash;&nbsp;lets the officer '
+        "reassign it right away</span>"
+    )
+
+
+def _reply_line(officer_name: str) -> str:
+    """WHERE A REPLY ACTUALLY GOES.
+
+    The design said "Reply to this email — it goes to our signing team."
+    There is no signing team. Owner-ruled out: a support channel that
+    does not exist is worse than no sentence, because she waits for an
+    answer from nobody.
+
+    Replies reach the officer, and the officer is named.
+    """
+    who = _esc(officer_name) or "the officer who sent it"
+    return _p(
+        f'<span style="font-size:13px;color:#8a94a0;">Questions about this '
+        f"signing? Replying to this email reaches {who} directly.</span>"
+    )
+
+
+#: The one legal footer for anything sent to somebody who is not our
+#: customer. Adopted verbatim from the design.
+SIGNING_FOOTER = (
+    "DeedPro prepares recorder-formatted documents at your direction. "
+    "Nothing in this email is legal advice."
+)
 
 
 def notary_dispatched(notary_name, officer_name, officer_company, deed_type,
                       property_address, county, when_text, location, link,
-                      expires_at) -> Rendered:
+                      expires_at, fee=None, signer_count=None,
+                      decline_link="", respond_by="") -> Rendered:
     """FLOW1 item 7 — officer → notary: can you take this, at this time?
+
+    ═══ THE PRIMARY VARIANT (EMAIL2) ═══
+
+    The owner's design was drawn for the availability case ("Post my
+    availability"), and the flow was RE-RULED after it was drawn:
+    dispatch is the primary path — the officer proposes a specific time
+    and the notary accepts or declines — with availability-posting as the
+    fallback. So this template gets the design's structure and the
+    dispatch question, and `notary_invited` keeps the design's original
+    ask.
 
     ═══ WHY THIS IS A SECOND TEMPLATE AND NOT A BRANCH ═══
 
@@ -419,35 +700,64 @@ def notary_dispatched(notary_name, officer_name, officer_company, deed_type,
     And it does not say the officer "confirmed" anything on the signers'
     behalf in a way that implies they spoke to us. She rang them. The
     email says she did.
+
+    ═══ AND NO DISTANCE ═══
+
+    The design shows "~6 mi from you". This product holds a notary's
+    city, state and postal code — not a geocoded point — so any mileage
+    would be arithmetic on data we do not have. §0: a figure that would
+    be roughly right most of the time is exactly the kind this product
+    declines. The block is omitted rather than shipped unreachable.
     """
     addr = _short_addr(property_address)
+    where = location or addr
     subject = f"Signing assignment — {addr}" if addr else "Notary signing assignment"
+
+    # PREHEADER — document · fee · respond-by, so she can triage from the
+    # inbox list without opening. The design's idea and a good one: a
+    # notary scanning ten requests decides which to open on exactly these.
+    preheader = " · ".join(x for x in [
+        _esc(deed_type) or "Signing request",
+        f"${_esc(fee)}" if (fee or "").strip() else "",
+        f"respond by {_esc(respond_by)}" if (respond_by or "").strip() else "",
+    ] if x)
+
     content = (
         _p(f"Hi {_esc(notary_name) or 'there'},")
         + _p(f"<strong>{_esc(officer_name)}</strong>"
              + (f" at {_esc(officer_company)}" if officer_company else "")
              + " is asking whether you can take a signing at a set time.")
-        + _facts([("When", when_text), ("Where", location or addr),
-                  ("Document", deed_type), ("County", county),
-                  ("Link expires", expires_at or "")])
-        + _button(link, "Accept or decline this time")
+        + _decision_block(when_text, fee, where, signer_count)
+        + _facts([("Document", deed_type), ("Address", property_address),
+                  ("County", county), ("Link expires", expires_at or "")])
+        + _respond_by(respond_by)
+        + _button(link, "Accept this signing")
+        + _escape_hatch(decline_link)
         + _p('<span style="font-size:13px;color:#8a94a0;">'
              f"{_esc(officer_name)} has already agreed this time with the "
              "signers. Nothing is booked until you accept — and if the time "
              "does not work, decline it and post the times you are free "
              "instead.</span>")
+        + _reply_line(officer_name)
+        + _p(f'<span style="font-size:12px;color:#8a94a0;">{SIGNING_FOOTER}</span>')
     )
     text = (
         f"{officer_name} is asking whether you can take a signing at a set time.\n\n"
-        f"When: {when_text}\nWhere: {location or addr}\n"
+        f"When: {when_text}\n"
+        + (f"Fee: ${fee}\n" if (fee or "").strip() else "")
+        + f"Where: {where}\n"
         f"Document: {deed_type}\nCounty: {county}\n"
-        f"Link expires: {expires_at or ''}\n\n"
-        f"Accept or decline: {link}\n\n"
-        f"{officer_name} has already agreed this time with the signers. "
+        f"Link expires: {expires_at or ''}\n"
+        + (f"Please respond by: {respond_by}\n" if (respond_by or "").strip() else "")
+        + f"\nAccept: {link}\n"
+        + (f"Can't take this one: {decline_link}\n" if decline_link else "")
+        + f"\n{officer_name} has already agreed this time with the signers. "
         "Nothing is booked until you accept. If it does not work, decline "
-        "it and post the times you are free instead."
+        "it and post the times you are free instead.\n\n"
+        f"Questions? Replying to this email reaches {officer_name} directly.\n\n"
+        f"{SIGNING_FOOTER}"
     )
-    return subject, _base(f"{officer_name} asked you to take a signing", content, True), text
+    return subject, _base(preheader, content, True), text
 
 
 def signing_windows_posted(signer_name, officer_name, officer_company, notary_name,

--- a/backend/utils/notifications.py
+++ b/backend/utils/notifications.py
@@ -212,10 +212,24 @@ def send_payment_failed_with_reason(user_email: str, full_name: str,
 def send_notary_invited(recipient_email: str, notary_name: str, officer_name: str,
                         officer_company: Optional[str], deed_type: str,
                         property_address: Optional[str], county: Optional[str],
-                        link: str, expires_at: Optional[str]) -> SendResult:
+                        link: str, expires_at: Optional[str],
+                        fee: Optional[str] = None,
+                        signer_count: Optional[str] = None,
+                        decline_link: str = "",
+                        respond_by: str = "") -> SendResult:
+    """EMAIL2 — `fee` is PASSED THROUGH, never derived.
+
+    It arrives from the officer's own typing and is displayed to the
+    person deciding whether to accept. Nothing in this module or the
+    template computes, defaults or suggests one, which is what keeps
+    NOTARY0b's no-fee-handling ruling intact: carrying a figure between
+    two people is not brokering between them.
+    """
     return _send("notary_invited", recipient_email, email_templates.notary_invited(
         notary_name, officer_name, officer_company, deed_type,
-        property_address, county, link, expires_at),
+        property_address, county, link, expires_at, fee=fee,
+        signer_count=signer_count, decline_link=decline_link,
+        respond_by=respond_by),
         context={"deed_type": deed_type})
 
 
@@ -224,13 +238,22 @@ def send_notary_dispatched(recipient_email: str, notary_name: str,
                            deed_type: str, property_address: Optional[str],
                            county: Optional[str], when_text: str,
                            location: Optional[str], link: str,
-                           expires_at: Optional[str]) -> SendResult:
-    """FLOW1 item 7 — the assignment. One time, a place, accept or decline."""
+                           expires_at: Optional[str],
+                           fee: Optional[str] = None,
+                           signer_count: Optional[str] = None,
+                           decline_link: str = "",
+                           respond_by: str = "") -> SendResult:
+    """FLOW1 item 7 — the assignment. One time, a place, accept or decline.
+
+    EMAIL2 — see `send_notary_invited` on the fee: passed through from
+    what the officer typed, never derived here or anywhere.
+    """
     return _send("notary_dispatched", recipient_email,
                  email_templates.notary_dispatched(
                      notary_name, officer_name, officer_company, deed_type,
                      property_address, county, when_text, location, link,
-                     expires_at),
+                     expires_at, fee=fee, signer_count=signer_count,
+                     decline_link=decline_link, respond_by=respond_by),
                  context={"deed_type": deed_type, "dispatched": True})
 
 

--- a/backend/utils/notifications.py
+++ b/backend/utils/notifications.py
@@ -213,21 +213,19 @@ def send_notary_invited(recipient_email: str, notary_name: str, officer_name: st
                         officer_company: Optional[str], deed_type: str,
                         property_address: Optional[str], county: Optional[str],
                         link: str, expires_at: Optional[str],
-                        fee: Optional[str] = None,
                         signer_count: Optional[str] = None,
                         decline_link: str = "",
                         respond_by: str = "") -> SendResult:
-    """EMAIL2 — `fee` is PASSED THROUGH, never derived.
+    """EMAIL2 — NO FEE ON THIS PATH, owner-ruled.
 
-    It arrives from the officer's own typing and is displayed to the
-    person deciding whether to accept. Nothing in this module or the
-    template computes, defaults or suggests one, which is what keeps
-    NOTARY0b's no-fee-handling ruling intact: carrying a figure between
-    two people is not brokering between them.
+    She is posting windows before anything is agreed, so a figure shown
+    now would read as an offer surviving whatever time is picked. The fee
+    lives on `send_notary_dispatched`, where it attaches to a specific
+    job at a specific time.
     """
     return _send("notary_invited", recipient_email, email_templates.notary_invited(
         notary_name, officer_name, officer_company, deed_type,
-        property_address, county, link, expires_at, fee=fee,
+        property_address, county, link, expires_at,
         signer_count=signer_count, decline_link=decline_link,
         respond_by=respond_by),
         context={"deed_type": deed_type})
@@ -245,8 +243,15 @@ def send_notary_dispatched(recipient_email: str, notary_name: str,
                            respond_by: str = "") -> SendResult:
     """FLOW1 item 7 — the assignment. One time, a place, accept or decline.
 
-    EMAIL2 — see `send_notary_invited` on the fee: passed through from
-    what the officer typed, never derived here or anywhere.
+    EMAIL2 — `fee` is PASSED THROUGH, never derived. It arrives from the
+    officer's own typing and is shown to the person deciding whether to
+    accept. Nothing in this module or the template computes, defaults or
+    suggests one, which is what keeps NOTARY0b's no-fee-handling ruling
+    intact: carrying a figure between two people is not brokering between
+    them.
+
+    Dispatch only — see `send_notary_invited` for why the availability
+    path carries no fee.
     """
     return _send("notary_dispatched", recipient_email,
                  email_templates.notary_dispatched(

--- a/docs/DOCTRINE_CONFORMANCE.md
+++ b/docs/DOCTRINE_CONFORMANCE.md
@@ -1246,6 +1246,20 @@ exists. This is the same failure in the instruments: a green tick and an
 unexecuted check are indistinguishable from the outside, and both are
 believed by default.
 
+**And the fifth, which is the same family from the other end: an
+instrument that ALTERS what it measures.** `git stash` was used twice in
+one day as though it were a query — "does this break on main too?" is a
+read-shaped question, and the command answers it by pocketing the entire
+working tree. The first time it made an empty stash and the comparison
+silently tested the branch under suspicion; the second it removed a
+narrowed `ADMIN_ROLES` and an edited model, so three passing tests looked
+broken and two phantom failures were chased before the cause was found.
+
+The generalisable form: **a command that changes state is not a query,
+however read-shaped the question was.** For "does main break too", copy
+the file or use a second checkout; never move the tree you are standing
+on.
+
 ---
 
 ## Change log


### PR DESCRIPTION
Documentation and comments only. No behaviour changes.

## §14.2 gains a fifth instrument — one that alters what it measures

The four already recorded fail by *not measuring*. This one fails by *changing the thing*:

`git stash` was used twice in one day as though it were a query. "Does this break on main too?" is a read-shaped question, and the command answers it by pocketing the entire working tree.

- The **first** time the stash was empty (everything was committed), so the comparison silently tested the branch under suspicion — and would have exonerated it.
- The **second** time it removed a narrowed `ADMIN_ROLES` and an edited request model, so three passing tests looked broken. Two phantom failures were chased before the cause was found.

**A command that changes state is not a query, however read-shaped the question was.** For "does main break too", copy the file or use a second checkout — never move the tree you are standing on.

## The deploy window, recorded as reasoning rather than caution

Removing the legacy `role` field from the registration model broke **ten test fixtures at once** — every one registering with `role`, every one failing with no access token.

Those fixtures are exactly what a browser holding the previous bundle would have been. The comment at the site now says so, because the pair looked like fussiness when it was written and the record should show it was the deploy topology made visible.

## Gates

banned-claims clean. No source behaviour touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_