### PR TITLE
The recording county has a home she can reach

### DIFF
--- a/frontend/src/__tests__/countyField.test.tsx
+++ b/frontend/src/__tests__/countyField.test.tsx
@@ -1,0 +1,140 @@
+/**
+ * DASH-FIX #1 — the recording county has a home she can reach.
+ *
+ * ═══ THE FINDING ═══
+ *
+ * The day-one checklist's "Set county" button routed to
+ * `/account-settings`, which had no county field. The only open setup
+ * step could not be completed from its own call to action, and the only
+ * surface in the product that wrote `default_county` was the one-time
+ * onboarding flow.
+ *
+ * ═══ AND IT WAS THE SECOND HOME, HALF-BUILT ═══
+ *
+ * Not a missing feature so much as an unfinished one. `ProfilePatch` has
+ * accepted `default_county` since SETTINGS1, the `user_profiles` upsert
+ * writes it, and this form has always PATCHed its whole `formData` to
+ * that endpoint. The control was the only piece that was never added —
+ * the same shape as SETTINGS1's own finding, where the patch surface had
+ * to be built before the button could be wired to anything.
+ *
+ * Routing to `/onboarding` was refused: it writes `onboarding_completed`
+ * and navigates to the builder, so re-entering it to change one field
+ * re-runs a completion she did not ask for.
+ */
+import { describe, expect, it } from '@jest/globals';
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join } from 'path';
+
+import { codeOnly } from '../test-support/sourceText';
+import { CA_COUNTY_NAMES, COUNTIES } from '../lib/jurisdictions';
+
+const SRC = join(__dirname, '..');
+const SETTINGS = join(SRC, 'app', 'account-settings', 'page.tsx');
+const ONBOARDING = join(SRC, 'app', 'onboarding', 'page.tsx');
+const read = (p: string) => codeOnly(readFileSync(p, 'utf8'));
+
+describe('the county picker', () => {
+  it('offers every California county, because she may record in any of them', () => {
+    expect(CA_COUNTY_NAMES).toHaveLength(58);
+    expect(CA_COUNTY_NAMES).toContain('Los Angeles');
+    expect(CA_COUNTY_NAMES).toContain('Yuba');
+  });
+
+  it('is not the same set as the counties we hold recorder facts for', () => {
+    /**
+     * THE PIN THIS FILE EXISTS FOR.
+     *
+     * The two sets are different and the difference is load-bearing.
+     * Driving the picker off `COUNTIES` shrinks it to the handful we have
+     * researched; filling `COUNTIES` out to 58 would imply we hold PCOR
+     * routing and recorder preferences we do not — a place treated as a
+     * string and then reasoned about as though it were knowledge, which
+     * is what T-2 was built after.
+     *
+     * If this assertion ever fails because the sets converged, the
+     * question to answer is which of those two things happened.
+     */
+    expect(Object.keys(COUNTIES).length).toBeLessThan(CA_COUNTY_NAMES.length);
+    for (const key of Object.keys(COUNTIES)) {
+      expect(CA_COUNTY_NAMES.map((n) => n.toLowerCase())).toContain(key);
+    }
+  });
+
+  it('is declared once, and no picker carries its own copy', () => {
+    /** §14.3 — one DECLARATION, not one screen. It was a local const in
+     *  onboarding while onboarding was the only picker. */
+    const files: string[] = [];
+    const walk = (dir: string) => {
+      for (const entry of readdirSync(dir)) {
+        const full = join(dir, entry);
+        if (statSync(full).isDirectory()) {
+          if (entry !== '__tests__' && entry !== 'node_modules') walk(full);
+        } else if (/\.tsx?$/.test(entry)) files.push(full);
+      }
+    };
+    walk(SRC);
+    const carriers = files.filter((f) => {
+      const src = codeOnly(readFileSync(f, 'utf8'));
+      // A county list is recognisable by holding several county names
+      // that are not ordinary English — spelling-independent enough to
+      // survive a rename of the constant (§14.1).
+      return ['Calaveras', 'Tuolumne', 'Siskiyou'].every((n) => src.includes(`'${n}'`)
+        || src.includes(`"${n}"`));
+    });
+    expect(carriers.map((f) => f.replace(SRC, ''))).toEqual(['/lib/jurisdictions.ts']);
+  });
+});
+
+describe('account settings', () => {
+  it('has a recording county control', () => {
+    const src = read(SETTINGS);
+    expect(src).toContain('default_county');
+    expect(src).toContain('CA_COUNTY_NAMES');
+    expect(src).toContain('Recording county');
+  });
+
+  it('offers "Not set", because not set is a real state', () => {
+    /** A select with no blank option silently asserts its first entry —
+     *  which would make every officer who never touched this field read
+     *  as recording in Alameda. */
+    expect(read(SETTINGS)).toContain('<option value="">Not set</option>');
+  });
+
+  it('hydrates the county from the profile like every other field', () => {
+    /**
+     * Caught by tsc, not by a person, and it is the defect this effect
+     * exists for: a field added to the form and not to the hydration
+     * reads empty once the profile lands, so a county she set displays
+     * as "Not set" — and the next save writes that blank back over it.
+     */
+    const src = read(SETTINGS);
+    const start = src.indexOf('if (!userProfile) return');
+    // Sliced to the effect's own closing line, NOT to a character count:
+    // `codeOnly` blanks comments to spaces to preserve positions, so a
+    // fixed window shrinks whenever somebody explains something. The
+    // first version of this pin used 600 characters and failed on the
+    // comment justifying the very line it was checking for.
+    const effect = src.slice(start, src.indexOf('}, [userProfile])', start));
+    expect(effect).toContain('default_county: userProfile.default_county');
+  });
+
+  it('sends the whole form to the endpoint that already accepted county', () => {
+    expect(read(SETTINGS)).toContain('JSON.stringify(formData)');
+  });
+});
+
+describe('the checklist button', () => {
+  it('points at the page that now holds the field', () => {
+    const dash = read(join(SRC, 'app', 'dashboard', 'page.tsx'));
+    expect(dash).toContain('/account-settings');
+    // And NOT at the completion flow: re-entering onboarding to change
+    // one field re-runs `onboarding_completed` and a navigation she did
+    // not ask for.
+    expect(dash).not.toContain("'/onboarding'");
+  });
+
+  it('leaves onboarding importing the shared list rather than its own', () => {
+    expect(read(ONBOARDING)).toContain('CA_COUNTY_NAMES');
+  });
+});

--- a/frontend/src/app/account-settings/page.tsx
+++ b/frontend/src/app/account-settings/page.tsx
@@ -6,6 +6,7 @@ import Sidebar from "@/components/Sidebar"
 import { User, CreditCard, Bell, Lock, Check, Loader2 } from "lucide-react"
 import { toast } from "sonner"
 import { TIERS, priceLabel } from "@/lib/pricing"
+import { CA_COUNTY_NAMES } from "@/lib/jurisdictions"
 import EmailVerificationNotice from "@/features/account/EmailVerificationNotice"
 
 type Tab = "profile" | "billing" | "notifications" | "security"
@@ -26,6 +27,9 @@ interface UserProfile {
   company_name?: string
   business_address?: string
   state?: string
+  /* `user_profiles.default_county` — the county she records in most
+     often, and the default on every new deed. */
+  default_county?: string
   plan?: string
   plan_limits?: any
   /* PRICING1: the Widget Add-on TAB is deleted (owner-ruled). It priced
@@ -391,6 +395,15 @@ function ProfileTab({ userProfile, onSaved }: {
     phone: userProfile?.phone || "",
     state: userProfile?.state || "",
     business_address: userProfile?.business_address || "",
+    /* DASH-FIX #1 — THE SECOND HOME, WHICH WAS ALREADY HALF-BUILT.
+       `ProfilePatch` has accepted `default_county` since SETTINGS1 and
+       this form has always PATCHed its whole `formData` to it; the
+       control is the only piece that was missing. Until it existed the
+       only way to set a recording county was to re-enter onboarding —
+       and the day-one checklist's "Set county" button routed HERE, to a
+       page with no county on it, so the one open setup step could not be
+       finished from its own call to action. */
+    default_county: userProfile?.default_county || "",
   })
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -407,6 +420,12 @@ function ProfileTab({ userProfile, onSaved }: {
       phone: userProfile.phone || "",
       state: userProfile.state || "",
       business_address: userProfile.business_address || "",
+      // Caught by tsc rather than by a person, and it is exactly the
+      // defect this effect was written for: a field added to the form
+      // and not to the hydration reads empty after the profile lands,
+      // so the page shows a county she set as "Not set" — and saving
+      // anything else would then write that blank back over it.
+      default_county: userProfile.default_county || "",
     })
   }, [userProfile])
 
@@ -500,6 +519,29 @@ function ProfileTab({ userProfile, onSaved }: {
           {field("Phone", "phone", "tel")}
           {field("Company", "company_name")}
           {field("State", "state")}
+          <div>
+            <label htmlFor="default_county"
+                   className="block text-sm font-medium text-slate-700 mb-2">
+              Recording county
+            </label>
+            <select
+              id="default_county"
+              value={formData.default_county}
+              onChange={(e) => setFormData({ ...formData, default_county: e.target.value })}
+              className="w-full px-4 py-3 border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF] transition-colors"
+            >
+              {/* An empty option, because "not set" is a real state and
+                  a select with no blank silently asserts Alameda. */}
+              <option value="">Not set</option>
+              {CA_COUNTY_NAMES.map((c) => (
+                <option key={c} value={c}>{c} County</option>
+              ))}
+            </select>
+            <p className="mt-2 text-xs text-slate-500">
+              The county you record in most often. It becomes the default on new
+              deeds, and you can change it on any one of them.
+            </p>
+          </div>
           <div className="md:col-span-2">
             {field("Business address", "business_address")}
             <p className="mt-2 text-xs text-slate-500">

--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -13,17 +13,10 @@ import { useRouter } from "next/navigation"
 import Link from "next/link"
 import { ShieldCheck, MapPin, ArrowRight, Sparkles } from "lucide-react"
 
-// California counties for the dropdown
-const CA_COUNTIES = [
-  "Alameda", "Alpine", "Amador", "Butte", "Calaveras", "Colusa", "Contra Costa", "Del Norte",
-  "El Dorado", "Fresno", "Glenn", "Humboldt", "Imperial", "Inyo", "Kern", "Kings", "Lake",
-  "Lassen", "Los Angeles", "Madera", "Marin", "Mariposa", "Mendocino", "Merced", "Modoc",
-  "Mono", "Monterey", "Napa", "Nevada", "Orange", "Placer", "Plumas", "Riverside", "Sacramento",
-  "San Benito", "San Bernardino", "San Diego", "San Francisco", "San Joaquin", "San Luis Obispo",
-  "San Mateo", "Santa Barbara", "Santa Clara", "Santa Cruz", "Shasta", "Sierra", "Siskiyou",
-  "Solano", "Sonoma", "Stanislaus", "Sutter", "Tehama", "Trinity", "Tulare", "Tuolumne",
-  "Ventura", "Yolo", "Yuba"
-]
+// T-2's registry owns place identity, and now the county NAMES too:
+// this was a local 58-element array until account-settings grew the
+// second picker (DASH-FIX #1). One declaration, not one screen.
+import { CA_COUNTY_NAMES } from "@/lib/jurisdictions"
 
 export default function OnboardingPage() {
   const router = useRouter()
@@ -204,7 +197,7 @@ export default function OnboardingPage() {
                   autoFocus
                   className="w-full pl-11 pr-4 py-3 bg-white border border-gray-200 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:border-transparent transition-all appearance-none"
                 >
-                  {CA_COUNTIES.map((c) => (
+                  {CA_COUNTY_NAMES.map((c) => (
                     <option key={c} value={c}>
                       {c} County
                     </option>

--- a/frontend/src/lib/jurisdictions.ts
+++ b/frontend/src/lib/jurisdictions.ts
@@ -136,6 +136,51 @@ export interface Jurisdiction extends Place {
   pcorRouting?: PcorRouting;
 }
 
+/**
+ * EVERY CALIFORNIA COUNTY, BY NAME — the list a county picker offers.
+ *
+ * ═══ WHY THIS IS NOT `COUNTIES` BELOW, AND MUST NOT BECOME IT ═══
+ *
+ * These are two different sets and the difference is load-bearing:
+ *
+ *   `CA_COUNTY_NAMES`  every county an officer may record in — all 58,
+ *                      because she may record anywhere in the state and
+ *                      a picker that omits hers is a picker she cannot
+ *                      use.
+ *   `COUNTIES`         the counties we hold RECORDER FACTS for — PCOR
+ *                      routing, recorder preferences, local knowledge.
+ *                      A handful, and it grows one county at a time as
+ *                      each is actually researched.
+ *
+ * Collapsing them costs something in both directions. Driving the picker
+ * off `COUNTIES` shrinks it to the handful we have studied. Filling
+ * `COUNTIES` out to 58 would imply we hold recorder facts we do not —
+ * which is the shape §0 declines and the shape T-2 was built after: a
+ * place treated as a string that code then reasoned about as though it
+ * were knowledge.
+ *
+ * So: one list of names, imported by every picker, and it says here that
+ * a name is all it is.
+ *
+ * ═══ AND WHY IT LIVES HERE ═══
+ *
+ * It was a local `const CA_COUNTIES` inside `app/onboarding/page.tsx`,
+ * which was the only county picker in the product. The account-settings
+ * form is the second (DASH-FIX #1), and a second copy of a 58-element
+ * list is §14.3 — one DECLARATION, not one screen. This registry already
+ * owns place identity by ruling, so it owns the names too.
+ */
+export const CA_COUNTY_NAMES: readonly string[] = [
+  'Alameda', 'Alpine', 'Amador', 'Butte', 'Calaveras', 'Colusa', 'Contra Costa', 'Del Norte',
+  'El Dorado', 'Fresno', 'Glenn', 'Humboldt', 'Imperial', 'Inyo', 'Kern', 'Kings', 'Lake',
+  'Lassen', 'Los Angeles', 'Madera', 'Marin', 'Mariposa', 'Mendocino', 'Merced', 'Modoc',
+  'Mono', 'Monterey', 'Napa', 'Nevada', 'Orange', 'Placer', 'Plumas', 'Riverside', 'Sacramento',
+  'San Benito', 'San Bernardino', 'San Diego', 'San Francisco', 'San Joaquin', 'San Luis Obispo',
+  'San Mateo', 'Santa Barbara', 'Santa Clara', 'Santa Cruz', 'Shasta', 'Sierra', 'Siskiyou',
+  'Solano', 'Sonoma', 'Stanislaus', 'Sutter', 'Tehama', 'Trinity', 'Tulare', 'Tuolumne',
+  'Ventura', 'Yolo', 'Yuba',
+] as const;
+
 export const COUNTIES: Record<string, County> = {
   'los angeles': {
     name: 'Los Angeles',


### PR DESCRIPTION
DASH-FIX #1, first of the ordered batch.

The day-one checklist's "Set county" routed to `/account-settings`, which had no county field — so the one open setup step could not be finished from its own call to action, and the only surface that wrote `default_county` was the one-time onboarding flow.

## Not a third home — the second one, half-built

`ProfilePatch` has accepted `default_county` since SETTINGS1, the `user_profiles` upsert writes it, and this form has always `PATCH`ed its whole `formData` to that endpoint. **The control was the only piece missing.** That is SETTINGS1's own finding in miniature: there, the patch surface had to exist before the save button could be wired to anything.

Routing to `/onboarding` was refused as ruled — it writes `onboarding_completed` and navigates to the builder, so re-entering it to change one field re-runs a completion she didn't ask for.

## The county list moved — the part worth reviewing

It was a local 58-element const in onboarding, which was fine while onboarding was the only picker. A second copy in settings is §14.3, one week old. It now lives in `lib/jurisdictions.ts` as `CA_COUNTY_NAMES`, beside — and deliberately **not** merged into — `COUNTIES`.

| | what it is |
|---|---|
| `CA_COUNTY_NAMES` | every county she may record in — all 58, because a picker missing hers is a picker she can't use |
| `COUNTIES` | the counties we hold **recorder facts** for: PCOR routing, recorder preferences, real local knowledge. A handful, growing one researched county at a time |

Driving the picker off `COUNTIES` shrinks it to what we've studied. Filling `COUNTIES` out to 58 implies facts we don't hold — a place treated as a string and then reasoned about as though it were knowledge, which is what T-2 was built after. A pin asserts the sets stay different and says which question to answer if they ever converge.

## Two things caught by instruments rather than by me

**tsc refused the form** until `default_county` was added to the hydration effect — the exact defect that effect exists for. A field in the form but not in the hydration reads empty once the profile lands, so a county she set displays as "Not set", and the next save writes that blank back over it. It would have shipped as "settings doesn't keep my county."

**The pin holding that line was measuring wrong.** First version sliced a 600-character window; `codeOnly` blanks comments to spaces to preserve positions, so the comment justifying the line pushed the line out of the window. It now slices to the effect's own closing brace. A fixed character window is a measurement that shrinks whenever somebody explains something.

## Gates

jest **1057**/75 (+9, +1 suite), pytest **1463**, tsc **88** unchanged, banned-claims clean. Hydration pin mutation-probed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_