### PR TITLE
The route-guard sweep asserts the property, and two pages get real guards

### DIFF
--- a/frontend/src/__tests__/routeGuards.test.ts
+++ b/frontend/src/__tests__/routeGuards.test.ts
@@ -54,12 +54,83 @@ const PUBLIC_ROUTES = new Set([
   // the shape and PROVES the exemption instead of asserting it.
 ]);
 
-const GUARD_MARKERS = [
-  'useRequireAuth',
-  'AuthManager',
-  "localStorage.getItem('access_token')",
-  'localStorage.getItem("access_token")',
-];
+/**
+ * ═══ WHAT COUNTS AS A GUARD, AND WHY THE LIST WAS NOT IT ═══
+ *
+ * This used to be four strings, one of which was
+ * `localStorage.getItem('access_token')` — a line that appears in EVERY
+ * file calling an authenticated endpoint, because that is how you build
+ * an Authorization header. So a page reading a token TO SEND IT counted
+ * as a page that guards its route.
+ *
+ * Three of fourteen non-public pages passed that way: `/onboarding`,
+ * `/deeds/[id]/preview` and `/partners`. None had a guard. The first was
+ * found only when an unrelated refactor moved its token read into a
+ * module and took the string with it — the sweep then reported what had
+ * always been true.
+ *
+ * §14.1.1's silent half, in a security sweep, which is the worst
+ * habitat it has appeared in: a pin matching a string rather than a
+ * property did not merely miss the gap, it CERTIFIED it. A later audit
+ * had no reason to open a file whose test was green.
+ *
+ * ═══ THE PROPERTY ═══
+ *
+ * A guard is not "the file mentions a token". It is: **when no token is
+ * present, the page does not render its content.** That is one of two
+ * shapes, and both are checkable:
+ *
+ *   1. `useRequireAuth()` — the hook, which reads the token and
+ *      `router.replace`s to /login when it is absent. Verified as
+ *      behaviour rather than trusted as a name: five pages rest entirely
+ *      on it, so a hook that was a name without a behaviour would have
+ *      made this a five-page finding instead of a two-page one.
+ *
+ *   2. An inline redirect on ABSENCE — a `!token` test whose branch
+ *      navigates. `if (!res.ok)` does not qualify: that is the page
+ *      discovering it is unauthenticated by being REFUSED, which is the
+ *      late failure this sweep exists to prevent.
+ */
+
+/**
+ * Shape 1: the shared hook, AND the render gate it hands back.
+ *
+ * The hook navigates from an effect, so a page that calls it and ignores
+ * its `checked` flag still paints its content for a frame. The property
+ * is not "redirects eventually" — it is "does not render its content
+ * when no token is present", and `if (!checked) return null` is what
+ * delivers the second half.
+ *
+ * Asserting only the hook's name would have been this sweep repeating
+ * its own original mistake one level up: matching the presence of a
+ * mechanism rather than its effect. `/team` had both halves; two pages
+ * moved onto the hook in this ticket got both because of this check.
+ */
+function usesGuardHook(src: string): boolean {
+  return src.includes('useRequireAuth')
+      && /if\s*\(\s*!\s*checked\s*\)\s*return/.test(src);
+}
+
+/**
+ * Shape 2: a test for an ABSENT token whose branch leaves the page.
+ *
+ * Matched as a pair rather than as two independent facts — a file may
+ * legitimately contain both a `!token` check and an unrelated redirect,
+ * so the redirect must be inside the branch. The window is the branch's
+ * own text up to its close, NOT a character count (§14.1.1's cousin: a
+ * fixed window shrinks by whatever prose is added inside it).
+ */
+function redirectsWhenTokenAbsent(src: string): boolean {
+  const test = /if\s*\(\s*!\s*(?:\w*[Tt]oken|localStorage\.getItem\([^)]*token[^)]*\))\s*\)/gi;
+  let m: RegExpExecArray | null;
+  // eslint-disable-next-line no-cond-assign
+  while ((m = test.exec(src)) !== null) {
+    const after = src.slice(m.index, m.index + 400);
+    const branch = after.slice(0, after.indexOf('}') + 1 || after.length);
+    if (/router\.(push|replace)\(|redirect\(/.test(branch)) return true;
+  }
+  return false;
+}
 
 function collectPages(dir: string, route = ''): Array<{ route: string; file: string }> {
   const out: Array<{ route: string; file: string }> = [];
@@ -114,16 +185,19 @@ function isRedirectOnly(file: string): boolean {
   return !LEAK_SIGNS.some((sign) => src.includes(sign));
 }
 
+function guards(src: string): boolean {
+  return usesGuardHook(src) || redirectsWhenTokenAbsent(src);
+}
+
 function hasGuard(file: string): boolean {
-  const src = fs.readFileSync(file, 'utf8');
-  if (GUARD_MARKERS.some((m) => src.includes(m))) return true;
+  const src = codeOnly(fs.readFileSync(file, 'utf8'));
+  if (guards(src)) return true;
   // A layout guard covers its subtree (the admin section guards there).
   let dir = path.dirname(file);
   while (dir.startsWith(APP_DIR)) {
     const layout = path.join(dir, 'layout.tsx');
-    if (fs.existsSync(layout)) {
-      const layoutSrc = fs.readFileSync(layout, 'utf8');
-      if (GUARD_MARKERS.some((m) => layoutSrc.includes(m))) return true;
+    if (fs.existsSync(layout) && guards(codeOnly(fs.readFileSync(layout, 'utf8')))) {
+      return true;
     }
     dir = path.dirname(dir);
   }

--- a/frontend/src/app/deeds/[id]/preview/page.tsx
+++ b/frontend/src/app/deeds/[id]/preview/page.tsx
@@ -13,6 +13,7 @@ import {
   ArrowPathIcon 
 } from '@heroicons/react/24/solid';
 import Sidebar from '@/components/Sidebar';
+import { useRequireAuth } from '@/hooks/useRequireAuth';
 import { SessionExpiredError, apiFetch } from '@/lib/apiClient';
 import { PartnersProvider } from '@/features/partners/PartnersContext';
 import { ShareForReviewModal } from '@/features/signing/ShareForReviewModal';
@@ -36,6 +37,16 @@ interface DeedData {
 }
 
 export default function DeedPreviewPage() {
+  /* HX0 — THE ROUTE GUARD THIS PAGE NEVER HAD.
+     Its only `access_token` reference read a token to SEND it, inside a
+     data fetch, and the sweep detected guards by looking for that
+     string — so the page counted as guarded for as long as it called an
+     authenticated endpoint. A logged-out visitor loaded it and learned
+     she was logged out only when the fetch was refused.
+     The shared hook rather than a fifth inline check: it redirects to
+     /login carrying the path she was trying to reach. */
+  const { checked } = useRequireAuth();
+
   const params = useParams();
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -217,6 +228,14 @@ export default function DeedPreviewPage() {
   };
 
   // Loading state
+  /* THE HOOK REDIRECTS; THIS IS WHAT STOPS THE CONTENT RENDERING.
+     `useRequireAuth` navigates from an effect, so without this line the
+     page paints its chrome for a frame first — and the property the
+     sweep asserts is not "redirects eventually", it is "does not render
+     its content when no token is present". `/team` had both; adopting
+     only the hook would have been adopting half the mechanism. */
+  if (!checked) return null;
+
   if (loading) {
     return (
       <div style={{ display: 'flex' }}>

--- a/frontend/src/app/partners/page.tsx
+++ b/frontend/src/app/partners/page.tsx
@@ -45,6 +45,7 @@
 
 import React, { useState, useEffect, useMemo } from 'react';
 import { useRouter } from 'next/navigation';
+import { useRequireAuth } from '@/hooks/useRequireAuth';
 import {
   CalendarClock, Plus, Pencil, Trash2, X, Save, Search, Users, MapPin, Mail,
   Phone, Loader2,
@@ -110,6 +111,16 @@ export function partnerAddressLine(p: Partial<Partner>): string {
 }
 
 export default function PartnersPage() {
+  /* HX0 — THE ROUTE GUARD THIS PAGE NEVER HAD.
+     Its only `access_token` reference read a token to SEND it, inside a
+     data fetch, and the sweep detected guards by looking for that
+     string — so the page counted as guarded for as long as it called an
+     authenticated endpoint. A logged-out visitor loaded it and learned
+     she was logged out only when the fetch was refused.
+     The shared hook rather than a fifth inline check: it redirects to
+     /login carrying the path she was trying to reach. */
+  const { checked } = useRequireAuth();
+
   const router = useRouter();
   const [items, setItems] = useState<Partner[]>([]);
   const [loading, setLoading] = useState(false);
@@ -240,7 +251,15 @@ export default function PartnersPage() {
       lender: 'bg-gray-100 text-gray-700 ring-gray-300',
       other: 'bg-gray-50 text-gray-500 ring-gray-200',
     };
-    return (
+    /* THE HOOK REDIRECTS; THIS IS WHAT STOPS THE CONTENT RENDERING.
+     `useRequireAuth` navigates from an effect, so without this line the
+     page paints its chrome for a frame first — and the property the
+     sweep asserts is not "redirects eventually", it is "does not render
+     its content when no token is present". `/team` had both; adopting
+     only the hook would have been adopting half the mechanism. */
+  if (!checked) return null;
+
+  return (
       <span
         className={`inline-block whitespace-nowrap rounded-md px-2 py-1 text-xs font-medium ring-1 ring-inset ${tone[category] || tone.other}`}
       >


### PR DESCRIPTION
## The sweep was four strings

One of them was `localStorage.getItem('access_token')` — a line that appears in **every** file calling an authenticated endpoint, because that's how an Authorization header is built. A page reading a token *to send it* counted as a page that guards its route.

**Three of fourteen** non-public pages passed that way: `/onboarding` (found in #217 when an unrelated refactor moved its token read into a module and took the string with it), plus `/deeds/[id]/preview` and `/partners`.

§14.1.1's silent half in a security sweep — the worst habitat it has appeared in. A pin matching a string rather than a property didn't merely miss the gap, it **certified** it: a later audit had no reason to open a file whose test was green.

## The property it asserts now

**When no token is present, the page does not render its content.** Two shapes qualify: the shared `useRequireAuth` hook, or an inline test for an *absent* token whose branch navigates.

`if (!res.ok)` does **not** qualify — that's the page discovering it's unauthenticated by being *refused*, which is the late failure this sweep exists to prevent.

## The hook alone is not enough, which I nearly got wrong

`useRequireAuth` navigates from an effect, so a page that calls it and ignores its `checked` flag still paints its content for a frame. `/team` had `if (!checked) return null`; I had adopted only the hook.

**Asserting the hook's name would have been this sweep repeating its original mistake one level up** — matching the presence of a mechanism rather than its effect. Both halves are now required, and both were added to both pages.

## What the tightened sweep found

**Exactly the two predicted, and none of the four scored REAL without hand-verification.**

Going in, the expectation was that at least one of `/account-settings`, `/admin`, `/past-deeds`, `/requests` would fail, given three of fourteen were passing incidentally. None did. Reporting that plainly — a prediction that misses is worth the same note as one that lands.

`useRequireAuth` was verified as **behaviour** before being relied on: it reads the token and `router.replace`s to `/login` carrying the path she was trying to reach. Five pages rest entirely on it, so a hook that was a name without a behaviour would have made this a five-page finding.

## Severity — `/partners` is the worse one

`/deeds/[id]/preview` fails to load a document, which reads as *"this document is broken."* `/partners` renders an empty rolodex, which reads as *"you have no partners"* — an absence presented as a fact about her work rather than a fact about our request, and quieter than usual because an empty list looks like a valid state.

**Neither was an exposure.** The server refused every call and always did.

## Gates

pytest **1480**, jest **1088**/78, tsc **88**, `next build` clean, banned-claims clean, four harnesses green.

Two probes: removing the render gate while keeping the hook fails; reverting a page to a send-only token read fails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_