### PR TITLE
Finish setting up — the day-one checklist, with the mockup corrected

### DIFF
--- a/backend/tests/test_trial1_paid_path.py
+++ b/backend/tests/test_trial1_paid_path.py
@@ -52,13 +52,26 @@ def test_the_advertised_trial_length_matches_the_one_we_charge_on():
     from routers.users_auth import TRIAL_PERIOD_DAYS
 
     import re
-    page = (REPO / "frontend" / "src" / "app" / "page.tsx").read_text(encoding="utf-8")
+    FRONTEND = REPO / "frontend" / "src"
     # PRICING1 moved the copy to `Start {TRIAL_DAYS}-day trial`, so the
     # page states the number once as a constant instead of twice as
     # prose. Read the constant — that IS the claim now.
-    claimed = {int(n) for n in re.findall(r"const TRIAL_DAYS\s*=\s*(\d+)", page)}
-    claimed |= {int(n) for n in re.findall(r"(\d+)[\s-]day trial", page, re.I)}
-    assert claimed, "the marketing page no longer states a trial length"
+    #
+    # AND THE CONSTANT MOVED AGAIN, to `lib/trial.ts`, when the day-one
+    # dashboard grew a second mention of the trial. That is the same
+    # rule one level up: one number per side means one DECLARATION per
+    # side, not one per screen. The mirror follows the declaration.
+    trial = (FRONTEND / "lib" / "trial.ts").read_text(encoding="utf-8")
+    claimed = {int(n) for n in re.findall(r"TRIAL_DAYS\s*=\s*(\d+)", trial)}
+    assert claimed, "lib/trial.ts no longer states a trial length"
+    # Any surface that writes the number as PROSE instead of importing it
+    # is a second claim, and it is checked here rather than trusted.
+    for surface in sorted(FRONTEND.rglob("*.tsx")):
+        if "__tests__" in surface.parts:
+            continue
+        text = surface.read_text(encoding="utf-8")
+        for n in re.findall(r"(\d+)[\s-]day (?:free )?trial", text, re.I):
+            claimed.add(int(n))
     assert claimed == {TRIAL_PERIOD_DAYS}, (
         f"the page advertises {sorted(claimed)}-day trial(s); the server "
         f"opens Checkout with trial_period_days={TRIAL_PERIOD_DAYS}")

--- a/frontend/src/__tests__/dashboardDayOne.test.ts
+++ b/frontend/src/__tests__/dashboardDayOne.test.ts
@@ -78,9 +78,74 @@ describe('the day-one dashboard', () => {
     expect(src).toContain('Nothing is waiting on anyone');
   });
 
+  it('puts the setup checklist where the welcome card was', () => {
+    const src = dashboard();
+    expect(src).toContain('<SetupChecklist');
+    // And it is derived state, not a banner: the page reads the profile
+    // it already fetches rather than adding a request.
+    expect(src).toContain('default_county');
+    expect(src).toContain('company_name');
+  });
+
+  it('renders no checklist until the profile has answered', () => {
+    /**
+     * Same rule as the accuracy figure, and the same reason: defaulting
+     * to "nothing is set up" would tell a fully configured officer she
+     * has three things to do, for as long as the request takes.
+     */
+    const src = dashboard();
+    expect(src).toContain('useState<{');
+    expect(src).toMatch(/\{setup && \(/);
+  });
+
+  it('leads with the greeting rather than burying it under three cards', () => {
+    const src = dashboard();
+    const greeting = src.indexOf('<AIGreeting');
+    const resume = src.indexOf('<ResumeCard');
+    expect(greeting).toBeGreaterThan(-1);
+    expect(greeting).toBeLessThan(resume);
+  });
+
   it('still says plainly when the queue could not load', () => {
     // §4 survives the cleanup: an empty state we suppressed must not
     // become a silent failure. The error branch is untouched.
     expect(dashboard()).toContain("Couldn't load what's waiting");
+  });
+});
+
+describe('the trial length', () => {
+  it('is declared in exactly one place on this side of the wire', () => {
+    /**
+     * It lived as a `const` in the landing page with a comment saying
+     * "one number, stated once per side" — true while the landing page
+     * was the only surface that mentioned it. The day-one rail is a
+     * second surface, so the number moved to `lib/trial.ts` and both
+     * import it.
+     *
+     * TRIAL1's mirror compares that file with the server's
+     * TRIAL_PERIOD_DAYS. A screen that retypes the digits is a second
+     * claim the mirror would not see, so this counts declarations.
+     */
+    const { readdirSync, statSync } = require('fs');
+    const files: string[] = [];
+    const walk = (dir: string) => {
+      for (const entry of readdirSync(dir)) {
+        const full = join(dir, entry);
+        if (statSync(full).isDirectory()) {
+          if (entry !== '__tests__' && entry !== 'node_modules') walk(full);
+        } else if (/\.tsx?$/.test(entry)) files.push(full);
+      }
+    };
+    walk(SRC);
+    const declarations = files.filter((f) =>
+      /(?:const|let|var)\s+TRIAL_DAYS\s*=/.test(readFileSync(f, 'utf8')));
+    expect(declarations.map((f) => f.replace(SRC, ''))).toEqual(['/lib/trial.ts']);
+
+    // And nowhere writes the length as prose instead of importing it.
+    for (const f of files) {
+      if (f.endsWith('lib/trial.ts')) continue;
+      expect(codeOnly(readFileSync(f, 'utf8')))
+        .not.toMatch(/\d+[\s-]day (?:free )?trial/i);
+    }
   });
 });

--- a/frontend/src/__tests__/dashboardSetupChecklist.test.tsx
+++ b/frontend/src/__tests__/dashboardSetupChecklist.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * The setup checklist, and the four things the mockup asked for that we
+ * are not saying.
+ *
+ * `docs/design/dashboard_day_one.html` drew three steps. Two of them
+ * described states this product cannot observe or has already ruled
+ * against, and the pins below hold the corrections rather than the
+ * drawing — because the drawing is in the repo and the next person to
+ * read it will find the original copy, not this file's reasoning.
+ */
+import { describe, expect, it, jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import SetupChecklist, { setupSteps } from '../features/dashboard/SetupChecklist';
+import DayOneRail from '../features/dashboard/DayOneRail';
+
+const NOTHING_SET = { county: null, companyName: null, deedCount: 0 };
+
+describe('what the checklist derives', () => {
+  it('reads three steps off state the product already holds', () => {
+    const steps = setupSteps(NOTHING_SET);
+    expect(steps.map((s) => s.id)).toEqual(['county', 'company', 'first-deed']);
+    expect(steps.every((s) => !s.done)).toBe(true);
+  });
+
+  it('counts a step done from the field that backs it', () => {
+    const steps = setupSteps({
+      county: 'Los Angeles', companyName: 'All Good Escrow', deedCount: 2,
+    });
+    expect(steps.every((s) => s.done)).toBe(true);
+  });
+
+  it('treats whitespace as unset, because a space is not a company name', () => {
+    expect(setupSteps({ ...NOTHING_SET, companyName: '   ' })[1].done).toBe(false);
+  });
+
+  it('renders nothing once there is nothing left to set up', () => {
+    /** A checklist with every box ticked is the same guaranteed-empty
+     *  module its predecessor removed three of. */
+    const { container } = render(<SetupChecklist state={{
+      county: 'Los Angeles', companyName: 'All Good Escrow', deedCount: 1,
+    }} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('says how many are done, in words', () => {
+    render(<SetupChecklist state={{ ...NOTHING_SET, county: 'Orange' }} />);
+    expect(screen.getByTestId('setup-progress')).toHaveTextContent('1 of 3 done');
+  });
+
+  it('routes each step to the thing that fixes it', () => {
+    const onAct = jest.fn();
+    render(<SetupChecklist state={NOTHING_SET} onAct={onAct} />);
+    screen.getByRole('button', { name: 'Set county' }).click();
+    expect(onAct).toHaveBeenCalledWith('county');
+  });
+});
+
+describe('the copy the mockup asked for and did not get', () => {
+  it('never claims she picked a county we have no record of', () => {
+    /**
+     * THE PIN THIS FILE EXISTS FOR (first of two).
+     *
+     * Drawn: "You picked Los Angeles County during setup, but it never
+     * reached us." If it never reached us there is no Los Angeles to
+     * name — the mockup's own annotation says the items derive from
+     * `default_county` being null, and null yields "not set".
+     */
+    render(<SetupChecklist state={NOTHING_SET} />);
+    const text = document.body.textContent || '';
+    expect(text).not.toMatch(/never reached us|didn'?t save|Retry/i);
+    expect(screen.getByText('Set your recording county')).toBeInTheDocument();
+  });
+
+  it('asks for her company name and not for a partner', () => {
+    /**
+     * THE PIN THIS FILE EXISTS FOR (second of two).
+     *
+     * Drawn as "Add {company} as a partner". `requestedByDefault.ts`
+     * rules against filing yourself in the rolodex — "a partner is a
+     * counterparty" — and already defaults the box from
+     * `users.company_name`, so zero partners does not mean a blank box.
+     * The real gap is a blank company name, which is a real population
+     * because the field is optional at registration.
+     */
+    render(<SetupChecklist state={NOTHING_SET} />);
+    const text = document.body.textContent || '';
+    expect(text).toContain('Add your company name');
+    expect(text).not.toMatch(/partner/i);
+  });
+
+  it('makes no claim about what a county recorder will do', () => {
+    /** §1 — a legal assertion printed in our own UI. Drawn as "the
+     *  county will reject the document". */
+    render(<SetupChecklist state={NOTHING_SET} />);
+    const text = (document.body.textContent || '').toLowerCase();
+    for (const claim of ['reject', 'refuse', 'will not record', 'invalid']) {
+      expect(text).not.toContain(claim);
+    }
+  });
+
+  it('carries no status pills, because nothing has failed', () => {
+    /** OWNER-RULED rather than defaulted: a pill implies a status
+     *  CHANGE occurred. Both steps are "not set", which is not an
+     *  event. A real failure would earn a pill and its own copy. */
+    render(<SetupChecklist state={NOTHING_SET} />);
+    const text = (document.body.textContent || '').toLowerCase();
+    for (const pill of ['blocks recording', "didn't save", 'didn’t save', 'error', 'failed']) {
+      expect(text).not.toContain(pill);
+    }
+  });
+
+  it('marks a finished step with a word and not only a colour', () => {
+    /** The one rule from the mockup's pill design that survives it:
+     *  status never rides on hue alone, so it holds up in greyscale,
+     *  forced-colors and a screen reader. */
+    render(<SetupChecklist state={{ ...NOTHING_SET, county: 'Los Angeles' }} />);
+    expect(screen.getByText('Done')).toBeInTheDocument();
+  });
+});
+
+describe('the rail', () => {
+  it('shows where the company name lands, and marks the gap when it is blank', () => {
+    render(<DayOneRail companyName={null} county={null} plan="free" />);
+    expect(screen.getByText('RECORDING REQUESTED BY:')).toBeInTheDocument();
+    expect(screen.getByText('Your company name')).toBeInTheDocument();
+  });
+
+  it('shows the real name once she has one', () => {
+    render(<DayOneRail companyName="All Good Escrow" county="Los Angeles" plan="free" />);
+    expect(screen.getByText('All Good Escrow')).toBeInTheDocument();
+    expect(screen.queryByText('Your company name')).not.toBeInTheDocument();
+  });
+
+  it('never states a monthly deed allowance', () => {
+    /**
+     * MONEY1, and the reason this row is missing from a card the mockup
+     * drew it on. That ticket found `max_deeds_per_month: 5` returned
+     * from a hardcoded fallback while `check_plan_limits` had zero call
+     * sites — a cap nothing enforced, reported as though it were a rule.
+     * Free is uncapped and the payload says so with null.
+     *
+     * Rebuilding "0 of 5" on a screen restores it in the harder place
+     * to see: copy gets read by people, payloads do not.
+     */
+    render(<DayOneRail companyName="X" county="Los Angeles" plan="free" />);
+    const text = (document.body.textContent || '').toLowerCase();
+    expect(text).not.toMatch(/of 5|deeds this month|per month|allowance|limit/);
+  });
+
+  it('says the county is not set in words, not only in red', () => {
+    render(<DayOneRail companyName="X" county={null} plan="free" />);
+    expect(screen.getByText('Not set')).toBeInTheDocument();
+  });
+
+  it('states the trial length from the one place it is declared', () => {
+    /** TRIAL1's mirror compares `lib/trial.ts` with the server's
+     *  TRIAL_PERIOD_DAYS. Retyping the number here would have made it
+     *  two claims on this side of the wire, which is the defect that
+     *  mirror exists to catch. */
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { TRIAL_DAYS } = require('../lib/trial');
+    render(<DayOneRail companyName="X" county="Los Angeles" plan="free" />);
+    expect(screen.getByText(new RegExp(`${TRIAL_DAYS}-day free trial`)))
+      .toBeInTheDocument();
+  });
+
+  it('does not sell a trial to somebody already paying', () => {
+    render(<DayOneRail companyName="X" county="Los Angeles" plan="professional" />);
+    expect(document.body.textContent).not.toMatch(/free trial/);
+  });
+});

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -11,6 +11,8 @@ import EmailVerificationNotice from "@/features/account/EmailVerificationNotice"
 import AccuracySection from "@/features/dashboard/AccuracySection"
 import ResumeCard from "@/features/dashboard/ResumeCard"
 import StartSomethingNew from "@/features/dashboard/StartSomethingNew"
+import SetupChecklist, { setupSteps } from "@/features/dashboard/SetupChecklist"
+import DayOneRail from "@/features/dashboard/DayOneRail"
 import { pickInProgressDeed } from "@/lib/latestDraft"
 import { SessionExpiredError, apiFetch } from "@/lib/apiClient"
 import { 
@@ -62,6 +64,14 @@ export default function Dashboard() {
   // VERIFY-CHECK — this screen already fetches /users/profile, so saying
   // whether the address is confirmed costs one field and no request.
   const [account, setAccount] = useState<{ verified?: boolean; email?: string }>({})
+  /* Undefined until /users/profile answers. The checklist is NOT rendered
+     from a default of "nothing is set up" — that would tell a fully
+     configured officer she has three things to do, for as long as the
+     request takes. Same rule as the accuracy figure. */
+  const [setup, setSetup] = useState<{
+    county?: string | null; companyName?: string | null;
+    businessAddress?: string | null; plan?: string | null; deedCount: number;
+  } | null>(null)
   const [recentDeeds, setRecentDeeds] = useState<any[]>([])
   const [deedsError, setDeedsError] = useState<string | null>(null)
   const [summary, setSummary] = useState<{
@@ -107,7 +117,18 @@ export default function Dashboard() {
             setUserName(profileData.full_name.split(' ')[0])
           }
           setAccount({ verified: profileData.verified, email: profileData.email })
-          
+          /* The setup checklist's three signals, all of them already in
+             this response — no second request and no new endpoint. The
+             deed count is the server's, not `recentDeeds.length`, which
+             is a page of the list rather than the whole of it. */
+          setSetup({
+            county: profileData.default_county,
+            companyName: profileData.company_name,
+            businessAddress: profileData.business_address,
+            plan: profileData.plan,
+            deedCount: Number(profileData.total_deeds) || 0,
+          })
+
           // Check if onboarding is completed
           const onboardingComplete = localStorage.getItem("onboarding_completed") === "true"
           const hasDeeds = profileData.total_deeds > 0
@@ -252,6 +273,11 @@ export default function Dashboard() {
     String(b.updated_at || b.created_at || '').localeCompare(
       String(a.updated_at || a.created_at || '')))
 
+  /* The rail exists to explain the steps, so it goes when they do —
+     §13 rule 3: the page does not recompute "is setup finished", it
+     asks the one function that decides what a step is. */
+  const setupIncomplete = !!setup && setupSteps(setup).some((st) => !st.done)
+
   return (
     <div className="flex bg-gray-50 min-h-screen">
       <Sidebar />
@@ -261,6 +287,50 @@ export default function Dashboard() {
               and offers; it withholds nothing, because nothing in this
               product is gated on the answer. */}
           <EmailVerificationNotice verified={account.verified} email={account.email} />
+
+          {/* ═══ THE GREETING MOVED UP, AND IS NOT A HERO ═══
+
+              The day-one mockup puts it first and small. It was sitting
+              below three cards, which is neither.
+
+              WHAT DID NOT CHANGE, AND IS FLAGGED: the line under it.
+              "Keep as drawn: the one-line greeting" read literally
+              deletes "Here's where your deeds stand" — and that sentence
+              is U3's ruling, added deliberately so the greeting states
+              what the page IS rather than making a chat-style promise
+              with no chat behind it. The mockup's complaint is that the
+              greeting was a HERO, which is about weight and position,
+              and both of those are fixed here. Deleting a ruled sentence
+              on the strength of a phrase about size is the half I am not
+              deciding. */}
+          <div className="mb-6">
+            <AIGreeting userName={userName} />
+          </div>
+
+          {/* ═══ FINISH SETTING UP ═══
+
+              Where the welcome card and its four bullets used to be, and
+              the shape its removal argued for: a list derived from state
+              rather than a banner. It renders nothing once the three are
+              done, and nothing at all until the profile has answered. */}
+          {setup && (
+            <div className="mb-6 grid gap-4 lg:grid-cols-[2fr,1fr] items-start">
+              <SetupChecklist
+                state={setup}
+                onAct={(id) => router.push(
+                  id === 'first-deed' ? '/deed-builder' : '/account-settings')}
+              />
+              {setupIncomplete && (
+                <DayOneRail
+                  companyName={setup.companyName}
+                  businessAddress={setup.businessAddress}
+                  county={setup.county}
+                  plan={setup.plan}
+                  onSeePlans={() => router.push('/pricing')}
+                />
+              )}
+            </div>
+          )}
 
           {/* THE MOCKUP'S ORDER, AND IT IS AN ARGUMENT: resume is the
               highest-frequency action in a preparation tool, so it sits
@@ -283,11 +353,6 @@ export default function Dashboard() {
               accuracy={queue?.accuracy}
               onOpen={(id) => router.push(`/deeds/${id}`)}
             />
-          </div>
-
-          {/* AI Greeting */}
-          <div className="mb-8">
-            <AIGreeting userName={userName} />
           </div>
 
           {/* Draft deed card (Ticket R: resume is real — the card opens the

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -26,9 +26,11 @@ const AnimatedDeed = dynamic(() => import("@/components/landing-v2/AnimatedDeed"
 // "Contact information coming soon" — a tier nobody could buy, above a
 // contact route nobody could use.
 
-// TRIAL1's mirror reads this number off the page and compares it with
-// the server's TRIAL_PERIOD_DAYS. One number, stated once per side.
-const TRIAL_DAYS = 14
+// TRIAL1's mirror compares this with the server's TRIAL_PERIOD_DAYS.
+// It moved to `lib/trial.ts` when the day-one dashboard grew a second
+// mention: one number per side means one DECLARATION per side, not one
+// per screen.
+import { TRIAL_DAYS } from "@/lib/trial"
 
 export default function LandingPage() {
   return (

--- a/frontend/src/components/ui/AIGreeting.tsx
+++ b/frontend/src/components/ui/AIGreeting.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { useState, useEffect } from "react"
-import { Sparkles } from "lucide-react"
 
 interface AIGreetingProps {
   userName?: string
@@ -36,12 +35,12 @@ export function AIGreeting({ userName, className = "" }: AIGreetingProps) {
         ${className}
       `}
     >
-      <div className="w-10 h-10 rounded-full bg-emerald-100 flex items-center justify-center">
-        <Sparkles className="w-5 h-5 text-emerald-600 animate-pulse" />
-      </div>
+      {/* "One line, not a hero" (the day-one mockup). The pulsing badge
+          and the 2xl heading were the hero part; the sentence below is
+          not, and it is U3's ruling — see the dashboard's comment. */}
       <div>
-        <h1 className="text-2xl font-bold text-gray-900">
-          {greeting}, {displayName}!
+        <h1 className="text-xl font-bold text-gray-900">
+          {greeting}, {displayName}.
         </h1>
         {/* U3: no chat-style promise with no chat behind it — the line under
             the greeting states what the page actually is. */}

--- a/frontend/src/features/dashboard/DayOneRail.tsx
+++ b/frontend/src/features/dashboard/DayOneRail.tsx
@@ -1,0 +1,119 @@
+/**
+ * The rail beside the setup checklist: where her company name lands, and
+ * what her plan is.
+ *
+ * ═══ WHAT THIS REPLACED ═══
+ *
+ * Four bullets headed "what I can help with", which were landing-page
+ * copy shown to somebody who had already signed up. The mockup's
+ * argument for the swap is that a picture of where her own company name
+ * prints does the same persuading and doubles as the explanation for the
+ * step asking for it.
+ *
+ * ═══ THE PLAN CARD, MINUS ONE ROW ═══
+ *
+ * The mockup draws "Deeds this month — 0 of 5". Cut, owner-ruled, and
+ * the ruling already existed: MONEY1 found `max_deeds_per_month: 5`
+ * being returned from a hardcoded fallback while `check_plan_limits` had
+ * zero call sites, so nothing had ever counted a deed against a cap. An
+ * officer on Free was being told she had five a month by an API, and it
+ * was untrue in both directions — nothing stopped her at five, and
+ * nothing had decided she should be stopped. Free is uncapped and the
+ * payload says so with `null`.
+ *
+ * Rebuilding the row on a screen would restore exactly that, in the
+ * harder place to see: copy gets read by people, payloads do not.
+ *
+ * The trial line stays, because it is true — `TRIAL_PERIOD_DAYS = 14`
+ * on the server, mirrored by a test — and because today the trial is
+ * only ever discovered AFTER clicking Upgrade.
+ */
+'use client';
+
+import { TRIAL_DAYS } from '@/lib/trial';
+
+export default function DayOneRail({ companyName, businessAddress, county, plan, onSeePlans }: {
+  companyName?: string | null;
+  businessAddress?: string | null;
+  county?: string | null;
+  plan?: string | null;
+  onSeePlans?: () => void;
+}) {
+  const company = (companyName || '').trim();
+  const address = (businessAddress || '').trim();
+  const planName = (plan || '').trim();
+  const isFree = !planName || planName.toLowerCase() === 'free';
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-2xl border border-gray-200 bg-white p-5">
+        <h3 className="text-sm font-bold text-gray-900">Where your company lands</h3>
+
+        {/* A deed face, not a picture of one: these are the two lines
+            that print at the top of every recorded instrument, in the
+            order they print. */}
+        <div className="mt-3 rounded-lg border border-gray-200 bg-gray-50 p-3 text-[11px] leading-relaxed">
+          <div className="font-semibold tracking-wide text-gray-500">
+            RECORDING REQUESTED BY:
+          </div>
+          {company ? (
+            <div className="font-medium text-gray-900">{company}</div>
+          ) : (
+            <div className="rounded border border-dashed border-emerald-400 bg-emerald-50 px-1.5 py-0.5 text-emerald-800">
+              Your company name
+            </div>
+          )}
+          <div className="mt-2 font-semibold tracking-wide text-gray-500">
+            AND WHEN RECORDED MAIL TO:
+          </div>
+          {address ? (
+            <div className="text-gray-900">{address}</div>
+          ) : (
+            <div className="rounded border border-dashed border-gray-300 px-1.5 py-0.5 text-gray-500">
+              Your business address
+            </div>
+          )}
+          <hr className="my-2 border-gray-200" />
+          <div className="text-center font-bold tracking-widest text-gray-700">
+            GRANT DEED
+          </div>
+        </div>
+
+        <p className="mt-3 text-xs text-gray-500">
+          {company
+            ? 'This is where it prints, on every deed you make.'
+            : 'The dashed box is what the setup step fills in. It is the whole reason we ask.'}
+        </p>
+      </div>
+
+      <div className="rounded-2xl border border-gray-200 bg-white p-5">
+        <h3 className="text-sm font-bold text-gray-900">Your plan</h3>
+        <dl className="mt-3 space-y-2 text-sm">
+          <div className="flex items-center justify-between gap-3">
+            <dt className="text-gray-500">Plan</dt>
+            <dd className="font-semibold text-gray-900">
+              {planName ? planName[0].toUpperCase() + planName.slice(1) : 'Free'}
+            </dd>
+          </div>
+          <div className="flex items-center justify-between gap-3">
+            <dt className="text-gray-500">Recording county</dt>
+            {/* "Not set" is the word doing the work. The colour is a
+                second signal, never the only one. */}
+            <dd className={`font-semibold ${(county || '').trim() ? 'text-gray-900' : 'text-amber-700'}`}>
+              {(county || '').trim() || 'Not set'}
+            </dd>
+          </div>
+        </dl>
+        {isFree && (
+          <p className="mt-3 text-xs text-gray-500">
+            Professional includes a {TRIAL_DAYS}-day free trial — no charge today.{' '}
+            <button type="button" onClick={onSeePlans}
+                    className="font-semibold text-emerald-700 underline underline-offset-2">
+              See what&apos;s included
+            </button>
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/dashboard/SetupChecklist.tsx
+++ b/frontend/src/features/dashboard/SetupChecklist.tsx
@@ -1,0 +1,182 @@
+/**
+ * Finish setting up — the only content that can be true on day one.
+ *
+ * ═══ WHY A CHECKLIST AND NOT A WELCOME CARD ═══
+ *
+ * From `docs/design/dashboard_day_one.html`, whose argument is that
+ * every item here is derived from state the product already holds:
+ * `default_county` is null, `company_name` is blank, the deed count is
+ * zero. A welcome banner cannot notice any of that. This can, and each
+ * item is something the DEED needs rather than profile decoration.
+ *
+ * ═══ THE MOCKUP'S THREE STEPS, TWO OF THEM REWRITTEN ═══
+ *
+ * STEP 1 was drawn as "Confirm your recording county", with a red
+ * "Didn't save" pill, copy reading "You picked Los Angeles County during
+ * setup, but it never reached us", and a Retry button.
+ *
+ * Cut, owner-ruled, and the reason is that the sentence asserts
+ * something we cannot know. If the save never reached us there is no
+ * record of Los Angeles to name — the mockup's own annotation says the
+ * items derive from `default_county` being null, and null yields "not
+ * set", not "you picked LA". SETTINGS1 also closed that silent failure
+ * at its source: a failed submit keeps her on the onboarding page with
+ * the error, and a skip tells her plainly. What is left is the honest
+ * state — she has no default county — and that is what this says.
+ *
+ * STEP 2 was drawn as "Add {company} as a partner", with copy saying the
+ * RECORDING REQUESTED BY box "comes out blank and the county will
+ * reject the document".
+ *
+ * Three corrections, all owner-ruled. It targets her COMPANY NAME, not a
+ * partner: `requestedByDefault.ts` already falls back to a synthetic
+ * own-company option built from `users.company_name`, and adding herself
+ * to the rolodex is ruled against there — "a partner is a counterparty,
+ * and the rolodex is not a place to file yourself". The real gap is the
+ * narrower one where `company_name` is blank, which is a real
+ * population because the field is optional at registration. And the
+ * county-rejection line is cut under §1: it is a legal assertion about
+ * what a recorder will do, printed in our own UI.
+ *
+ * ═══ NO PILLS, AND THAT IS A RULING RATHER THAN A DEFAULT ═══
+ *
+ * The mockup gives each step a status pill — "Didn't save", "Blocks
+ * recording". Both steps here are "not set" states with nothing having
+ * failed, and a pill implies a status CHANGE occurred. It follows from
+ * cutting the rejection claim: we do not tell her something is blocked
+ * or broken when nothing is blocked or broken. A step is either not done
+ * yet or done. If a real failure state ever exists — a save that
+ * actually errored — that earns a pill and its own copy at that point.
+ *
+ * What survives from the mockup is the rule UNDER the pills: status is
+ * never carried by colour alone. A finished step is marked with a glyph
+ * AND the word "Done", and the meter states the count in words.
+ */
+'use client';
+
+export interface SetupState {
+  /** `user_profiles.default_county`, or null when she has not set one. */
+  county?: string | null;
+  /** `users.company_name` — optional at registration, hence this step. */
+  companyName?: string | null;
+  /** Every deed she has, deleted ones excluded. */
+  deedCount: number;
+}
+
+export interface SetupStep {
+  id: 'county' | 'company' | 'first-deed';
+  title: string;
+  detail: string;
+  action: string;
+  done: boolean;
+}
+
+const blank = (v?: string | null) => !((v || '').trim());
+
+/**
+ * The three steps and whether each is finished — exported because the
+ * page needs the count for its own line and must not recompute it.
+ * §13 rule 3: one place turns state into English.
+ */
+export function setupSteps(state: SetupState): SetupStep[] {
+  return [
+    {
+      id: 'county',
+      title: 'Set your recording county',
+      detail: 'The county you record in most often. It becomes the default on '
+            + 'every new deed, and you can change it on any one of them.',
+      action: 'Set county',
+      done: !blank(state.county),
+    },
+    {
+      id: 'company',
+      title: 'Add your company name',
+      detail: 'This is the name that prints in RECORDING REQUESTED BY at the top '
+            + 'of the deed. Without it that box starts empty and you fill it in '
+            + 'by hand each time.',
+      action: 'Add company',
+      done: !blank(state.companyName),
+    },
+    {
+      id: 'first-deed',
+      title: 'Make your first deed',
+      detail: 'Start from an address. The APN, legal description and current owner '
+            + 'come back from county records — you confirm every value before it '
+            + 'prints.',
+      action: 'Start',
+      done: state.deedCount > 0,
+    },
+  ];
+}
+
+export default function SetupChecklist({ state, onAct }: {
+  state: SetupState;
+  onAct?: (id: SetupStep['id']) => void;
+}) {
+  const steps = setupSteps(state);
+  const done = steps.filter((s) => s.done).length;
+
+  // Nothing left to set up: the card goes. A checklist with every box
+  // ticked is the guaranteed-empty module this ticket's predecessor
+  // removed three of.
+  if (done === steps.length) return null;
+
+  return (
+    <section aria-labelledby="setup-heading"
+             className="rounded-2xl border border-gray-200 bg-white p-5 md:p-6">
+      <h2 id="setup-heading" className="text-lg font-bold text-gray-900">
+        Finish setting up
+      </h2>
+      <p className="mt-1 text-sm text-gray-500">
+        Each step below is something the deed itself needs. None of it is
+        profile decoration.
+      </p>
+
+      <ol className="mt-5 space-y-4">
+        {steps.map((step, i) => (
+          <li key={step.id} className="flex items-start gap-3">
+            {/* STATUS IS NEVER COLOUR ALONE (the mockup's rule, kept).
+                A finished step carries a glyph and the word; an
+                unfinished one carries its position. Both survive
+                greyscale, forced-colors and a screen reader. */}
+            <span aria-hidden="true"
+                  className={`mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center
+                              rounded-full text-xs font-bold ${
+                    step.done ? 'bg-emerald-100 text-emerald-700'
+                              : 'bg-gray-100 text-gray-600'}`}>
+              {step.done ? '✓' : i + 1}
+            </span>
+            <div className="min-w-0 flex-1">
+              <div className="font-medium text-gray-900">
+                {step.title}
+                {step.done && (
+                  <span className="ml-2 text-xs font-semibold text-emerald-700">
+                    Done
+                  </span>
+                )}
+              </div>
+              {!step.done && (
+                <p className="mt-0.5 text-sm text-gray-500">{step.detail}</p>
+              )}
+            </div>
+            {!step.done && (
+              <button
+                type="button"
+                onClick={() => onAct?.(step.id)}
+                className="shrink-0 rounded-lg border border-gray-200 px-3 py-1.5
+                           text-sm font-semibold text-gray-800 hover:bg-gray-50"
+              >
+                {step.action}
+              </button>
+            )}
+          </li>
+        ))}
+      </ol>
+
+      <p className="mt-5 text-sm font-semibold text-gray-700"
+         data-testid="setup-progress">
+        {done} of {steps.length} done
+      </p>
+    </section>
+  );
+}

--- a/frontend/src/lib/trial.ts
+++ b/frontend/src/lib/trial.ts
@@ -1,0 +1,20 @@
+/**
+ * The trial length, stated once on this side of the wire.
+ *
+ * ═══ WHY IT MOVED OUT OF page.tsx ═══
+ *
+ * It lived as a `const` in the landing page, with a comment saying "one
+ * number, stated once per side" — and that was true while the landing
+ * page was the only surface that mentioned a trial.
+ *
+ * The day-one dashboard mentions it too. Retyping 14 there would have
+ * made it twice on this side, which is the exact defect TRIAL1's mirror
+ * exists to catch: an advertised length and a charged length that
+ * differ are discovered by the customer, on the day they are charged.
+ *
+ * So the number has one home and both surfaces import it.
+ * `test_trial1_paid_path.py` reads THIS file and compares it with the
+ * server's `TRIAL_PERIOD_DAYS`. Changing it here without changing the
+ * server fails that gate, which is the whole arrangement.
+ */
+export const TRIAL_DAYS = 14


### PR DESCRIPTION
Ticket 2 of two, from the `dashboard_day_one.html` diff. Goes where #206's welcome card was.

Three steps derived from state the product already holds — `default_county` is null, `company_name` is blank, the deed count is zero. All three come off the `/users/profile` response the dashboard already fetches: no new endpoint, no second request. It renders nothing until that response arrives (defaulting to "nothing is set up" would tell a fully configured officer she has three things to do, for as long as the request takes) and nothing once the three are done.

## The two rewritten steps

**Step 1** was drawn as *"You picked Los Angeles County during setup, but it never reached us"*, with a "Didn't save" pill and a Retry button. If it never reached us there is no Los Angeles to name — the mockup's own annotation derives its items from `default_county` being null, and null yields "not set". SETTINGS1 also closed that silent failure at source: a failed submit keeps her on the onboarding page with the error, and a skip tells her plainly.

→ **"Set your recording county."**

**Step 2** was drawn as *"Add {company} as a partner"*, with the box coming out blank and *"the county will reject the document"*. It targets her **company name** instead: `requestedByDefault.ts` already defaults the box from `users.company_name` and rules against filing yourself in the rolodex — *"a partner is a counterparty"*. The gap is the narrower one where company name is blank, which is a real population because the field is **optional at registration**. The rejection line is cut under §1.

→ **"Add your company name."**

## No pills

Ruled rather than defaulted. Both steps are "not set" with nothing having failed, and a pill implies a status *change* occurred. It follows from cutting the rejection claim: we don't tell her something is blocked or broken when nothing is blocked or broken.

What survives from the mockup's pill design is the rule underneath it — **status never rides on colour alone**. A finished step carries a glyph *and* the word "Done"; the meter states the count in words; "Not set" is a word, not a red swatch.

## The rail

Replaces the four bullets: a deed face showing where her company name lands (dashed placeholder when blank, the real name once set), and a plan card with Plan and Recording county.

**"Deeds this month — 0 of 5" is cut.** MONEY1 already found that cap being reported by an API that nothing enforced — `check_plan_limits` had zero call sites. Rebuilding it on a screen restores it in the harder place to see: copy gets read by people, payloads do not.

The trial line stays, because it's true.

## One discovery — the trial number

`TRIAL_DAYS` was a const in `app/page.tsx` carrying the comment *"one number, stated once per side"*. True while the landing page was the only surface mentioning a trial. **The rail is a second surface**, so retyping `14` would have made two claims on this side of the wire while TRIAL1's mirror reads only one — the exact defect that mirror exists to catch.

It now lives in `lib/trial.ts`; both surfaces import it; the mirror follows the declaration; and a new pin counts declarations across `src/` and refuses the length written as prose anywhere.

## Flagged, not decided

**The greeting kept its second line.** It moved to the top and lost its hero weight (the pulsing badge and the 2xl heading). *"Keep as drawn: the one-line greeting"* read literally also deletes *"Here's where your deeds stand"* — and that sentence is **U3's ruling**, added so the greeting states what the page is rather than making a chat-style promise with no chat behind it. The mockup's complaint is that the greeting was a *hero*, which is weight and position; both are fixed. Deleting a ruled sentence on the strength of a phrase about size is the half I'm not deciding — same precedent as #206.

## Gates

pytest **1463**, jest **1048**/74 (+21, +1 suite), tsc **88** unchanged, banned-claims clean, S1 + S3 + six-flow + api-baseline green.

Four mutations probed, all caught: step 2 reverted to "as a partner"; the county-rejection line restored; "0 of 5" added to the rail; the trial number retyped as a literal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_