### PR TITLE
The frontend batch: the fourth step, and seven pieces of friction

### DIFF
--- a/frontend/src/__tests__/authoringState.test.tsx
+++ b/frontend/src/__tests__/authoringState.test.tsx
@@ -22,7 +22,7 @@ import { join } from 'path';
 
 import { codeOnly } from '../test-support/sourceText';
 import {
-  authoringStateLabel, authoringStateHint, LAST_WORKED_ON,
+  authoringStateLabel, LAST_WORKED_ON,
 } from '../lib/authoringState';
 
 const SRC = join(__dirname, '..');
@@ -51,9 +51,40 @@ describe('authoring state is labelled as authoring state', () => {
     expect(authoringStateLabel('quarantined')).toBe('quarantined');
   });
 
-  it('offers a gloss that refuses the larger claim', () => {
-    expect(authoringStateHint('completed')).toMatch(/says nothing about signing or recording/);
-    expect(authoringStateHint('draft')).toBeNull();
+  it('needs no tooltip to be safe, and carries none', () => {
+    /**
+     * OWNER-RULED, cutting something added one PR earlier. The badge
+     * carried a `title` gloss saying the word meant nothing about
+     * signing or recording — invisible on touch and to anybody not
+     * hovering, so the qualification reached only some readers.
+     *
+     * A caveat only some readers get is worse than a word that does not
+     * need one. And "Prepared" does not need one: it is an ADJECTIVE
+     * ABOUT THE DOCUMENT rather than a claim about the transaction,
+     * which was the rename's whole purpose.
+     */
+    const src = codeOnly(readFileSync(join(SRC, 'lib', 'authoringState.ts'), 'utf8'));
+    expect(src).not.toMatch(/export function authoringStateHint/);
+    // The gloss is gone from everywhere rather than from one call site.
+    // NOT asserted as "no `title=` on the dashboard": three QueueList
+    // headings legitimately carry one, and a pin that forbids an
+    // attribute rather than a claim would have made those a violation.
+    const files: string[] = [];
+    const walk = (dir: string) => {
+      for (const e of readdirSync(dir)) {
+        const full = join(dir, e);
+        if (statSync(full).isDirectory()) {
+          // __tests__ excluded, and the reason is this very assertion:
+          // codeOnly strips comments but NOT string contents, so the
+          // pin searching for the name would find its own search term.
+          if (e !== 'node_modules' && e !== '__tests__') walk(full);
+        } else if (/\.tsx?$/.test(e)) files.push(full);
+      }
+    };
+    walk(SRC);
+    for (const f of files) {
+      expect(codeOnly(readFileSync(f, 'utf8'))).not.toContain('authoringStateHint');
+    }
   });
 
   it('is the only place either surface turns the column into English', () => {

--- a/frontend/src/__tests__/dashboardAccuracyRender.test.tsx
+++ b/frontend/src/__tests__/dashboardAccuracyRender.test.tsx
@@ -210,7 +210,14 @@ describe('start something new', () => {
      * and must not become the only way in.
      */
     render(<StartSomethingNew instruments={[]} />);
-    expect(screen.getByText('grant-deed')).toBeInTheDocument();
+    /* Asserted on the LABEL, not the slug. This read `getByText
+       ('grant-deed')` — the pin was holding our storage key as though
+       it were the product's vocabulary, so it passed while the screen
+       showed her a string she never chose. UX2 item 3 fixed that
+       vocabulary on three surfaces; this was the fourth, and its own
+       test was pinning the defect in place. */
+    expect(screen.getByText('Grant Deed')).toBeInTheDocument();
+    expect(screen.queryByText('grant-deed')).not.toBeInTheDocument();
     expect(screen.queryByText('most used')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/__tests__/dashboardSetupChecklist.test.tsx
+++ b/frontend/src/__tests__/dashboardSetupChecklist.test.tsx
@@ -15,18 +15,24 @@ import '@testing-library/jest-dom';
 import SetupChecklist, { setupSteps } from '../features/dashboard/SetupChecklist';
 import DayOneRail from '../features/dashboard/DayOneRail';
 
-const NOTHING_SET = { county: null, companyName: null, deedCount: 0 };
+const NOTHING_SET = { county: null, companyName: null, businessAddress: null, deedCount: 0 };
 
 describe('what the checklist derives', () => {
-  it('reads three steps off state the product already holds', () => {
+  it('reads four steps off state the product already holds', () => {
+    /** The fourth arrived from an audit: the list counted itself
+     *  complete at 2 of 3 while `business_address` was empty, and the
+     *  rail beside it was drawing a gap in AND WHEN RECORDED MAIL TO —
+     *  a box that PRINTS. It qualifies on this list's own test: every
+     *  step is something the deed itself needs. */
     const steps = setupSteps(NOTHING_SET);
-    expect(steps.map((s) => s.id)).toEqual(['county', 'company', 'first-deed']);
+    expect(steps.map((s) => s.id)).toEqual(['county', 'company', 'address', 'first-deed']);
     expect(steps.every((s) => !s.done)).toBe(true);
   });
 
   it('counts a step done from the field that backs it', () => {
     const steps = setupSteps({
-      county: 'Los Angeles', companyName: 'All Good Escrow', deedCount: 2,
+      county: 'Los Angeles', companyName: 'All Good Escrow',
+      businessAddress: '1200 Wilshire Blvd, Ste 400', deedCount: 2,
     });
     expect(steps.every((s) => s.done)).toBe(true);
   });
@@ -39,14 +45,15 @@ describe('what the checklist derives', () => {
     /** A checklist with every box ticked is the same guaranteed-empty
      *  module its predecessor removed three of. */
     const { container } = render(<SetupChecklist state={{
-      county: 'Los Angeles', companyName: 'All Good Escrow', deedCount: 1,
+      county: 'Los Angeles', companyName: 'All Good Escrow',
+      businessAddress: '1200 Wilshire Blvd', deedCount: 1,
     }} />);
     expect(container).toBeEmptyDOMElement();
   });
 
   it('says how many are done, in words', () => {
     render(<SetupChecklist state={{ ...NOTHING_SET, county: 'Orange' }} />);
-    expect(screen.getByTestId('setup-progress')).toHaveTextContent('1 of 3 done');
+    expect(screen.getByTestId('setup-progress')).toHaveTextContent('1 of 4 done');
   });
 
   it('routes each step to the thing that fixes it', () => {
@@ -124,7 +131,25 @@ describe('the rail', () => {
   it('shows where the company name lands, and marks the gap when it is blank', () => {
     render(<DayOneRail companyName={null} county={null} plan="free" />);
     expect(screen.getByText('RECORDING REQUESTED BY:')).toBeInTheDocument();
-    expect(screen.getByText('Your company name')).toBeInTheDocument();
+    expect(screen.getByText('your company name')).toBeInTheDocument();
+  });
+
+  it('marks the gaps as text rather than as inputs that do nothing', () => {
+    /** Both placeholders were styled as dashed boxes — an affordance
+     *  promising a field, inside a preview. The way to fill them is the
+     *  checklist step beside them, which is a real button. */
+    const { container } = render(<DayOneRail companyName={null} county={null} plan="free" />);
+    expect(container.querySelectorAll('input, textarea, [contenteditable]'))
+      .toHaveLength(0);
+    expect(container.innerHTML).not.toContain('border-dashed');
+  });
+
+  it('names no instrument, because on day one there is no document', () => {
+    /** It was hardcoded to GRANT DEED beside a catalog offering
+     *  twenty-one. This card is about where a NAME lands; picking an
+     *  instrument would be choosing her document for her. */
+    const { container } = render(<DayOneRail companyName="X" county="LA" plan="free" />);
+    expect(container.textContent).not.toMatch(/GRANT DEED/i);
   });
 
   it('shows the real name once she has one', () => {

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -13,7 +13,8 @@ import StartSomethingNew from "@/features/dashboard/StartSomethingNew"
 import SetupChecklist, { setupSteps } from "@/features/dashboard/SetupChecklist"
 import DayOneRail from "@/features/dashboard/DayOneRail"
 import { pickInProgressDeed } from "@/lib/latestDraft"
-import { authoringStateLabel, authoringStateHint, LAST_WORKED_ON } from "@/lib/authoringState"
+import { authoringStateLabel, LAST_WORKED_ON } from "@/lib/authoringState"
+import { deedTypeLabel } from "@/lib/deedTypes"
 import { SessionExpiredError, apiFetch } from "@/lib/apiClient"
 import { 
   FileText, Clock, CheckCircle, Send, 
@@ -430,7 +431,12 @@ export default function Dashboard() {
                 value={summary?.lastThirtyDays ?? 0}
                 icon={<TrendingUp className="w-5 h-5" />}
                 color="blue"
-                href="/past-deeds"
+                /* This pointed at the unfiltered list, so the tile
+                   counting 10 recent deeds and the tile counting all 10
+                   deeds were the same click with the same result — and
+                   Past Deeds' own docstring calls that "the dead-button
+                   defect wearing a URL". */
+                href="/past-deeds?since=30"
               />
               <StatCard
                 label="Completed"
@@ -652,7 +658,14 @@ function ActionQueue({ queue, error, hasDeeds }: {
             rows={queue.idle_drafts.map((r) => ({
               key: `id-${r.id}`,
               title: r.property || `Deed #${r.id}`,
-              detail: 'Draft — nobody is waiting on this but you.',
+              /* FOUR IDENTICAL CARDS. An audit found four of these at
+                 one address, byte-for-byte the same — same title, same
+                 sentence, same "16 days" — opening four different
+                 drafts. She had to click one to learn which it was.
+                 The row now carries what actually DIFFERS between them:
+                 the instrument and the document number. */
+              detail: `${deedTypeLabel(r.deed_type)} · Doc #${r.id} — `
+                    + 'nobody is waiting on this but you.',
               meta: r.days_idle === null ? 'untouched' : `${r.days_idle} days`,
               urgent: false,
               // Deliberately NOT the deed page. A draft has exactly one
@@ -661,6 +674,15 @@ function ActionQueue({ queue, error, hasDeeds }: {
               onOpen: () => router.push(
                 `/deed-builder/${r.deed_type || 'grant-deed'}?resume=${r.id}`),
             }))}
+            /* THE REMEDY LIVES ON THE OTHER PAGE. Past Deeds already
+               offers "Archive the N older" over exactly these drafts
+               (`lib/staleDrafts.ts`), and this screen flagged them stale
+               while offering nothing. Linked rather than reimplemented:
+               a second implementation of an archive action is a second
+               opinion about which drafts are superseded. */
+            footer={queue.idle_drafts.length
+              ? { label: 'Archive older drafts', onClick: () => router.push('/past-deeds?status=draft') }
+              : null}
           />
         </div>
       )}
@@ -677,10 +699,12 @@ type QueueRow = {
   onOpen: () => void
 }
 
-function QueueList({ title, rows, emptyNote }: {
+function QueueList({ title, rows, emptyNote, footer = null }: {
   title: string
   rows: QueueRow[]
   emptyNote: string
+  /** An action that belongs to the whole column rather than a row. */
+  footer?: { label: string; onClick: () => void } | null
 }) {
   return (
     <div className="rounded-2xl border border-gray-200 bg-white overflow-hidden">
@@ -711,6 +735,16 @@ function QueueList({ title, rows, emptyNote }: {
             </li>
           ))}
         </ul>
+      )}
+      {footer && rows.length > 0 && (
+        <button
+          type="button"
+          onClick={footer.onClick}
+          className="w-full border-t border-gray-100 px-4 py-2.5 text-left text-sm
+                     font-semibold text-[#7C4DFF] hover:bg-gray-50"
+        >
+          {footer.label}
+        </button>
       )}
     </div>
   )
@@ -878,8 +912,7 @@ function DeedRow({ deed }: { deed: any }) {
             "completed" while its signing sat unanswered in the queue
             below. `deeds.status` is AUTHORING state; one place turns it
             into English now. */}
-        <span title={authoringStateHint(deed.status) ?? undefined}
-              className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium ${getStatusStyle(deed.status)}`}>
+        <span className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium ${getStatusStyle(deed.status)}`}>
           {getStatusIcon(deed.status)}
           {authoringStateLabel(deed.status)}
         </span>

--- a/frontend/src/app/past-deeds/page.tsx
+++ b/frontend/src/app/past-deeds/page.tsx
@@ -111,6 +111,18 @@ function PastDeedsList() {
      product choosing her document), so it carries the notary here and
      the deed is chosen where the deeds are. */
   const notaryFromPartner = params?.get("notary") || null
+  /* DASH-FIX friction — "Last 30 days" linked HERE and arrived at the
+     full list, so the tile counting 10 and the tile counting all 10 were
+     the same click with the same outcome. This page's own docstring
+     already names that: "a link that arrives and shows an unfiltered
+     list is the dead-button defect wearing a URL".
+     `?since=<days>` seeds a window, and the banner below says the list
+     is windowed and offers the way out — a filter nobody can see is a
+     list that looks broken. */
+  const [sinceDays, setSinceDays] = useState<number | null>(() => {
+    const raw = Number(params?.get("since"))
+    return Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : null
+  })
   /* UX2 items 8/9 — the nudge. The rule is lib/staleDrafts.ts so it can
      be asked a question; this screen only renders the answer. */
   const [archiving, setArchiving] = useState(false)
@@ -310,6 +322,13 @@ function PastDeedsList() {
     if (deed.archived_at) return false
     if (statusFilter === "completed" && deed.status !== "completed") return false
     if (statusFilter === "draft" && deed.status === "completed") return false
+    if (sinceDays !== null) {
+      // A row we cannot date stays IN. Dropping it would let a missing
+      // timestamp hide a deed she made, which is the more expensive
+      // mistake of the two (§4, and `days_since`'s reasoning).
+      const made = deed.created_at ? new Date(deed.created_at).getTime() : null
+      if (made !== null && made < Date.now() - sinceDays * 86400_000) return false
+    }
     const q = searchQuery.trim().toLowerCase()
     if (!q) return true
     return [
@@ -356,6 +375,22 @@ function PastDeedsList() {
                     className="w-full pl-9 pr-3 py-2 text-sm border border-slate-300 rounded-lg focus:ring-2 focus:ring-[#7C4DFF] focus:border-[#7C4DFF]"
                   />
                 </div>
+                {sinceDays !== null && (
+                  /* The window, said out loud. A list silently showing a
+                     subset is a list she reads as "where did my deeds
+                     go" — and the way out is beside the statement rather
+                     than in a URL she would have to know about. */
+                  <div className="flex items-center gap-2 rounded-lg border border-blue-200 bg-blue-50 px-3 py-2 text-sm text-blue-900">
+                    <span>Last {sinceDays} days</span>
+                    <button
+                      type="button"
+                      onClick={() => setSinceDays(null)}
+                      className="font-semibold underline underline-offset-2"
+                    >
+                      Show all
+                    </button>
+                  </div>
+                )}
                 <select
                   value={statusFilter}
                   onChange={(e) => setStatusFilter(

--- a/frontend/src/features/dashboard/DayOneRail.tsx
+++ b/frontend/src/features/dashboard/DayOneRail.tsx
@@ -59,9 +59,10 @@ export default function DayOneRail({ companyName, businessAddress, county, plan,
           {company ? (
             <div className="font-medium text-gray-900">{company}</div>
           ) : (
-            <div className="rounded border border-dashed border-emerald-400 bg-emerald-50 px-1.5 py-0.5 text-emerald-800">
-              Your company name
-            </div>
+            /* Same treatment: a marker for a gap, not an input. It
+               keeps its tint because it is the box the step beside it
+               fills, and loses the border that made it look editable. */
+            <div className="italic text-emerald-700">your company name</div>
           )}
           <div className="mt-2 font-semibold tracking-wide text-gray-500">
             AND WHEN RECORDED MAIL TO:
@@ -69,14 +70,20 @@ export default function DayOneRail({ companyName, businessAddress, county, plan,
           {address ? (
             <div className="text-gray-900">{address}</div>
           ) : (
-            <div className="rounded border border-dashed border-gray-300 px-1.5 py-0.5 text-gray-500">
-              Your business address
-            </div>
+            /* A MARKER, NOT A CONTROL. This was styled as a dashed input
+               box and was not clickable — an affordance promising a
+               field, on a preview. It reads as text now, and the way to
+               fill it is the checklist step beside it, which is a real
+               button that goes to a real form. */
+            <div className="italic text-gray-400">not set yet</div>
           )}
-          <hr className="my-2 border-gray-200" />
-          <div className="text-center font-bold tracking-widest text-gray-700">
-            GRANT DEED
-          </div>
+          {/* THE INSTRUMENT TITLE IS GONE. It was hardcoded to GRANT
+              DEED regardless of what she files — an audit found it
+              beside a catalog offering twenty-one instruments. This card
+              is about WHERE A NAME LANDS, and on day one there is no
+              document to name: showing one instrument would be picking
+              hers for her, and the honest version of a fact we do not
+              have is not a smaller fact, it is no line. */}
         </div>
 
         <p className="mt-3 text-xs text-gray-500">

--- a/frontend/src/features/dashboard/SetupChecklist.tsx
+++ b/frontend/src/features/dashboard/SetupChecklist.tsx
@@ -61,10 +61,12 @@ export interface SetupState {
   companyName?: string | null;
   /** Every deed she has, deleted ones excluded. */
   deedCount: number;
+  /** `user_profiles.business_address` — see the fourth step. */
+  businessAddress?: string | null;
 }
 
 export interface SetupStep {
-  id: 'county' | 'company' | 'first-deed';
+  id: 'county' | 'company' | 'address' | 'first-deed';
   title: string;
   detail: string;
   action: string;
@@ -96,6 +98,26 @@ export function setupSteps(state: SetupState): SetupStep[] {
             + 'by hand each time.',
       action: 'Add company',
       done: !blank(state.companyName),
+    },
+    {
+      // ═══ THE FOURTH STEP, ADDED AFTER AN AUDIT ═══
+      //
+      // The checklist counted itself complete at 2 of 3 while
+      // `business_address` was empty — and the rail beside it was
+      // rendering a dashed placeholder in AND WHEN RECORDED MAIL TO,
+      // which is a box that PRINTS on the instrument. The screen was
+      // showing her a gap and not counting it.
+      //
+      // It qualifies on this list's own stated test: every step is
+      // something the deed itself needs. The return address is on the
+      // face of the document, which is a stronger claim to a place here
+      // than the county default has.
+      id: 'address',
+      title: 'Add your business address',
+      detail: 'This prints under AND WHEN RECORDED MAIL TO, directly below your '
+            + 'company name. It is where the recorder sends the document back.',
+      action: 'Add address',
+      done: !blank(state.businessAddress),
     },
     {
       id: 'first-deed',

--- a/frontend/src/features/dashboard/StartSomethingNew.tsx
+++ b/frontend/src/features/dashboard/StartSomethingNew.tsx
@@ -21,6 +21,8 @@
  */
 'use client';
 
+import { deedTypeLabel } from '@/lib/deedTypes';
+
 export interface InstrumentUse {
   deed_type: string;
   count: number;
@@ -54,7 +56,11 @@ export default function StartSomethingNew({ instruments, onStart, onBrowse }: {
               onClick={() => onStart?.(row.deed_type)}
               className="flex w-full items-center justify-between rounded-lg border border-slate-200 px-3 py-2 text-left text-sm"
             >
-              <span className="text-slate-800">{row.deed_type}</span>
+              {/* UX2 item 3's vocabulary, on the surface it had not reached.
+                  This rendered `grant-deed` and `affidavit-death-jt` —
+                  our storage keys, which she never chose — two clicks
+                  from a screen that says "Grant Deed". */}
+              <span className="text-slate-800">{deedTypeLabel(row.deed_type)}</span>
               <span className="text-xs text-slate-500">
                 {/* "most used" only where it is TRUE — the top row of a
                     list she has actually filed from. On day one there is

--- a/frontend/src/lib/authoringState.ts
+++ b/frontend/src/lib/authoringState.ts
@@ -71,17 +71,23 @@ export function authoringStateLabel(status: AuthoringStatus | null | undefined):
   }
 }
 
-/**
- * The one-line gloss, for surfaces with room for it.
+/*
+ * ═══ THE GLOSS THAT WAS HERE, CUT ═══
  *
- * Its job is to stop "Prepared" being read as a smaller "Completed". The
- * document exists; nothing here claims anybody has acted on it.
+ * `authoringStateHint` returned "Document generated — this says nothing
+ * about signing or recording", and the badge carried it as a `title`.
+ *
+ * Owner-ruled out, on the argument that removed it: a tooltip is
+ * invisible on touch and to anybody not hovering, so the qualification
+ * that was supposed to make "Prepared" safe reached only some readers.
+ * A caveat only some readers get is worse than a word that does not
+ * need one.
+ *
+ * And "Prepared" does not need one. It is an ADJECTIVE ABOUT THE
+ * DOCUMENT rather than a claim about the transaction, which was the
+ * whole purpose of renaming it — the gloss was propping up a word that
+ * already stood on its own.
  */
-export function authoringStateHint(status: AuthoringStatus | null | undefined): string | null {
-  return (status || '').toLowerCase().trim() === 'completed'
-    ? 'Document generated — this says nothing about signing or recording'
-    : null;
-}
 
 /**
  * The column a surface displays a date FROM, named.


### PR DESCRIPTION
The frontend half of DASH-FIX. Opens with the ruled cut, then #6, then the friction list.

## The ruled cut

`authoringStateHint` is gone — three PRs after it was ruled out, flagged in each. The argument that removed it: a tooltip is invisible on touch and to anyone not hovering, so the qualification meant to make "Prepared" safe reached only some readers. And "Prepared" doesn't need one — it's an adjective about the document rather than a claim about the transaction, which was the rename's whole purpose.

## #6 — the fourth step

The checklist counted itself complete at **2 of 3** while `business_address` was empty, and the rail beside it drew a gap in `AND WHEN RECORDED MAIL TO` — a box that **prints**. The screen was showing her a hole and not counting it.

It qualifies on the list's own stated test: *every step is something the deed itself needs.* A return address on the face of the instrument has a stronger claim to a place here than the county default does.

## The friction list

**Raw slugs** in "Start something new" now read through `deedTypeLabel` — UX2 item 3's vocabulary reaching its fourth surface. Worth noting: **its own test was asserting `getByText('grant-deed')`**, so the pin was holding our storage key in place as though it were the product's language. The defect and its guard were the same line.

**"Last 30 days"** pointed at the unfiltered list, so the tile counting ten recent deeds and the tile counting all ten deeds were one click with one outcome. Past Deeds' own docstring calls that *"the dead-button defect wearing a URL"* — a documented violation of a rule written on the page it linked to. `?since=` now windows the list, with a visible banner and a "Show all" out. An invisible filter is a list that looks broken.

**Four byte-identical "Untouched" cards** opened four different drafts. The row now carries what actually differs: the instrument and the document number.

**The archive remedy is linked, not reimplemented.** Past Deeds already offers "Archive the N older" over exactly these drafts (`lib/staleDrafts.ts`); a second implementation would be a second opinion about which drafts are superseded.

**The preview's hardcoded `GRANT DEED`** is gone. It sat beside a catalog offering twenty-one instruments, and on day one there is no document to name — picking one would be choosing hers for her.

**Both preview placeholders** were dashed boxes styled as inputs and weren't clickable — an affordance promising a field, inside a picture. They read as text now; the way to fill them is the checklist step beside them, which is a real button.

**AICard dismissal not persisting needs no fix** — that component was deleted in #210 at zero call sites. Reporting it rather than silently skipping it.

## Gates

pytest **1480**, jest **1077**/77 (+2), tsc **88** unchanged, banned-claims clean, S1 + S3 + six-flow + api-baseline green. Both suites on everything, per #214.

An intermediate pytest run hit the local Postgres death signature again (72 failed / 140 errors); restarted and re-ran clean before committing.

## Still to report on — not touched

The three ROUGH items whose claims are structural rather than behavioural: the ~390px collapse of "Recently worked on" rows, the ~300px empty-column gap, and the dead band under the progress line. Those need verifying rather than fixing, and I'll report before changing layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_