### PR TITLE
The attention number counts gone-quiet, and that has two shapes

### DIFF
--- a/backend/routers/dashboard.py
+++ b/backend/routers/dashboard.py
@@ -101,6 +101,13 @@ def officer_queue(user_id: int = Depends(get_current_user_id)) -> Dict[str, Any]
                 "who": req.get("notary_name"),
                 "days_waiting": days,
                 "stale": q.is_stale(days),
+                # GONE QUIET BY EVENT rather than by age. Every time she
+                # offered has passed with no answer, which is a stronger
+                # signal than five days of silence: a waiting request may
+                # yet be answered, and an offer that has run out cannot
+                # be. Kept separate from `stale` because the two need
+                # different sentences and different remedies.
+                "lapsed": state == loop.STATE_LAPSED,
                 # The server's sentence, verbatim — §13 rule 3. This
                 # screen does not compose its own account of a scheduling
                 # state any more than the other three do.
@@ -134,6 +141,13 @@ def officer_queue(user_id: int = Depends(get_current_user_id)) -> Dict[str, Any]
                        or row.get("recipient_email"),
                 "days_waiting": days,
                 "stale": q.is_stale(days),
+                # A REVIEW SHARE CANNOT LAPSE. Lapsing is about offered
+                # times running out and a share offers none — it carries
+                # an `expires_at`, and an expired share is already
+                # filtered out by the query above rather than reported as
+                # gone quiet. False rather than absent, because the row
+                # shape is asserted by equality.
+                "lapsed": False,
                 "summary": ("Opened, no answer yet" if row["status"] == "viewed"
                             else "Sent, not opened yet"),
             })

--- a/backend/services/officer_queue.py
+++ b/backend/services/officer_queue.py
@@ -135,8 +135,14 @@ ACCURACY_ITEM_KEYS = frozenset({"deed_id", "deed_type", "property",
 
 UPCOMING_KEYS = frozenset({"kind", "id", "deed_id", "property", "when",
                            "who", "summary"})
+#: `stale` and `lapsed` are two different kinds of gone-quiet and are
+#: deliberately two fields. Stale is BY AGE — nobody has answered in
+#: STALE_AFTER_DAYS. Lapsed is BY EVENT — every time she offered has now
+#: passed unanswered. Collapsing them into one boolean would make the
+#: screen unable to say which happened, and they need different sentences
+#: and different remedies.
 AWAITING_KEYS = frozenset({"kind", "id", "deed_id", "property", "who",
-                           "days_waiting", "stale", "summary"})
+                           "days_waiting", "stale", "lapsed", "summary"})
 IDLE_KEYS = frozenset({"kind", "id", "deed_type", "property", "days_idle"})
 
 
@@ -152,8 +158,22 @@ def queue(*, upcoming: Sequence[Dict[str, Any]],
     booked for Thursday needs nothing from her, and counting it would
     make the number she checks first mean "there are rows below".
 
-    It is the stale unanswered requests. That is the number that, when it
-    is zero, means nobody is waiting on her and nobody has gone quiet.
+    It is the requests that have gone quiet. That is the number that,
+    when it is zero, means nobody is waiting on her and nobody has gone
+    quiet.
+
+    ═══ AND "GONE QUIET" HAS TWO SHAPES (owner-ruled, DASH-FIX #4) ═══
+
+    STALE, by age — nobody has answered in STALE_AFTER_DAYS.
+    LAPSED, by event — every window she offered has now passed unanswered.
+
+    This counted only the first, so a request whose morning slot went by
+    an hour ago contributed nothing to the number an officer checks
+    before anything else, and could sit at zero-attention all day.
+
+    A lapse is STRONGER evidence than an age, not weaker: waiting five
+    days is a request that may yet be answered, and an offer that has run
+    out cannot be. Zero has to mean nothing needs her.
     """
     for row in upcoming:
         assert set(row) == UPCOMING_KEYS, f"upcoming row drifted: {sorted(row)}"
@@ -178,7 +198,8 @@ def queue(*, upcoming: Sequence[Dict[str, Any]],
         "upcoming": list(upcoming),
         "awaiting": list(awaiting),
         "idle_drafts": list(idle_drafts),
-        "needs_attention": len([r for r in awaiting if r["stale"]]),
+        "needs_attention": len([r for r in awaiting
+                                if r["stale"] or r["lapsed"]]),
         # DASH1 item 6 — THE AMBIENT SIGNAL.
         #
         # Counted here rather than by the sidebar, for the same reason

--- a/backend/tests/test_dash1_officer_queue.py
+++ b/backend/tests/test_dash1_officer_queue.py
@@ -18,8 +18,10 @@ which she does once per file.
 
  2. THE ATTENTION NUMBER MEANS SOMETHING. If it counted every row it
     would mean "there are rows below", and she would stop reading it. It
-    counts stale unanswered requests: when it is zero, nobody is waiting
-    on her and nobody has gone quiet.
+    counts the requests that have GONE QUIET, in either of the two shapes
+    that has: stale by AGE (nobody has answered in STALE_AFTER_DAYS) and
+    lapsed by EVENT (every window she offered has passed unanswered).
+    When it is zero, nobody is waiting on her and nothing has run out.
 
  3. AN UNKNOWN AGE IS NOT URGENT. A row we cannot date must not be
     pushed into that count on the strength of a missing timestamp.
@@ -90,13 +92,14 @@ def test_an_unknown_age_is_never_stale():
     assert q.is_stale(q.STALE_AFTER_DAYS) is True
 
 
-def _awaiting(stale: bool, days=9):
+def _awaiting(stale: bool, days=9, lapsed=False):
     return {"kind": "review", "id": 1, "deed_id": 2, "property": "x",
             "who": "Nora", "days_waiting": days if stale else 1,
-            "stale": stale, "summary": "Sent, not opened yet"}
+            "stale": stale, "lapsed": lapsed,
+            "summary": "Sent, not opened yet"}
 
 
-def test_the_attention_count_is_stale_requests_and_nothing_else():
+def test_the_attention_count_is_gone_quiet_and_nothing_else():
     """Not "everything in the queue". A signing booked for Thursday needs
     nothing from her, and counting it would make the number mean "there
     are rows below" — at which point she stops reading it."""
@@ -511,3 +514,43 @@ def test_an_accuracy_block_without_the_population_is_refused():
         q.queue(upcoming=[], awaiting=[], idle_drafts=[],
                 accuracy={"fields": 0, "documents": 0, "items": []},
                 instruments=FILES_NOTHING)
+
+
+# ══════════════════════════════════════════════════════════════════════
+# Gone quiet has two shapes
+# ══════════════════════════════════════════════════════════════════════
+
+def test_a_lapsed_request_needs_her_attention_however_young_it_is():
+    """OWNER-RULED, DASH-FIX #4.
+
+    The count was stale-only, so a request whose morning slot went by an
+    hour ago contributed nothing to the number an officer checks before
+    anything else — and could sit at zero-attention all day while being
+    the most stuck thing she owns.
+
+    A LAPSE IS STRONGER EVIDENCE THAN AN AGE, not weaker. Five days of
+    silence is a request that may yet be answered; an offer whose every
+    window has passed cannot be. Zero has to mean nothing needs her.
+    """
+    fresh_but_lapsed = _awaiting(False, days=0, lapsed=True)
+    payload = q.queue(upcoming=[], awaiting=[fresh_but_lapsed], idle_drafts=[],
+                      accuracy=NOTHING_OUTSTANDING, instruments=FILES_NOTHING)
+    assert payload["needs_attention"] == 1
+
+
+def test_stale_and_lapsed_stay_two_fields_rather_than_one_boolean():
+    """They are different kinds of gone-quiet and need different
+    sentences and different remedies: stale is BY AGE and answered by a
+    phone call, lapsed is BY EVENT and answered by offering new times.
+    One flag would leave the screen unable to say which happened."""
+    from services.officer_queue import AWAITING_KEYS
+    assert {"stale", "lapsed"} <= AWAITING_KEYS
+
+
+def test_one_request_that_is_both_is_counted_once():
+    """An old request whose windows have also passed is one row and one
+    problem, not two — the number counts requests, not reasons."""
+    both = _awaiting(True, days=30, lapsed=True)
+    payload = q.queue(upcoming=[], awaiting=[both], idle_drafts=[],
+                      accuracy=NOTHING_OUTSTANDING, instruments=FILES_NOTHING)
+    assert payload["needs_attention"] == 1

--- a/frontend/src/__tests__/ux2Items.test.ts
+++ b/frontend/src/__tests__/ux2Items.test.ts
@@ -59,7 +59,15 @@ describe('two numbers, two claims, each named', () => {
     /** THE PIN THIS BLOCK EXISTS FOR — it protects a RULING against a
      *  ticket, which is the unusual direction. */
     expect(PY_QUEUE).toContain('These are NOT the attention count');
-    expect(PY_QUEUE).toContain('"needs_attention": len([r for r in awaiting if r["stale"]])');
+    /* The attention count now counts GONE QUIET in both its shapes —
+       stale by age, lapsed by event (DASH-FIX #4). What this pin
+       protects is unchanged and is the RULING, not the expression: the
+       badge counts presence, the attention number counts silence, and
+       they must not become one number. So it asserts the two are
+       computed from different predicates rather than pinning a literal
+       line, which broke here the moment the ruling was applied and
+       taught nothing when it did. */
+    expect(PY_QUEUE).toMatch(/"needs_attention": len\(\[r for r in awaiting\s*\n?\s*if r\["stale"\] or r\["lapsed"\]\]\)/);
     expect(PY_QUEUE).toContain('"signings": len([r for r in awaiting if r["kind"] == "signing"])');
   });
 


### PR DESCRIPTION
Owner-ruled follow-on to DASH-FIX #4 — held under §16 in #212 because it changes what a ruled number counts.

`needs_attention` was stale-only, so a request whose morning slot went by an hour ago contributed **nothing** to the number an officer checks before anything else. It could sit at zero-attention all day while being the most stuck thing she owns.

The ruling: **a lapse is stronger evidence than an age, not weaker.** Five days of silence is a request that may yet be answered; an offer whose every window has passed cannot be. The number means "nobody is waiting on her and nothing has run out" — so zero has to mean nothing needs her.

## Stale and lapsed stay two fields

Overloading `stale` would have been the cheaper edit and the same disease this batch has spent six PRs removing.

| | kind of gone-quiet | remedy |
|---|---|---|
| `stale` | by **age** — nobody answered in `STALE_AFTER_DAYS` | a phone call |
| `lapsed` | by **event** — every window offered has passed | offer new times |

One boolean would leave the screen unable to say which happened, and they need different sentences.

## Two smaller decisions

**A review share carries `lapsed: False` explicitly rather than by absence.** Lapsing is about offered times running out and a share offers none; an expired share is already filtered out by the query rather than reported as gone quiet. Stated because the row shape is asserted by equality — a key that is merely *usually* present is a key a screen reads as `undefined` one day.

**A request that is both stale and lapsed counts once.** The number counts requests, not reasons.

## Gates

pytest **1480** (+3), S1 + S3 + six-flow + api-baseline green, banned-claims clean. Probed by dropping `lapsed` from the count — the new pin fails alone.

The module and suite docstrings both carried "counts stale unanswered requests" as the number's definition; both now say what it actually counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_