### PR TITLE
"Failed to fetch" when setting the county, and a route guard that was a string

### DIFF
--- a/frontend/src/__tests__/countyField.test.tsx
+++ b/frontend/src/__tests__/countyField.test.tsx
@@ -120,7 +120,13 @@ describe('account settings', () => {
   });
 
   it('sends the whole form to the endpoint that already accepted county', () => {
-    expect(read(SETTINGS)).toContain('JSON.stringify(formData)');
+    /* Asserted as "the whole form reaches the save", not as the literal
+       `JSON.stringify(formData)` — that string moved into
+       `lib/profileSave.ts` when the two save paths converged, and a pin
+       quoting it went red on a change that fixed a bug (§14.1.1). */
+    expect(read(SETTINGS)).toContain('saveProfile(formData)');
+    expect(codeOnly(readFileSync(join(SRC, 'lib', 'profileSave.ts'), 'utf8')))
+      .toContain('JSON.stringify(patch)');
   });
 });
 

--- a/frontend/src/__tests__/profileSave.test.ts
+++ b/frontend/src/__tests__/profileSave.test.ts
@@ -1,0 +1,135 @@
+/**
+ * The profile save, tested as a function rather than as a source file.
+ *
+ * ═══ THE REPORT THAT PRODUCED IT ═══
+ *
+ * "In my new user. I tried to set county and it said failed to fetch."
+ *
+ * `Failed to fetch` is the browser's own TypeError for a request that
+ * never completed, surfaced verbatim into the error box and the toast.
+ * Onboarding had a two-attempt retry for exactly that — this API sleeps
+ * — and account-settings had a bare `fetch`. Same endpoint, same
+ * payload, one tolerant of a cold start and the other not.
+ *
+ * And DASH-FIX #1 had just pointed the day-one checklist's "Set county"
+ * at the intolerant one, which is the page a BRAND-NEW account reaches
+ * first and therefore the population most certain to meet a sleeping
+ * server. The routing was right; its consequence was not checked.
+ *
+ * ═══ WHY THESE ARE BEHAVIOURAL ═══
+ *
+ * The pins that guarded this before asserted `method: "PATCH"` and
+ * `await fetch` appeared in the settings page — the implementation's
+ * LOCATION, not the button's behaviour — so they went red on a refactor
+ * that fixed a bug and could never have said whether a retry retried the
+ * right things. §14.1.1. Now it is a function, so it gets called.
+ */
+import { describe, expect, it, jest, beforeEach, afterEach } from '@jest/globals';
+
+import { saveProfile, ProfileSaveError, UNREACHABLE } from '../lib/profileSave';
+
+const ok = () => ({ ok: true } as Response);
+const refused = (status: number, detail?: string) => ({
+  ok: false, status, json: async () => (detail ? { detail } : {}),
+} as unknown as Response);
+
+/* `any` deliberately: @jest/globals types a bare `jest.fn()` as taking
+   `never`, so every `mockResolvedValue` below became a type error and
+   the tsc baseline rose by nine. The alternative is a full signature
+   for `fetch` in a file whose subject is not `fetch`'s type. */
+let fetchMock: any;
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  fetchMock = jest.fn();
+  (global as any).fetch = fetchMock;
+  (global as any).localStorage = { getItem: () => 'tok' };
+});
+afterEach(() => { jest.useRealTimers(); });
+
+/**
+ * Runs `p` to completion, letting the retry's timer fire, and returns
+ * the OUTCOME rather than re-throwing.
+ *
+ * Written this way because the first version used
+ * `expect(settle(p)).rejects`, which attaches its handler after the
+ * promise has already rejected — six tests failed as unhandled
+ * rejections while the code under test was correct. The helper now
+ * attaches before advancing the clock, and hands back a value the
+ * assertions can read plainly.
+ */
+async function run(p: Promise<void>): Promise<{ error?: any }> {
+  const settled = p.then(() => ({}), (error) => ({ error }));
+  await jest.advanceTimersByTimeAsync(5000);
+  return settled;
+}
+
+describe('a request that never arrived is tried again', () => {
+  it('succeeds on the second attempt when the first never lands', async () => {
+    /** THE PIN THIS FILE EXISTS FOR. A sleeping server answers the
+     *  second time, and the officer sees a save rather than a browser
+     *  error string. */
+    fetchMock.mockRejectedValueOnce(new TypeError('Failed to fetch'))
+             .mockResolvedValueOnce(ok());
+    expect(await run(saveProfile({ default_county: 'Los Angeles' }))).toEqual({});
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('gives up in words somebody wrote, never the browser\'s', async () => {
+    fetchMock.mockRejectedValue(new TypeError('Failed to fetch'));
+    const { error } = await run(saveProfile({}));
+    expect(error.message).toBe(UNREACHABLE);
+    expect(error.unreachable).toBe(true);
+    expect(UNREACHABLE).not.toMatch(/failed to fetch/i);
+  });
+});
+
+describe('a request the server answered is a decision, not an absence', () => {
+  it('does NOT retry a refusal', async () => {
+    /**
+     * The half that matters as much as the retry. Asking again after a
+     * 400 is how a client turns a "no" into a race — and on this
+     * endpoint a second attempt would re-send a patch the server has
+     * already rejected once.
+     */
+    fetchMock.mockResolvedValue(refused(400, 'State must be two letters'));
+    const { error } = await run(saveProfile({ state: 'Californiaa' }));
+    expect(error.message).toBe('State must be two letters');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry a 5xx either, because the server still spoke', async () => {
+    fetchMock.mockResolvedValue(refused(500));
+    const { error } = await run(saveProfile({}));
+    expect(error.message).toMatch(/500/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('carries the server\'s reason rather than replacing it', async () => {
+    /** §4 — the reason travels. "Something went wrong" sends her to
+     *  support with nothing. */
+    fetchMock.mockResolvedValue(refused(422, 'That county is not in California'));
+    const { error } = await run(saveProfile({}));
+    expect(error.message).toBe('That county is not in California');
+  });
+
+  it('marks a refusal as reachable, so no caller mistakes it for a network fault',
+    async () => {
+      fetchMock.mockResolvedValue(refused(400, 'nope'));
+      const { error } = await run(saveProfile({}));
+      expect(error).toBeInstanceOf(ProfileSaveError);
+      expect(error.unreachable).toBe(false);
+    });
+});
+
+describe('it never reports a save it did not get', () => {
+  it('resolves only on a 2xx', async () => {
+    /** §4, and the ticket SETTINGS1 was originally about: that handler
+     *  used to toast success unconditionally. */
+    fetchMock.mockResolvedValue(ok());
+    expect(await run(saveProfile({}))).toEqual({});
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(refused(403, 'no'));
+    expect((await run(saveProfile({}))).error).toBeDefined();
+  });
+});

--- a/frontend/src/__tests__/settingsSave.test.ts
+++ b/frontend/src/__tests__/settingsSave.test.ts
@@ -39,14 +39,23 @@ import { codeOnly } from '../test-support/sourceText';
 const SRC = path.join(__dirname, '..');
 const read = (...p: string[]) => codeOnly(fs.readFileSync(path.join(SRC, ...p), 'utf8'));
 const SETTINGS = read('app', 'account-settings', 'page.tsx');
+const SAVE_MODULE = codeOnly(
+  fs.readFileSync(path.join(SRC, 'lib', 'profileSave.ts'), 'utf8'));
 const ONBOARDING = read('app', 'onboarding', 'page.tsx');
 
 describe('Save Changes issues a request', () => {
   it('actually calls the profile endpoint', () => {
-    // The whole ticket. A button that reports an outcome it never
-    // requested is the defect; this is its absence.
-    expect(SETTINGS).toContain('method: "PATCH"');
-    expect(SETTINGS).toContain('/users/profile');
+    /* The whole ticket. A button that reports an outcome it never
+       requested is the defect; this is its absence.
+
+       ASSERTED AGAINST THE MODULE, not against this page. The request
+       moved to `lib/profileSave.ts` when onboarding and settings stopped
+       having two of it — pinning `method: "PATCH"` HERE was pinning
+       where the code lives rather than that the button issues a request,
+       and it went red on a refactor that fixed a bug (§14.1.1). */
+    expect(SETTINGS).toContain('saveProfile(formData)');
+    expect(SAVE_MODULE).toContain("method: 'PATCH'");
+    expect(SAVE_MODULE).toContain('/users/profile');
   });
 
   it('never announces success before the response', () => {
@@ -57,18 +66,19 @@ describe('Save Changes issues a request', () => {
      */
     const handler = SETTINGS.slice(SETTINGS.indexOf('const handleSave'));
     const body = handler.slice(0, handler.indexOf('const field'));
-    const fetchAt = body.indexOf('await fetch');
-    const okCheck = body.indexOf('!response.ok');
+    const saveAt = body.indexOf('await saveProfile');
     const success = body.indexOf('toast.success');
-    expect(fetchAt).toBeGreaterThan(-1);
-    expect(okCheck).toBeGreaterThan(fetchAt);
-    expect(success).toBeGreaterThan(okCheck);
+    expect(saveAt).toBeGreaterThan(-1);
+    expect(success).toBeGreaterThan(saveAt);
+    // And the module throws rather than returning a verdict the caller
+    // could ignore — which is what makes the ordering above sufficient.
+    expect(SAVE_MODULE).toContain('throw new ProfileSaveError');
   });
 
   it('a failed save is visible, and says why', () => {
     // §4: the reason travels. "Something went wrong" sends her to
     // support with nothing; the server's detail sends her to the cause.
-    expect(SETTINGS).toContain('data.detail');
+    expect(SAVE_MODULE).toContain('detail');
     expect(SETTINGS).toContain('toast.error');
     expect(SETTINGS).toContain('setError(message)');
   });
@@ -125,8 +135,12 @@ describe('skipping onboarding may leave, but may not lie', () => {
   it('retries before giving up', () => {
     // The first action anybody takes in the product, against a service
     // that cold-starts. One attempt is a coin flip.
-    expect(ONBOARDING).toContain('saveProfileOnce');
-    expect(ONBOARDING).toMatch(/for \(const wait of \[0, \d+\]\)/);
+    /* The retry moved to `lib/profileSave.ts` so that settings got it
+       too — it had none, and DASH-FIX #1 then pointed a first-run
+       action at that page. Pinned where it lives, and its BEHAVIOUR is
+       pinned in `profileSave.test.ts` against the function itself. */
+    expect(ONBOARDING).toContain('saveProfile(');
+    expect(SAVE_MODULE).toMatch(/const WAITS = \[0, \d+\]/);
   });
 
   it('tells her when the skip was not recorded', () => {

--- a/frontend/src/app/account-settings/page.tsx
+++ b/frontend/src/app/account-settings/page.tsx
@@ -7,6 +7,7 @@ import { User, CreditCard, Bell, Lock, Check, Loader2 } from "lucide-react"
 import { toast } from "sonner"
 import { TIERS, priceLabel } from "@/lib/pricing"
 import { CA_COUNTY_NAMES } from "@/lib/jurisdictions"
+import { saveProfile } from "@/lib/profileSave"
 import EmailVerificationNotice from "@/features/account/EmailVerificationNotice"
 
 type Tab = "profile" | "billing" | "notifications" | "security"
@@ -433,20 +434,15 @@ function ProfileTab({ userProfile, onSaved }: {
     setSaving(true)
     setError(null)
     try {
-      const api = process.env.NEXT_PUBLIC_API_URL || "https://deedpro-main-api.onrender.com"
-      const token = localStorage.getItem("access_token")
-      const response = await fetch(`${api}/users/profile`, {
-        method: "PATCH",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(formData),
-      })
-      if (!response.ok) {
-        const data = await response.json().catch(() => ({}))
-        throw new Error(data.detail || `Save failed (${response.status})`)
-      }
+      /* DASH-FIX bug report: "I tried to set county and it said failed
+         to fetch." This was a bare `fetch` whose `TypeError` message —
+         the browser's own "Failed to fetch" — went straight into the
+         error box and the toast. Onboarding had a two-attempt retry for
+         exactly this and this page had none, and DASH-FIX #1 then
+         pointed a FIRST-RUN action here, at the population most likely
+         to meet a sleeping server. One save path now, with the
+         tolerance, and a sentence somebody wrote. */
+      await saveProfile(formData)
       // Re-read rather than trusting what we sent: the server normalises
       // whitespace and upper-cases the state, so what she sees after
       // saving is what is stored, not what she typed.

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -357,7 +357,14 @@ export default function Dashboard() {
           {/* THE MOCKUP'S ORDER, AND IT IS AN ARGUMENT: resume is the
               highest-frequency action in a preparation tool, so it sits
               above everything, with the remaining checks NAMED. */}
-          <div className="mb-6 grid gap-4 lg:grid-cols-[2fr,1fr]">
+          {/* ROUGH — `items-start`. Without it these two stretch to the
+              taller of them, so a short resume card is padded out to
+              match the catalog beside it. The audit reported this as a
+              "dead band under 2 of 3 done" and located it one row up, at
+              the checklist grid — which already carries `items-start`
+              and whose ~68px is ordinary card padding. An auditor sees a
+              symptom and places it approximately; this is where it is. */}
+          <div className="mb-6 grid gap-4 lg:grid-cols-[2fr,1fr] items-start">
             <ResumeCard
               target={resumeTarget}
               onResume={(id) => router.push(`/deed-builder/grant-deed?resume=${id}`)}
@@ -611,7 +618,15 @@ function ActionQueue({ queue, error, hasDeeds }: {
           </p>
         </div>
       ) : (
-        <div className="grid gap-4 lg:grid-cols-3">
+        /* ROUGH — `items-start`, and it is one class for ~300px of
+           white. All three columns stretched to the tallest, so an empty
+           "Signing in the next 7 days" holding one sentence was padded
+           out to match a column holding five rows.
+
+           NOT hidden: DASH1 ruled the empty state is a RESULT, not an
+           absence, and the card still says its sentence. It just stops
+           taking a third of the row to say it. */
+        <div className="grid gap-4 lg:grid-cols-3 items-start">
           <QueueList
             title={`Signing in the next ${queue.thresholds.upcoming_days} days`}
             emptyNote="Nothing booked this week."
@@ -877,7 +892,19 @@ function DeedRow({ deed }: { deed: any }) {
   return (
     // X2.7: drafts read as "needs action" at a glance — amber edge + a
     // labeled Continue button, not an unexplained arrow.
-    <div className={`p-4 hover:bg-gray-50 transition-colors flex items-center justify-between gap-4 ${
+    /* ROUGH — THE ROW STACKS BELOW `sm`, and stacking is the only
+       remedy that exists. The right-hand cluster is `flex-shrink-0` and
+       every item in it is already at its minimum, so there is nothing
+       to shrink: at 390px the title and parties line was left roughly
+       60px of the ~240px it needs, which truncates "Grant Deed - 1358
+       5th St" to about four characters.
+
+       NOTARYPHONE1's principle decides the priority. The officer is at a
+       desk most of the time and on a phone at a client's table or
+       between appointments — and the surfaces nobody complains about are
+       the ones that break. A row truncated to four characters is not
+       degraded, it is unusable. */
+    <div className={`p-4 hover:bg-gray-50 transition-colors flex flex-col sm:flex-row sm:items-center justify-between gap-3 sm:gap-4 ${
       needsAction ? 'border-l-4 border-amber-400' : ''
     }`}>
       {/* DASH1: THE ROW LINKS TO THE DEED. A feed of things she has
@@ -906,7 +933,7 @@ function DeedRow({ deed }: { deed: any }) {
         </div>
       </button>
 
-      <div className="flex items-center gap-3 flex-shrink-0">
+      <div className="flex items-center gap-3 flex-shrink-0 pl-14 sm:pl-0">
         {/* DASH-FIX #3 — this rendered `{deed.status}` RAW, so the badge
             showed the database's own token and a generated document read
             "completed" while its signing sat unanswered in the queue

--- a/frontend/src/app/onboarding/page.tsx
+++ b/frontend/src/app/onboarding/page.tsx
@@ -8,7 +8,7 @@
 // server-side, and the builder route is /deed-builder.
 import type React from "react"
 
-import { useState } from "react"
+import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import Link from "next/link"
 import { ShieldCheck, MapPin, ArrowRight, Sparkles } from "lucide-react"
@@ -17,6 +17,7 @@ import { ShieldCheck, MapPin, ArrowRight, Sparkles } from "lucide-react"
 // this was a local 58-element array until account-settings grew the
 // second picker (DASH-FIX #1). One declaration, not one screen.
 import { CA_COUNTY_NAMES } from "@/lib/jurisdictions"
+import { saveProfile } from "@/lib/profileSave"
 
 export default function OnboardingPage() {
   const router = useRouter()
@@ -29,6 +30,36 @@ export default function OnboardingPage() {
   const [error, setError] = useState("")
 
   /**
+   * ═══ THE ROUTE GUARD THIS PAGE NEVER HAD ═══
+   *
+   * Found by the HX0 sweep going red during an unrelated refactor, and
+   * the way it was found is the finding.
+   *
+   * `routeGuards.test.ts` detects a guard by looking for one of four
+   * strings in the file, one of which is
+   * `localStorage.getItem("access_token")`. This page contained that
+   * string — INSIDE the save function, reading a token to send it — and
+   * so counted as guarded for as long as the save was written inline.
+   * Moving the save into `lib/profileSave.ts` took the string with it
+   * and the sweep immediately said what had always been true: there was
+   * no guard here at all.
+   *
+   * A logged-out visitor could open the first screen a new customer
+   * sees, choose a county, press Finish, and learn only then that
+   * nothing had been saved — because the API refused a bearer token
+   * reading `null`. Not a data exposure; the server was never fooled.
+   * A late, confusing failure on the page least able to afford one.
+   *
+   * §14.1.1's silent half, in a security sweep: a pin matching a string
+   * rather than the property CERTIFIED the gap it was meant to close.
+   */
+  useEffect(() => {
+    if (!localStorage.getItem("access_token")) {
+      router.push("/login?redirect=/onboarding")
+    }
+  }, [router])
+
+  /**
    * SETTINGS1 — RETRY, because the first thing anybody does in this
    * product is the thing we least want to lose.
    *
@@ -39,37 +70,11 @@ export default function OnboardingPage() {
    * Retrying is asking again, not deciding: a failure that survives both
    * attempts is REPORTED, never swallowed.
    */
-  const saveProfile = async (body: { default_county?: string; onboarding_completed: boolean }) => {
-    let lastError: Error | null = null
-    for (const wait of [0, 1200]) {
-      if (wait) await new Promise((r) => setTimeout(r, wait))
-      try {
-        return await saveProfileOnce(body)
-      } catch (err) {
-        lastError = err instanceof Error ? err : new Error("Save failed")
-      }
-    }
-    throw lastError
-  }
-
-  const saveProfileOnce = async (body: { default_county?: string; onboarding_completed: boolean }) => {
-    const token = localStorage.getItem("access_token")
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL || "https://deedpro-main-api.onrender.com"}/users/profile`,
-      {
-        method: "PATCH",
-        headers: {
-          Authorization: `Bearer ${token}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(body),
-      }
-    )
-    if (!response.ok) {
-      const data = await response.json().catch(() => ({}))
-      throw new Error(data.detail || `Save failed (${response.status})`)
-    }
-  }
+  /* The retry that used to live here moved to `lib/profileSave.ts`.
+     It was written for this page and account-settings never got it —
+     same endpoint, same payload, one tolerant of a sleeping server and
+     the other not, neither knowing the other existed. §14.3: one
+     declaration, not one screen. */
 
   const handleComplete = async (destination: string) => {
     setLoading(true)

--- a/frontend/src/lib/profileSave.ts
+++ b/frontend/src/lib/profileSave.ts
@@ -1,0 +1,114 @@
+/**
+ * Saving the profile, in one place, with the tolerance the first-run
+ * flow already had and the settings form never did.
+ *
+ * ═══ THE REPORT ═══
+ *
+ * "In my new user. I tried to set county and it said failed to fetch."
+ *
+ * `Failed to fetch` is not a sentence anybody in this product wrote. It
+ * is the browser's own `TypeError` for a request that never completed —
+ * DNS, connection refused, CORS, or a server that did not answer — and
+ * `account-settings` was surfacing `err.message` verbatim into the error
+ * box and the toast.
+ *
+ * ═══ TWO DEFECTS, AND THE SECOND IS MINE ═══
+ *
+ * ONE. `onboarding/page.tsx` wrapped its save in a two-attempt retry,
+ * added because this API sleeps and the first request after a quiet
+ * period can simply not arrive. `account-settings/page.tsx` had a single
+ * bare `fetch`. Same endpoint, same payload, one of them tolerant of a
+ * cold start and the other not — and neither knew the other existed.
+ *
+ * TWO. DASH-FIX #1 pointed the day-one checklist's "Set county" at
+ * account-settings, because that is where the form belongs. That is
+ * still right, and it moved a FIRST-RUN action onto the page WITHOUT the
+ * first-run tolerance — which is exactly the population that meets a
+ * sleeping server, because a brand-new account is the one nobody has
+ * warmed up. The routing was correct and the consequence was not
+ * checked.
+ *
+ * ═══ WHAT THIS DOES AND DELIBERATELY DOES NOT DO ═══
+ *
+ * It retries a request that never completed. It does NOT retry one the
+ * server answered: a 400 or a 422 is a decision, and asking again is how
+ * a client turns a refusal into a race. A 5xx is likewise left alone —
+ * the server spoke, and this module does not have an opinion about what
+ * it meant.
+ *
+ * And it never reports success it did not get (§4). The retry exists to
+ * survive a sleeping server, not to make a failure look like a save.
+ */
+
+const API = () => process.env.NEXT_PUBLIC_API_URL
+  || 'https://deedpro-main-api.onrender.com';
+
+/**
+ * The waits between attempts, in milliseconds.
+ *
+ * Two attempts, from onboarding's own ladder. Not more: a person is
+ * watching a spinner, and a third attempt buys a small chance of success
+ * at the cost of a page that appears to have hung.
+ */
+const WAITS = [0, 1200];
+
+/**
+ * A network-level failure, in words a person can act on.
+ *
+ * The browser says "Failed to fetch" and means "the request did not
+ * arrive". She cannot do anything with the first sentence and can with
+ * the second.
+ */
+export const UNREACHABLE =
+  'Could not reach the server — your changes were not saved. Please try again.';
+
+export class ProfileSaveError extends Error {
+  /** True when the request never completed, as opposed to being refused. */
+  readonly unreachable: boolean;
+  constructor(message: string, unreachable = false) {
+    super(message);
+    this.name = 'ProfileSaveError';
+    this.unreachable = unreachable;
+  }
+}
+
+/**
+ * PATCH /users/profile, retried only when nothing arrived.
+ *
+ * Throws `ProfileSaveError` on every failure, so no caller has to decide
+ * what a `TypeError` from `fetch` means.
+ */
+export async function saveProfile(patch: Record<string, unknown>): Promise<void> {
+  let unreachable: ProfileSaveError | null = null;
+
+  for (const wait of WAITS) {
+    if (wait) await new Promise((r) => setTimeout(r, wait));
+    let response: Response;
+    try {
+      response = await fetch(`${API()}/users/profile`, {
+        method: 'PATCH',
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem('access_token')}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(patch),
+      });
+    } catch {
+      // NOTHING ARRIVED. This is the only case worth trying again, and
+      // it is the case the browser describes as "Failed to fetch".
+      unreachable = new ProfileSaveError(UNREACHABLE, true);
+      continue;
+    }
+
+    if (response.ok) return;
+
+    // THE SERVER ANSWERED, so this is a decision rather than an absence.
+    // Returned immediately without a second attempt: asking again after
+    // a refusal is how a client turns a "no" into a race.
+    const body = await response.json().catch(() => ({}));
+    throw new ProfileSaveError(
+      (body as { detail?: string }).detail || `Save failed (${response.status})`);
+  }
+
+  throw unreachable ?? new ProfileSaveError(UNREACHABLE, true);
+}


### PR DESCRIPTION
Bug report from a new account: *"I tried to set county and it said failed to fetch."* Plus the three ROUGH fixes.

## The bug

`Failed to fetch` is the **browser's own TypeError** for a request that never completed, going straight into the error box and the toast. Nobody in this product wrote that sentence.

**Two defects, and the second is mine.**

Onboarding wrapped its save in a two-attempt retry, added because this API sleeps. Account-settings had a bare `fetch`. Same endpoint, same payload — one tolerant of a cold start and one not, neither knowing the other existed.

And **DASH-FIX #1 pointed the day-one checklist's "Set county" at account-settings.** That routing was right and stays right, but it moved a *first-run* action onto the page without the *first-run* tolerance — the population most certain to meet a sleeping server, because a brand-new account is the one nobody has warmed up.

`lib/profileSave.ts` is now the one save path. It retries only a request that never **arrived**; a 400 or 422 is a decision, and asking again is how a client turns a refusal into a race. A 5xx is left alone because the server still spoke.

## ⚠️ I cannot confirm the root cause from here

Cold start is likeliest — it's what onboarding's retry exists for — but **CORS or a wrong `NEXT_PUBLIC_API_URL` on that deployment produce the identical browser error.** The retry and the copy are right either way, but if this recurs after deploy I need one of: the browser console's network entry (status vs "failed"), or whether the *first* attempt succeeds after the app has been used for a minute.

## The route guard — found by accident, and the accident is the finding

**`/onboarding` had no guard at all.** Its only `access_token` reference was inside the save function, reading a token to send it — and `routeGuards.test.ts` detects a guard by looking for that string in the file. Moving the save into a module took the string with it, and the sweep immediately said what had always been true.

A logged-out visitor could open the first screen a new customer sees, choose a county, press Finish, and learn only then that nothing had been saved. The server was never fooled — this is a late, confusing failure, not an exposure. A real guard is added.

**That is §14.1.1's silent half for the third time today, and this time in a security sweep**: a pin matching a string rather than a property *certified* the gap it existed to close. Hardening the sweep is **reported, not attempted** — it may reveal more pages, and that's a ticket rather than a side-effect.

## The three ROUGH fixes

- **`items-start` on the queue grid** — three columns stretched to the tallest, so an empty "Signing in the next 7 days" was padded out to match a column of five rows. Not hidden; DASH1 ruled the empty state is a result.
- **`items-start` on the resume/start grid** — the audit placed the dead band one row up, at a grid that already carries `items-start` and whose ~68px is ordinary padding. This is where it actually is.
- **`flex-col sm:flex-row` on the deed row** — every item in the right cluster is already at its minimum, so stacking is the only remedy that exists.

## A syntax error I introduced, and what caught it

A `{/* comment */}` in a ternary branch is invalid JSX. **The tsc count fell from 88 to six** — which is what a parse failure looks like when you read it as a count, and I nearly reported it as an improvement.

**Jest stayed green at 1084 throughout**, because no test imports the dashboard page. A page can be unparseable and the frontend suite will not notice. `next build` and `tsc` are the only gates that see it — worth knowing given both were nearly skipped by shape reasoning a few PRs ago.

## Gates

pytest **1480**, jest **1084**/78 (+7, +1 suite), tsc **88**, `next build` clean, banned-claims clean, four harnesses green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_