### PR TITLE
Authoring state says it is authoring state, and a date says which one

### DIFF
--- a/frontend/src/__tests__/authoringState.test.tsx
+++ b/frontend/src/__tests__/authoringState.test.tsx
@@ -1,0 +1,117 @@
+/**
+ * DASH-FIX #3 and #5 — one word doing two jobs, and one date doing two.
+ *
+ * ═══ THE FINDING ═══
+ *
+ * An audit found a single document reported three ways on three
+ * surfaces: badged "Completed" in Recently worked on, listed under
+ * "Waiting on a reply" in the queue, and "Out for signing" in its own
+ * record. All three read real data; only one answered the question.
+ *
+ * `deeds.status = 'completed'` means THE DOCUMENT WAS GENERATED. It says
+ * nothing about signing, sending, or recording. Rendering it as
+ * "Completed" invites the one reading the product has no evidence for.
+ *
+ * The same audit found the same shape in a date: the dashboard renders
+ * `updated_at`, Past Deeds renders `created_at`, and both showed a bare
+ * date. The same document read 7/29 in one place and 07/28 in the other.
+ */
+import { describe, expect, it } from '@jest/globals';
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join } from 'path';
+
+import { codeOnly } from '../test-support/sourceText';
+import {
+  authoringStateLabel, authoringStateHint, LAST_WORKED_ON,
+} from '../lib/authoringState';
+
+const SRC = join(__dirname, '..');
+const read = (...p: string[]) => codeOnly(readFileSync(join(SRC, ...p), 'utf8'));
+
+describe('authoring state is labelled as authoring state', () => {
+  it('never renders a generated document as "Completed"', () => {
+    /**
+     * THE PIN THIS FILE EXISTS FOR. Authoring-complete is not
+     * transaction-complete, and "Completed" is only ever read as the
+     * second one.
+     */
+    expect(authoringStateLabel('completed')).toBe('Prepared');
+    expect(authoringStateLabel('COMPLETED')).toBe('Prepared');
+    expect(authoringStateLabel(' completed ')).toBe('Prepared');
+  });
+
+  it('leaves the authoring words that were never mistakable', () => {
+    expect(authoringStateLabel('draft')).toBe('Draft');
+    expect(authoringStateLabel('in_progress')).toBe('In progress');
+    expect(authoringStateLabel(null)).toBe('Draft');
+  });
+
+  it('shows an unrecognised status as itself rather than guessing', () => {
+    /** §4 — a token we do not know is not evidence of any state. */
+    expect(authoringStateLabel('quarantined')).toBe('quarantined');
+  });
+
+  it('offers a gloss that refuses the larger claim', () => {
+    expect(authoringStateHint('completed')).toMatch(/says nothing about signing or recording/);
+    expect(authoringStateHint('draft')).toBeNull();
+  });
+
+  it('is the only place either surface turns the column into English', () => {
+    /**
+     * §13 rule 3. The dashboard rendered `{deed.status}` RAW — the badge
+     * was the database's own token — while Past Deeds carried a private
+     * `labels` map saying "Completed". Two surfaces, two vocabularies,
+     * neither citing the other.
+     */
+    const dash = read('app', 'dashboard', 'page.tsx');
+    const past = read('app', 'past-deeds', 'page.tsx');
+    expect(dash).toContain('authoringStateLabel(deed.status)');
+    expect(dash).not.toContain('{deed.status || ');
+    expect(past).toContain('authoringStateLabel(status)');
+    expect(past).not.toMatch(/completed:\s*"Completed"/);
+  });
+
+  it('lets no surface write its own status vocabulary', () => {
+    /** §14.1 — the property, not the spelling: any file mapping the
+     *  three status tokens to display strings of its own is a second
+     *  vocabulary, whatever the map is called. */
+    const files: string[] = [];
+    const walk = (dir: string) => {
+      for (const e of readdirSync(dir)) {
+        const full = join(dir, e);
+        if (statSync(full).isDirectory()) {
+          if (e !== '__tests__' && e !== 'node_modules') walk(full);
+        } else if (/\.tsx?$/.test(e)) files.push(full);
+      }
+    };
+    walk(SRC);
+    const carriers = files.filter((f) => {
+      const src = codeOnly(readFileSync(f, 'utf8'));
+      return /completed:\s*['"]Completed['"]/.test(src)
+          || /in_progress:\s*['"]In Progress['"]/i.test(src);
+    });
+    expect(carriers.map((f) => f.replace(SRC, ''))).toEqual([]);
+  });
+});
+
+describe('a date carries the name of the column it came from', () => {
+  it('the dashboard says which date it is showing', () => {
+    /**
+     * DASH-FIX #5. The dashboard is RIGHT to sort and show `updated_at`
+     * — "Recently worked on" is the module's whole purpose — but a bare
+     * date invites a reader to compare it with a creation date elsewhere
+     * and conclude one of them is broken.
+     */
+    const dash = read('app', 'dashboard', 'page.tsx');
+    expect(dash).toContain('{LAST_WORKED_ON} {formatDate(deed.updated_at || deed.created_at)}');
+    expect(LAST_WORKED_ON).toBe('Last worked on');
+  });
+
+  it('leaves Past Deeds showing what it has always shown', () => {
+    /** Its column IS creation, and its table has a header saying so.
+     *  The defect was never that the two differed — it was that neither
+     *  said which it was. */
+    expect(read('app', 'past-deeds', 'page.tsx'))
+      .toContain('formatDate(deed.created_at)');
+  });
+});

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -13,6 +13,7 @@ import StartSomethingNew from "@/features/dashboard/StartSomethingNew"
 import SetupChecklist, { setupSteps } from "@/features/dashboard/SetupChecklist"
 import DayOneRail from "@/features/dashboard/DayOneRail"
 import { pickInProgressDeed } from "@/lib/latestDraft"
+import { authoringStateLabel, authoringStateHint, LAST_WORKED_ON } from "@/lib/authoringState"
 import { SessionExpiredError, apiFetch } from "@/lib/apiClient"
 import { 
   FileText, Clock, CheckCircle, Send, 
@@ -872,12 +873,22 @@ function DeedRow({ deed }: { deed: any }) {
       </button>
 
       <div className="flex items-center gap-3 flex-shrink-0">
-        <span className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium ${getStatusStyle(deed.status)}`}>
+        {/* DASH-FIX #3 — this rendered `{deed.status}` RAW, so the badge
+            showed the database's own token and a generated document read
+            "completed" while its signing sat unanswered in the queue
+            below. `deeds.status` is AUTHORING state; one place turns it
+            into English now. */}
+        <span title={authoringStateHint(deed.status) ?? undefined}
+              className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium ${getStatusStyle(deed.status)}`}>
           {getStatusIcon(deed.status)}
-          {deed.status || 'Draft'}
+          {authoringStateLabel(deed.status)}
         </span>
+        {/* DASH-FIX #5 — the date is `updated_at`, which is correct for a
+            module called "Recently worked on" and is NOT what Past Deeds
+            shows. A bare date invites a reader to compare two different
+            facts, so it carries its name. */}
         <span className="text-sm text-gray-400 hidden sm:block">
-          {formatDate(deed.updated_at || deed.created_at)}
+          {LAST_WORKED_ON} {formatDate(deed.updated_at || deed.created_at)}
         </span>
         
         {/* Actions */}

--- a/frontend/src/app/past-deeds/page.tsx
+++ b/frontend/src/app/past-deeds/page.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import type React from "react"
+import { authoringStateLabel } from "@/lib/authoringState"
 import { Suspense, useState, useEffect } from "react"
 import Link from "next/link"
 import { useRouter, useSearchParams } from "next/navigation"
@@ -276,11 +277,10 @@ function PastDeedsList() {
       in_progress: "bg-blue-100 text-blue-800 border-blue-200",
     }
 
-    const labels = {
-      completed: "Completed",
-      draft: "Draft",
-      in_progress: "In Progress",
-    }
+    // DASH-FIX #3 — the labels moved to `lib/authoringState.ts`. This
+    // map said "Completed" while the dashboard rendered the raw token
+    // and the queue said the same document was waiting on a reply: two
+    // surfaces, two vocabularies, neither citing the other.
 
     return (
       <span
@@ -288,7 +288,7 @@ function PastDeedsList() {
       >
         {status === "completed" && <CheckCircle className="w-3.5 h-3.5" />}
         {status === "in_progress" && <Clock className="w-3.5 h-3.5" />}
-        {labels[status]}
+        {authoringStateLabel(status)}
       </span>
     )
   }

--- a/frontend/src/lib/authoringState.ts
+++ b/frontend/src/lib/authoringState.ts
@@ -1,0 +1,102 @@
+/**
+ * `deeds.status` is AUTHORING state, and every surface that renders it
+ * must say so.
+ *
+ * ═══ ONE WORD DOING TWO JOBS ═══
+ *
+ * An external audit found one document reported three ways on three
+ * surfaces: badged "Completed" in Recently worked on, listed under
+ * "Waiting on a reply" in the queue, and "Out for signing" in its own
+ * record. All three were reading real data. Only one of them was
+ * answering the question a reader asks.
+ *
+ * `deeds.status = 'completed'` means THE DOCUMENT WAS GENERATED. It says
+ * nothing about whether anybody signed it, whether it was sent, whether
+ * a notary answered, or whether it reached a recorder. A deed can be
+ * `completed` on its first morning and still be waiting on three people.
+ *
+ * Rendering that word as "Completed" invites exactly one reading —
+ * this transaction is done — which the product has no evidence for and
+ * §13 forbids it to assert. **Authoring-complete is not
+ * transaction-complete.**
+ *
+ * ═══ THE RULING ═══
+ *
+ * The badge says what the column means: the document is PREPARED. Any
+ * surface that wants the whole state derives it from
+ * `signing_loop.state_label`, which is the authority for workflow and
+ * has been since T-5 ("the state, COMPUTED — there is no status column
+ * and there must not be").
+ *
+ * ═══ AND WHY THIS IS A MODULE AND NOT A RENAMED STRING ═══
+ *
+ * The label existed twice with two vocabularies: the dashboard rendered
+ * `{deed.status}` RAW, so the badge read the database's own token, and
+ * Past Deeds carried its own `labels` map reading "Completed" / "In
+ * Progress". Two surfaces, two answers, neither citing the other — which
+ * is the shape §13 rule 3 exists to prevent and the shape §14.3 caught
+ * one ticket ago. One place turns this column into English.
+ */
+
+/** The statuses `deeds.status` actually holds. */
+export type AuthoringStatus = 'draft' | 'in_progress' | 'completed' | string;
+
+/**
+ * What the column means, in her words.
+ *
+ * `completed` is deliberately NOT "Completed". Everything else keeps the
+ * plain reading, because "Draft" and "In progress" already describe
+ * authoring and are not mistakable for a transaction outcome.
+ */
+export function authoringStateLabel(status: AuthoringStatus | null | undefined): string {
+  switch ((status || '').toLowerCase().trim()) {
+    case 'completed':
+      // NOT "Completed". The document is prepared; what happens to it
+      // afterwards is the queue's subject and state_label's sentence.
+      return 'Prepared';
+    case 'in_progress':
+      return 'In progress';
+    case 'draft':
+    case '':
+      return 'Draft';
+    case 'shared':
+      return 'Shared';
+    case 'pending':
+      return 'Pending';
+    default:
+      // An unknown token is shown as itself rather than mapped to a
+      // guess — a status we do not recognise is not evidence of any
+      // particular state (§4).
+      return status as string;
+  }
+}
+
+/**
+ * The one-line gloss, for surfaces with room for it.
+ *
+ * Its job is to stop "Prepared" being read as a smaller "Completed". The
+ * document exists; nothing here claims anybody has acted on it.
+ */
+export function authoringStateHint(status: AuthoringStatus | null | undefined): string | null {
+  return (status || '').toLowerCase().trim() === 'completed'
+    ? 'Document generated — this says nothing about signing or recording'
+    : null;
+}
+
+/**
+ * The column a surface displays a date FROM, named.
+ *
+ * ═══ DASH-FIX #5 ═══
+ *
+ * The dashboard renders `updated_at || created_at` and Past Deeds
+ * renders `created_at`, both through a bare date with no label. The same
+ * document therefore showed 7/29 in one place and 07/28 in the other,
+ * and a reader comparing them has no way to learn they are different
+ * facts rather than a bug.
+ *
+ * The dashboard is RIGHT to sort and show `updated_at` — "Recently
+ * worked on" is the module's entire purpose. What it may not do is show
+ * that date bare, so the label travels with it.
+ */
+export const LAST_WORKED_ON = 'Last worked on';
+export const CREATED = 'Created';


### PR DESCRIPTION
DASH-FIX #3 and #5, paired as ruled — the same defect at two scales: one word doing two jobs, and one bare date doing two.

## #3 — authoring-complete is not transaction-complete

`deeds.status = 'completed'` means **the document was generated**. It says nothing about signing, sending, or recording — a deed can be `completed` on its first morning and still be waiting on three people. Rendering that word as "Completed" invites the single reading the product has no evidence for and §13 forbids it to assert.

The badge now reads **"Prepared"**, with a title gloss — *"Document generated — this says nothing about signing or recording"*. Anything wanting the whole state derives it from `signing_loop.state_label`, the workflow authority since T-5.

**It's a module rather than a renamed string, because the label already existed twice with two vocabularies:**

| surface | before |
|---|---|
| dashboard | `{deed.status}` **raw** — the badge was the database's own token |
| Past Deeds | a private `labels` map reading "Completed" / "In Progress" |

Neither cited the other, which is what §13 rule 3 exists to prevent and what §14.3 caught one ticket ago. `lib/authoringState.ts` is the one place now, and a sweep refuses any file that writes its own status vocabulary — matching the property (a map from the three tokens to display strings) rather than the map's name.

An unrecognised token renders as itself rather than mapped to a guess. §4: a status we don't know is not evidence of any particular state.

## #5 — a date carries the name of its column

The dashboard renders `updated_at`, Past Deeds renders `created_at`, and both showed a bare date — so the same document read 7/29 in one place and 07/28 in the other, with nothing to tell a reader those are *different facts* rather than a bug.

The dashboard is **right** to sort and show `updated_at`; "Recently worked on" is the module's whole purpose. So the label travels with the date rather than the column changing: **"Last worked on 7/29/2026"**.

**The sort anomaly stays unconfirmed and untouched.** It needs the payload, and guessing at it would be inventing a defect.

## Gates

jest **1075**/77 (+8, +1 suite), pytest **1463**, tsc **88** unchanged, banned-claims clean, S1 + S3 + six-flow + api-baseline green. Two mutations probed, both caught.

One note: an intermediate pytest run showed 72 failed / 140 errors — the local Postgres death signature, not this change (which is frontend-only). Restarted and re-ran clean at 1463 before committing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_