### PR TITLE
A signing offer whose times have all passed is stuck, and now says so

### DIFF
--- a/backend/services/signing_loop.py
+++ b/backend/services/signing_loop.py
@@ -130,6 +130,26 @@ STATE_PARTIALLY_AGREED = "partially_agreed"
 STATE_BOOKED = "booked"
 STATE_CANCELLED = "cancelled"
 STATE_EXPIRED = "expired"
+#: Times were offered and every one of them has now passed, unanswered.
+#:
+#: DASH-FIX #4. An audit found a request with a window offered for that
+#: morning, 10:00–12:00, which had gone by half an hour before the audit
+#: ran. "Signing in the next 7 days" said "Nothing booked this week",
+#: which was true; the sidebar badged Signings 1, which was also true;
+#: and the request's own sentence still read "You proposed 10:00 — waiting
+#: on them to accept", about a time that no longer exists.
+#:
+#: Nothing in the vocabulary could say otherwise, because `request_state`
+#: had no notion of a window's time passing. STATE_EXPIRED is about
+#: `expires_at` on the REQUEST — the whole invitation timing out — not
+#: about the offer inside it going stale.
+#:
+#: It is NOT terminal. A lapsed request is the most actionable thing on
+#: the page: nobody has refused anything, the times simply ran out, and
+#: somebody has to offer new ones. That is precisely the stuck state the
+#: agenda exists to surface, and it was the one state the agenda could
+#: not see.
+STATE_LAPSED = "lapsed"
 
 
 #: The states in which a request is still somebody's problem. Cancelled
@@ -171,7 +191,30 @@ def request_state(request: Dict[str, Any], windows: Sequence[Dict[str, Any]],
         return STATE_REQUESTED
     if any(r.get("answer") == ANSWER_AVAILABLE for r in responses):
         return STATE_PARTIALLY_AGREED
+    # ── EVERY OFFERED TIME HAS PASSED ───────────────────────────────
+    #
+    # Checked AFTER partial agreement, deliberately. If somebody said
+    # they were available for a window that has since gone by, this is
+    # not "nobody answered" — it is an agreement that did not finish
+    # converging, and calling it lapsed would erase an answer a person
+    # actually gave.
+    #
+    # `ends_at`, not `starts_at`: a window running 10:00–12:00 is still
+    # a live offer at 11:00. A naive timestamp is treated as UTC the
+    # same way `days_since` does rather than raising — but note that it
+    # is READ, not guessed at, and a window with no end is not lapsed.
+    if live and all(_has_passed(w.get("ends_at"), now) for w in live):
+        return STATE_LAPSED
     return STATE_WINDOWS_POSTED
+
+
+def _has_passed(when: Optional[datetime], now: datetime) -> bool:
+    """Is this instant in the past. A missing one is NOT (§4)."""
+    if not when:
+        return False
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=timezone.utc)
+    return when < now
 
 
 # ── Convergence ──────────────────────────────────────────────────────
@@ -263,6 +306,22 @@ def state_label(request: Dict[str, Any], windows: Sequence[Dict[str, Any]],
         return "Signing request cancelled"
     if state == STATE_EXPIRED:
         return "Signing request expired — nobody agreed a time before the links lapsed"
+    if state == STATE_LAPSED:
+        # DASH-FIX #4, and every word here is load-bearing under §13.
+        #
+        # It says the TIMES passed. It does not say the signing failed,
+        # that anybody refused, or that anybody was at fault — none of
+        # which this product knows. The notary may have been ill, or the
+        # email may have gone to spam, or she may have offered a slot two
+        # hours out on a Friday.
+        #
+        # And it names the action, because a stuck request that does not
+        # say what unsticks it is a row somebody looks at every morning
+        # and does nothing about.
+        live = [w for w in windows if not w.get("declined_at")]
+        n = len(live)
+        return (f"{n} time{'' if n == 1 else 's'} offered, all now passed "
+                f"with no answer — offer new times")
     if state == STATE_BOOKED:
         when = _fmt_instant(request.get("booked_at"), request.get("tz_name"))
         if request.get("booked_by") == BOOKED_BY_OFFICER:

--- a/backend/tests/test_notary2_coordination.py
+++ b/backend/tests/test_notary2_coordination.py
@@ -185,6 +185,15 @@ def test_no_state_means_it_happened():
     assert set(consts.values()) == {
         "requested", "windows_posted", "partially_agreed",
         "booked", "cancelled", "expired",
+        # DASH-FIX #4. Added here as a DECISION, which is what an
+        # equality assertion over a vocabulary is for — this test went
+        # red the moment `lapsed` existed, so no state can join the
+        # vocabulary without somebody writing it down next to the rule
+        # it has to satisfy.
+        #
+        # It satisfies it: "lapsed" is about the OFFER running out, and
+        # says nothing about whether a signing occurred.
+        "lapsed",
     }
     for value in consts.values():
         assert "complete" not in value and "happen" not in value and "signed" not in value

--- a/backend/tests/test_signing_lapsed.py
+++ b/backend/tests/test_signing_lapsed.py
@@ -1,0 +1,162 @@
+"""DASH-FIX #4 — the offer whose times have all gone by.
+
+═══ THE FINDING ═══
+
+An audit found a signing request with a window offered for that morning,
+10:00–12:00, which had passed half an hour before the audit ran.
+
+Three surfaces described it and none of them was wrong:
+
+  "Signing in the next 7 days"   "Nothing booked this week" — true, it is
+                                 not booked
+  the sidebar                    "Signings 1" — true, there is one
+  the request's own sentence     "You proposed 10:00 — waiting on them to
+                                 accept" — about a time that no longer
+                                 exists
+
+Nothing in the vocabulary could say otherwise, because `request_state`
+had no notion of a window's time passing. `STATE_EXPIRED` is about
+`expires_at` on the REQUEST — the whole invitation timing out — not about
+the offer inside it going stale.
+
+═══ WHY THIS IS A STATE AND NOT A SCREEN'S FILTER ═══
+
+T-5's ruling, fourth application. A screen computing "have all the
+windows passed" is that judgement copied into a client, and the copy is
+the one that gets missed when a state is added. The state is derived in
+one place and every surface inherits both the state and its sentence.
+
+═══ AND IT IS NOT TERMINAL ═══
+
+Nobody refused anything and nothing failed. The times ran out and
+somebody has to offer new ones — which makes a lapsed request the most
+actionable row on the page, and it was the one row the agenda could not
+see.
+"""
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from services import signing_loop as loop
+
+NOW = datetime(2026, 8, 14, 18, 0, tzinfo=timezone.utc)
+
+
+def _req(**over):
+    return {"id": 1, "expires_at": NOW + timedelta(days=7),
+            "tz_name": "America/Los_Angeles", **over}
+
+
+def _win(id_, start_offset_h, length_h=2, **over):
+    starts = NOW + timedelta(hours=start_offset_h)
+    return {"id": id_, "starts_at": starts, "ends_at": starts + timedelta(hours=length_h),
+            "origin": loop.ORIGIN_NOTARY, "proposed_by": 9, "declined_at": None, **over}
+
+
+def _state(windows, responses=(), **req):
+    return loop.request_state(_req(**req), windows, responses, now=NOW)
+
+
+# ── The state ────────────────────────────────────────────────────────
+
+def test_every_offered_time_gone_by_is_lapsed():
+    """THE PIN THIS FILE EXISTS FOR."""
+    assert _state([_win(1, -8), _win(2, -30)]) == loop.STATE_LAPSED
+
+
+def test_one_time_still_ahead_is_not_lapsed():
+    assert _state([_win(1, -8), _win(2, +24)]) == loop.STATE_WINDOWS_POSTED
+
+
+def test_a_window_running_right_now_is_still_a_live_offer():
+    """`ends_at`, not `starts_at`. A window of 10:00–12:00 is a real
+    offer at 11:00, and calling it lapsed would tell her to re-offer a
+    time somebody could still accept."""
+    assert _state([_win(1, -1, length_h=3)]) == loop.STATE_WINDOWS_POSTED
+
+
+def test_an_answer_survives_its_window_passing():
+    """THE ORDERING DECISION, and it is deliberate.
+
+    Partial agreement is checked BEFORE lapse. If somebody said they
+    were available for a window that has since gone by, this is not
+    "nobody answered" — it is an agreement that did not finish
+    converging, and reporting it as lapsed would erase an answer a
+    person actually gave.
+    """
+    responses = [{"window_id": 1, "participant_id": 5,
+                  "answer": loop.ANSWER_AVAILABLE}]
+    assert _state([_win(1, -8)], responses) == loop.STATE_PARTIALLY_AGREED
+
+
+def test_a_declined_window_is_not_one_of_the_offers_that_lapsed():
+    declined = _win(1, -8, declined_at=NOW - timedelta(days=1))
+    # Only the declined one has passed; the live one is ahead.
+    assert _state([declined, _win(2, +24)]) == loop.STATE_WINDOWS_POSTED
+    # And with nothing live at all it is back to `requested`, not lapsed:
+    # no offer stands, which is a different thing from every offer having
+    # run out.
+    assert _state([declined]) == loop.STATE_REQUESTED
+
+
+def test_a_window_with_no_end_is_not_assumed_to_have_passed():
+    """§4 — a missing instant is not evidence that it went by."""
+    assert _state([_win(1, -8, ends_at=None)]) == loop.STATE_WINDOWS_POSTED
+
+
+def test_a_naive_end_is_read_as_utc_rather_than_crashing():
+    naive = _win(1, -8)
+    naive["ends_at"] = naive["ends_at"].replace(tzinfo=None)
+    assert _state([naive]) == loop.STATE_LAPSED
+
+
+@pytest.mark.parametrize("field,value,expected", [
+    ("booked_at", NOW - timedelta(days=1), loop.STATE_BOOKED),
+    ("cancelled_at", NOW - timedelta(days=1), loop.STATE_CANCELLED),
+    ("expires_at", NOW - timedelta(days=1), loop.STATE_EXPIRED),
+])
+def test_the_settled_states_still_win(field, value, expected):
+    """A booked signing whose time has passed is STILL BOOKED — §13's
+    oldest rule in this file, and adding a state that reasons about
+    clocks is exactly when it could have been broken."""
+    assert _state([_win(1, -8)], **{field: value}) == expected
+
+
+def test_lapsed_is_not_terminal_because_it_is_the_most_actionable_state():
+    assert loop.STATE_LAPSED not in loop.TERMINAL_STATES
+    assert loop.is_live(loop.STATE_LAPSED) is True
+
+
+# ── The sentence ─────────────────────────────────────────────────────
+
+def _label(windows, responses=(), participants=(), **req):
+    return loop.state_label(_req(**req), windows, responses, participants, now=NOW)
+
+
+def test_it_says_the_times_passed_and_names_what_unsticks_it():
+    said = _label([_win(1, -8)])
+    assert "passed" in said
+    assert "offer new times" in said
+    assert said.startswith("1 time offered")
+    assert _label([_win(1, -8), _win(2, -30)]).startswith("2 times offered")
+
+
+def test_it_never_says_anybody_refused_or_that_anything_failed():
+    """§13, and the temptation is real: a lapsed slot LOOKS like a
+    refusal and is not one. The notary may have been ill, the email may
+    have gone to spam, or the officer may have offered a slot two hours
+    out on a Friday. The product knows the clock, and nothing else."""
+    said = _label([_win(1, -8)]).lower()
+    for claim in ("declined", "refused", "rejected", "failed", "missed",
+                  "did not attend", "no-show", "ignored"):
+        assert claim not in said, said
+
+
+def test_the_dispatch_sentence_stops_describing_a_time_that_is_gone():
+    """The audited row exactly: the officer proposed a slot, nobody
+    accepted, and the sentence still read "waiting on them to accept"
+    about a morning that had ended."""
+    win = _win(1, -8, origin=loop.ORIGIN_OFFICER)
+    said = _label([win])
+    assert "waiting on" not in said.lower()
+    assert "passed" in said


### PR DESCRIPTION
DASH-FIX #4.

A request had a window offered for that morning, 10:00–12:00, which passed half an hour before the audit ran. **Three surfaces described it and none was wrong:**

| surface | said | true? |
|---|---|---|
| "Signing in the next 7 days" | "Nothing booked this week" | yes — it isn't booked |
| sidebar badge | "Signings 1" | yes — there is one |
| the request's own sentence | "You proposed 10:00 — waiting on them to accept" | about a time that no longer exists |

Nothing in the vocabulary could say otherwise. `request_state` had no notion of a window's time passing — `STATE_EXPIRED` is about `expires_at` on the **request** (the whole invitation timing out), not about the offer inside it going stale.

`STATE_LAPSED` is derived in one place and every surface inherits both the state and its sentence (T-5, fourth application). A screen computing "have all the windows passed" would be that judgement copied into a client, and the copy is the one missed when a state is added.

## Three decisions inside it, each pinned and each probed

**`ends_at`, not `starts_at`.** A window of 10:00–12:00 is a real offer at 11:00; calling it lapsed would tell her to re-offer a time somebody could still accept.

**Checked *after* partial agreement.** If somebody said they were available for a window that has since gone by, that's an agreement which didn't finish converging — not "nobody answered". Reporting it as lapsed would erase an answer a person actually gave.

**A window with no `ends_at` is not assumed to have passed** (§4).

## Not terminal, and the sentence is careful

Nobody refused and nothing failed — the times ran out and somebody has to offer new ones. That makes this the most actionable row on the page and the one row the agenda couldn't see.

> *"1 time offered, all now passed with no answer — offer new times"*

A pin holds that it never says anybody declined, refused, or failed. **A lapsed slot looks like a refusal and is not one** — the notary may have been ill, the email may have gone to spam, or the slot may have been two hours out on a Friday. The product knows the clock and nothing else.

## The vocabulary pin earned its keep

`test_no_state_means_it_happened` asserts the state set **by equality**, so it went red the moment `lapsed` existed. A new state can't join the vocabulary without somebody writing it down next to the rule it has to satisfy. Added deliberately, with that note in place.

## Gates

pytest **1477** (+14), jest **1075**, tsc **88**, banned-claims clean, S1 + S3 + six-flow + api-baseline green. Two mutations probed, both caught (`ends_at`→`starts_at` fails 2; lapse-before-agreement fails 1).

## Flagged, not decided

**`needs_attention` does not count lapsed requests.** That number was ruled to mean *stale unanswered requests* — "when it is zero, nobody is waiting on her and nobody has gone quiet." A lapsed request is stuck regardless of age, so it arguably belongs in the count; but including it changes what a ruled number means, which is §16 territory. The row surfaces in "Waiting on a reply" with its own sentence either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_