### PR TITLE
DASH-SOFTEN — one step at a time, and a header that assembles itself

### DIFF
--- a/docs/design/dashboard-soften/README.md
+++ b/docs/design/dashboard-soften/README.md
@@ -1,0 +1,72 @@
+# DeedPro dashboard — softened onboarding
+
+Five files. Drop `components/dashboard/*` in as-is; `app-dashboard-page.tsx`
+is the composition — rename to `app/dashboard/page.tsx` and wire
+`getDashboardData()` to your real data layer.
+
+```
+components/dashboard/setup-steps.ts          ← copy + state logic, no JSX
+components/dashboard/setup-checklist.tsx     ← the accordion
+components/dashboard/deed-header-preview.tsx ← the live-filling right card
+components/dashboard/start-something-new.tsx ← teaser → primary, two states
+components/dashboard/email-notice.tsx        ← slim replacement for the banner
+app-dashboard-page.tsx                       ← → app/dashboard/page.tsx
+```
+
+## The color rule
+
+Four jobs, no others. If a fifth use of color appears, one of these stops working.
+
+| Color | Token | Means | Budget |
+|---|---|---|---|
+| Violet | `--color-brand` `#7C4DFF` | the one thing to do next | **exactly once per screen** |
+| Green | `emerald-500/600` | done | done only, never "good" generally |
+| Amber | `--color-warning` | a real problem the user must fix | rejected recording, failed signature — *never* an unfilled field |
+| Grey | `gray-*` | everything else | most of the page |
+
+The failure mode in the current build is #4 masquerading as #3: "Not set" in
+orange, and a full amber banner, both firing before the user has done
+anything wrong. Empty ≠ error.
+
+## The accordion invariant
+
+`SetupChecklist` expands exactly one step — the first incomplete one — and it
+is the only component on the page allowed a violet button. Completed steps
+collapse to one line; later steps render title-only with no body copy and no
+button. This is enforced in the component, not by convention: `activeStep()`
+derives it from state, so there's no way to render two.
+
+Consequence worth knowing: **the good explanatory copy is not deleted, it's
+deferred.** Each step still carries its `why`, it just only renders when it's
+that step's turn. Total words on screen drops from ~90 to ~18.
+
+## What changed, and why
+
+1. **One step expanded** — was four, ~90 words of body copy at once.
+2. **Progress bar at the top** — "1 of 4 done" was 12px grey at the bottom of
+   the card, i.e. the reward was hidden.
+3. **One CTA** — was three (finish setup / start a deed / upgrade).
+4. **Right card stops repeating the left** — it now shows the deed header
+   assembling itself. Same pixels, flips from noise to feedback.
+5. **Plan card → one line**, orange "Not set" gone.
+6. **"Start something new" demoted** until setup completes, then it becomes
+   the primary card once `SetupChecklist` unmounts.
+
+## Notes
+
+- Uses your existing CSS custom properties (`--color-brand`,
+  `--color-brand-light`, `--color-brand-hover`) via Tailwind arbitrary values,
+  so nothing new lands in `tailwind.config`.
+- Class conventions match what's already on the page: `rounded-2xl border
+  border-gray-200 bg-white p-5 md:p-6`, `text-lg font-bold text-gray-900`.
+- A11y: `role="progressbar"` with live counts, `aria-current="step"` on the
+  active row, `sr-only` "done" on completed rows, `motion-reduce` guards on
+  both animations.
+- `SetupChecklist` returns `null` when setup is complete — it does not linger
+  as an all-green trophy card. Reclaim the space.
+
+## One thing to verify before shipping
+
+The company name on the live dashboard reads **"All Good Escow"** — likely a
+typo in seed data, but if it came from user input it will print on every
+recorded deed. Worth a look either way.

--- a/docs/design/dashboard-soften/app-dashboard-page.tsx
+++ b/docs/design/dashboard-soften/app-dashboard-page.tsx
@@ -1,0 +1,102 @@
+// app/dashboard/page.tsx  (App Router — server component)
+//
+// Drop-in replacement for the current dashboard body. Data fetching is
+// stubbed at `getDashboardData` — wire it to whatever you already use.
+
+import { SetupChecklist } from "@/components/dashboard/setup-checklist";
+import { DeedHeaderPreview } from "@/components/dashboard/deed-header-preview";
+import { StartSomethingNew } from "@/components/dashboard/start-something-new";
+import { EmailNotice } from "@/components/dashboard/email-notice";
+import { isSetupComplete, type SetupState } from "@/components/dashboard/setup-steps";
+import Link from "next/link";
+
+export default async function DashboardPage() {
+  const d = await getDashboardData();
+
+  const setup: SetupState = {
+    company_name: Boolean(d.companyName),
+    recording_county: Boolean(d.county),
+    business_address: Boolean(d.mailToAddress),
+    first_deed: d.deedCount > 0,
+  };
+  const complete = isSetupComplete(setup);
+
+  return (
+    <div className="mx-auto max-w-6xl">
+      {!d.emailConfirmed && (
+        <EmailNotice email={d.email} onResend={resendConfirmation} />
+      )}
+
+      <h1 className="mt-5 text-xl font-bold text-gray-900">
+        {greeting()}, {d.firstName}.
+      </h1>
+      {/* Subhead states the next move, not the abstract state of things.
+          "Here's where your deeds stand" is false on day one — they have none. */}
+      <p className="mt-1 text-sm text-gray-500">
+        {complete
+          ? "Here's where your deeds stand."
+          : "One quick thing, then you can make your first deed."}
+      </p>
+
+      <div className="mt-5 grid items-start gap-4 lg:grid-cols-[2fr,1fr]">
+        <div>
+          <SetupChecklist
+            state={setup}
+            values={{ company_name: d.companyName ?? undefined }}
+          />
+          <StartSomethingNew setupComplete={complete} countyName={d.county} />
+        </div>
+
+        <div>
+          <DeedHeaderPreview
+            companyName={d.companyName}
+            mailToAddress={d.mailToAddress}
+            county={d.county}
+          />
+
+          {/* Plan card demoted to one line. It was a third competing CTA and
+              its "Recording county: Not set" row duplicated step 2 — in
+              orange, which read as an error. */}
+          <div className="mt-4 flex items-center justify-between gap-3 rounded-xl border border-gray-200 bg-white px-4 py-3 text-xs text-gray-500">
+            <span>
+              {d.plan === "free"
+                ? "Free plan · Professional is free for 14 days"
+                : "Professional plan"}
+            </span>
+            <Link
+              href="/settings/plan"
+              className="shrink-0 font-semibold text-[var(--color-brand)] hover:underline"
+            >
+              Compare
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function greeting() {
+  const h = new Date().getHours();
+  return h < 12 ? "Good morning" : h < 18 ? "Good afternoon" : "Good evening";
+}
+
+/* ---- replace these two with your real data layer ---- */
+
+async function getDashboardData() {
+  return {
+    firstName: "Jaxxon",
+    email: "info@modernagent.io",
+    emailConfirmed: false,
+    companyName: "All Good Escrow" as string | null,
+    mailToAddress: null as string | null,
+    county: null as string | null,
+    deedCount: 0,
+    plan: "free" as "free" | "professional",
+  };
+}
+
+async function resendConfirmation() {
+  "use server";
+  // POST /api/auth/resend-confirmation
+}

--- a/docs/design/dashboard-soften/components/dashboard/deed-header-preview.tsx
+++ b/docs/design/dashboard-soften/components/dashboard/deed-header-preview.tsx
@@ -1,0 +1,94 @@
+// components/dashboard/deed-header-preview.tsx
+"use client";
+
+/**
+ * Replaces "Where your company lands" + the "Recording county: Not set" row
+ * in the plan card.
+ *
+ * The old version restated the checklist in different words, so a new user
+ * read the same three facts twice. This version shows the ACTUAL artifact
+ * being assembled, and each line fills in as its step completes — the card
+ * turns from redundant noise into feedback.
+ *
+ * Empty lines are grey and say which step fills them. They are never red or
+ * amber: nothing is wrong, the user just hasn't got there yet.
+ */
+
+interface Props {
+  companyName?: string | null;
+  mailToAddress?: string | null;
+  county?: string | null;
+  /** Set when a value landed this session — plays a one-off highlight. */
+  justFilled?: "companyName" | "mailToAddress" | "county" | null;
+}
+
+export function DeedHeaderPreview({
+  companyName,
+  mailToAddress,
+  county,
+  justFilled = null,
+}: Props) {
+  return (
+    <section className="rounded-2xl border border-gray-200 bg-white p-5 md:p-6">
+      <h2 className="text-sm font-bold text-gray-900">Your deed header</h2>
+
+      <dl className="mt-3 rounded-xl border border-gray-200 bg-gray-50/60 p-3.5 text-[12.5px] leading-relaxed">
+        <Line
+          label="RECORDING REQUESTED BY"
+          value={companyName}
+          fallback="fills in at step 1"
+          highlight={justFilled === "companyName"}
+        />
+        <Line
+          label="AND WHEN RECORDED MAIL TO"
+          value={mailToAddress}
+          fallback="fills in at step 3"
+          highlight={justFilled === "mailToAddress"}
+        />
+        <Line
+          label="COUNTY"
+          value={county}
+          fallback="fills in at step 2"
+          highlight={justFilled === "county"}
+        />
+      </dl>
+
+      <p className="mt-3 text-xs leading-relaxed text-gray-500">
+        This block prints at the top of every deed you make.
+      </p>
+    </section>
+  );
+}
+
+function Line({
+  label,
+  value,
+  fallback,
+  highlight,
+}: {
+  label: string;
+  value?: string | null;
+  fallback: string;
+  highlight?: boolean;
+}) {
+  return (
+    <div className="mt-2 first:mt-0">
+      <dt className="text-[9.5px] font-bold tracking-[0.09em] text-gray-400">
+        {label}:
+      </dt>
+      <dd
+        className={
+          value
+            ? `-mx-1 rounded px-1 font-semibold text-gray-900 ${
+                highlight
+                  ? "bg-[var(--color-brand-light)] text-[var(--color-brand)] motion-safe:animate-pulse"
+                  : ""
+              }`
+            : "italic text-gray-400"
+        }
+      >
+        {value || fallback}
+      </dd>
+    </div>
+  );
+}

--- a/docs/design/dashboard-soften/components/dashboard/email-notice.tsx
+++ b/docs/design/dashboard-soften/components/dashboard/email-notice.tsx
@@ -1,0 +1,47 @@
+// components/dashboard/email-notice.tsx
+"use client";
+
+import { useState } from "react";
+
+/**
+ * Was: a full amber alert banner, top of page, before the user has done
+ * anything wrong. Amber is reserved for real problems (a rejected recording,
+ * a failed signature) — spend it there, not here.
+ *
+ * Now: a neutral strip with a single amber dot, and copy that states the
+ * consequence rather than the state.
+ */
+export function EmailNotice({
+  email,
+  onResend,
+}: {
+  email: string;
+  onResend: () => Promise<void>;
+}) {
+  const [status, setStatus] = useState<"idle" | "sending" | "sent">("idle");
+
+  return (
+    <div className="mt-4 flex items-center gap-2.5 rounded-xl border border-gray-200 bg-white px-3.5 py-2.5 text-[13.5px]">
+      <span
+        className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500"
+        aria-hidden
+      />
+      <span className="min-w-0 flex-1 text-gray-500">
+        Confirm your email so signing invites can reach you.
+        <span className="hidden text-gray-400 sm:inline"> ({email})</span>
+      </span>
+      <button
+        type="button"
+        disabled={status !== "idle"}
+        onClick={async () => {
+          setStatus("sending");
+          await onResend();
+          setStatus("sent");
+        }}
+        className="shrink-0 font-semibold text-[var(--color-brand)] hover:underline disabled:opacity-60"
+      >
+        {status === "sent" ? "Sent ✓" : status === "sending" ? "Sending…" : "Resend link"}
+      </button>
+    </div>
+  );
+}

--- a/docs/design/dashboard-soften/components/dashboard/setup-checklist.tsx
+++ b/docs/design/dashboard-soften/components/dashboard/setup-checklist.tsx
@@ -1,0 +1,164 @@
+// components/dashboard/setup-checklist.tsx
+"use client";
+
+import Link from "next/link";
+import {
+  SETUP_STEPS,
+  activeStep,
+  completedCount,
+  type SetupState,
+  type SetupStep,
+} from "./setup-steps";
+
+/**
+ * THE ONE RULE THIS COMPONENT ENFORCES:
+ * exactly one step is expanded, and it is the first incomplete one.
+ *
+ * Completed steps collapse to a single line with a green check.
+ * Later steps render as title-only, muted, with no body copy and no button.
+ * If you add a second primary (violet) button anywhere on this page, the
+ * hierarchy breaks and you're back to the old dashboard.
+ */
+
+interface Props {
+  state: SetupState;
+  /** e.g. { company_name: "All Good Escrow" } — shown as a chip on done rows. */
+  values?: Partial<Record<SetupStep["id"], string>>;
+}
+
+export function SetupChecklist({ state, values = {} }: Props) {
+  const active = activeStep(state);
+  const done = completedCount(state);
+  const total = SETUP_STEPS.length;
+  const pct = Math.round((done / total) * 100);
+
+  if (!active) return null; // setup finished — render nothing, free the space
+
+  return (
+    <section
+      className="rounded-2xl border border-gray-200 bg-white p-5 md:p-6"
+      aria-labelledby="setup-heading"
+    >
+      <h2 id="setup-heading" className="text-lg font-bold text-gray-900">
+        Getting set up
+      </h2>
+
+      {/* Progress lives at the TOP. "1 of 4 done" buried at the bottom is a
+          reward the user never sees. */}
+      <div className="mt-3 flex items-center gap-3">
+        <div
+          className="h-1.5 flex-1 overflow-hidden rounded-full bg-gray-100"
+          role="progressbar"
+          aria-valuenow={done}
+          aria-valuemin={0}
+          aria-valuemax={total}
+          aria-label={`${done} of ${total} setup steps complete`}
+        >
+          <div
+            className="h-full rounded-full bg-[var(--color-brand)] transition-[width] duration-500 ease-out motion-reduce:transition-none"
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+        <span className="text-xs font-bold tabular-nums text-gray-500">
+          {done} of {total}
+        </span>
+      </div>
+
+      <ol className="mt-3 space-y-2">
+        {SETUP_STEPS.map((step, i) => {
+          if (state[step.id]) {
+            return (
+              <DoneRow key={step.id} step={step} value={values[step.id]} />
+            );
+          }
+          if (step.id === active.id) {
+            return <ActiveRow key={step.id} step={step} index={i + 1} />;
+          }
+          return <PendingRow key={step.id} step={step} index={i + 1} />;
+        })}
+      </ol>
+
+      {/* The reassurance line the old design put at the top, where it competed
+          with the steps. It belongs after them, as a footnote. */}
+      <p className="mt-4 border-t border-gray-100 pt-3 text-xs text-gray-500">
+        Every step here is something the deed itself prints — none of it is
+        profile decoration.
+      </p>
+    </section>
+  );
+}
+
+/* ---------- rows ---------- */
+
+function DoneRow({ step, value }: { step: SetupStep; value?: string }) {
+  return (
+    <li className="flex items-center gap-3 rounded-xl px-3.5 py-3 opacity-70">
+      <span
+        className="flex h-[23px] w-[23px] shrink-0 items-center justify-center rounded-full border border-emerald-200 bg-emerald-50 text-[11px] font-bold text-emerald-600"
+        aria-hidden
+      >
+        ✓
+      </span>
+      <span className="flex-1 text-sm font-medium text-gray-700">
+        {step.title}
+        <span className="sr-only"> — done</span>
+      </span>
+      {value && (
+        <span className="max-w-[45%] truncate rounded-full bg-emerald-50 px-2 py-0.5 text-[11.5px] font-semibold text-emerald-600">
+          {value}
+        </span>
+      )}
+    </li>
+  );
+}
+
+function ActiveRow({ step, index }: { step: SetupStep; index: number }) {
+  return (
+    <li
+      className="flex items-start gap-3 rounded-xl border border-[#E4DDFF] bg-[var(--color-brand-light)] p-4"
+      aria-current="step"
+    >
+      <span
+        className="mt-0.5 flex h-[23px] w-[23px] shrink-0 items-center justify-center rounded-full bg-[var(--color-brand)] text-[11.5px] font-bold text-white"
+        aria-hidden
+      >
+        {index}
+      </span>
+      <div className="min-w-0 flex-1">
+        <h3 className="text-[15.5px] font-semibold text-gray-900">
+          {step.activeTitle}
+        </h3>
+        {/* The ONLY body copy on the card. */}
+        <p className="mt-1 max-w-[52ch] text-[13px] leading-relaxed text-[#4B3B7A]">
+          {step.why}
+        </p>
+        <Link
+          href={step.href}
+          className="mt-3 inline-flex items-center rounded-lg bg-[var(--color-brand)] px-3.5 py-2 text-[13px] font-semibold text-white shadow-sm transition hover:bg-[var(--color-brand-hover)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--color-brand)]"
+        >
+          {step.cta}
+        </Link>
+      </div>
+    </li>
+  );
+}
+
+function PendingRow({ step, index }: { step: SetupStep; index: number }) {
+  return (
+    <li className="flex items-center gap-3 rounded-xl border border-gray-100 px-3.5 py-3">
+      <span
+        className="flex h-[23px] w-[23px] shrink-0 items-center justify-center rounded-full bg-gray-100 text-[11.5px] font-bold text-gray-400"
+        aria-hidden
+      >
+        {index}
+      </span>
+      {/* No `why`, no button. Deliberately. */}
+      <span className="flex-1 text-sm font-medium text-gray-700">
+        {step.title}
+      </span>
+      <span className="rounded-full bg-gray-100 px-2 py-0.5 text-[11.5px] font-semibold text-gray-400">
+        next
+      </span>
+    </li>
+  );
+}

--- a/docs/design/dashboard-soften/components/dashboard/setup-steps.ts
+++ b/docs/design/dashboard-soften/components/dashboard/setup-steps.ts
@@ -1,0 +1,76 @@
+// components/dashboard/setup-steps.ts
+//
+// Single source of truth for onboarding. The dashboard, the settings page and
+// any "you still need to…" nudge should all read from this — so copy never
+// drifts between surfaces.
+
+export type SetupStepId =
+  | "company_name"
+  | "recording_county"
+  | "business_address"
+  | "first_deed";
+
+export interface SetupStep {
+  id: SetupStepId;
+  /** Short label. Used when the step is collapsed. Keep under ~28 chars. */
+  title: string;
+  /** Longer label, shown only while the step is the active one. */
+  activeTitle: string;
+  /**
+   * Why this matters, in deed terms. ONE sentence, max ~20 words.
+   * Only ever rendered for the active step — see the accordion rule below.
+   */
+  why: string;
+  cta: string;
+  href: string;
+}
+
+export const SETUP_STEPS: SetupStep[] = [
+  {
+    id: "company_name",
+    title: "Company name",
+    activeTitle: "Add your company name",
+    why: "Prints on the RECORDING REQUESTED BY line at the top of every deed.",
+    cta: "Add company name",
+    href: "/settings/company",
+  },
+  {
+    id: "recording_county",
+    title: "Recording county",
+    activeTitle: "Set your recording county",
+    why: "Becomes the default on every new deed. You can change it on any single one.",
+    cta: "Set county",
+    href: "/settings/county",
+  },
+  {
+    id: "business_address",
+    title: "Business address",
+    activeTitle: "Add your business address",
+    why: "Where the recorder mails the document back after it records.",
+    cta: "Add address",
+    href: "/settings/address",
+  },
+  {
+    id: "first_deed",
+    title: "Make your first deed",
+    activeTitle: "Make your first deed",
+    why: "Start from an address — APN, legal description and owner come back from county records.",
+    cta: "Start a deed",
+    href: "/deeds/new",
+  },
+];
+
+export type SetupState = Record<SetupStepId, boolean>;
+
+/** The first incomplete step, in declared order. `null` once setup is done. */
+export function activeStep(state: SetupState): SetupStep | null {
+  return SETUP_STEPS.find((s) => !state[s.id]) ?? null;
+}
+
+export function completedCount(state: SetupState): number {
+  return SETUP_STEPS.filter((s) => state[s.id]).length;
+}
+
+export function isSetupComplete(state: SetupState): boolean {
+  return completedCount(state) === SETUP_STEPS.length;
+}

--- a/docs/design/dashboard-soften/components/dashboard/start-something-new.tsx
+++ b/docs/design/dashboard-soften/components/dashboard/start-something-new.tsx
@@ -1,0 +1,72 @@
+// components/dashboard/start-something-new.tsx
+"use client";
+
+import Link from "next/link";
+
+/**
+ * Two states, on purpose.
+ *
+ * While setup is incomplete this renders as a quiet dashed teaser with a
+ * GREY button — it must not compete with the violet CTA in the checklist.
+ * Once setup is done the checklist unmounts and this becomes the primary
+ * card, with the full instrument list.
+ */
+
+const FEATURED = ["Grant Deed", "Interspousal Transfer Deed", "Quitclaim Deed"];
+
+export function StartSomethingNew({
+  setupComplete,
+  countyName,
+}: {
+  setupComplete: boolean;
+  countyName?: string | null;
+}) {
+  if (!setupComplete) {
+    return (
+      <div className="mt-4 flex items-center gap-3 rounded-2xl border border-dashed border-gray-200 bg-white px-5 py-4">
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-semibold text-gray-700">
+            Start something new
+          </p>
+          <p className="mt-0.5 text-xs text-gray-500">
+            21 California instruments, ready once your county is set.
+          </p>
+        </div>
+        <Link
+          href="/deeds/instruments"
+          className="shrink-0 rounded-lg border border-gray-300 bg-white px-3.5 py-2 text-[13px] font-semibold text-gray-700 transition hover:bg-gray-50"
+        >
+          Peek at the list
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <section className="mt-4 rounded-2xl border border-gray-200 bg-white p-5 md:p-6">
+      <h2 className="text-lg font-bold text-gray-900">Start something new</h2>
+      {countyName && (
+        <p className="mt-1 text-sm text-gray-500">
+          Recording in {countyName} County.
+        </p>
+      )}
+      <div className="mt-3 flex flex-wrap gap-2.5">
+        {FEATURED.map((name) => (
+          <Link
+            key={name}
+            href={`/deeds/new?type=${encodeURIComponent(name)}`}
+            className="rounded-xl border border-[#E4DDFF] bg-gradient-to-b from-white to-[var(--color-brand-light)] px-3.5 py-2.5 text-[13.5px] font-semibold text-[var(--color-brand-hover)] transition hover:border-[var(--color-brand)]"
+          >
+            {name}
+          </Link>
+        ))}
+      </div>
+      <Link
+        href="/deeds/instruments"
+        className="mt-3 inline-block text-[13px] font-semibold text-[var(--color-brand)] hover:underline"
+      >
+        Browse all 21 California instruments →
+      </Link>
+    </section>
+  );
+}

--- a/frontend/src/__tests__/countyField.test.tsx
+++ b/frontend/src/__tests__/countyField.test.tsx
@@ -132,12 +132,20 @@ describe('account settings', () => {
 
 describe('the checklist button', () => {
   it('points at the page that now holds the field', () => {
-    const dash = read(join(SRC, 'app', 'dashboard', 'page.tsx'));
-    expect(dash).toContain('/account-settings');
-    // And NOT at the completion flow: re-entering onboarding to change
-    // one field re-runs `onboarding_completed` and a navigation she did
-    // not ask for.
-    expect(dash).not.toContain("'/onboarding'");
+    /* Asserted against the STEP, not the page. DASH-SOFTEN moved each
+       destination onto its step definition so the page holds no second
+       opinion about where "Set county" goes — and this pin, which
+       quoted the route string as it appeared in `page.tsx`, went red on
+       that move while the property it guards was untouched (§14.1.1). */
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { setupSteps } = require('../features/dashboard/SetupChecklist');
+    const county = setupSteps({ deedCount: 0 })
+      .find((st: { id: string }) => st.id === 'county');
+    expect(county.href).toBe('/account-settings');
+    // And NOT the completion flow: re-entering onboarding to change one
+    // field re-runs `onboarding_completed` and a navigation she did not
+    // ask for.
+    expect(county.href).not.toContain('/onboarding');
   });
 
   it('leaves onboarding importing the shared list rather than its own', () => {

--- a/frontend/src/__tests__/dashboardSetupChecklist.test.tsx
+++ b/frontend/src/__tests__/dashboardSetupChecklist.test.tsx
@@ -12,55 +12,138 @@ import { describe, expect, it, jest } from '@jest/globals';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
-import SetupChecklist, { setupSteps } from '../features/dashboard/SetupChecklist';
+import SetupChecklist, { setupSteps, activeStep } from '../features/dashboard/SetupChecklist';
 import DayOneRail from '../features/dashboard/DayOneRail';
 
 const NOTHING_SET = { county: null, companyName: null, businessAddress: null, deedCount: 0 };
 
-describe('what the checklist derives', () => {
-  it('reads four steps off state the product already holds', () => {
-    /** The fourth arrived from an audit: the list counted itself
-     *  complete at 2 of 3 while `business_address` was empty, and the
-     *  rail beside it was drawing a gap in AND WHEN RECORDED MAIL TO —
-     *  a box that PRINTS. It qualifies on this list's own test: every
-     *  step is something the deed itself needs. */
+describe('the accordion invariant', () => {
+  it('expands exactly one step, and it is the first incomplete one', () => {
+    /**
+     * THE PIN THIS FILE EXISTS FOR (first of three).
+     *
+     * Not "the component happens to render one" — `activeStep()` DERIVES
+     * it from state, so no prop opens a second and no arrangement of
+     * state yields two. Structural, like the officer queue asserting its
+     * key set rather than trusting its callers.
+     */
+    render(<SetupChecklist state={NOTHING_SET} />);
+    expect(document.querySelectorAll('[aria-current="step"]')).toHaveLength(1);
+    expect(screen.getByRole('button', { name: 'Add company name' })).toBeInTheDocument();
+  });
+
+  it('opens exactly one whatever combination of steps is done', () => {
+    /** Every reachable state rather than a sample: sixteen combinations
+     *  of four booleans, each rendering one open row or none at all. */
+    for (let c = 0; c < 16; c += 1) {
+      const { container, unmount } = render(<SetupChecklist state={{
+        companyName: c & 1 ? 'X' : null,
+        businessAddress: c & 2 ? 'Y' : null,
+        county: c & 4 ? 'Z' : null,
+        deedCount: c & 8 ? 1 : 0,
+      }} />);
+      expect(container.querySelectorAll('[aria-current="step"]').length)
+        .toBe(c === 15 ? 0 : 1);
+      unmount();
+    }
+  });
+
+  it('carries exactly one button, on the open step', () => {
+    /** ONE VIOLET CTA PER SCREEN. A later step renders title-only — no
+     *  `why`, no button — because it is not her turn. */
+    render(<SetupChecklist state={NOTHING_SET} />);
+    expect(screen.getAllByRole('button')).toHaveLength(1);
+  });
+
+  it('defers the copy rather than deleting it', () => {
+    /** Every step still carries its `why`, rendering on that step's
+     *  turn. ~90 words on screen became ~18 and nothing was lost. */
     const steps = setupSteps(NOTHING_SET);
-    expect(steps.map((s) => s.id)).toEqual(['county', 'company', 'address', 'first-deed']);
-    expect(steps.every((s) => !s.done)).toBe(true);
+    expect(steps.every((s) => s.why.length > 20)).toBe(true);
+    render(<SetupChecklist state={NOTHING_SET} />);
+    expect(screen.queryByText(/mails the document back/)).not.toBeInTheDocument();
+    expect((document.body.textContent || '').trim().split(/\s+/).length)
+      .toBeLessThan(70);
   });
 
-  it('counts a step done from the field that backs it', () => {
-    const steps = setupSteps({
-      county: 'Los Angeles', companyName: 'All Good Escrow',
-      businessAddress: '1200 Wilshire Blvd, Ste 400', deedCount: 2,
-    });
-    expect(steps.every((s) => s.done)).toBe(true);
-  });
-
-  it('treats whitespace as unset, because a space is not a company name', () => {
-    expect(setupSteps({ ...NOTHING_SET, companyName: '   ' })[1].done).toBe(false);
-  });
-
-  it('renders nothing once there is nothing left to set up', () => {
-    /** A checklist with every box ticked is the same guaranteed-empty
-     *  module its predecessor removed three of. */
-    const { container } = render(<SetupChecklist state={{
-      county: 'Los Angeles', companyName: 'All Good Escrow',
-      businessAddress: '1200 Wilshire Blvd', deedCount: 1,
-    }} />);
+  it('renders nothing at all once setup is done', () => {
+    /** It does not linger as an all-green trophy. */
+    const DONE = { companyName: 'X', businessAddress: 'Y', county: 'Z', deedCount: 1 };
+    expect(activeStep(DONE)).toBeNull();
+    const { container } = render(<SetupChecklist state={DONE} />);
     expect(container).toBeEmptyDOMElement();
   });
+});
 
-  it('says how many are done, in words', () => {
-    render(<SetupChecklist state={{ ...NOTHING_SET, county: 'Orange' }} />);
-    expect(screen.getByTestId('setup-progress')).toHaveTextContent('1 of 4 done');
+describe('the steps are in the order the deed header prints', () => {
+  it('runs company, address, county, first deed', () => {
+    /**
+     * THE PIN THIS FILE EXISTS FOR (second of three), OWNER-RULED.
+     *
+     * `DeedHeaderPreview`'s lines are in print order — RECORDING
+     * REQUESTED BY, AND WHEN RECORDED MAIL TO, COUNTY — so this order
+     * makes the preview fill strictly top-down, which is the reward loop
+     * the redesign rests on.
+     *
+     * The reference set led with company but placed county second, and
+     * its own COUNTY line then read "fills in at step 2" while sitting
+     * third. What shipped before led with county. Neither filled the
+     * picture in order.
+     */
+    expect(setupSteps(NOTHING_SET).map((s) => s.id))
+      .toEqual(['company', 'address', 'county', 'first-deed']);
   });
 
-  it('routes each step to the thing that fixes it', () => {
-    const onAct = jest.fn();
-    render(<SetupChecklist state={NOTHING_SET} onAct={onAct} />);
-    screen.getByRole('button', { name: 'Set county' }).click();
-    expect(onAct).toHaveBeenCalledWith('county');
+  it('numbers the header lines to match', () => {
+    render(<DayOneRail companyName={null} businessAddress={null} county={null} plan="free" />);
+    const text = document.body.textContent || '';
+    expect(text.indexOf('fills in at step 1')).toBeLessThan(text.indexOf('fills in at step 2'));
+    expect(text.indexOf('fills in at step 2')).toBeLessThan(text.indexOf('fills in at step 3'));
+  });
+
+  it('sends every step to a route this product actually has', () => {
+    /** The reference set invented /settings/company, /settings/county,
+     *  /settings/address and /deeds/new. The dead-link class. */
+    for (const step of setupSteps(NOTHING_SET)) {
+      expect(['/account-settings', '/deed-builder']).toContain(step.href);
+    }
+  });
+});
+
+describe('the colour rule, in our vocabulary', () => {
+  it('puts no doctrinal colour on the card', () => {
+    /**
+     * THE PIN THIS FILE EXISTS FOR (third of three).
+     *
+     * AMBER is reserved for unconfirmed external data — "a machine
+     * suggested this; a human has not yet said yes". Nothing here is
+     * county-sourced. RED is failure, and nothing here has failed: an
+     * unfilled field is an absence, and BRAND.md is explicit that
+     * absence is neutral grey.
+     *
+     * The reference set gave amber "a real problem the user must fix —
+     * rejected recording, failed signature": two meanings in one row,
+     * both wrong here. The first is red in our system; the second names
+     * recording-lifecycle states this product does not have.
+     *
+     * VIOLET is doctrinal too and went unflagged — "proposed legal
+     * choice". BRAND.md resolves it one surface over, in the
+     * admin-console section: where there are no officer decisions it
+     * "has nothing to attach to and purple is simply the accent". A
+     * company name is not a vesting proposal.
+     */
+    const { container } = render(<SetupChecklist state={NOTHING_SET} />);
+    for (const forbidden of ['amber', 'orange', 'red-', 'yellow']) {
+      expect(container.innerHTML).not.toContain(forbidden);
+    }
+  });
+
+  it('keeps the rail free of them too, with every field empty', () => {
+    const { container } = render(
+      <DayOneRail companyName={null} businessAddress={null} county={null} plan="free" />);
+    for (const forbidden of ['amber', 'orange', 'red-', 'yellow']) {
+      expect(container.innerHTML).not.toContain(forbidden);
+    }
   });
 });
 
@@ -74,7 +157,7 @@ describe('the copy the mockup asked for and did not get', () => {
      * name — the mockup's own annotation says the items derive from
      * `default_county` being null, and null yields "not set".
      */
-    render(<SetupChecklist state={NOTHING_SET} />);
+    render(<SetupChecklist state={{ ...NOTHING_SET, companyName: 'X', businessAddress: 'Y' }} />);
     const text = document.body.textContent || '';
     expect(text).not.toMatch(/never reached us|didn'?t save|Retry/i);
     expect(screen.getByText('Set your recording county')).toBeInTheDocument();
@@ -122,8 +205,8 @@ describe('the copy the mockup asked for and did not get', () => {
     /** The one rule from the mockup's pill design that survives it:
      *  status never rides on hue alone, so it holds up in greyscale,
      *  forced-colors and a screen reader. */
-    render(<SetupChecklist state={{ ...NOTHING_SET, county: 'Los Angeles' }} />);
-    expect(screen.getByText('Done')).toBeInTheDocument();
+    render(<SetupChecklist state={{ ...NOTHING_SET, companyName: 'All Good Escrow' }} />);
+    expect(screen.getByText('— done')).toBeInTheDocument();
   });
 });
 
@@ -131,7 +214,7 @@ describe('the rail', () => {
   it('shows where the company name lands, and marks the gap when it is blank', () => {
     render(<DayOneRail companyName={null} county={null} plan="free" />);
     expect(screen.getByText('RECORDING REQUESTED BY:')).toBeInTheDocument();
-    expect(screen.getByText('your company name')).toBeInTheDocument();
+    expect(screen.getByText('fills in at step 1')).toBeInTheDocument();
   });
 
   it('marks the gaps as text rather than as inputs that do nothing', () => {
@@ -155,7 +238,7 @@ describe('the rail', () => {
   it('shows the real name once she has one', () => {
     render(<DayOneRail companyName="All Good Escrow" county="Los Angeles" plan="free" />);
     expect(screen.getByText('All Good Escrow')).toBeInTheDocument();
-    expect(screen.queryByText('Your company name')).not.toBeInTheDocument();
+    expect(screen.queryByText('fills in at step 1')).not.toBeInTheDocument();
   });
 
   it('never states a monthly deed allowance', () => {
@@ -174,9 +257,14 @@ describe('the rail', () => {
     expect(text).not.toMatch(/of 5|deeds this month|per month|allowance|limit/);
   });
 
-  it('says the county is not set in words, not only in red', () => {
+  it('states the recording county exactly once on the screen', () => {
+    /** It was a row in the plan card AND a line in the preview AND a
+     *  checklist step — the restatement problem in miniature. The plan
+     *  card's row is gone; the header line and the step remain, and
+     *  those are the artifact and the action rather than two labels. */
     render(<DayOneRail companyName="X" county={null} plan="free" />);
-    expect(screen.getByText('Not set')).toBeInTheDocument();
+    expect(screen.queryByText('Not set')).not.toBeInTheDocument();
+    expect(screen.getByText('COUNTY:')).toBeInTheDocument();
   });
 
   it('states the trial length from the one place it is declared', () => {

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -10,7 +10,7 @@ import EmailVerificationNotice from "@/features/account/EmailVerificationNotice"
 import AccuracySection from "@/features/dashboard/AccuracySection"
 import ResumeCard from "@/features/dashboard/ResumeCard"
 import StartSomethingNew from "@/features/dashboard/StartSomethingNew"
-import SetupChecklist, { setupSteps } from "@/features/dashboard/SetupChecklist"
+import SetupChecklist, { activeStep } from "@/features/dashboard/SetupChecklist"
 import DayOneRail from "@/features/dashboard/DayOneRail"
 import { pickInProgressDeed } from "@/lib/latestDraft"
 import { authoringStateLabel, LAST_WORKED_ON } from "@/lib/authoringState"
@@ -297,8 +297,10 @@ export default function Dashboard() {
 
   /* The rail exists to explain the steps, so it goes when they do —
      §13 rule 3: the page does not recompute "is setup finished", it
-     asks the one function that decides what a step is. */
-  const setupIncomplete = !!setup && setupSteps(setup).some((st) => !st.done)
+     asks the one function that decides which step is open. `activeStep`
+     returning null IS "setup is done", and there is no second way to
+     ask. */
+  const setupIncomplete = !!setup && activeStep(setup) !== null
 
   return (
     <div className="flex bg-gray-50 min-h-screen">
@@ -337,11 +339,13 @@ export default function Dashboard() {
               done, and nothing at all until the profile has answered. */}
           {setup && (
             <div className="mb-6 grid gap-4 lg:grid-cols-[2fr,1fr] items-start">
-              <SetupChecklist
-                state={setup}
-                onAct={(id) => router.push(
-                  id === 'first-deed' ? '/deed-builder' : '/account-settings')}
-              />
+              {/* The step carries its own destination, so the page does
+                  not hold a second opinion about where "Add address"
+                  goes. Invented routes in the reference set —
+                  /settings/company, /settings/county, /settings/address,
+                  /deeds/new — are corrected at the source rather than
+                  translated here. */}
+              <SetupChecklist state={setup} onAct={(_id, href) => router.push(href)} />
               {setupIncomplete && (
                 <DayOneRail
                   companyName={setup.companyName}
@@ -371,6 +375,7 @@ export default function Dashboard() {
             />
             <StartSomethingNew
               instruments={queue?.instruments}
+              muted={setupIncomplete}
               onStart={(t) => router.push(`/deed-builder/${t}`)}
               onBrowse={() => router.push('/create-deed')}
             />

--- a/frontend/src/features/dashboard/DayOneRail.tsx
+++ b/frontend/src/features/dashboard/DayOneRail.tsx
@@ -1,32 +1,48 @@
 /**
- * The rail beside the setup checklist: where her company name lands, and
- * what her plan is.
+ * The deed header, assembling itself.
  *
- * ═══ WHAT THIS REPLACED ═══
+ * ═══ WHAT THIS REPLACED, AND WHY IT IS THE BEST IDEA IN THE REDESIGN ═══
  *
- * Four bullets headed "what I can help with", which were landing-page
- * copy shown to somebody who had already signed up. The mockup's
- * argument for the swap is that a picture of where her own company name
- * prints does the same persuading and doubles as the explanation for the
- * step asking for it.
+ * The previous card restated the checklist in different words: a picture
+ * of a deed face with "your company name" written where her company name
+ * would go, beside a list telling her to add her company name. A new
+ * officer read the same three facts twice, and the column earned
+ * nothing.
  *
- * ═══ THE PLAN CARD, MINUS ONE ROW ═══
+ * This shows the ACTUAL artifact being assembled. Each line fills in as
+ * its step completes, so the same pixels flip from redundant noise into
+ * feedback — she watches the thing she is building appear. It is also
+ * the best answer anybody has given to "where does my company name go?",
+ * because it does not answer the question, it shows the place.
  *
- * The mockup draws "Deeds this month — 0 of 5". Cut, owner-ruled, and
- * the ruling already existed: MONEY1 found `max_deeds_per_month: 5`
- * being returned from a hardcoded fallback while `check_plan_limits` had
- * zero call sites, so nothing had ever counted a deed against a cap. An
- * officer on Free was being told she had five a month by an API, and it
- * was untrue in both directions — nothing stopped her at five, and
- * nothing had decided she should be stopped. Free is uncapped and the
- * payload says so with `null`.
+ * ═══ THE LINES ARE IN PRINT ORDER, AND THE STEPS FOLLOW THEM ═══
  *
- * Rebuilding the row on a screen would restore exactly that, in the
- * harder place to see: copy gets read by people, payloads do not.
+ * RECORDING REQUESTED BY, then AND WHEN RECORDED MAIL TO, then the
+ * county. `setupSteps()` is ordered to match, so completing step one
+ * fills line one — the card fills strictly top-down.
  *
- * The trial line stays, because it is true — `TRIAL_PERIOD_DAYS = 14`
- * on the server, mirrored by a test — and because today the trial is
- * only ever discovered AFTER clicking Upgrade.
+ * The reference implementation had these two out of step: its COUNTY
+ * line read "fills in at step 2" while sitting third. Fixed by moving
+ * the STEPS, not the lines, because the lines are not ours to reorder —
+ * that is the order a recorder sees.
+ *
+ * ═══ EMPTY LINES ARE GREY ═══
+ *
+ * Never amber, never red. Amber is reserved for unconfirmed external
+ * data and nothing here is county-sourced; red is failure and nothing
+ * here has failed. An unfilled field is an absence, and BRAND.md is
+ * explicit that absence is neutral grey — "a fact about our
+ * instrumentation, not a warning about data".
+ *
+ * ═══ AND THE PLAN CARD IS ONE LINE ═══
+ *
+ * It was three rows and a paragraph, one of them an orange "Not set"
+ * firing before she had done anything wrong. What survives is the plan
+ * name and the trial, because the trial is true and is otherwise
+ * discovered only after clicking Upgrade. The recording county left this
+ * card entirely: it is a step in the checklist and a line in the header
+ * above, and a third statement of it was the restatement problem in
+ * miniature.
  */
 'use client';
 
@@ -39,88 +55,59 @@ export default function DayOneRail({ companyName, businessAddress, county, plan,
   plan?: string | null;
   onSeePlans?: () => void;
 }) {
-  const company = (companyName || '').trim();
-  const address = (businessAddress || '').trim();
   const planName = (plan || '').trim();
   const isFree = !planName || planName.toLowerCase() === 'free';
 
   return (
     <div className="space-y-4">
-      <div className="rounded-2xl border border-gray-200 bg-white p-5">
-        <h3 className="text-sm font-bold text-gray-900">Where your company lands</h3>
+      <section className="rounded-2xl border border-gray-200 bg-white p-5 md:p-6">
+        <h2 className="text-sm font-bold text-gray-900">Your deed header</h2>
 
-        {/* A deed face, not a picture of one: these are the two lines
-            that print at the top of every recorded instrument, in the
-            order they print. */}
-        <div className="mt-3 rounded-lg border border-gray-200 bg-gray-50 p-3 text-[11px] leading-relaxed">
-          <div className="font-semibold tracking-wide text-gray-500">
-            RECORDING REQUESTED BY:
-          </div>
-          {company ? (
-            <div className="font-medium text-gray-900">{company}</div>
-          ) : (
-            /* Same treatment: a marker for a gap, not an input. It
-               keeps its tint because it is the box the step beside it
-               fills, and loses the border that made it look editable. */
-            <div className="italic text-emerald-700">your company name</div>
-          )}
-          <div className="mt-2 font-semibold tracking-wide text-gray-500">
-            AND WHEN RECORDED MAIL TO:
-          </div>
-          {address ? (
-            <div className="text-gray-900">{address}</div>
-          ) : (
-            /* A MARKER, NOT A CONTROL. This was styled as a dashed input
-               box and was not clickable — an affordance promising a
-               field, on a preview. It reads as text now, and the way to
-               fill it is the checklist step beside it, which is a real
-               button that goes to a real form. */
-            <div className="italic text-gray-400">not set yet</div>
-          )}
-          {/* THE INSTRUMENT TITLE IS GONE. It was hardcoded to GRANT
-              DEED regardless of what she files — an audit found it
-              beside a catalog offering twenty-one instruments. This card
-              is about WHERE A NAME LANDS, and on day one there is no
-              document to name: showing one instrument would be picking
-              hers for her, and the honest version of a fact we do not
-              have is not a smaller fact, it is no line. */}
-        </div>
-
-        <p className="mt-3 text-xs text-gray-500">
-          {company
-            ? 'This is where it prints, on every deed you make.'
-            : 'The dashed box is what the setup step fills in. It is the whole reason we ask.'}
-        </p>
-      </div>
-
-      <div className="rounded-2xl border border-gray-200 bg-white p-5">
-        <h3 className="text-sm font-bold text-gray-900">Your plan</h3>
-        <dl className="mt-3 space-y-2 text-sm">
-          <div className="flex items-center justify-between gap-3">
-            <dt className="text-gray-500">Plan</dt>
-            <dd className="font-semibold text-gray-900">
-              {planName ? planName[0].toUpperCase() + planName.slice(1) : 'Free'}
-            </dd>
-          </div>
-          <div className="flex items-center justify-between gap-3">
-            <dt className="text-gray-500">Recording county</dt>
-            {/* "Not set" is the word doing the work. The colour is a
-                second signal, never the only one. */}
-            <dd className={`font-semibold ${(county || '').trim() ? 'text-gray-900' : 'text-amber-700'}`}>
-              {(county || '').trim() || 'Not set'}
-            </dd>
-          </div>
+        <dl className="mt-3 rounded-xl border border-gray-200 bg-gray-50/60 p-3.5
+                       text-[12.5px] leading-relaxed">
+          <Line label="RECORDING REQUESTED BY" value={companyName}
+                fallback="fills in at step 1" />
+          <Line label="AND WHEN RECORDED MAIL TO" value={businessAddress}
+                fallback="fills in at step 2" />
+          <Line label="COUNTY" value={county} fallback="fills in at step 3" />
         </dl>
+
+        <p className="mt-3 text-xs leading-relaxed text-gray-500">
+          This block prints at the top of every deed you make.
+        </p>
+      </section>
+
+      <section className="rounded-2xl border border-gray-200 bg-white p-5">
+        <div className="flex items-center gap-3">
+          <h2 className="text-sm font-bold text-gray-900">Your plan</h2>
+          <span className="ml-auto text-sm font-semibold text-gray-900">
+            {planName ? planName[0].toUpperCase() + planName.slice(1) : 'Free'}
+          </span>
+        </div>
         {isFree && (
-          <p className="mt-3 text-xs text-gray-500">
+          <p className="mt-2 text-xs leading-relaxed text-gray-500">
             Professional includes a {TRIAL_DAYS}-day free trial — no charge today.{' '}
             <button type="button" onClick={onSeePlans}
-                    className="font-semibold text-emerald-700 underline underline-offset-2">
+                    className="font-semibold text-[var(--color-brand)] underline underline-offset-2">
               See what&apos;s included
             </button>
           </p>
         )}
-      </div>
+      </section>
+    </div>
+  );
+}
+
+function Line({ label, value, fallback }: {
+  label: string; value?: string | null; fallback: string;
+}) {
+  const filled = (value || '').trim();
+  return (
+    <div className="mt-2 first:mt-0">
+      <dt className="text-[9.5px] font-bold tracking-[0.09em] text-gray-400">{label}:</dt>
+      <dd className={filled ? 'font-semibold text-gray-900' : 'italic text-gray-400'}>
+        {filled || fallback}
+      </dd>
     </div>
   );
 }

--- a/frontend/src/features/dashboard/SetupChecklist.tsx
+++ b/frontend/src/features/dashboard/SetupChecklist.tsx
@@ -1,204 +1,315 @@
 /**
- * Finish setting up — the only content that can be true on day one.
+ * Finish setting up — one step at a time.
  *
- * ═══ WHY A CHECKLIST AND NOT A WELCOME CARD ═══
+ * ═══ THE DIAGNOSIS, WHICH IS SHARPER THAN THE REQUEST ═══
  *
- * From `docs/design/dashboard_day_one.html`, whose argument is that
- * every item here is derived from state the product already holds:
- * `default_county` is null, `company_name` is blank, the deed count is
- * zero. A welcome banner cannot notice any of that. This can, and each
- * item is something the DEED needs rather than profile decoration.
+ * The question asked was "is this cognitive overload, can we colour it
+ * up". The answer this was rebuilt on: the problem is not QUANTITY, it
+ * is that nothing tells the eye what to read first — four steps expanded
+ * at once, three competing calls to action, and a right-hand column
+ * restating the left in different words. The fix is not more colour. It
+ * is colour that means something, and one thing to do next.
  *
- * ═══ THE MOCKUP'S THREE STEPS, TWO OF THEM REWRITTEN ═══
+ * `docs/design/dashboard-soften/` is the reference implementation this
+ * was built against, committed whole so the next reader sees what was
+ * proposed as well as what was adopted.
  *
- * STEP 1 was drawn as "Confirm your recording county", with a red
- * "Didn't save" pill, copy reading "You picked Los Angeles County during
- * setup, but it never reached us", and a Retry button.
+ * ═══ THE ACCORDION INVARIANT, ENFORCED STRUCTURALLY ═══
  *
- * Cut, owner-ruled, and the reason is that the sentence asserts
- * something we cannot know. If the save never reached us there is no
- * record of Los Angeles to name — the mockup's own annotation says the
- * items derive from `default_county` being null, and null yields "not
- * set", not "you picked LA". SETTINGS1 also closed that silent failure
- * at its source: a failed submit keeps her on the onboarding page with
- * the error, and a skip tells her plainly. What is left is the honest
- * state — she has no default county — and that is what this says.
+ * Exactly one step is expanded: the first incomplete one. That is not a
+ * convention this component follows, it is a value `activeStep()`
+ * DERIVES from state — there is no prop that could open a second, and no
+ * arrangement of state that yields two. Same instinct as the officer
+ * queue asserting its key set rather than trusting its callers.
  *
- * STEP 2 was drawn as "Add {company} as a partner", with copy saying the
- * RECORDING REQUESTED BY box "comes out blank and the county will
- * reject the document".
+ * ═══ THE COPY IS DEFERRED, NOT DELETED ═══
  *
- * Three corrections, all owner-ruled. It targets her COMPANY NAME, not a
- * partner: `requestedByDefault.ts` already falls back to a synthetic
- * own-company option built from `users.company_name`, and adding herself
- * to the rolodex is ruled against there — "a partner is a counterparty,
- * and the rolodex is not a place to file yourself". The real gap is the
- * narrower one where `company_name` is blank, which is a real
- * population because the field is optional at registration. And the
- * county-rejection line is cut under §1: it is a legal assertion about
- * what a recorder will do, printed in our own UI.
+ * Every step still carries its `why`. It renders only on that step's
+ * turn, so the card holds ~18 words instead of ~90 and the reasoning is
+ * all still there, arriving when it is the thing she is doing.
  *
- * ═══ NO PILLS, AND THAT IS A RULING RATHER THAN A DEFAULT ═══
+ * ═══ THE COLOUR RULE, IN OUR VOCABULARY ═══
  *
- * The mockup gives each step a status pill — "Didn't save", "Blocks
- * recording". Both steps here are "not set" states with nothing having
- * failed, and a pill implies a status CHANGE occurred. It follows from
- * cutting the rejection claim: we do not tell her something is blocked
- * or broken when nothing is blocked or broken. A step is either not done
- * yet or done. If a real failure state ever exists — a save that
- * actually errored — that earns a pill and its own copy at that point.
+ * The reference set proposed four jobs with stated budgets, which is
+ * right, and assigned amber to "a real problem the user must fix —
+ * rejected recording, failed signature". Both halves of that are wrong
+ * here and BRAND.md already says why.
  *
- * What survives from the mockup is the rule UNDER the pills: status is
- * never carried by colour alone. A finished step is marked with a glyph
- * AND the word "Done", and the meter states the count in words.
+ * AMBER IS RESERVED for unconfirmed external data — "a machine suggested
+ * this; a human has not yet said yes". Nothing on this card is
+ * county-sourced, so amber never appears on it. BRAND.md's admin section
+ * states the general form: "Absence is neutral gray, not amber: that is
+ * a fact about our instrumentation, not a warning about data." That IS
+ * the reference set's own "Empty ≠ error", written down before it.
+ *
+ * FAILURE IS RED, not amber — so the row was carrying two meanings and
+ * splits into two. And its examples go rather than being translated:
+ * rejected recording and failed signature are recording-lifecycle states
+ * this product does not have.
+ *
+ * VIOLET was the correction nobody had flagged. It is doctrinal too —
+ * "proposed legal choice; the system proposes, only the officer's
+ * explicit acceptance records it" — and the reference set leans on it
+ * harder than on amber, making it the one-CTA colour. BRAND.md resolves
+ * it one surface over, in the admin-console section: where there are no
+ * officer decisions, violet's meaning "has nothing to attach to and
+ * purple is simply the accent there". A company name is not a vesting
+ * proposal, so violet is the accent here too.
+ *
+ * NET: this card uses NO DOCTRINAL COLOUR AT ALL. Violet as accent,
+ * green for done, grey for everything else — including every empty
+ * field. That is tighter than the four-job rule it came from, and it
+ * falls out of our own doctrine rather than being imposed on it.
  */
 'use client';
 
+export type SetupStepId = 'company' | 'address' | 'county' | 'first-deed';
+
 export interface SetupState {
-  /** `user_profiles.default_county`, or null when she has not set one. */
-  county?: string | null;
-  /** `users.company_name` — optional at registration, hence this step. */
+  /** `users.company_name` — optional at registration, hence step one. */
   companyName?: string | null;
+  /** `user_profiles.business_address`. */
+  businessAddress?: string | null;
+  /** `user_profiles.default_county`. */
+  county?: string | null;
   /** Every deed she has, deleted ones excluded. */
   deedCount: number;
-  /** `user_profiles.business_address` — see the fourth step. */
-  businessAddress?: string | null;
 }
 
 export interface SetupStep {
-  id: 'county' | 'company' | 'address' | 'first-deed';
+  id: SetupStepId;
+  /** Shown when the step is collapsed — done or still to come. */
   title: string;
-  detail: string;
-  action: string;
+  /** Shown while the step is the active one. */
+  activeTitle: string;
+  /** Why it matters, IN DEED TERMS. Rendered only on this step's turn. */
+  why: string;
+  cta: string;
+  href: string;
   done: boolean;
+  /** The value she supplied, echoed back on a completed row. */
+  value?: string;
 }
 
 const blank = (v?: string | null) => !((v || '').trim());
+const trim = (v?: string | null) => (v || '').trim() || undefined;
 
 /**
- * The three steps and whether each is finished — exported because the
- * page needs the count for its own line and must not recompute it.
- * §13 rule 3: one place turns state into English.
+ * The four steps, IN THE ORDER THE DEED HEADER PRINTS THEM.
+ *
+ * ═══ AND THAT ORDER IS A DECISION, OWNER-RULED ═══
+ *
+ * Three orders were on the table. What shipped in #207 led with the
+ * county. The reference set led with the company name. This leads with
+ * company → address → county, which is neither, and the reason is the
+ * card beside it.
+ *
+ * `DeedHeaderPreview` shows the block that prints at the top of every
+ * deed, and its lines are in PRINT order: RECORDING REQUESTED BY, AND
+ * WHEN RECORDED MAIL TO, COUNTY. Matching the steps to that order makes
+ * the preview fill strictly TOP-DOWN as she works, which is the reward
+ * loop the whole redesign rests on.
+ *
+ * The reference set's own copy convicts the alternative: under its
+ * order, its COUNTY line reads "fills in at step 2" while sitting third.
+ * A design admitting its sequence does not match its own picture.
+ *
+ * Consistency with onboarding's county-first prompt is worth less than
+ * this: she passes through onboarding once, and watches this card
+ * assemble every time she comes back.
  */
 export function setupSteps(state: SetupState): SetupStep[] {
   return [
     {
-      id: 'county',
-      title: 'Set your recording county',
-      detail: 'The county you record in most often. It becomes the default on '
-            + 'every new deed, and you can change it on any one of them.',
-      action: 'Set county',
-      done: !blank(state.county),
-    },
-    {
       id: 'company',
-      title: 'Add your company name',
-      detail: 'This is the name that prints in RECORDING REQUESTED BY at the top '
-            + 'of the deed. Without it that box starts empty and you fill it in '
-            + 'by hand each time.',
-      action: 'Add company',
+      title: 'Company name',
+      activeTitle: 'Add your company name',
+      why: 'Prints on the RECORDING REQUESTED BY line at the top of every deed.',
+      cta: 'Add company name',
+      href: '/account-settings',
       done: !blank(state.companyName),
+      value: trim(state.companyName),
     },
     {
-      // ═══ THE FOURTH STEP, ADDED AFTER AN AUDIT ═══
-      //
-      // The checklist counted itself complete at 2 of 3 while
-      // `business_address` was empty — and the rail beside it was
-      // rendering a dashed placeholder in AND WHEN RECORDED MAIL TO,
-      // which is a box that PRINTS on the instrument. The screen was
-      // showing her a gap and not counting it.
-      //
-      // It qualifies on this list's own stated test: every step is
-      // something the deed itself needs. The return address is on the
-      // face of the document, which is a stronger claim to a place here
-      // than the county default has.
       id: 'address',
-      title: 'Add your business address',
-      detail: 'This prints under AND WHEN RECORDED MAIL TO, directly below your '
-            + 'company name. It is where the recorder sends the document back.',
-      action: 'Add address',
+      title: 'Business address',
+      activeTitle: 'Add your business address',
+      why: 'Where the recorder mails the document back after it records.',
+      cta: 'Add address',
+      href: '/account-settings',
       done: !blank(state.businessAddress),
+      value: trim(state.businessAddress),
+    },
+    {
+      id: 'county',
+      title: 'Recording county',
+      activeTitle: 'Set your recording county',
+      why: 'Becomes the default on every new deed. You can change it on any single one.',
+      cta: 'Set county',
+      href: '/account-settings',
+      done: !blank(state.county),
+      value: trim(state.county),
     },
     {
       id: 'first-deed',
       title: 'Make your first deed',
-      detail: 'Start from an address. The APN, legal description and current owner '
-            + 'come back from county records — you confirm every value before it '
-            + 'prints.',
-      action: 'Start',
+      activeTitle: 'Make your first deed',
+      why: 'Start from an address — the APN, legal description and current owner '
+         + 'come back from county records, and you confirm every value before it prints.',
+      cta: 'Start a deed',
+      href: '/deed-builder',
       done: state.deedCount > 0,
     },
   ];
 }
 
+/**
+ * The first incomplete step, or null once there is nothing left.
+ *
+ * THE INVARIANT LIVES HERE. Every render asks this one function which
+ * step is open, so "exactly one is expanded" is a property of the data
+ * rather than a rule the JSX remembers to follow.
+ */
+export function activeStep(state: SetupState): SetupStep | null {
+  return setupSteps(state).find((s) => !s.done) ?? null;
+}
+
+export function completedCount(state: SetupState): number {
+  return setupSteps(state).filter((s) => s.done).length;
+}
+
 export default function SetupChecklist({ state, onAct }: {
   state: SetupState;
-  onAct?: (id: SetupStep['id']) => void;
+  onAct?: (id: SetupStepId, href: string) => void;
 }) {
   const steps = setupSteps(state);
-  const done = steps.filter((s) => s.done).length;
+  const active = activeStep(state);
+  const done = completedCount(state);
 
-  // Nothing left to set up: the card goes. A checklist with every box
-  // ticked is the guaranteed-empty module this ticket's predecessor
-  // removed three of.
-  if (done === steps.length) return null;
+  // Nothing left to set up: the card GOES. It does not linger as an
+  // all-green trophy — a checklist with every box ticked is the
+  // guaranteed-empty module whose siblings were removed in #206.
+  if (!active) return null;
 
   return (
     <section aria-labelledby="setup-heading"
              className="rounded-2xl border border-gray-200 bg-white p-5 md:p-6">
-      <h2 id="setup-heading" className="text-lg font-bold text-gray-900">
-        Finish setting up
-      </h2>
-      <p className="mt-1 text-sm text-gray-500">
-        Each step below is something the deed itself needs. None of it is
-        profile decoration.
-      </p>
+      <div className="flex items-center gap-3">
+        <h2 id="setup-heading" className="text-lg font-bold text-gray-900">
+          Finish setting up
+        </h2>
+        {/* PROGRESS AT THE TOP. It was 12px grey at the bottom of the
+            card, which put the reward where nobody looks. */}
+        <div className="ml-auto flex items-center gap-2">
+          <div role="progressbar" aria-valuenow={done} aria-valuemin={0}
+               aria-valuemax={steps.length}
+               aria-label={`${done} of ${steps.length} steps done`}
+               className="h-1.5 w-24 overflow-hidden rounded-full bg-gray-100">
+            <div className="h-full rounded-full bg-emerald-500 transition-all
+                            motion-reduce:transition-none"
+                 style={{ width: `${(done / steps.length) * 100}%` }} />
+          </div>
+          <span className="text-xs font-bold tabular-nums text-gray-500"
+                data-testid="setup-progress">
+            {done} of {steps.length}
+          </span>
+        </div>
+      </div>
 
-      <ol className="mt-5 space-y-4">
-        {steps.map((step, i) => (
-          <li key={step.id} className="flex items-start gap-3">
-            {/* STATUS IS NEVER COLOUR ALONE (the mockup's rule, kept).
-                A finished step carries a glyph and the word; an
-                unfinished one carries its position. Both survive
-                greyscale, forced-colors and a screen reader. */}
-            <span aria-hidden="true"
-                  className={`mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center
-                              rounded-full text-xs font-bold ${
-                    step.done ? 'bg-emerald-100 text-emerald-700'
-                              : 'bg-gray-100 text-gray-600'}`}>
-              {step.done ? '✓' : i + 1}
-            </span>
-            <div className="min-w-0 flex-1">
-              <div className="font-medium text-gray-900">
-                {step.title}
-                {step.done && (
-                  <span className="ml-2 text-xs font-semibold text-emerald-700">
-                    Done
-                  </span>
-                )}
-              </div>
-              {!step.done && (
-                <p className="mt-0.5 text-sm text-gray-500">{step.detail}</p>
-              )}
-            </div>
-            {!step.done && (
-              <button
-                type="button"
-                onClick={() => onAct?.(step.id)}
-                className="shrink-0 rounded-lg border border-gray-200 px-3 py-1.5
-                           text-sm font-semibold text-gray-800 hover:bg-gray-50"
-              >
-                {step.action}
-              </button>
-            )}
-          </li>
-        ))}
+      <ol className="mt-4 space-y-2">
+        {steps.map((step, i) => {
+          if (step.done) return <DoneRow key={step.id} step={step} />;
+          if (step.id === active.id) {
+            return <ActiveRow key={step.id} step={step} index={i + 1} onAct={onAct} />;
+          }
+          return <PendingRow key={step.id} step={step} index={i + 1} />;
+        })}
       </ol>
 
-      <p className="mt-5 text-sm font-semibold text-gray-700"
-         data-testid="setup-progress">
-        {done} of {steps.length} done
+      {/* The reassurance line, demoted to a footnote. At the top it
+          competed with the steps for the eye it was meant to settle. */}
+      <p className="mt-4 border-t border-gray-100 pt-3 text-xs text-gray-500">
+        Every step here is something the deed itself prints — none of it is
+        profile decoration.
       </p>
     </section>
+  );
+}
+
+function DoneRow({ step }: { step: SetupStep }) {
+  return (
+    <li className="flex items-center gap-3 rounded-xl px-3.5 py-3 opacity-70">
+      <span aria-hidden
+            className="flex h-[23px] w-[23px] shrink-0 items-center justify-center
+                       rounded-full border border-emerald-200 bg-emerald-50
+                       text-[11px] font-bold text-emerald-600">
+        ✓
+      </span>
+      <span className="flex-1 text-sm font-medium text-gray-700">
+        {step.title}
+        {/* Status never rides on colour alone — the rule that outlived
+            the pill design it was written for (#207). */}
+        <span className="sr-only"> — done</span>
+      </span>
+      {step.value && (
+        <span className="max-w-[45%] truncate rounded-full bg-emerald-50 px-2 py-0.5
+                         text-[11.5px] font-semibold text-emerald-600">
+          {step.value}
+        </span>
+      )}
+    </li>
+  );
+}
+
+function ActiveRow({ step, index, onAct }: {
+  step: SetupStep; index: number;
+  onAct?: (id: SetupStepId, href: string) => void;
+}) {
+  return (
+    <li aria-current="step"
+        className="flex items-start gap-3 rounded-xl border border-[#E4DDFF]
+                   bg-[var(--color-brand-light)] p-4">
+      <span aria-hidden
+            className="mt-0.5 flex h-[23px] w-[23px] shrink-0 items-center justify-center
+                       rounded-full bg-[var(--color-brand)] text-[11.5px] font-bold text-white">
+        {index}
+      </span>
+      <div className="min-w-0 flex-1">
+        <h3 className="text-[15.5px] font-semibold text-gray-900">{step.activeTitle}</h3>
+        {/* THE ONLY BODY COPY ON THE CARD. */}
+        <p className="mt-1 max-w-[52ch] text-[13px] leading-relaxed text-[#4B3B7A]">
+          {step.why}
+        </p>
+        <button
+          type="button"
+          onClick={() => onAct?.(step.id, step.href)}
+          className="mt-3 inline-flex items-center rounded-lg bg-[var(--color-brand)]
+                     px-3.5 py-2 text-[13px] font-semibold text-white shadow-sm
+                     transition hover:bg-[var(--color-brand-hover)]
+                     focus-visible:outline focus-visible:outline-2
+                     focus-visible:outline-offset-2 focus-visible:outline-[var(--color-brand)]"
+        >
+          {step.cta}
+        </button>
+      </div>
+    </li>
+  );
+}
+
+function PendingRow({ step, index }: { step: SetupStep; index: number }) {
+  return (
+    <li className="flex items-center gap-3 rounded-xl border border-gray-100 px-3.5 py-3">
+      <span aria-hidden
+            className="flex h-[23px] w-[23px] shrink-0 items-center justify-center
+                       rounded-full bg-gray-100 text-[11.5px] font-bold text-gray-400">
+        {index}
+      </span>
+      {/* No `why`, no button. Deliberately: this step is not her turn. */}
+      <span className="flex-1 text-sm font-medium text-gray-700">{step.title}</span>
+      <span className="rounded-full bg-gray-100 px-2 py-0.5 text-[11.5px]
+                       font-semibold text-gray-400">
+        next
+      </span>
+    </li>
   );
 }

--- a/frontend/src/features/dashboard/StartSomethingNew.tsx
+++ b/frontend/src/features/dashboard/StartSomethingNew.tsx
@@ -32,10 +32,21 @@ export interface InstrumentUse {
 /** The types offered when she has filed nothing yet. */
 export const STARTERS = ['grant-deed', 'interspousal-transfer', 'quitclaim-deed'];
 
-export default function StartSomethingNew({ instruments, onStart, onBrowse }: {
+export default function StartSomethingNew({ instruments, onStart, onBrowse, muted = false }: {
   instruments?: InstrumentUse[] | null;
   onStart?: (deedType: string) => void;
   onBrowse?: () => void;
+  /**
+   * ONE VIOLET CALL TO ACTION PER SCREEN.
+   *
+   * While the setup checklist is on the page it owns the accent, because
+   * it holds the thing to do next. This card stays grey and becomes
+   * primary the moment the checklist unmounts — which is not a taste
+   * decision but the budget: a second violet control means neither is
+   * "the one thing", and the officer has to choose which prominent
+   * button to believe.
+   */
+  muted?: boolean;
 }) {
   const used = instruments ?? [];
   const rows = used.length
@@ -44,7 +55,9 @@ export default function StartSomethingNew({ instruments, onStart, onBrowse }: {
 
   return (
     <section aria-labelledby="start-heading"
-             className="rounded-xl border border-slate-200 bg-white p-5">
+             data-muted={muted ? 'true' : undefined}
+             className={`rounded-xl border bg-white p-5 ${
+               muted ? 'border-slate-200' : 'border-[#E4DDFF] ring-1 ring-[var(--color-brand-light)]'}`}>
       <h3 id="start-heading" className="font-semibold text-slate-900">
         Start something new
       </h3>


### PR DESCRIPTION
The reference set is committed whole to `docs/design/dashboard-soften/`, so the next reader sees what was proposed as well as what was adopted.

Its diagnosis is adopted and is sharper than the question that produced it: the day-one card's problem was never quantity — it was that **nothing told the eye what to read first.**

## What was adopted

**The accordion is structural.** `activeStep()` derives the open step from state, so there's no prop that opens a second and no arrangement of state that yields two. Pinned across **all sixteen combinations** of four booleans rather than a sample.

**The copy is deferred, not deleted.** Every step keeps its `why` and renders it on its turn — ~90 words on screen became ~18, and none of the reasoning was lost.

**The right card stops restating the left** and becomes the deed header assembling itself. Same pixels, flipped from redundant noise to feedback — and the best answer anybody has given to *"where does my company name go?"*, because it doesn't answer the question, it shows the place.

Plus: progress at the top, one violet CTA (`StartSomethingNew` grey until setup completes), and the checklist returning `null` rather than lingering as an all-green trophy.

## Four corrections

**1 — Amber, restated.** The reference row carried *two* meanings and splits into two. Amber is reserved for unconfirmed external data; nothing here is county-sourced. "A real problem the user must fix" is **red** in our system. Its examples — rejected recording, failed signature — go entirely rather than being translated, since those are recording-lifecycle states this product doesn't have.

**2 — Violet, which nobody flagged, and the set leans on it harder.** It's doctrinal too — *"proposed legal choice"* — and BRAND.md resolves it **one surface over**, in the admin-console section: where there are no officer decisions it *"has nothing to attach to and purple is simply the accent there"*. A company name is not a vesting proposal. §15.1's shape again.

**Net effect, tighter than the rule it came from: this card uses no doctrinal colour at all.** Violet as accent, green for done, grey for everything else including every empty field. Pinned on both the checklist and the rail.

**3 — Invented routes** corrected at the source. Each step carries its own destination, so the page holds no second opinion.

**4 — The step list needed no union.** The sets were identical; only the order differed. It's now **print order** — company, address, county, first deed — matching the header's lines so the preview fills strictly top-down. The reference set's own copy convicted the alternative: its COUNTY line read "fills in at step 2" while sitting third.

## The verification: "All Good Escow" is a real row

The string appears **nowhere in this repository**. Every occurrence of the name is correctly spelled, and all are in fixtures. So it's a real row on a real account — yours to correct — and `requestedByDefault.ts` makes `users.company_name` the RECORDING REQUESTED BY default, so it would print.

Recorded as its own note: **a typo in a profile field reaches the face of a recorded instrument with no confirmation step between.** Correctly *not* fixed by a gate — the officer typing her own company name is the authority on it — but it's the shortest path from a keystroke to a recorded document in this product.

## Gates

pytest **1480**, jest **1088**/78 (+4), tsc **88**, `next build` clean, banned-claims clean, four harnesses green.

Two invariants mutation-probed: opening every incomplete step fails 4 assertions; breaking print order fails 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_