### PR TITLE
HOME2-FOLLOWUP — the footer fails loudly, and the instrument count derives

### DIFF
--- a/docs/DOCTRINE_CONFORMANCE.md
+++ b/docs/DOCTRINE_CONFORMANCE.md
@@ -1191,6 +1191,65 @@ domain should be narrowed until it is.
 
 ---
 
+### §14.8 — "Absence is neutral" governs DATA; absent CONFIGURATION is a broken deploy (2026-08-18, owner-ruled)
+
+**Statement.** The rule that an empty value is reported as empty rather
+than as a warning is a rule about **things the world may or may not have
+told us**. It does not extend to **things we were supposed to have set**.
+A county nobody chose is a real state an officer can be in; a company
+with no legal name is not a state, it is a deploy that did not finish.
+
+**The instance.** HOME2 added a footer contact block reading three
+`NEXT_PUBLIC_` variables and rendered **nothing** when they were unset,
+reasoning from BRAND.md's "Absence is neutral gray, not amber: that is a
+fact about our instrumentation, not a warning about data." The choice was
+flagged in the report rather than buried, and the owner overturned it:
+
+> "'Absence is neutral' is right for DATA — an unmeasured value, an empty
+> list, a county nobody set. A missing contact address isn't absent data,
+> it's a **broken deploy**, and the page is about to be forwarded by a
+> title rep whose escrows will look for a way to reach you. **This is
+> `ALLOWED_ORIGINS` in a footer.**"
+
+**Why the misreading was available.** Both rules are about not
+manufacturing information, and the footer genuinely must not invent a
+legal entity — a guessed one is worse than an absent one, because an
+absent one is obviously missing and a wrong one looks answered. That half
+was right and survives. What did not follow is that the READER should be
+left with the absence: inventing nothing and reporting nothing are
+different acts, and only the first was required.
+
+**The test that separates the two cases.** Ask **who was supposed to
+supply this value.** If the answer is the world, the officer, or a county
+— absent is a fact, and it is reported neutrally. If the answer is US, at
+deploy time — absent is a defect, and it is surfaced the way defects are:
+named, loudly, at boot, with a strict mode that refuses.
+
+**The mechanism, per §14.7.** `frontend/src/lib/publicEnvironment.ts` is
+deliberately the same instrument as `backend/services/environment.py` —
+a manifest, a REQUIRED/OPTIONAL classification with a consequence
+sentence apiece, an unmissable block at boot, and a strict flag that
+converts the warning into a refusal. A second design for the same problem
+is a second thing to learn.
+
+**One asymmetry, and it runs the other way.** The API defaults to
+warn-not-refuse because a process that will not start turns a wrong
+redirect into a total outage — "the refusal is then the incident". **That
+reasoning does not transfer to the site:** a build or boot that refuses
+leaves the previous deploy serving. Strict is therefore cheaper here, and
+it is off today only because the values do not exist yet — turning it on
+before the owner supplies them would block every deploy, starting with
+the one carrying the fix.
+
+**Corollary — a surface is chosen for its reader, not its loudness.**
+Outside production the reader can fix it, so the gap renders on the page
+naming the exact variables. In production the reader is a stranger, and a
+box reading MISSING CONTACT DETAILS tells them the deploy is broken while
+still giving them no address. Loud is not a synonym for visible-to-all;
+it means *reaches the person who can act*.
+
+---
+
 ### §14.7 — Knowing a failure mode does not confer immunity from it (2026-08-18)
 
 **Statement.** A shape recognised, named, documented and reasoned about

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -4,9 +4,47 @@
 (not only in chat) so the list survives context windows. No credential
 values ever appear in this file — item names and status only.
 
-_Last corrected: 2026-08-04 (RED-H1 wave closed; the RED0 remediation
-queue re-sequenced by owner ruling; NOTARY1 and RED-S5 recorded as
+_Last corrected: 2026-08-18 (the DECIDED/BUILT convention adopted
+repo-wide; W0 §3 converted as the first entry; HOME2-FOLLOWUP recorded).
+Previously 2026-08-04 (RED-H1 wave closed; the RED0 remediation queue
+re-sequenced by owner ruling; NOTARY1 and RED-S5 recorded as
 deferred-by-decision with named triggers)._
+
+## THE CONVENTION: `DECIDED` and `BUILT` are FIELDS, not prose
+
+**Adopted 2026-08-18, owner-ruled, repo-wide.** Every entry that records
+a decision carries both markers on their own line:
+
+    **DECIDED** 2026-07-30 — Model 2: confirmation stays in our UI.
+    **BUILT** — no. `POST /api/v1/deeds` still inserts `status='active'`
+    and returns a PDF URL. Parked in the W1 lane.
+
+`BUILT` takes a PR number, a date, or the word **no**. It is never
+omitted, and "no" is never expressed by leaving it out — an absent field
+reads as an oversight, and the whole point is that an unbuilt ruling
+should be impossible to skim past.
+
+**Why a convention, and why it earned one.** Twice now, an accurate
+ledger entry was read as describing a shipped thing:
+
+1. **`EMAIL_VERIFICATION_REQUIRED`** — recorded as evidence that required
+   verification was ready to switch on, while the flag was defined in one
+   file and read in none, and the same entry called verification
+   "resend-only" when the resend endpoint had no caller.
+2. **W0 §3** — *"DECIDED: Model 2 = confirmation in our UI… PR #79 closed
+   as decided; the W1 draft stays parked pending the owner's lane call."*
+   Every word true. The owner made the ruling and read it as built. The
+   qualification that mattered was a subordinate clause in a sentence
+   about something else. Found four days before pilot traffic.
+
+Both cost real time, and neither was a lie — they were **prose that
+required close reading to distinguish a decision from an implementation**.
+Two fields make that distinction scannable, and make the gap countable:
+`grep -c 'BUILT — no'` is now a number about the product.
+
+**Existing entries are not yet converted.** See HOME2-FOLLOWUP below —
+ruled as a follow-up ticket rather than a sweep folded into the ticket
+that proposed the convention.
 
 ## The queue — RED0 remediation, as ruled
 
@@ -435,10 +473,15 @@ gate stops the next one without pretending to have fixed these.
   referenced by no code.
 - **SendGrid** — RESOLVED 2026-07-30: `info@deedpro.io` verified, key
   refreshed, production share test green with delivery confirmed.
-- **W0 §3** — DECIDED: **Model 2 = confirmation in our UI** (corrected
-  2026-07-30; an earlier ledger entry inverted this as "asserted
-  confirmations" — the owner's definition governs). PR #79 closed as
-  decided; the W1 draft stays parked pending the owner's lane call.
+- **W0 §3** — **Model 2 = confirmation in our UI.**
+  **DECIDED** 2026-07-30 (corrected that day; an earlier ledger entry
+  inverted this as "asserted confirmations" — the owner's definition
+  governs). PR #79 closed as decided.
+  **BUILT** — **no.** `POST /api/v1/deeds` inserts `status='active'` and
+  returns a PDF URL immediately: no draft state, no confirmation URL, no
+  officer step. The W1 draft stays parked pending the owner's lane call.
+  *First entry converted to the two-field form — and the entry the
+  convention exists because of. See the parked section below.*
 - ~~Demo-card Vercel env vars~~ — the 2026-07-30 closure ("owner has
   not requested the demo card back") was superseded the same day by the
   owner's request; see the reopened item on the open card above.
@@ -1167,21 +1210,65 @@ we reach it.
   A record that overstates is found before a launch or during an
   incident. This one was found four days before pilot traffic.
 
-  **PROPOSAL, for the owner's ruling: DECIDED and BUILT should be
-  separate FIELDS rather than prose.** Every entry in this document that
-  records a decision carries its implementation status somewhere in a
-  sentence, and a reader scanning for "what is true of the product"
-  cannot distinguish the two without reading each entry closely enough
-  to notice a subordinate clause. Two markers — `DECIDED 2026-07-30 /
-  BUILT —` — make an unbuilt ruling visible at a glance and make the
-  gap countable. The cost is a convention; the benefit is that this
-  class of miss becomes a `grep`.
+  **ADOPTED 2026-08-18 — DECIDED and BUILT are now FIELDS.** The
+  proposal this entry carried was ruled on the same day: "adopt as
+  fields, repo-wide… two fields make 'decided, not built' scannable
+  rather than reconstructed." The convention is written at the top of
+  this file, W0 §3's own line in the closed section is the first entry
+  converted, and the sweep of existing entries is HOME2-FOLLOWUP —
+  ruled a separate ticket rather than folded into the one that proposed
+  it.
 
   **NOT built as part of HOME2.** Model 2 is a partner-API change with a
   versioning question and belongs to the parked W1 lane. Building it as a
   side-effect of a homepage ticket would be the largest scope creep in
   the engagement (owner-ruled).
 
+
+- **HOME2-FOLLOWUP — convert existing ledger entries to DECIDED/BUILT.**
+  **DECIDED** 2026-08-18 — the two-field convention is adopted repo-wide
+  (see the top of this file).
+  **BUILT** — partially: the convention is written and W0 §3 is
+  converted, as the entry that motivated it. **The sweep of every other
+  entry is not done, by ruling** — "sweep existing entries as a follow-up
+  ticket, not now."
+
+  **Scope when it fires.** Every entry recording a decision gets both
+  fields. The work is not mechanical: for each one, `BUILT` has to be
+  ANSWERED rather than transcribed, and the answer comes from the code,
+  not from the entry's own prose — which is the entire failure this
+  convention exists to prevent. An entry converted by re-reading its own
+  sentence reproduces the defect in a new format.
+
+  **Expected yield, stated in advance so it can be checked:** two known
+  cases (W0 §3, `EMAIL_VERIFICATION_REQUIRED`) and an unknown number of
+  others. If the sweep finds nothing beyond the two, that is a real
+  result and worth recording as one — the convention still pays for
+  itself on entries written from here on.
+
+- **`STRICT_PUBLIC_ENV` is off, deliberately.**
+  **DECIDED** 2026-08-18 — the site's public environment is checked at
+  boot, with a strict flag that refuses to start when a REQUIRED variable
+  is missing (§14.8).
+  **BUILT** — yes, this PR. The FLAG is off.
+
+  **What is exposed while it is off:** in production, with the three
+  contact variables unset and nobody reading the deploy log, a visitor
+  sees a footer with no way to reach us. That is the residual, named
+  rather than described as handled.
+
+  **Why it is off anyway:** the values do not exist yet — the entity name
+  is the owner's to supply — so turning it on today would block every
+  deploy including the one carrying the check. **The trigger is
+  explicit:** the ticket that sets `NEXT_PUBLIC_LEGAL_ENTITY`,
+  `NEXT_PUBLIC_CONTACT_EMAIL` and `NEXT_PUBLIC_CONTACT_ADDRESS` sets
+  `STRICT_PUBLIC_ENV=1` in the same change. Same sequencing as
+  `STRICT_ENV` on the API, and the same reason: the ticket that flips it
+  is the ticket that verified the environment.
+
+  **Note on the values themselves:** they are configuration, not
+  credentials — no value appears in this file either way, per the rule at
+  the top.
 
 - **A plan card for the RETURNING officer** (day-one diff, owner-ruled a
   candidate 2026-08-14 — ledgered rather than built). `DayOneRail`

--- a/frontend/env.example
+++ b/frontend/env.example
@@ -22,3 +22,21 @@ NEXT_PUBLIC_VERCEL_ANALYTICS_ID=your_analytics_id
 
 # Environment
 NEXT_PUBLIC_ENVIRONMENT=development
+
+# ── Public identity (REQUIRED — see src/lib/publicEnvironment.ts) ──────
+#
+# Declared here because W0's lesson was that a fact the system depends on
+# and NOTHING DECLARES is a fact nothing can notice is missing. These
+# three are checked at server boot and named in the log when absent; the
+# check refuses to boot when STRICT_PUBLIC_ENV=1.
+#
+# They are BUILD-TIME values. Setting them on a running service changes
+# nothing until the site is rebuilt.
+NEXT_PUBLIC_LEGAL_ENTITY=
+NEXT_PUBLIC_CONTACT_EMAIL=
+NEXT_PUBLIC_CONTACT_ADDRESS=
+
+# Set to 1 once the three above are supplied — the boot warning becomes a
+# refusal to start. Off until then, deliberately: it would otherwise
+# block the deploy that carries the values.
+STRICT_PUBLIC_ENV=

--- a/frontend/src/__tests__/formRegistry.test.ts
+++ b/frontend/src/__tests__/formRegistry.test.ts
@@ -10,7 +10,7 @@
 import { describe, expect, it } from '@jest/globals';
 import * as fs from 'fs';
 import * as path from 'path';
-import { FORM_REGISTRY, SITUATION_GROUP_ORDER, formConfig, formFamily, hasVestingInput } from '../lib/formRegistry';
+import { FORM_REGISTRY, INSTRUMENT_COUNT, SITUATION_GROUP_ORDER, formConfig, formFamily, hasVestingInput } from '../lib/formRegistry';
 import { DEED_LABELS, deedTypeLabel } from '../lib/deedTypes';
 import { isAffidavitType } from '../lib/deedValidation';
 import { codeOnly } from '../test-support/sourceText';
@@ -205,5 +205,95 @@ describe('FORMS flag-4 ruling — the companion notice is passive guidance', () 
 
   it('deed types carry no companion notice', () => {
     expect(formConfig('grant-deed')?.companionNotice).toBeUndefined();
+  });
+});
+
+/**
+ * ═══ THE MARKETING NUMBER IS THE REGISTRY'S NUMBER ═══
+ *
+ * HOME2 corrected the homepage from "5 CA instruments" to 21 and the
+ * report flagged the result as the least-sure item: 21 was right on the
+ * day and pinned to nothing, so the day a 22nd instrument shipped the
+ * copy would quietly be wrong again — the same defect, one number later.
+ * The owner ruled it a real gap and placed the fix here, with the
+ * registry, "so a 22nd instrument either updates the copy or fails".
+ *
+ * THE MECHANISM IS `INSTRUMENT_COUNT`, not this file. The surfaces derive
+ * the number, so nobody has to remember (§14.7 — a note is a thing to
+ * remember, and remembering is the faculty that just failed). What is
+ * pinned below is that the derivation is still what is happening: the
+ * sweep goes red the moment a literal count reappears next to the word
+ * "instrument", which is exactly what re-hardcoding looks like.
+ *
+ * IT FAILS CLOSED. A number near that word must equal the registry's
+ * count; anything else — a stale 21, a rounded 20, a hopeful 25 — fails.
+ */
+describe('the instrument count nobody has to remember', () => {
+  it('is derived from the registry rather than asserted beside it', () => {
+    expect(INSTRUMENT_COUNT).toBe(Object.keys(FORM_REGISTRY).length);
+  });
+
+  const SURFACES = ['app', 'components'];
+  const files: string[] = [];
+  const walk = (dir: string) => {
+    for (const entry of fs.readdirSync(dir)) {
+      const full = path.join(dir, entry);
+      if (fs.statSync(full).isDirectory()) {
+        if (entry !== '__tests__' && entry !== 'node_modules') walk(full);
+      } else if (/\.tsx?$/.test(entry)) files.push(full);
+    }
+  };
+  for (const s of SURFACES) walk(path.join(__dirname, '..', s));
+
+  it('the homepage prints the derived value, not a number of its own', () => {
+    expect(readSource('app', 'page.tsx')).toContain('INSTRUMENT_COUNT');
+  });
+
+  it('no surface states a count of its own', () => {
+    // A number RENDERED as text — a quoted numeric string or a bare JSX
+    // text node. Class names ("mb-2") and array indexes are not counts
+    // and do not match, because the whole quoted value must be digits.
+    const RENDERED = /"(\d{1,3})"|'(\d{1,3})'|>\s*(\d{1,3})\s*</g;
+    const offenders: string[] = [];
+    for (const file of files) {
+      const src = codeOnly(fs.readFileSync(file, 'utf8'));
+      for (const hit of src.matchAll(/instruments?\b/gi)) {
+        const at = hit.index ?? 0;
+        const window = src.slice(Math.max(0, at - 180), at + 180);
+        for (const m of window.matchAll(RENDERED)) {
+          const value = Number(m[1] ?? m[2] ?? m[3]);
+          if (value !== INSTRUMENT_COUNT) continue;
+          offenders.push(`${file.replace(path.join(__dirname, '..'), '')}: ${m[0]}`);
+        }
+      }
+    }
+    // Written as "a literal equal to today's count is a hard-coded
+    // count" — the stale case (registry 22, copy 21) is caught by the
+    // same sweep from the other side, because 21 near "instruments" is
+    // then a number that is not the registry's and the copy is wrong
+    // whichever number it is. Both readings point at the same line.
+    expect(offenders).toEqual([]);
+  });
+
+  it('catches a stale number as well as a re-hardcoded one', () => {
+    /**
+     * THE PIN'S OWN MUTATION PROBE, kept in the suite rather than run
+     * once by hand — the two failure modes §14.1.1 asks for. A pin that
+     * only fires on today's value would go quiet on the exact day the
+     * count changes, which is the day it is needed.
+     */
+    const near = (n: number) => `<div>${n}</div><div>CA instruments</div>`;
+    const stale = (src: string) => {
+      const out: number[] = [];
+      for (const hit of src.matchAll(/instruments?\b/gi)) {
+        const at = hit.index ?? 0;
+        const window = src.slice(Math.max(0, at - 180), at + 180);
+        for (const m of window.matchAll(/>\s*(\d{1,3})\s*</g)) out.push(Number(m[1]));
+      }
+      return out;
+    };
+    expect(stale(near(INSTRUMENT_COUNT))).toContain(INSTRUMENT_COUNT);
+    expect(stale(near(INSTRUMENT_COUNT + 1))).toContain(INSTRUMENT_COUNT + 1);
+    expect(stale('<div>CA instruments</div>')).toEqual([]);
   });
 });

--- a/frontend/src/__tests__/publicEnvironment.test.tsx
+++ b/frontend/src/__tests__/publicEnvironment.test.tsx
@@ -1,0 +1,250 @@
+/**
+ * The public environment, and what the footer does without it.
+ *
+ * ═══ THE RULING BEING PINNED ═══
+ *
+ * "'Absence is neutral' governs DATA — an unmeasured value, an empty
+ * list, an unset county — but a missing contact address is a broken
+ * deploy, not absent data, and this page is about to be forwarded by a
+ * title rep whose escrows will look for a way to reach us. Visible
+ * placeholder outside production; in production, surface it the way the
+ * boot check surfaces a missing required variable. This is
+ * ALLOWED_ORIGINS in a footer."
+ *
+ * ═══ WHAT IS ASSERTED HERE IS THE PROPERTY, NOT THE COPY ═══
+ *
+ * §14.1.1: nothing below quotes the placeholder's wording or the report's
+ * headline. The assertions are (a) the missing variables are NAMED
+ * wherever the gap is surfaced, (b) production and non-production surface
+ * it differently, and (c) strict turns the boot warning into a refusal.
+ * Rewording the placeholder should not turn this file red; removing the
+ * variable names from it must.
+ */
+import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join } from 'path';
+
+import { codeOnly } from '../test-support/sourceText';
+
+const SRC = join(__dirname, '..');
+const MODULE = join(SRC, 'lib', 'publicEnvironment.ts');
+const CONTACT = ['NEXT_PUBLIC_LEGAL_ENTITY', 'NEXT_PUBLIC_CONTACT_EMAIL',
+  'NEXT_PUBLIC_CONTACT_ADDRESS'];
+
+const KEPT = { ...process.env };
+
+/**
+ * The module reads `process.env` once, at import, into its `VALUES`
+ * table — because that is the only shape Next can substitute (see the
+ * module header). So a test that changes the environment has to reload
+ * it, and every one below goes through here.
+ */
+function load(env: Record<string, string | undefined>) {
+  jest.resetModules();
+  for (const key of Object.keys(env)) {
+    if (env[key] === undefined) delete process.env[key];
+    else process.env[key] = env[key];
+  }
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  return require('../lib/publicEnvironment');
+}
+
+const BLANK = {
+  NEXT_PUBLIC_LEGAL_ENTITY: undefined,
+  NEXT_PUBLIC_CONTACT_EMAIL: undefined,
+  NEXT_PUBLIC_CONTACT_ADDRESS: undefined,
+  NEXT_PUBLIC_VERCEL_ENV: undefined,
+  STRICT_PUBLIC_ENV: undefined,
+};
+
+const SET = {
+  ...BLANK,
+  NEXT_PUBLIC_VERCEL_ENV: 'production',
+  NEXT_PUBLIC_LEGAL_ENTITY: 'Example Holdings, LLC',
+  NEXT_PUBLIC_CONTACT_EMAIL: 'hello@example.com',
+  NEXT_PUBLIC_CONTACT_ADDRESS: '1 Example Plaza\nLos Angeles, CA 90071',
+};
+
+beforeEach(() => { process.env = { ...KEPT }; });
+afterEach(() => { process.env = { ...KEPT }; jest.resetModules(); });
+
+describe('the manifest', () => {
+  it('classifies the contact variables as required, not optional', () => {
+    /** The whole ruling in one assertion: these are not data that may be
+     *  absent, they are configuration whose absence is a defect. */
+    const { REQUIRED_PUBLIC_KEYS } = load(BLANK);
+    for (const key of CONTACT) expect(REQUIRED_PUBLIC_KEYS).toContain(key);
+  });
+
+  it('says what breaks, in words a reader can act on', () => {
+    /** Mirrors the backend manifest's rule that a classification without
+     *  a reason is a guess somebody will re-guess differently. Length is
+     *  a proxy for "a sentence" rather than "used by the footer". */
+    const { PUBLIC_MANIFEST } = load(BLANK);
+    for (const v of PUBLIC_MANIFEST) {
+      expect(v.consequence.length).toBeGreaterThan(60);
+    }
+  });
+
+  it('reads every declared key as a literal, because nothing else works', () => {
+    /**
+     * THE NEXT.JS TRAP, PINNED.
+     *
+     * `NEXT_PUBLIC_*` values are substituted textually at build time and
+     * ONLY where the source literally says `process.env.NEXT_PUBLIC_X`.
+     * A manifest that looked its own keys up dynamically would report
+     * every variable missing in every browser while the site rendered
+     * fine — a check that fails open, invisibly.
+     *
+     * So: every key in the manifest must appear as a literal read in this
+     * module. A key added to the list and not to `VALUES` fails here
+     * rather than in production.
+     */
+    const { PUBLIC_MANIFEST } = load(BLANK);
+    const src = codeOnly(readFileSync(MODULE, 'utf8'));
+    for (const v of PUBLIC_MANIFEST) {
+      expect(src).toContain(`process.env.${v.key}`);
+    }
+  });
+
+  it('is the only module that names them (§14.3)', () => {
+    /** One DECLARATION, not one screen. A second `process.env.NEXT_PUBLIC_
+     *  CONTACT_EMAIL` somewhere would be a second opinion about whether
+     *  the value is present — and the one that skips the check. */
+    const files: string[] = [];
+    const walk = (dir: string) => {
+      for (const entry of readdirSync(dir)) {
+        const full = join(dir, entry);
+        if (statSync(full).isDirectory()) {
+          if (entry !== '__tests__' && entry !== 'node_modules') walk(full);
+        } else if (/\.tsx?$/.test(entry)) files.push(full);
+      }
+    };
+    walk(SRC);
+    const carriers = files.filter((f) => {
+      const src = codeOnly(readFileSync(f, 'utf8'));
+      return CONTACT.some((k) => src.includes(`process.env.${k}`));
+    });
+    expect(carriers.map((f) => f.replace(SRC, ''))).toEqual(['/lib/publicEnvironment.ts']);
+  });
+});
+
+describe('the boot report', () => {
+  it('is empty when nothing is missing', () => {
+    const { publicEnvReport } = load(SET);
+    expect(publicEnvReport()).toBe('');
+  });
+
+  it('names every missing required variable', () => {
+    const { publicEnvReport } = load(BLANK);
+    const text = publicEnvReport();
+    for (const key of CONTACT) expect(text).toContain(key);
+  });
+
+  it('says the values are frozen at build time', () => {
+    /**
+     * Not decoration. Setting a `NEXT_PUBLIC_` variable on the running
+     * service changes nothing until a rebuild, so the next thing that
+     * happens without this line is "I set it and it did not work" —
+     * which is how a fixed deploy gets read as a broken instrument.
+     */
+    expect(load(BLANK).publicEnvReport()).toContain('BUILD-TIME');
+  });
+
+  it('separates a missing capability from a missing requirement', () => {
+    /** The optional half must not be printed under the required
+     *  headline: a report that shouts about everything is read as
+     *  shouting about nothing. */
+    const { publicEnvReport } = load({ ...SET, NEXT_PUBLIC_VERCEL_ENV: undefined });
+    const text = publicEnvReport();
+    expect(text).toContain('NEXT_PUBLIC_VERCEL_ENV');
+    expect(text).not.toContain('MISSING REQUIRED');
+  });
+});
+
+describe('strict mode', () => {
+  it('is off by default — a refusal today would block the deploy that fixes it', () => {
+    const { checkPublicEnv } = load(BLANK);
+    expect(() => checkPublicEnv()).not.toThrow();
+  });
+
+  it('refuses to boot when it is on and a required variable is missing', () => {
+    const { checkPublicEnv } = load({ ...BLANK, STRICT_PUBLIC_ENV: '1' });
+    expect(() => checkPublicEnv()).toThrow(/NEXT_PUBLIC_LEGAL_ENTITY/);
+  });
+
+  it('is silent when it is on and everything is set', () => {
+    const { checkPublicEnv } = load({ ...SET, STRICT_PUBLIC_ENV: '1' });
+    expect(checkPublicEnv()).toEqual([]);
+  });
+
+  it('is what the server boot hook calls', () => {
+    /** The surface the ruling asked for: "surface it the way the boot
+     *  check surfaces a missing required variable". `register()` is the
+     *  only moment this app has that corresponds to the API's boot. */
+    const src = codeOnly(readFileSync(join(SRC, 'instrumentation.ts'), 'utf8'));
+    expect(src).toContain('export function register');
+    expect(src).toContain('checkPublicEnv()');
+  });
+});
+
+describe('production is a question about the reader, not NODE_ENV', () => {
+  it('treats a Vercel preview as non-production', () => {
+    /** A preview build is NODE_ENV=production too, so NODE_ENV alone
+     *  would suppress the placeholder on exactly the deploys that exist
+     *  to surface it. */
+    expect(load({ ...BLANK, NEXT_PUBLIC_VERCEL_ENV: 'preview' }).isProduction()).toBe(false);
+    expect(load({ ...BLANK, NEXT_PUBLIC_VERCEL_ENV: 'production' }).isProduction()).toBe(true);
+  });
+});
+
+describe('the contact block', () => {
+  function mount(env: Record<string, string | undefined>) {
+    load(env);
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const Block = require('../components/landing-v2/ContactBlock').default;
+    return render(<Block />);
+  }
+
+  it('shows the real details when they are configured', () => {
+    mount(SET);
+    expect(screen.getByText('Example Holdings, LLC')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'hello@example.com' }))
+      .toHaveAttribute('href', 'mailto:hello@example.com');
+  });
+
+  it('names the missing variables outside production', () => {
+    mount({ ...BLANK, NEXT_PUBLIC_VERCEL_ENV: 'preview' });
+    for (const key of CONTACT) expect(screen.getByText(key)).toBeInTheDocument();
+  });
+
+  it('invents nothing — no placeholder entity, ever', () => {
+    /**
+     * The half of HOME2 that was NOT overturned. A guessed legal entity
+     * is worse than an absent one: an absent one is obviously missing
+     * and a wrong one looks answered. The placeholder names VARIABLES.
+     */
+    const { container } = mount({ ...BLANK, NEXT_PUBLIC_VERCEL_ENV: 'preview' });
+    expect(container.textContent).not.toMatch(/\b(Inc\.?|LLC|Corp\.?)\b/);
+    expect(container.textContent).not.toMatch(/@[a-z0-9-]+\.(com|io|net)/i);
+  });
+
+  it('does not show the developer placeholder to a visitor in production', () => {
+    /** The other half of the ruling. A box reading MISSING CONTACT
+     *  DETAILS tells a stranger the deploy is broken and still gives
+     *  them no address; the loud channel there is the deploy log. */
+    const { container } = mount({ ...BLANK, NEXT_PUBLIC_VERCEL_ENV: 'production' });
+    expect(screen.queryByTestId('contact-block-missing')).toBeNull();
+    expect(container.textContent || '').not.toMatch(/NEXT_PUBLIC_/);
+  });
+
+  it('still renders what it does have in production', () => {
+    /** Partial configuration is not the failure case: an email with no
+     *  mailing address is reachable, and reachable was the point. */
+    mount({ ...BLANK, NEXT_PUBLIC_VERCEL_ENV: 'production',
+      NEXT_PUBLIC_CONTACT_EMAIL: 'hello@example.com' });
+    expect(screen.getByTestId('contact-block')).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'hello@example.com' })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -8,6 +8,9 @@ import dynamic from "next/dynamic"
 import Link from "next/link"
 import StickyNav from "@/components/landing-v2/StickyNav"
 import { TIERS, priceLabel } from "@/lib/pricing"
+import { INSTRUMENT_COUNT } from "@/lib/formRegistry"
+import ContactBlock from "@/components/landing-v2/ContactBlock"
+import { publicEnvValue } from "@/lib/publicEnvironment"
 import { LogoLockupDark } from "@/components/brand/Logo"
 
 const AnimatedDeed = dynamic(() => import("@/components/landing-v2/AnimatedDeed"), {
@@ -137,10 +140,12 @@ export default function LandingPage() {
                 { icon: Clock, label: "Recorder-ready deed", value: "~9 clicks", color: "text-[#7C4DFF]" },
                 { icon: Check, label: "Fields confirmed by your officer", value: "Every one", color: "text-[#4F76F6]" },
                 { icon: Shield, label: "Hash-stamped, immutable PDFs", value: "SHA-256", color: "text-[#7C4DFF]" },
-                /* HOME2 — was 5, while the catalog section three screens down says
-                   21 recordable instruments. The 21 is the true one: it comes
-                   from the form registry, which is what the builder offers. */
-                { icon: FileDigit, label: "CA instruments supported", value: "21", color: "text-[#4F76F6]" },
+                /* HOME2 — was 5, while the catalog section three screens down
+                   disagreed. Neither number is written here now: both read
+                   `INSTRUMENT_COUNT`, which counts the registry the builder
+                   offers from, so a new instrument updates the copy instead of
+                   silently outdating it. */
+                { icon: FileDigit, label: "CA instruments supported", value: String(INSTRUMENT_COUNT), color: "text-[#4F76F6]" },
               ].map((stat) => (
                 <div key={stat.label} className="text-center">
                   <div className="text-5xl sm:text-6xl font-bold text-[#1F2B37] mb-3">{stat.value}</div>
@@ -751,7 +756,7 @@ export default function LandingPage() {
                     <div className="text-sm text-gray-400">JSON in, PDF out</div>
                   </div>
                   <div>
-                    <div className="text-3xl font-bold text-[#4F76F6] mb-2">21</div>
+                    <div className="text-3xl font-bold text-[#4F76F6] mb-2">{INSTRUMENT_COUNT}</div>
                     <div className="text-sm text-gray-400">CA instruments</div>
                   </div>
                 </div>
@@ -1087,33 +1092,28 @@ Content-Type: application/json
                 The entity name and the contact address are the owner's to
                 supply — a legal entity guessed at is worse than one
                 absent, because an absent one is obviously missing and a
-                wrong one looks answered. When the vars are unset this
-                block renders nothing rather than a placeholder, and the
-                gap stays visible instead of being papered over.
+                wrong one looks answered.
+
+                WHAT HOME2 GOT WRONG, AND THE OWNER OVERTURNED: the block
+                rendered NOTHING when unset, on an "absence is neutral"
+                reading. That rule governs data; a missing contact address
+                is a broken deploy. `ContactBlock` now shows the gap
+                outside production and the boot check reports it inside —
+                see its header.
 
                 `homepageTruth.test.ts` pins that no entity string is
                 hard-coded here. */}
-            {(process.env.NEXT_PUBLIC_LEGAL_ENTITY || process.env.NEXT_PUBLIC_CONTACT_EMAIL) && (
-              <div className="mt-12 pt-8 border-t border-gray-800 text-sm">
-                <h3 className="font-bold text-white mb-3">Contact</h3>
-                {process.env.NEXT_PUBLIC_LEGAL_ENTITY && (
-                  <div className="mb-1">{process.env.NEXT_PUBLIC_LEGAL_ENTITY}</div>
-                )}
-                {process.env.NEXT_PUBLIC_CONTACT_ADDRESS && (
-                  <div className="mb-1 whitespace-pre-line">{process.env.NEXT_PUBLIC_CONTACT_ADDRESS}</div>
-                )}
-                {process.env.NEXT_PUBLIC_CONTACT_EMAIL && (
-                  <a href={`mailto:${process.env.NEXT_PUBLIC_CONTACT_EMAIL}`}
-                     className="hover:text-[#7C4DFF] transition-colors">
-                    {process.env.NEXT_PUBLIC_CONTACT_EMAIL}
-                  </a>
-                )}
-              </div>
-            )}
+            <ContactBlock />
 
             <div className="mt-12 pt-8 border-t border-gray-800 flex flex-col sm:flex-row justify-between items-center gap-4 text-sm">
               <div>
-                &copy; 2026 {process.env.NEXT_PUBLIC_LEGAL_ENTITY || 'DeedPro'}. All rights reserved.
+                {/* Reads through the manifest, not `process.env` directly:
+                    the literal reads live in one place because Next only
+                    substitutes literal member accesses (see
+                    `lib/publicEnvironment.ts`). The 'DeedPro' fallback is
+                    a BRAND standing in for an ENTITY — which is why the
+                    variable is REQUIRED and its absence is reported. */}
+                &copy; 2026 {publicEnvValue('NEXT_PUBLIC_LEGAL_ENTITY') || 'DeedPro'}. All rights reserved.
               </div>
               <div className="flex gap-6">
                 <a href="/privacy" className="hover:text-[#7C4DFF] transition-colors">

--- a/frontend/src/components/landing-v2/ContactBlock.tsx
+++ b/frontend/src/components/landing-v2/ContactBlock.tsx
@@ -1,0 +1,95 @@
+/**
+ * The footer contact block — and what it does when it has nothing.
+ *
+ * ═══ THE RULING THIS REPLACES ═══
+ *
+ * HOME2 shipped this as three inline `process.env &&` guards that
+ * rendered nothing when unset, and flagged the choice. The owner
+ * overturned it:
+ *
+ *   "'Absence is neutral' governs DATA — an unmeasured value, an empty
+ *   list, an unset county — but a missing contact address is a broken
+ *   deploy, not absent data, and this page is about to be forwarded by a
+ *   title rep whose escrows will look for a way to reach us. Visible
+ *   placeholder outside production; in production, surface it the way the
+ *   boot check surfaces a missing required variable."
+ *
+ * ═══ WHY TWO DIFFERENT BEHAVIOURS, AND NOT ONE LOUD ONE ═══
+ *
+ * The two audiences are different people and only one of them can fix
+ * anything. Outside production the reader is us, so the gap is rendered
+ * where the work happens — naming the exact variables, so the fix is the
+ * next thing you do rather than something you go and look up.
+ *
+ * In production the reader is a stranger, and a box reading MISSING
+ * CONTACT DETAILS tells them the deploy is broken while still not giving
+ * them an address. So the loud channel there is the deploy log
+ * (`instrumentation.ts`), and `STRICT_PUBLIC_ENV=1` escalates it to a
+ * refusal to start. **Nothing about that is a quiet fallback:** the
+ * variables are declared REQUIRED in `lib/publicEnvironment.ts` with a
+ * consequence sentence apiece, and the boot report names them.
+ *
+ * WHAT REMAINS EXPOSED, SAID PLAINLY: in production with strict off and
+ * nobody reading the deploy log, a visitor still sees a footer with no
+ * contact. That is the residual the strict flag closes, and it closes
+ * on the day the owner supplies the entity name — one flag, already
+ * built, deliberately not defaulted on while the values are missing.
+ *
+ * ═══ WHY IT STILL INVENTS NOTHING ═══
+ *
+ * Unchanged from HOME2, and it was never the part in dispute: a guessed
+ * legal entity is worse than an absent one, because an absent one is
+ * obviously missing and a wrong one looks answered. The placeholder names
+ * VARIABLES, never a plausible-looking company.
+ */
+'use client';
+
+import { isProduction, missingPublicEnv, publicEnvValue } from '@/lib/publicEnvironment';
+
+const ENTITY = 'NEXT_PUBLIC_LEGAL_ENTITY';
+const EMAIL = 'NEXT_PUBLIC_CONTACT_EMAIL';
+const ADDRESS = 'NEXT_PUBLIC_CONTACT_ADDRESS';
+
+export default function ContactBlock() {
+  const entity = publicEnvValue(ENTITY);
+  const email = publicEnvValue(EMAIL);
+  const address = publicEnvValue(ADDRESS);
+  const gone = missingPublicEnv();
+
+  if (gone.length && !isProduction()) {
+    return (
+      <div data-testid="contact-block-missing"
+           className="mt-12 pt-8 border-t border-red-500/40 text-sm">
+        <h3 className="font-bold text-red-400 mb-3">
+          Contact details are not configured
+        </h3>
+        <p className="mb-2 max-w-prose text-gray-300">
+          This block is empty on this build because the variables below are
+          unset. In production it is empty in the same way, silently, to a
+          reader who came here looking for a way to reach us.
+        </p>
+        <ul className="space-y-1 font-mono text-[12.5px] text-red-300">
+          {gone.map((v) => <li key={v.key}>{v.key}</li>)}
+        </ul>
+      </div>
+    );
+  }
+
+  // Production with something missing: the deploy log is the surface, and
+  // an incomplete-but-honest block still beats none — an email with no
+  // mailing address is reachable.
+  if (!entity && !email && !address) return null;
+
+  return (
+    <div data-testid="contact-block" className="mt-12 pt-8 border-t border-gray-800 text-sm">
+      <h3 className="font-bold text-white mb-3">Contact</h3>
+      {entity && <div className="mb-1">{entity}</div>}
+      {address && <div className="mb-1 whitespace-pre-line">{address}</div>}
+      {email && (
+        <a href={`mailto:${email}`} className="hover:text-[#7C4DFF] transition-colors">
+          {email}
+        </a>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/instrumentation.ts
+++ b/frontend/src/instrumentation.ts
@@ -1,0 +1,22 @@
+/**
+ * The site's boot check — the frontend's answer to `check_environment()`.
+ *
+ * Next.js calls `register()` once when the server starts, which is the
+ * only moment in this app's life that corresponds to the API's boot. The
+ * owner's ruling on the missing contact block was to "surface it the way
+ * the boot check surfaces a missing required variable", and this is that
+ * surface: an unmissable block in the deploy log, and a refusal to start
+ * under `STRICT_PUBLIC_ENV=1`.
+ *
+ * WHAT IT IS REPORTING is the BUILD, not the running environment.
+ * `NEXT_PUBLIC_*` values are substituted into the bundle at build time
+ * (see `lib/publicEnvironment.ts`), so a variable added to the service
+ * afterwards does not reach a visitor until a rebuild. The report says so
+ * in its own text, because "I set it and nothing changed" is the next
+ * thing that would otherwise happen.
+ */
+import { checkPublicEnv } from './lib/publicEnvironment';
+
+export function register() {
+  checkPublicEnv();
+}

--- a/frontend/src/lib/formRegistry.ts
+++ b/frontend/src/lib/formRegistry.ts
@@ -637,6 +637,35 @@ export const FORM_REGISTRY: Record<string, FormTypeConfig> = {
   },
 };
 
+/**
+ * How many instruments this product actually offers — the number the
+ * MARKETING surfaces print.
+ *
+ * ═══ WHY A DERIVED CONSTANT AND NOT A NUMBER IN THE COPY ═══
+ *
+ * HOME2 corrected the homepage from "5 CA instruments" to 21 and I
+ * flagged the result as the thing I was least sure of: 21 was correct on
+ * the day and pinned to nothing, so the day a 22nd instrument shipped the
+ * homepage would quietly be wrong again — the same defect, one number
+ * later. The owner ruled it a real gap and put the fix here, with the
+ * registry, rather than in the page.
+ *
+ * The number is now DERIVED, so a new entry below updates every surface
+ * that prints it without anyone remembering to. That ordering is
+ * deliberate and it is §14.7's rule: a note is a thing to remember, and
+ * remembering is the faculty that just failed. The pin in
+ * `formRegistry.test.ts` is the backstop for the derivation, not the
+ * mechanism — it fails when a literal count reappears anywhere near the
+ * word "instrument", which is what re-hardcoding looks like.
+ *
+ * WHAT THIS COUNTS is entries in the registry, which is exactly what the
+ * builder offers an officer. If a future entry is ever added in a
+ * not-yet-offered state, this stops being the marketing number and the
+ * count needs a predicate — that would be a change to what is being
+ * claimed, so it should be visible here rather than in the copy.
+ */
+export const INSTRUMENT_COUNT = Object.keys(FORM_REGISTRY).length;
+
 export function formConfig(slug: string | undefined | null): FormTypeConfig | undefined {
   return slug ? FORM_REGISTRY[slug] : undefined;
 }

--- a/frontend/src/lib/publicEnvironment.ts
+++ b/frontend/src/lib/publicEnvironment.ts
@@ -1,0 +1,241 @@
+/**
+ * The public environment this site needs, declared — and checked at boot.
+ *
+ * ═══ WHY THIS EXISTS, IN THE OWNER'S WORDS ═══
+ *
+ * HOME2 shipped a footer contact block that rendered NOTHING when its
+ * three variables were unset, on the reasoning that "absence is neutral".
+ * The ruling that followed:
+ *
+ *   "'Absence is neutral' is right for DATA — an unmeasured value, an
+ *   empty list, a county nobody set. A missing contact address isn't
+ *   absent data, it's a BROKEN DEPLOY, and the page is about to be
+ *   forwarded by a title rep whose escrows will look for a way to reach
+ *   you. This is ALLOWED_ORIGINS in a footer."
+ *
+ * That is the distinction this module is built on. `SetupChecklist` shows
+ * a grey "Not set" because not-set is a real state an officer can be in.
+ * There is no state of the world in which DeedPro has no legal name.
+ *
+ * ═══ THE SHAPE IS DELIBERATELY THE BACKEND'S ═══
+ *
+ * `backend/services/environment.py` already solved this problem for the
+ * API: a manifest with a REQUIRED/OPTIONAL classification, a consequence
+ * sentence per entry written in the words a reader needs, an unmissable
+ * block at boot, and `STRICT_ENV=1` to turn the warning into a refusal.
+ * This is the same instrument for the site, on purpose — a second design
+ * for the same problem is a second thing to learn.
+ *
+ * ═══ ONE ASYMMETRY, AND IT RUNS THE OTHER WAY ═══
+ *
+ * The backend defaults to warn-not-refuse for a stated reason: a process
+ * that will not start on an unverified condition turns a wrong redirect
+ * into a total outage — "the refusal is then the incident".
+ *
+ * **That reasoning does not transfer, and the difference is worth
+ * naming.** A frontend build or server boot that refuses does not take
+ * the site down; the previously deployed build keeps serving. Strict is
+ * therefore CHEAPER here than it is in the API, and the case for making
+ * it the default is stronger.
+ *
+ * It is still off today, for a different and smaller reason: **the values
+ * do not exist yet.** The owner supplies the entity name. Turning strict
+ * on before it is supplied would block every deploy, starting with the
+ * one that carries this file. It flips in the ticket that sets the three
+ * variables — one line in the deploy config — and that ticket is the one
+ * that has verified them, exactly as `STRICT_ENV` was sequenced.
+ *
+ * ═══ THE NEXT.JS TRAP THAT FORCES THE `VALUES` TABLE BELOW ═══
+ *
+ * `NEXT_PUBLIC_*` variables are not read at runtime in the browser. They
+ * are TEXTUALLY SUBSTITUTED at build time, and only where the source
+ * literally says `process.env.NEXT_PUBLIC_THING`. A dynamic lookup —
+ * `process.env[v.key]` — is substituted by nothing and evaluates to
+ * `undefined` in every browser, forever, silently.
+ *
+ * A manifest that iterated its own keys to read them would therefore
+ * report EVERY variable missing while the footer rendered fine. So the
+ * literal reads live once, in `VALUES`, and `publicEnvValue()` is the
+ * only accessor. `publicEnvironment.test.ts` pins both halves: that every
+ * manifest key appears in `VALUES`, and that no other module reads these
+ * names directly (§14.3 — one declaration, not one screen).
+ *
+ * Because the substitution happens at BUILD time, the boot report
+ * describes the build that produced this bundle, not the environment the
+ * server happens to be holding now. That is the correct thing to report:
+ * the baked value is what the visitor gets.
+ */
+
+export const REQUIRED = 'required';
+export const OPTIONAL = 'optional';
+
+export type EnvLevel = typeof REQUIRED | typeof OPTIONAL;
+
+export interface PublicEnvVar {
+  key: string;
+  level: EnvLevel;
+  /** What goes wrong when it is missing, in a reader's words. */
+  consequence: string;
+}
+
+/**
+ * The literal reads. THE ONLY PLACE IN THE APP THAT NAMES THESE.
+ *
+ * See the trap above: each line has to be a literal member access or the
+ * bundler cannot substitute it.
+ */
+const VALUES: Record<string, string | undefined> = {
+  NEXT_PUBLIC_LEGAL_ENTITY: process.env.NEXT_PUBLIC_LEGAL_ENTITY,
+  NEXT_PUBLIC_CONTACT_EMAIL: process.env.NEXT_PUBLIC_CONTACT_EMAIL,
+  NEXT_PUBLIC_CONTACT_ADDRESS: process.env.NEXT_PUBLIC_CONTACT_ADDRESS,
+  NEXT_PUBLIC_VERCEL_ENV: process.env.NEXT_PUBLIC_VERCEL_ENV,
+};
+
+/**
+ * REQUIRED means: absent, the page tells a visitor something WRONG —
+ * including by omission, when the omission is indistinguishable from "no
+ * such company". OPTIONAL means: absent, a capability is off and
+ * everything else is unaffected.
+ */
+export const PUBLIC_MANIFEST: ReadonlyArray<PublicEnvVar> = [
+  {
+    key: 'NEXT_PUBLIC_LEGAL_ENTITY',
+    level: REQUIRED,
+    consequence:
+      'The site names no legal entity. Every other surface — the deed '
+      + 'footer, the terms, the invoice — is issued by a company, and the '
+      + 'public page that is forwarded to escrows would be the one place '
+      + 'that names nobody. Also the copyright line, which falls back to '
+      + '"DeedPro" and so LOOKS correct while asserting a brand rather '
+      + 'than an entity.',
+  },
+  {
+    key: 'NEXT_PUBLIC_CONTACT_EMAIL',
+    level: REQUIRED,
+    consequence:
+      'THE REASON THIS MODULE EXISTS. A title rep forwards this page to '
+      + 'escrow officers who need a way to reach us, and there is none. '
+      + 'The failure is invisible from the inside: the page renders, '
+      + 'nothing errors, and the loss is a message nobody sent.',
+  },
+  {
+    key: 'NEXT_PUBLIC_CONTACT_ADDRESS',
+    level: REQUIRED,
+    consequence:
+      'No mailing address. Owner-classified REQUIRED against the '
+      + 'narrower reading that a footer with a name and an email degrades '
+      + 'honestly: this product prepares instruments that carry a '
+      + 'RECORDING REQUESTED BY address, and a preparer with no findable '
+      + 'address of its own reads as a shell to the exact audience being '
+      + 'asked to trust it.',
+  },
+  {
+    key: 'NEXT_PUBLIC_VERCEL_ENV',
+    level: OPTIONAL,
+    consequence:
+      'Exposed automatically by Vercel ("production" | "preview" | '
+      + '"development"). Absent, `isProduction()` falls back to '
+      + 'NODE_ENV, so a PREVIEW build reads as production and hides the '
+      + 'placeholder that a preview exists to show. Nothing a visitor '
+      + 'sees on production changes, which is why it is OPTIONAL — the '
+      + 'cost of its absence is a check that is quieter than intended.',
+  },
+];
+
+export const REQUIRED_PUBLIC_KEYS = PUBLIC_MANIFEST
+  .filter((v) => v.level === REQUIRED).map((v) => v.key);
+
+/** The build-time value of a declared variable, trimmed, or undefined. */
+export function publicEnvValue(key: string): string | undefined {
+  return (VALUES[key] || '').trim() || undefined;
+}
+
+/**
+ * Production means "a stranger is reading this", not "NODE_ENV says so".
+ *
+ * A Vercel preview build is NODE_ENV=production too, so NODE_ENV alone
+ * would suppress the placeholder on exactly the deploys built to catch
+ * this. `NEXT_PUBLIC_VERCEL_ENV` distinguishes them; NODE_ENV is the
+ * fallback for `next start` on a box that is not Vercel.
+ */
+export function isProduction(): boolean {
+  const vercel = publicEnvValue('NEXT_PUBLIC_VERCEL_ENV');
+  if (vercel) return vercel === 'production';
+  return process.env.NODE_ENV === 'production';
+}
+
+export function missingPublicEnv(level: EnvLevel = REQUIRED): PublicEnvVar[] {
+  return PUBLIC_MANIFEST.filter((v) => v.level === level && !publicEnvValue(v.key));
+}
+
+/** `STRICT_PUBLIC_ENV=1` turns the boot report into a refusal to start. */
+export function strictPublicEnv(): boolean {
+  return ['1', 'true', 'True'].includes((process.env.STRICT_PUBLIC_ENV || '').trim());
+}
+
+/**
+ * The block printed at boot. Empty string when nothing is missing.
+ *
+ * Written to be unmissable in a deploy log, for the same reason the
+ * backend's is: a one-line warning among startup chatter is a warning
+ * nobody reads, and this instrument exists because the last failure was
+ * silent.
+ */
+export function publicEnvReport(): string {
+  const goneRequired = missingPublicEnv(REQUIRED);
+  const goneOptional = missingPublicEnv(OPTIONAL);
+  if (!goneRequired.length && !goneOptional.length) return '';
+
+  const lines: string[] = ['', '='.repeat(72)];
+  if (goneRequired.length) {
+    lines.push('!! MISSING REQUIRED PUBLIC ENVIRONMENT — the site will tell '
+      + 'visitors something WRONG, not merely less');
+    lines.push('='.repeat(72));
+    for (const v of goneRequired) {
+      lines.push(`  ${v.key}`);
+      lines.push(`      ${v.consequence}`);
+    }
+    lines.push('');
+    lines.push('  These are BUILD-TIME values. Setting them on the running '
+      + 'service is not enough —');
+    lines.push('  the site has to be rebuilt for a visitor to see them.');
+  }
+  if (goneOptional.length) {
+    lines.push('-'.repeat(72));
+    lines.push('Optional variables absent — a capability is off, nothing is wrong:');
+    for (const v of goneOptional) lines.push(`  ${v.key} — ${v.consequence}`);
+  }
+  lines.push('='.repeat(72));
+  lines.push('');
+  return lines.join('\n');
+}
+
+export class PublicEnvironmentError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PublicEnvironmentError';
+  }
+}
+
+/**
+ * Print the report; refuse to boot under `STRICT_PUBLIC_ENV`.
+ *
+ * Returns the missing REQUIRED variables so a caller can decide for
+ * itself, which is how the backend's `check()` behaves and how the
+ * contact block asks its question.
+ */
+export function checkPublicEnv(): PublicEnvVar[] {
+  const text = publicEnvReport();
+  if (text) {
+    // eslint-disable-next-line no-console
+    console.error(text);
+  }
+  const gone = missingPublicEnv(REQUIRED);
+  if (gone.length && strictPublicEnv()) {
+    throw new PublicEnvironmentError(
+      'STRICT_PUBLIC_ENV is set and these required variables are missing: '
+      + gone.map((v) => v.key).join(', '),
+    );
+  }
+  return gone;
+}


### PR DESCRIPTION
Three items from the HOME2 review: the overturned footer ruling, the DECIDED/BUILT convention, and the registry-side pin I flagged as least-sure.

## 1. The footer fails loudly (§14.8 recorded)

HOME2 rendered nothing when the contact variables were unset, on an "absence is neutral" reading. The ruling that overturned it is now doctrine: **that rule governs DATA — an unmeasured value, an empty list, a county nobody set. A missing contact address is a broken deploy.** The test that separates the two cases is *who was supposed to supply this value*: if the answer is the world, the officer, or a county, absent is a fact; if the answer is us, at deploy time, absent is a defect.

**`frontend/src/lib/publicEnvironment.ts`** is deliberately the same instrument as `backend/services/environment.py` — a manifest, REQUIRED/OPTIONAL with a consequence sentence apiece, an unmissable block at boot, and a strict flag that converts the warning into a refusal. A second design for the same problem is a second thing to learn.

**`frontend/src/instrumentation.ts`** — Next calls `register()` at server start, which is the only moment this app has corresponding to the API's boot. That is where the report prints and where `STRICT_PUBLIC_ENV=1` refuses.

**`ContactBlock.tsx`** picks its surface by its reader. Outside production the gap renders on the page naming the exact variables, because the reader can fix it. In production the reader is a stranger, and a box reading MISSING CONTACT DETAILS tells them the deploy is broken while still giving them no address — so the loud channel there is the deploy log. Partial configuration still renders: an email with no mailing address is reachable, and reachable was the point.

What did **not** change: nothing is invented. A guessed legal entity is worse than an absent one, because an absent one is obviously missing and a wrong one looks answered. The placeholder names variables, never a plausible company — pinned.

**One asymmetry with the API, and it runs the other way.** The backend defaults to warn-not-refuse because a process that will not start turns a wrong redirect into a total outage — "the refusal is then the incident". That reasoning does not transfer: a frontend build or boot that refuses leaves the previous deploy serving. Strict is *cheaper* here. It is off today only because the values do not exist yet — turning it on would block every deploy, starting with this one. Ledgered with an explicit trigger: the ticket that sets the three variables sets the flag in the same change.

The three variables are also declared in `frontend/env.example`, because W0's lesson was that a fact nothing declares is a fact nothing can notice is missing.

## 2. DECIDED and BUILT are fields, repo-wide

Written at the top of `OWNER_LEDGER.md`. `BUILT` takes a PR number, a date, or the word **no**, and is never omitted — an absent field reads as an oversight, which is the exact failure being fixed. `grep -c 'BUILT — no'` is now a number about the product.

W0 §3 is converted as the first entry, being the one the convention exists because of. The sweep of the rest is ledgered as **HOME2-FOLLOWUP**, per the ruling — and scoped with the trap named: `BUILT` has to be *answered from the code*, not transcribed from the entry's own prose, or the conversion reproduces the defect in a new format. Expected yield stated in advance (the two known cases plus an unknown number) so a sweep that finds nothing else counts as a result rather than a disappointment.

## 3. The instrument count is derived, not remembered

`INSTRUMENT_COUNT` lives with the registry and both homepage surfaces read it, so a 22nd instrument updates the copy rather than silently outdating it. The pin in `formRegistry.test.ts` is the backstop, not the mechanism (§14.7): it fails **closed** when a literal count reappears anywhere near the word "instrument", and it carries its own mutation probe for the two failure directions §14.1.1 asks for — a re-hardcoded number and a stale one.

## Self-review

**Premises checked, and what was found**
- *The homepage states the count once* — **false, twice.** The stats bar and the API section both printed `21` independently. The second was the live drift risk and the reason the fix is derivation rather than a pin on one line.
- *A pin on the literal would satisfy the ruling* — it would, and I built the stronger form instead. A pin that greps `value: "21"` breaks on any restyle of the stats array and, worse, stops covering silently if the shape changes without the string. Derivation removes the failure mode; the pin then guards the derivation.
- *`instrumentation.ts` needs an experimental flag* — **false** on Next 15.4; it is stable, and `next build` is clean.
- *Vercel preview builds are distinguishable by `NODE_ENV`* — **false.** A preview build is `NODE_ENV=production` too, so NODE_ENV alone would suppress the placeholder on exactly the deploys built to surface it. `NEXT_PUBLIC_VERCEL_ENV` is the discriminator, declared OPTIONAL with the consequence of its own absence spelled out.

**Pins changed, and in which direction**
All tightening, no loosening. Two new pin families: the public-env manifest (including a §14.3 sweep that no other module reads those names, and a pin that every declared key has a *literal* read — a dynamic lookup would report every variable missing in every browser while the site rendered fine, a check that fails open invisibly), and the instrument-count sweep. Both mutation-probed: re-hardcoding `"21"` fails the sweep; adding a second `process.env.NEXT_PUBLIC_CONTACT_EMAIL` elsewhere fails the §14.3 pin.

**Least sure about**
The `NEXT_PUBLIC_CONTACT_ADDRESS` classification. By the manifest's own test — *does its absence change behaviour silently and wrongly?* — a footer with a name and an email degrades honestly rather than lying, which argues OPTIONAL. It is REQUIRED because you classified it that way explicitly, and the entry says so in its own words rather than dressing my reasoning as yours. Worth a second look when the values are supplied.

**What would be cut if forced**
The `env.example` declarations. They are the cheapest part and the most redundant with the manifest — though redundancy is the point of a file people read before deploying.

**Anything decided rather than flagged**
The homepage now imports the form registry, which costs **~6 kB of first-load JS** on the landing page (measured: 124 kB → 130 kB; page chunk 21.3 kB → 22.5 kB). I decided that trade rather than asking, on the grounds that the alternative was the pin-a-literal design I'd already rejected. The registry is a zero-import leaf data module, so nothing else came with it. Flagging it because it is a marketing page and the number is real.

## Gates

pytest **1480** · jest **1111** / 79 suites (was 1089/78) · tsc **88** · `next build` clean · banned-claims clean (14 rules, 243 files) · four harnesses green (s1, s3, six-flow verify, api-baseline verify).

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_