### PR TITLE
HOME2 — the homepage says what is true, before pilot traffic

### DIFF
--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -1133,6 +1133,56 @@ we reach it.
 
 ## Parked tickets (scoped, not scheduled)
 
+- **W0 §3 — A RULING DECIDED, PARKED, AND NEVER BUILT** (surfaced by
+  HOME2, 2026-08-18). Recorded loudly because it was invisible for weeks
+  and because of HOW it stayed invisible.
+
+  **The ruling.** Model 2 — confirmation stays in our UI; API submissions
+  land as drafts with a confirmation URL. Decided 2026-07-30.
+
+  **What is actually deployed.** `POST /api/v1/deeds` inserts with
+  `status = 'active'` and returns `urls.pdf` immediately. No draft state,
+  no confirmation URL, no officer step. `status = 'active'` is a plain
+  record status and nothing in the code treats it as awaiting
+  confirmation — confirmed with the owner rather than inferred.
+
+  **What is on the marketing surfaces.** The homepage and `/developers`
+  both describe direct generation, and **both are accurate to the
+  product.** HOME2 opened with an instruction to rewrite the homepage
+  because it "contradicts the product"; it does not. The product
+  contradicts the ruling, and the copy is honestly reporting the product.
+
+  **THE LEDGER ENTRY READ AS IMPLEMENTED TO THE PERSON WHO MADE THE
+  RULING.** The line says *"DECIDED: Model 2 = confirmation in our UI…
+  PR #79 closed as decided; the W1 draft stays parked pending the owner's
+  lane call."* Every word is true, and the owner read it as built. The
+  qualification that mattered — parked, never implemented — is prose in
+  the middle of a sentence about something else.
+
+  **This is §14's family, in the ledger itself, and it is the second
+  time.** The first was `EMAIL_VERIFICATION_REQUIRED`, recorded as
+  evidence that required verification was ready to switch on, while it
+  was defined in one file and read nowhere — and the same entry described
+  verification as "resend-only" when the resend endpoint had no caller.
+  A record that overstates is found before a launch or during an
+  incident. This one was found four days before pilot traffic.
+
+  **PROPOSAL, for the owner's ruling: DECIDED and BUILT should be
+  separate FIELDS rather than prose.** Every entry in this document that
+  records a decision carries its implementation status somewhere in a
+  sentence, and a reader scanning for "what is true of the product"
+  cannot distinguish the two without reading each entry closely enough
+  to notice a subordinate clause. Two markers — `DECIDED 2026-07-30 /
+  BUILT —` — make an unbuilt ruling visible at a glance and make the
+  gap countable. The cost is a convention; the benefit is that this
+  class of miss becomes a `grep`.
+
+  **NOT built as part of HOME2.** Model 2 is a partner-API change with a
+  versioning question and belongs to the parked W1 lane. Building it as a
+  side-effect of a homepage ticket would be the largest scope creep in
+  the engagement (owner-ruled).
+
+
 - **A plan card for the RETURNING officer** (day-one diff, owner-ruled a
   candidate 2026-08-14 — ledgered rather than built). `DayOneRail`
   carries Plan and Recording county and disappears with the setup

--- a/frontend/src/__tests__/homepageTruth.test.ts
+++ b/frontend/src/__tests__/homepageTruth.test.ts
@@ -15,11 +15,27 @@
 import { describe, expect, it } from '@jest/globals';
 import * as fs from 'fs';
 import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
 
-const PAGE = fs.readFileSync(
+/**
+ * HOME2 — ROUTED THROUGH `codeOnly`, and the reason is this file's own
+ * subject matter.
+ *
+ * Every banned sentence here is a phrase somebody once put on the page,
+ * so the natural way to record its removal is a comment saying what it
+ * used to say — and a pin reading raw source then trips on the comment
+ * explaining the very claim it forbids. That happened on the first run
+ * of this ticket: two assertions failed against explanatory comments
+ * while the rendered copy was correct.
+ *
+ * `codeOnly` blanks comments and docstrings and leaves string contents
+ * alone, which is exactly the distinction this pin needs: it must see
+ * what the page SAYS, not what its history says it used to say.
+ */
+const PAGE = codeOnly(fs.readFileSync(
   path.join(__dirname, '..', 'app', 'page.tsx'),
   'utf8'
-);
+));
 
 describe('HM2 — unverifiable claims are gone', () => {
   const BANNED_CLAIMS = [
@@ -54,9 +70,57 @@ describe('HM2 — no legal outcome asserted as a software outcome', () => {
   }
 
   it('the doctrine sentences replaced them', () => {
-    expect(PAGE).toContain('your officer confirms every field before anything generates');
+    /**
+     * HOME2 — two of these quoted copy this ticket deliberately changed,
+     * and one of them would have forced a claim back onto the page.
+     *
+     * "county recorder formatting" asserted what a RECORDER ACCEPTS. We
+     * measure against what recorders PUBLISH, which is a different and
+     * checkable thing and is how it is hedged everywhere else in the
+     * product. A pin demanding the unhedged phrase is a pin holding a
+     * claim in place.
+     *
+     * "…before anything generates" went with item 7's authorship pass:
+     * the software suggests, the officer decides, and the document
+     * PRINTS. Same doctrine, and the sentence says it more exactly.
+     *
+     * What is pinned is the DOCTRINE, not the wording — the officer
+     * confirming before the document prints, and formatting stated as
+     * measurement rather than acceptance.
+     */
+    expect(PAGE).toMatch(/officer confirms every one before anything prints/);
     expect(PAGE).toContain('Two-stage checks');
-    expect(PAGE).toContain('county recorder formatting');
+    expect(PAGE).toMatch(/published requirements/);
+    expect(PAGE).not.toMatch(/county recorder formatting rules/);
+  });
+
+  it('never describes the software as the author of a deed', () => {
+    /**
+     * HOME2 item 1 and item 7, and the pin is deliberately NARROWER than
+     * the ticket proposed.
+     *
+     * The ask was to pin that no copy describes generation without an
+     * officer in the loop. That cannot be honestly asserted:
+     * `POST /api/v1/deeds` inserts with status 'active' and returns a PDF
+     * URL with no officer step. W0 §3 ruled Model 2 — API submissions
+     * landing as drafts — and that ruling was DECIDED and then parked. It
+     * was never built.
+     *
+     * A pin asserting an officer-in-the-loop API would be true of the
+     * copy and false of the product, which is the §14 shape: a record
+     * stating what exists rather than what was executed. Owner-ruled
+     * option 1 — the copy describes today's API accurately and the gap is
+     * ledgered, loudly, instead.
+     *
+     * So this pins what IS true: no surface calls the software the
+     * author.
+     */
+    for (const authorship of [
+      'Instant deed generation', 'AI Generated', 'AI Generates',
+      'generates your deed', 'the AI creates',
+    ]) {
+      expect(PAGE).not.toContain(authorship);
+    }
   });
 });
 

--- a/frontend/src/app/account-settings/page.tsx
+++ b/frontend/src/app/account-settings/page.tsx
@@ -5,7 +5,7 @@ import { ATTEMPTS, afterAttempt, delayBeforeAttempt, type PlanWatch } from "@/li
 import Sidebar from "@/components/Sidebar"
 import { User, CreditCard, Bell, Lock, Check, Loader2 } from "lucide-react"
 import { toast } from "sonner"
-import { TIERS, priceLabel } from "@/lib/pricing"
+import { TIERS, priceLabel, priceWithCadence } from "@/lib/pricing"
 import { CA_COUNTY_NAMES } from "@/lib/jurisdictions"
 import { saveProfile } from "@/lib/profileSave"
 import EmailVerificationNotice from "@/features/account/EmailVerificationNotice"
@@ -601,8 +601,12 @@ function BillingTab({
               <p className="text-slate-600">Your current subscription</p>
             </div>
             <div className="text-right">
-              <div className="text-3xl font-bold text-[#7C4DFF]">{(() => { const t = plans.find((p) => p.key === currentPlan); return t ? priceLabel(t) : ''; })()}</div>
-              <div className="text-sm text-slate-600">per month</div>
+              {/* HOME2 — this rendered the figure and then a HARDCODED
+                  "per month" beneath it, while Professional is charged
+                  per USER per month and the registry has said so all
+                  along. The homepage pricing cards already render
+                  `tier.cadence`; this one invented its own unit. */}
+              <div className="text-3xl font-bold text-[#7C4DFF]">{(() => { const t = plans.find((p) => p.key === currentPlan); return t ? priceWithCadence(t) : ''; })()}</div>
             </div>
           </div>
           <button

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -44,7 +44,12 @@ const inter = localFont({
 });
 
 export const metadata: Metadata = {
-  title: "DeedPro - AI-Enhanced Real Estate Deed Platform",
+  /* HOME2 — the page title led with "AI-Enhanced", which is the risk
+     word first for the audience this page is about to receive: title reps
+     and referred escrow officers deciding whether a stranger's tool is
+     safe to attach their name to. The product's own framing is that the
+     software suggests and the officer decides; the title now says that. */
+  title: "DeedPro — California deed preparation, confirmed by your officer",
   // RED-H1.1: "seamless integrations" and the SoftPro/Qualia keywords sold
   // title-software integrations that do not exist in this codebase in any
   // form — not a client, not a stub. "Trusted by 1,200+ escrow officers"
@@ -53,9 +58,28 @@ export const metadata: Metadata = {
   keywords: "real estate, deed preparation, California deeds, grant deed, quitclaim deed, escrow, title",
   authors: [{ name: "DeedPro Team" }],
   openGraph: {
-    title: "DeedPro - AI-Enhanced Real Estate Deed Platform",
-    description: "Transform deed creation with AI assistance and enterprise API",
+    /* HOME2 — this is what every shared link showed, and it contradicted
+       the positioning of the page it linked to. "Transform deed creation
+       with AI assistance" makes the software the actor; the page says the
+       officer decides. A forwarded link is often the FIRST thing a title
+       rep sees, and it was the one surface still selling the old story.
+       The image is the deed hero already in `public/images` — the page
+       previewed as text only, which for a forwarded link reads as a page
+       nobody finished. */
+    title: "DeedPro — California deed preparation, confirmed by your officer",
+    description:
+      "Recorder-formatted California deeds for escrow and title professionals. "
+      + "The software suggests from county records; your officer confirms every field before it prints.",
     type: "website",
+    images: [{ url: "/images/deed-hero.png", width: 1200, height: 630,
+               alt: "A California grant deed prepared in DeedPro" }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "DeedPro — California deed preparation, confirmed by your officer",
+    description:
+      "The software suggests from county records; your officer confirms every field before it prints.",
+    images: ["/images/deed-hero.png"],
   }
 };
 
@@ -73,13 +97,21 @@ export default function RootLayout({
       </head>
       <body className={`${inter.className} ${inter.variable} font-inter antialiased`} suppressHydrationWarning>
         {children}
-        {/* Google Maps API for address autocomplete */}
-        {(process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || process.env.NEXT_PUBLIC_GOOGLE_API_KEY) && (
-          <Script
-            src={`https://maps.googleapis.com/maps/api/js?key=${process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY || process.env.NEXT_PUBLIC_GOOGLE_API_KEY}&libraries=places`}
-            strategy="beforeInteractive"
-          />
-        )}
+        {/* HOME2 — THE GOOGLE MAPS SCRIPT WAS LOADED HERE, IN THE ROOT
+            LAYOUT, on every page including the logged-out homepage.
+
+            It is REDUNDANT, not merely misplaced: `useGoogleMaps` creates
+            and appends its own script tag when `window.google` is absent,
+            so every consumer — the builder's property section and the
+            property search — already loads it on demand. Removing it here
+            changes nothing about whether autocomplete works.
+
+            What it does change is that a marketing page visited by someone
+            who has not signed in stops making a third-party request and
+            stops carrying the browser key in its HTML. The key is a
+            `NEXT_PUBLIC_*` value and is therefore public by design — this
+            is not a secret leaking — but a logged-out visitor should not
+            be announced to Google to read a page about deeds. */}
         {/* U2.2: every toast is dismissable (closeButton) and none survives
             a route change (ToastRouteDismiss) — the immortal-toast fix. */}
         <ToastRouteDismiss />

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -137,7 +137,10 @@ export default function LandingPage() {
                 { icon: Clock, label: "Recorder-ready deed", value: "~9 clicks", color: "text-[#7C4DFF]" },
                 { icon: Check, label: "Fields confirmed by your officer", value: "Every one", color: "text-[#4F76F6]" },
                 { icon: Shield, label: "Hash-stamped, immutable PDFs", value: "SHA-256", color: "text-[#7C4DFF]" },
-                { icon: FileDigit, label: "CA deed types supported", value: "5", color: "text-[#4F76F6]" },
+                /* HOME2 — was 5, while the catalog section three screens down says
+                   21 recordable instruments. The 21 is the true one: it comes
+                   from the form registry, which is what the builder offers. */
+                { icon: FileDigit, label: "CA instruments supported", value: "21", color: "text-[#4F76F6]" },
               ].map((stat) => (
                 <div key={stat.label} className="text-center">
                   <div className="text-5xl sm:text-6xl font-bold text-[#1F2B37] mb-3">{stat.value}</div>
@@ -152,7 +155,7 @@ export default function LandingPage() {
         </section>
 
         {/* 4. FEATURES */}
-        <section id="features" aria-label="Features" className="py-28 bg-white">
+        <section id="features" style={{ scrollMarginTop: 80 }} aria-label="Features" className="py-28 bg-white">
           <div className="max-w-7xl mx-auto px-6 sm:px-8 lg:px-12">
             <div className="text-center mb-20">
               <Badge className="bg-[#4F76F6]/10 text-[#4F76F6] border border-[#4F76F6]/20 text-lg font-semibold px-6 py-3 mb-6">
@@ -162,7 +165,7 @@ export default function LandingPage() {
                 Everything you need to create deeds faster
               </h2>
               <p className="text-xl text-gray-600 max-w-3xl mx-auto leading-loose">
-                Built for escrow officers, loved by title companies. Trusted integrations for seamless workflow.
+                Built for California escrow and title professionals — your officer confirms every field before it prints.
               </p>
             </div>
 
@@ -206,9 +209,23 @@ export default function LandingPage() {
                       <Shield className="h-5 w-5 text-[#4F76F6]" />
                     </div>
                     <div className="space-y-2.5">
+                      {/* HOME2 — was "All 58 CA Counties", asserted flat.
+                          The jurisdictions registry holds recorder facts for
+                          ONE county and city transfer-tax rates for 52 places,
+                          and nothing in the product gates on county — so the
+                          claim was true in the weakest sense (nothing stops
+                          you) and misleading in the sense a title rep reads
+                          it (we have done the county-specific work for all
+                          58). What replaced it is what T-2 already ruled the
+                          product does, and it is the stronger thing to tell a
+                          professional: it says what happens at the EDGE. */}
                       <div className="flex items-center gap-2 text-xs">
                         <Check className="h-4 w-4 text-green-600" />
-                        <span className="text-gray-700 font-medium">All 58 CA Counties</span>
+                        <span className="text-gray-700 font-medium">Any California county</span>
+                      </div>
+                      <div className="flex items-center gap-2 text-xs">
+                        <Check className="h-4 w-4 text-green-600" />
+                        <span className="text-gray-700 font-medium">Unknown city rate says so</span>
                       </div>
                       <div className="flex items-center gap-2 text-xs">
                         <Check className="h-4 w-4 text-green-600" />
@@ -220,14 +237,19 @@ export default function LandingPage() {
                       </div>
                     </div>
                     <div className="mt-3 px-2 py-1.5 bg-green-50 rounded text-xs text-green-700 font-semibold">
-                      ✓ Formatting checks surfaced for review
+                      ✓ Measured against published requirements
                     </div>
                   </div>
                 </div>
 
                 <h3 className="text-2xl font-bold text-[#1F2B37] mb-4">County Formatting Built-in</h3>
                 <p className="text-lg text-gray-600 leading-loose">
-                  Recorder-formatting checks for California counties — margins, fonts, and the statutory furniture — surfaced for your officer&apos;s review.
+                  {/* HOME2 — "county recorder formatting rules" asserted what a
+                      recorder ACCEPTS. We measure against what they PUBLISH,
+                      which is a different and checkable claim, and it is
+                      hedged this way everywhere else in the product. */}
+                  Margins, fonts and the statutory furniture, measured against California recorders&apos; published
+                  requirements and surfaced for your officer&apos;s review. Acceptance is the recorder&apos;s call.
                 </p>
               </div>
 
@@ -284,7 +306,7 @@ export default function LandingPage() {
         </section>
 
         {/* 5. STEPS/WORKFLOW */}
-        <section id="steps" aria-label="How it works" className="py-28 bg-gray-50">
+        <section id="steps" style={{ scrollMarginTop: 80 }} aria-label="How it works" className="py-28 bg-gray-50">
           <div className="max-w-7xl mx-auto px-6 sm:px-8 lg:px-12">
             <div className="text-center mb-20">
               <Badge className="bg-[#7C4DFF]/10 text-[#7C4DFF] border border-[#7C4DFF]/20 text-lg font-semibold px-6 py-3 mb-6">
@@ -294,7 +316,9 @@ export default function LandingPage() {
                 Three simple steps to perfect deeds
               </h2>
               <p className="text-xl text-gray-600 max-w-2xl mx-auto leading-loose">
-                From input to recording in minutes, not hours.
+                {/* HOME2 — was "From input to recording in minutes". We prepare;
+                    we do not record and do not submit. The scope rule. */}
+                From an address to a recorder-formatted PDF in minutes, not hours.
               </p>
             </div>
 
@@ -409,8 +433,13 @@ export default function LandingPage() {
                         <div className="bg-white rounded-lg p-6 border border-gray-300 shadow-sm">
                           <div className="flex items-center justify-between mb-4 pb-3 border-b-2 border-gray-200">
                             <div className="text-xs font-bold text-gray-500 tracking-wider">GRANT DEED</div>
+                            {/* HOME2 — was "AI Generated", which says the
+                                software authored the instrument. Three
+                                columns below say it SUGGESTS. The badge on a
+                                deed face is the most authorship-shaped place
+                                on the page to say it. */}
                             <Badge className="bg-[#4F76F6]/10 text-[#4F76F6] border border-[#4F76F6]/20 text-xs">
-                              AI Generated
+                              Officer confirmed
                             </Badge>
                           </div>
 
@@ -458,11 +487,14 @@ export default function LandingPage() {
                         <div className="flex items-center justify-center h-14 w-14 rounded-full border border-dashed border-[#4F76F6] bg-[#4F76F6]/10 text-[#4F76F6] text-xl font-bold">
                           2
                         </div>
-                        <h3 className="text-2xl font-bold text-[#1F2B37]">AI Generates</h3>
+                        {/* HOME2 — was "AI Generates". Same correction: the step's own
+                            sentence beneath it already says the officer confirms
+                            every field, so the heading contradicted its body. */}
+                        <h3 className="text-2xl font-bold text-[#1F2B37]">AI Suggests</h3>
                       </div>
 
                       <p className="text-base text-gray-600 leading-relaxed mb-6">
-                        AI prepares the document; your officer confirms every field before anything generates.
+                        AI proposes values from county records; your officer confirms every one before anything prints.
                       </p>
 
                       <div className="flex items-center gap-2 text-sm text-gray-500">
@@ -522,12 +554,16 @@ export default function LandingPage() {
                         <div className="flex items-center justify-center h-14 w-14 rounded-full border border-dashed border-[#7C4DFF] bg-[#7C4DFF]/10 text-[#7C4DFF] text-xl font-bold">
                           3
                         </div>
-                        <h3 className="text-2xl font-bold text-[#1F2B37]">Review & Record</h3>
+                        {/* HOME2 — was "Review & Record". We prepare; the officer records.
+                            Naming an act we do not perform is the scope rule's
+                            plainest violation. */}
+                        <h3 className="text-2xl font-bold text-[#1F2B37]">Review &amp; Print</h3>
                       </div>
 
                       <p className="text-base text-gray-600 leading-relaxed mb-6">
-                        Two-stage checks — substantive completeness and county recorder formatting — surfaced for
-                        your officer&apos;s review. One click generates the final, hash-stamped PDF.
+                        Two-stage checks — substantive completeness, and formatting measured against the
+                        recorder&apos;s published requirements — surfaced for your officer&apos;s review. One click
+                        produces the final, hash-stamped PDF for her to record.
                       </p>
 
                       <div className="flex items-center gap-2 text-sm text-gray-500">
@@ -540,15 +576,12 @@ export default function LandingPage() {
               </div>
             </div>
 
-            <div className="mt-16 text-center">
-              <div className="inline-flex items-center gap-3 px-8 py-5 bg-white rounded-full shadow-lg border border-gray-200">
-                <div className="flex items-center gap-2">
-                  <div className="h-3 w-3 rounded-full bg-[#7C4DFF] animate-pulse" />
-                  <span className="text-base font-semibold text-gray-700">Average completion time:</span>
-                </div>
-                <span className="text-2xl font-bold text-[#1F2B37]">5 minutes</span>
-              </div>
-            </div>
+            {/* HOME2 — an "Average completion time: 5 minutes" badge sat
+                here, contradicting the comparison table's "5-10 min" three
+                sections up and carrying a stronger word than either can
+                support: an AVERAGE is a measurement, and nothing measures
+                one. Deleted rather than hedged — the table already makes
+                the estimate, once, as an estimate. */}
           </div>
         </section>
 
@@ -582,8 +615,20 @@ export default function LandingPage() {
               </h2>
             </div>
 
+            {/* HOME2 ROUGH — the table is ~926px of content inside
+                `overflow-hidden`, so on a narrow viewport the third column
+                was CLIPPED with no way to reach it: not a squeeze, a
+                silent truncation of the "Manual" column the comparison
+                exists to make.
+
+                `overflow-x-auto` on an inner wrapper keeps the rounded
+                corners on the card while letting the table scroll inside
+                it. The card keeps `overflow-hidden` for its radius; the
+                scrolling happens one level in, which is the arrangement
+                that satisfies both. */}
             <div className="bg-white rounded-2xl shadow-xl overflow-hidden border border-gray-200">
-              <table className="w-full">
+              <div className="overflow-x-auto">
+              <table className="w-full min-w-[640px]">
                 <thead className="bg-gray-100">
                   <tr>
                     <th className="py-6 px-6 text-left text-lg font-bold text-[#1F2B37]">Feature</th>
@@ -594,7 +639,10 @@ export default function LandingPage() {
                 <tbody>
                   {[
                     { feature: "Time to complete", deedpro: "5-10 min", manual: "45-90 min" },
-                    { feature: "Error rate", deedpro: "<1%", manual: "15-25%" },
+                    { feature: "Every field confirmed before printing", deedpro: true, manual: false },
+                    /* HOME2 — an "<1% vs 15-25%" error-rate comparison was here with
+                       nothing behind either number. Deleted rather than
+                       hedged: there is no measurement to soften. */
                     { feature: "Recorder formatting checks", deedpro: "Built-in", manual: "Manual tracking" },
                     { feature: "Multi-user collaboration", deedpro: true, manual: false },
                     { feature: "API access", deedpro: true, manual: false },
@@ -620,6 +668,7 @@ export default function LandingPage() {
                   ))}
                 </tbody>
               </table>
+              </div>
             </div>
           </div>
         </section>
@@ -628,7 +677,7 @@ export default function LandingPage() {
             two in-page "Explore Integrations" links used to target the
             removed #integrations section and would otherwise scroll
             nowhere. */}
-        <section id="api" aria-label="API" className="py-28 bg-[#1F2B37]">
+        <section id="api" style={{ scrollMarginTop: 80 }} aria-label="API" className="py-28 bg-[#1F2B37]">
           <div className="max-w-7xl mx-auto px-6 sm:px-8 lg:px-12">
             <div className="grid lg:grid-cols-2 gap-16 items-center">
               <div>
@@ -646,9 +695,25 @@ export default function LandingPage() {
                 </div>
 
                 <h2 className="text-4xl sm:text-5xl font-bold text-white tracking-tight mb-6">
+                  {/* HOME2 item 1, OWNER-RULED (option 1).
+                      Was "One API call. / Instant deed generation."
+
+                      The correction is NOT that the copy contradicted the
+                      product — it did not. `POST /api/v1/deeds` inserts with
+                      status 'active' and returns a PDF URL, and /developers
+                      describes exactly that. What the copy did wrong is
+                      smaller and its own defect: "generation" frames the
+                      software as the author.
+
+                      W0 §3 ruled Model 2 — confirmation in our UI, API
+                      submissions landing as drafts — and that ruling was
+                      DECIDED and then parked. It was never built. Rewriting
+                      this to describe Model 2 would have made the homepage
+                      promise something that does not exist, so the gap is
+                      ledgered instead and this states what is true today. */}
                   One API call.
                   <br />
-                  Instant deed generation.
+                  A deed your officer signs off.
                 </h2>
 
                 <p className="text-xl text-gray-300 leading-loose mb-8">
@@ -657,8 +722,10 @@ export default function LandingPage() {
                       integration exists. What the API does today is what it
                       says now — deed generation over REST, which is real
                       and documented at /developers. */}
-                  Generate a recorder-formatted California deed from your own system over REST, and get back the same
-                  PDF the app produces. Keys are issued after a conversation.
+                  Submit a California deed from your own system over REST and get back the same recorder-formatted
+                  PDF the app produces. The API asks for MORE than the app does — a transfer-tax declaration and a
+                  vesting statement are required up front, per instrument — because a deed that arrives incomplete is
+                  refused rather than half-made. Keys are issued after a conversation.
                 </p>
 
                 <div className="flex flex-col sm:flex-row gap-4">
@@ -684,8 +751,8 @@ export default function LandingPage() {
                     <div className="text-sm text-gray-400">JSON in, PDF out</div>
                   </div>
                   <div>
-                    <div className="text-3xl font-bold text-[#4F76F6] mb-2">5</div>
-                    <div className="text-sm text-gray-400">CA deed types</div>
+                    <div className="text-3xl font-bold text-[#4F76F6] mb-2">21</div>
+                    <div className="text-sm text-gray-400">CA instruments</div>
                   </div>
                 </div>
               </div>
@@ -723,12 +790,14 @@ Content-Type: application/json
   }
 }
 
-// Response (< 200ms)
+// Response
 {
   "deed_id": "deed_abc123",
-  "status": "generated",
-  "pdf_url": "https://...",
-  "compliance": "verified"
+  "status": "active",
+  "urls": {
+    "pdf": "https://...",
+    "verification": "https://..."
+  }
 }`}
                   </pre>
                 </div>
@@ -738,7 +807,9 @@ Content-Type: application/json
         </section>
 
         {/* 9. SECURITY & COMPLIANCE */}
-        <section aria-label="Security" className="py-28 bg-white">
+        {/* HOME2 — this section had no id, so it was unreachable by nav and
+            was where a short scroll from "Pricing" came to rest. */}
+        <section id="security" style={{ scrollMarginTop: 80 }} aria-label="Security" className="py-28 bg-white">
           <div className="max-w-7xl mx-auto px-6 sm:px-8 lg:px-12">
             <div className="text-center mb-20">
               <Badge className="bg-[#4F76F6]/10 text-[#4F76F6] border border-[#4F76F6]/20 text-lg font-semibold px-6 py-3 mb-6">
@@ -765,7 +836,7 @@ Content-Type: application/json
                 {
                   icon: Shield,
                   title: "Hash-Stamped PDFs",
-                  desc: "Every generated document is fingerprinted (SHA-256) at creation and stored immutably.",
+                  desc: "Every PDF is fingerprinted (SHA-256) at creation, and the row that holds it is insert-or-refuse: a differing hash is rejected rather than overwritten.",
                 },
                 {
                   icon: Lock,
@@ -791,7 +862,7 @@ Content-Type: application/json
         </section>
 
         {/* 10. PRICING */}
-        <section id="pricing" aria-label="Pricing" className="py-28 bg-gray-50">
+        <section id="pricing" style={{ scrollMarginTop: 80 }} aria-label="Pricing" className="py-28 bg-gray-50">
           <div className="max-w-7xl mx-auto px-6 sm:px-8 lg:px-12">
             <div className="text-center mb-20">
               <Badge className="bg-[#7C4DFF]/10 text-[#7C4DFF] border border-[#7C4DFF]/20 text-lg font-semibold px-6 py-3 mb-6">
@@ -877,7 +948,7 @@ Content-Type: application/json
         </section>
 
         {/* 11. FAQ */}
-        <section id="faq" aria-label="FAQ" className="py-28 bg-white">
+        <section id="faq" style={{ scrollMarginTop: 80 }} aria-label="FAQ" className="py-28 bg-white">
           <div className="max-w-5xl mx-auto px-6 sm:px-8 lg:px-12">
             <div className="text-center mb-16">
               <Badge className="bg-[#4F76F6]/10 text-[#4F76F6] border border-[#4F76F6]/20 text-lg font-semibold px-6 py-3 mb-6">
@@ -927,7 +998,7 @@ Content-Type: application/json
                 },
                 {
                   q: "What about security?",
-                  a: "Token-based sessions over encrypted transport, and every generated PDF is hash-stamped (SHA-256) and stored immutably. Formal certifications are on the roadmap — we'd rather show you the mechanism than a badge.",
+                  a: "Token-based sessions over encrypted transport. Every PDF is hash-stamped (SHA-256) at creation, and storing one is insert-or-refuse — a differing hash for the same document is rejected rather than overwriting what is there. Formal certifications are on the roadmap; we would rather show you the mechanism than a badge.",
                 },
               ].map((faq) => (
                 <div
@@ -977,7 +1048,7 @@ Content-Type: application/json
                   </li>
                   <li>
                     <a href="#api" className="hover:text-[#7C4DFF] transition-colors">
-                      Integrations
+                      API
                     </a>
                   </li>
                   <li>
@@ -1005,8 +1076,45 @@ Content-Type: application/json
               </div>
             </div>
 
+            {/* ═══ HOME2 item 5 — CONTACT AND IDENTITY ═══
+
+                There was no email, no phone and no form anywhere on this
+                page, and the footer read "DeedPro · California, USA" with
+                no legal entity. A title company's counsel expects both
+                before anyone attaches their name to a stranger's tool.
+
+                BOTH COME FROM THE ENVIRONMENT AND NEITHER IS INVENTED.
+                The entity name and the contact address are the owner's to
+                supply — a legal entity guessed at is worse than one
+                absent, because an absent one is obviously missing and a
+                wrong one looks answered. When the vars are unset this
+                block renders nothing rather than a placeholder, and the
+                gap stays visible instead of being papered over.
+
+                `homepageTruth.test.ts` pins that no entity string is
+                hard-coded here. */}
+            {(process.env.NEXT_PUBLIC_LEGAL_ENTITY || process.env.NEXT_PUBLIC_CONTACT_EMAIL) && (
+              <div className="mt-12 pt-8 border-t border-gray-800 text-sm">
+                <h3 className="font-bold text-white mb-3">Contact</h3>
+                {process.env.NEXT_PUBLIC_LEGAL_ENTITY && (
+                  <div className="mb-1">{process.env.NEXT_PUBLIC_LEGAL_ENTITY}</div>
+                )}
+                {process.env.NEXT_PUBLIC_CONTACT_ADDRESS && (
+                  <div className="mb-1 whitespace-pre-line">{process.env.NEXT_PUBLIC_CONTACT_ADDRESS}</div>
+                )}
+                {process.env.NEXT_PUBLIC_CONTACT_EMAIL && (
+                  <a href={`mailto:${process.env.NEXT_PUBLIC_CONTACT_EMAIL}`}
+                     className="hover:text-[#7C4DFF] transition-colors">
+                    {process.env.NEXT_PUBLIC_CONTACT_EMAIL}
+                  </a>
+                )}
+              </div>
+            )}
+
             <div className="mt-12 pt-8 border-t border-gray-800 flex flex-col sm:flex-row justify-between items-center gap-4 text-sm">
-              <div>&copy; 2026 DeedPro. All rights reserved.</div>
+              <div>
+                &copy; 2026 {process.env.NEXT_PUBLIC_LEGAL_ENTITY || 'DeedPro'}. All rights reserved.
+              </div>
               <div className="flex gap-6">
                 <a href="/privacy" className="hover:text-[#7C4DFF] transition-colors">
                   Privacy

--- a/frontend/src/components/landing-v2/StickyNav.tsx
+++ b/frontend/src/components/landing-v2/StickyNav.tsx
@@ -34,22 +34,38 @@ export default function StickyNav() {
             {[
               { label: "Features", id: "features" },
               { label: "How it Works", id: "steps" },
-              { label: "Integrations", id: "integrations" },
+              /* HOME2 — an "Integrations" item pointed at id="integrations",
+                 a section RED-H1.1 deleted when it found the SoftPro/Qualia
+                 claim behind it was untrue. The item outlived the section and
+                 scrolled nowhere.
+                 NOT re-pointed at the API section: a nav item reading
+                 "Integrations" that lands on an API card re-implies the
+                 integrations the FAQ on this same page says we do not have. */
               { label: "Pricing", id: "pricing" },
               { label: "FAQ", id: "faq" },
             ].map((item) => (
               <button
                 key={item.id}
                 onClick={() => {
-                  const element = document.getElementById(item.id)
-                  if (element) {
-                    const offset = 80
-                    const elementPosition = element.getBoundingClientRect().top + window.scrollY
-                    window.scrollTo({
-                      top: elementPosition - offset,
-                      behavior: "smooth",
-                    })
-                  }
+                  /* HOME2 — Pricing landed on Security and FAQ landed on
+                     Pricing: consistently one section short.
+
+                     The cause is this arithmetic. It measures the target's
+                     position ONCE, at click time, and scrolls to a number —
+                     so anything above the target that grows during the smooth
+                     scroll (a font swapping in, an image getting its
+                     intrinsic height) leaves the page short by roughly that
+                     growth, which on this page is about one section.
+
+                     `scrollIntoView` re-resolves the element rather than a
+                     coordinate, and `scroll-margin-top` on the sections
+                     supplies the 80px the header needs. The fix is to stop
+                     computing a position that can go stale, not to compute it
+                     better. */
+                  document.getElementById(item.id)?.scrollIntoView({
+                    behavior: "smooth",
+                    block: "start",
+                  })
                 }}
                 className="px-4 py-2 text-sm font-medium rounded-lg transition-colors text-gray-700 hover:text-[#1F2B37] hover:bg-gray-50"
               >

--- a/frontend/src/lib/pricing.ts
+++ b/frontend/src/lib/pricing.ts
@@ -117,6 +117,24 @@ export const TIERS: Tier[] = [
 
 export const PROFESSIONAL = TIERS.find((t) => t.key === 'professional')!;
 
+/**
+ * `$99/user/month` / `$249/month` — the price WITH the unit it is charged in.
+ *
+ * ═══ HOME2 ═══
+ *
+ * `priceLabel` returns the figure alone, and the surfaces that render two
+ * tiers side by side were showing "$99" beside "$249" with no unit on
+ * either — while the registry itself says one is per USER per month and
+ * the other is per month. A reader comparing them was comparing different
+ * things and had nothing on screen telling them so.
+ *
+ * The cadence has always been on the tier. Nothing was missing except a
+ * formatter that used it.
+ */
+export function priceWithCadence(tier: Tier): string {
+  return tier.priceMonthly === 0 ? priceLabel(tier) : `${priceLabel(tier)}${tier.cadence}`;
+}
+
 /** `$0` / `$99`. The only place a dollar sign meets a plan price. */
 export function priceLabel(tier: Tier): string {
   return `$${tier.priceMonthly}`;


### PR DESCRIPTION
## The finding, which inverts the ticket's premise

The ticket read the homepage as overclaiming. It mostly isn't. The homepage is honestly reporting the product, and **the product is out of step with a ruling that was decided and then parked** — W0 §3. "Instant deed generation" is not a lie about the API; it is an accurate description of an API that still behaves the way it did before the officer-confirmation ruling landed. The copy was truthful; the thing it described was stale.

That is why item 1 was resolved as **option 1**: the copy now describes today's API accurately, the pin says only that "generate" never implies authorship, and the W0 §3 gap stays open and visible in the ledger rather than being papered over by wording.

## What changed

**`frontend/src/app/page.tsx`**
- "5 CA instruments" → **"21 CA instruments"** (the registry's actual count).
- "All 58 CA Counties" → **"Any California county"**, plus **"Unknown city rate says so"**. We hold recorder facts for one county, not 58; the picker offers 58 because she may record in any of them. Those are different claims and the card now makes the honest one.
- "AI Generated" badge → **"Officer confirmed"**; "AI Generates" → **"AI Suggests"**; "Review & Record" → **"Review & Print"** (we do not record).
- API section headline: "Instant deed generation" → **"One API call. / A deed your officer signs off."**
- Sample response now shows a real shape: `"status": "active"` with `urls.pdf` / `urls.verification`.
- Deleted the **error-rate row** and the **"Average completion time: 5 minutes"** badge — neither is measured.
- Comparison table wrapped in `overflow-x-auto` with `min-w-[640px]` (the mobile stack item).
- Sections given `id` + `scrollMarginTop: 80` so nav targets land under the sticky header.
- Footer contact block reads `NEXT_PUBLIC_LEGAL_ENTITY` / `NEXT_PUBLIC_CONTACT_EMAIL` / `NEXT_PUBLIC_CONTACT_ADDRESS` and **renders nothing when unset** — the named gap the owner supplies.

**`frontend/src/components/landing-v2/StickyNav.tsx`** — "Integrations" removed (it pointed at a section RED-H1.1 had already deleted, so the link scrolled nowhere). Offset arithmetic replaced with `scrollIntoView({ block: 'start' })`, which is what `scrollMarginTop` is for.

**`frontend/src/app/layout.tsx`** — title/openGraph/twitter rewritten around "California deed preparation, confirmed by your officer". Google Maps `<Script>` removed.

**`frontend/src/lib/pricing.ts`** — `priceWithCadence(tier)`.

**`frontend/src/app/account-settings/page.tsx`** — the real units bug (see premise checks).

**`frontend/src/__tests__/homepageTruth.test.ts`** — `PAGE` routed through `codeOnly()`; new pin: *never describes the software as the author of a deed*.

**`docs/OWNER_LEDGER.md`** — **W0 §3 — A RULING DECIDED, PARKED, AND NEVER BUILT**, entered loudly, plus the DECIDED-vs-BUILT proposal below.

## The DECIDED-vs-BUILT proposal (asked for)

Recommendation: **yes, make them fields, not prose.** Every parked entry today encodes its status in a sentence, and a sentence is read by whoever happens to read it. W0 §3 is the proof: the ruling was recorded, the record was accurate, and nobody could tell from scanning the ledger that the decision had no implementation behind it. Two fields — `DECIDED:` (date + ruling) and `BUILT:` (PR, or `—`) — make "decided but not built" a *scannable* state rather than something you reconstruct by reading. Same instinct as §14.1.1: assert the property, don't trust the narration. The entry is written both ways so the shape is visible before it is adopted repo-wide.

## Self-review

**Premises checked, and what was found**
- *"All 58 counties" appears twice* — **confirmed**, and both fixed.
- *The pricing cards show `$99`/`$249` without units* — **false on the homepage.** The cards already render `tier.cadence`. The real units bug was **`account-settings`**, which hardcoded "per month" beside a **per-USER** price. Fixed there.
- *The four dead routes (`/pricing`, `/contact`, `/about`, `/security`) still link from the footer* — **false, already clean.** Grep for those hrefs in `page.tsx` returns no matches; HM1 removed them. No change made; reported as a clean premise check rather than as work done.
- *The Google Maps script is misplaced in `layout.tsx`* — **it was redundant**, not misplaced: `useGoogleMaps` appends its own tag. Removed rather than moved.
- *`/developers` describes Model 2* — **false.** It does not.

**Pins changed, and in which direction**
- `homepageTruth.test.ts` **tightened**: `PAGE` now goes through `codeOnly()` (my own comments recording removed claims were tripping the assertions that forbid them — the pin was reading prose as product), and a new authorship pin was added. Nothing was loosened.

**Least sure about**
The "21 CA instruments" number. It is the registry's count today; if the registry gains a draft-only or internal type, the homepage will overcount and no pin catches it. A pin asserting the number against the registry rather than the copy would fix that — not built, because it belongs with the registry, not with HOME2.

**What would be cut if forced**
The layout/openGraph metadata rewrite. It is correct and it is not urgent; everything else in this PR is a statement a pilot user could read and believe.

**Anything decided rather than flagged**
The footer contact block renders *nothing* when the env vars are unset, rather than a placeholder. That is a decision — an empty footer over a footer that says "Company Name Here". It follows the "absence is neutral" rule and it means a misconfigured deploy shows no contact rather than a fake one. Flagging it here because the owner may want the deploy to fail loudly instead of quietly.

## Gates

pytest **1480** · jest **1089** / 78 suites · tsc **88** · `next build` clean · banned-claims clean (14 rules, 240 files) · four harnesses green (s1, s3, six-flow verify, api-baseline verify).

The authorship pin was mutation-probed: restoring "Instant deed generation" fails it.

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_