### PR TITLE
CORS1 — every settings save died at the preflight, on one missing method

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -61,25 +61,65 @@ if os.getenv("ENVIRONMENT") == "staging":
         enable_detailed_logging=True
     )
 
-# Allow CORS for local dev and frontend
+# ── CORS: who may call this API from a browser, and how ──────────────
+#
+# CORS1. The old list here omitted PATCH, which is the method the entire
+# settings and onboarding save path uses — so every profile save died at
+# the preflight, and the browser reported "failed to fetch", which is
+# what it says when a preflight is refused and is indistinguishable from
+# the API being down. The owner could not set his own recording county.
+#
+# It stayed invisible because `"*"` was in the origin list: every origin
+# was already accepted, so no origin experiment could ever fail and the
+# method list was never the suspect. Two rounds went into ALLOWED_ORIGINS,
+# a variable nothing read.
+#
+# The policy — origins, preview regex, methods, and the reasoning for
+# each — now lives in services/cors_policy.py, where a pin can assert
+# properties about it. The one that matters:
+# `test_cors_contract.py::every method the app serves is allowed`.
+from services.cors_policy import (
+    ALLOWED_METHODS as _CORS_METHODS,
+    PREVIEW_ORIGIN_REGEX as _CORS_PREVIEW_REGEX,
+    effective_origins as _cors_origins,
+    policy_report as _cors_report,
+)
+
+print(_cors_report(), flush=True)
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "http://localhost:3000",
-        "https://deedpro-frontend-new.vercel.app",
-        "https://deedpro-frontend-new-*.vercel.app",  # Preview deployments
-        "*"  # Fallback for development
-    ],
+    allow_origins=_cors_origins(),
+    # Preview deployments. The old list carried this as a literal glob
+    # string in `allow_origins`, where Starlette compares exactly and
+    # never globs — so it matched nothing, and previews worked only
+    # because of the wildcard that is now gone.
+    allow_origin_regex=_CORS_PREVIEW_REGEX,
     allow_credentials=True,
-    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    allow_methods=list(_CORS_METHODS),
     allow_headers=["*"],
 )
 
 # RED-S1: one connection per request, checked out here and returned here.
 #
-# Registered AFTER the metrics middleware below, which means Starlette
-# runs it FIRST — the connection is bound before any handler touches
-# `db.conn` and returned after the response is produced.
+# ⚠️ THE ORDERING SENTENCE HERE WAS WRONG, corrected during CORS1 and
+# left visible rather than quietly replaced. It read: "Registered AFTER
+# the metrics middleware below, which means Starlette runs it FIRST."
+# This decorator runs BEFORE metrics' at import, and `add_middleware`
+# prepends — so the real order, outermost first, is metrics → this →
+# CORS → routes. Verified by reading `app.user_middleware` rather than by
+# reasoning about it a second time.
+#
+# The claim that MATTERED is unaffected: this middleware still wraps every
+# route, so the connection is bound before any handler touches `db.conn`
+# and returned after the response is produced.
+#
+# ⚠️ AND CORS IS INNERMOST, which has a cost worth naming: a preflight
+# OPTIONS passes through both middlewares and OPENS A DATABASE CONNECTION
+# before CORS answers it — measured, one connection per preflight, for a
+# request that never reaches a route. Reported rather than changed in
+# CORS1 (owner-scoped); the fix is either an OPTIONS early-return here or
+# registering CORS last so it becomes outermost.
 #
 # Before this, every request shared one connection and therefore one
 # TRANSACTION: request B's commit() could commit request A's uncommitted

--- a/backend/services/cors_policy.py
+++ b/backend/services/cors_policy.py
@@ -1,0 +1,219 @@
+"""Who may call this API from a browser, and with which methods.
+
+═══ THE DEFECT THIS FILE IS BUILT AROUND ═══
+
+`allow_methods` listed GET, POST, PUT, DELETE and OPTIONS. **It did not
+list PATCH.** `frontend/src/lib/profileSave.ts` — the single save path
+for the whole settings and onboarding surface — sends PATCH. So every
+profile save died at the CORS PREFLIGHT, before the request existed as
+far as the API was concerned: OPTIONS with `Access-Control-Request-
+Method: GET` returned 200, the same request with PATCH returned 400.
+
+The owner could not set his own recording county. The symptom reported
+was "failed to fetch", which is what a browser says when a preflight is
+refused, and which is indistinguishable from the API being down.
+
+═══ WHY IT WAS INVISIBLE FOR SO LONG, AND THIS IS THE REAL LESSON ═══
+
+The origin list contained `"*"`. Every origin was therefore already
+accepted, which meant every CORS experiment "worked" and no origin
+question could ever be the answer — while the METHOD list, which is where
+the actual refusal lived, went unexamined.
+
+Two rounds were spent on `ALLOWED_ORIGINS`, a variable that **nothing
+read**. It was declared REQUIRED in the manifest on a claim about CORS
+that was never true, the boot check dutifully reported it missing, the
+owner set it, and setting it changed nothing — because `main.py`
+hardcoded its list. The manifest was later corrected to OPTIONAL with the
+note "Read by NOTHING today", and that correction was written before this
+incident and read after it.
+
+**A boot check verifies PRESENCE, not CONSUMPTION.** That is the shape
+worth carrying: a variable can be declared, required, set, and reported
+healthy while being wired to nothing. See the ledger entry.
+
+═══ WHAT THIS MODULE DOES, AND WHAT IT DELIBERATELY DOES NOT ═══
+
+It owns the origin list, the preview-deployment regex, and the method
+list, so that all three are in ONE place with the reasoning attached, and
+so that `test_cors_contract.py` can assert properties about them —
+principally that **every method registered on any router is allowed**,
+which is the pin that would have caught the original defect the day PATCH
+was introduced.
+
+It does NOT decide the middleware ORDER. See main.py: CORS is currently
+the innermost of three middlewares, so every preflight opens and returns
+a database connection before CORS answers it. That is reported, not
+changed, in this ticket.
+"""
+from __future__ import annotations
+
+import os
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+# ── The origins we know about ────────────────────────────────────────
+#
+# THE FLOOR, not the whole list: `ALLOWED_ORIGINS` may add to it (see
+# `effective_origins`). Every entry is a real host this API is called
+# from by a browser.
+#
+# `"*"` IS DELIBERATELY ABSENT. It was in the old list as a "fallback for
+# development" and it is invalid in this configuration: the CORS spec
+# forbids `Access-Control-Allow-Origin: *` together with
+# `Access-Control-Allow-Credentials: true`, and browsers reject the pair
+# on any credentialed request. It happened not to bite because the
+# frontend authenticates with an `Authorization` header rather than
+# cookies — so the pair was merely broken rather than breaking — but it
+# is what made a wrong origin list unfalsifiable for two rounds.
+DEFAULT_ORIGINS: Tuple[str, ...] = (
+    "http://localhost:3000",
+    "https://deedpro-frontend-new.vercel.app",
+    # Owner-named, 2026-08-18: both the apex and the www host belong in
+    # the list. Declared here rather than waiting for a dashboard value,
+    # because an origin missing from this list is a total failure for
+    # everyone browsing from that host.
+    "https://deedpro.io",
+    "https://www.deedpro.io",
+)
+
+# ── Preview deployments ──────────────────────────────────────────────
+#
+# The old list carried `"https://deedpro-frontend-new-*.vercel.app"` as a
+# literal string. **Starlette does not glob `allow_origins`** — it
+# compares them exactly, and globbing exists only through
+# `allow_origin_regex`. That entry has therefore never matched a single
+# preview deployment in its life; previews worked because of `"*"`, and
+# would have stopped working the moment the wildcard was removed with the
+# glob left in place.
+PREVIEW_ORIGIN_REGEX = r"^https://deedpro-frontend-new-[a-z0-9-]+\.vercel\.app$"
+
+# ── The methods this API answers ─────────────────────────────────────
+#
+# Written out rather than derived from the route table, and the choice is
+# deliberate. Deriving would make any newly registered method allowed
+# automatically — including one added by accident — whereas this list
+# plus its pin makes widening the browser-facing surface a thing somebody
+# WROTE DOWN. The pin (`test_cors_contract.py`) fails closed: a route
+# registered with a method missing here turns CI red, which is exactly
+# the event that did not happen when PATCH arrived.
+ALLOWED_METHODS: Tuple[str, ...] = (
+    "GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS",
+)
+
+#: Rejected out of hand if it appears in `ALLOWED_ORIGINS`. See above:
+#: with credentials enabled this is not a permissive setting, it is an
+#: invalid one, and it hides every other origin mistake.
+WILDCARD = "*"
+
+
+def parse_origins(raw: Optional[str]) -> Tuple[List[str], List[str]]:
+    """Split a comma-separated `ALLOWED_ORIGINS` into (accepted, refused).
+
+    Refused entries are returned rather than dropped so the boot report
+    can NAME them. A value silently ignored is how the last two rounds
+    went.
+    """
+    accepted: List[str] = []
+    refused: List[str] = []
+    for piece in (raw or "").split(","):
+        origin = piece.strip().rstrip("/")
+        if not origin:
+            continue
+        if origin == WILDCARD:
+            refused.append(origin)
+        elif "*" in origin:
+            # A glob here is not a permissive rule, it is a string that
+            # matches nothing — the exact defect the old list carried.
+            refused.append(origin)
+        else:
+            accepted.append(origin)
+    return accepted, refused
+
+
+def effective_origins(env: Optional[Dict[str, str]] = None) -> List[str]:
+    """The list handed to the middleware: the floor, plus whatever the
+    deploy config adds.
+
+    ═══ WHY UNION AND NOT REPLACEMENT — FLAGGED, NOT DECIDED ═══
+
+    The ruling was that the deploy config should OWN the origin list.
+    Replacement is one line from here and it is deliberately not taken
+    yet, for a reason that is about this specific moment rather than
+    about the design:
+
+    `render.yaml` declares `ALLOWED_ORIGINS` as a single origin
+    (`https://deedpro-frontend-new.vercel.app`), the dashboard value is
+    not readable from this repository, and the variable has never been
+    consumed — so nobody has ever had a reason to keep it correct. Under
+    replacement, the first deploy of this file would hand the middleware
+    whatever that stale value happens to be and could remove
+    `deedpro.io` from the allowed set: a total outage for every browser
+    on the real domain, shipped by the ticket that fixed a CORS bug.
+
+    So the env can ADD but not REMOVE until the value is known good. The
+    boot report prints the effective list, which is how it becomes known
+    good. Flipping to replacement is: `return accepted or list(DEFAULT_
+    ORIGINS)`.
+    """
+    source = os.environ if env is None else env
+    accepted, _ = parse_origins(source.get("ALLOWED_ORIGINS"))
+    merged = list(DEFAULT_ORIGINS)
+    for origin in accepted:
+        if origin not in merged:
+            merged.append(origin)
+    return merged
+
+
+def route_methods(routes: Iterable) -> List[str]:
+    """Every HTTP method registered on the app, HEAD excluded.
+
+    HEAD is added automatically by Starlette beside every GET and is not
+    something a browser sends through a preflight, so it is not part of
+    the surface this policy governs.
+    """
+    found = set()
+    for route in routes:
+        for method in (getattr(route, "methods", None) or ()):
+            if method != "HEAD":
+                found.add(method)
+    return sorted(found)
+
+
+def uncovered_methods(routes: Iterable,
+                      allowed: Sequence[str] = ALLOWED_METHODS) -> List[str]:
+    """Methods the app serves that a browser is not allowed to preflight.
+
+    This is the whole ticket in one function. It returned `['PATCH']` for
+    the entire life of the settings page.
+    """
+    allow = {m.upper() for m in allowed}
+    return [m for m in route_methods(routes) if m.upper() not in allow]
+
+
+def policy_report(env: Optional[Dict[str, str]] = None) -> str:
+    """What this API will accept, printed at boot.
+
+    The origin list has been wrong in production for months and no log
+    line anywhere said what it was. This is that line — and it is also
+    how the `ALLOWED_ORIGINS` value becomes known good enough to switch
+    `effective_origins` to replacement.
+    """
+    source = os.environ if env is None else env
+    accepted, refused = parse_origins(source.get("ALLOWED_ORIGINS"))
+    lines = ["", "-" * 72, "CORS policy in effect:"]
+    for origin in effective_origins(source):
+        where = "env + code" if origin in accepted else "code"
+        lines.append(f"  {origin}   [{where}]")
+    lines.append(f"  preview deployments matching  {PREVIEW_ORIGIN_REGEX}")
+    lines.append(f"  methods: {', '.join(ALLOWED_METHODS)}")
+    if refused:
+        lines.append("")
+        lines.append("  !! IGNORED entries in ALLOWED_ORIGINS — a wildcard is "
+                     "invalid with credentials,")
+        lines.append("     and a glob matches nothing (Starlette globs only "
+                     "via allow_origin_regex):")
+        for origin in refused:
+            lines.append(f"       {origin}")
+    lines.append("-" * 72)
+    lines.append("")
+    return "\n".join(lines)

--- a/backend/services/environment.py
+++ b/backend/services/environment.py
@@ -103,30 +103,39 @@ MANIFEST: Tuple[EnvVar, ...] = (
            "checkout failed at Stripe with an error about a price that "
            "was never real. Fail loudly with a named reason, never fall "
            "back to a placeholder."),
-    # ⚠️ THIS ENTRY WAS WRONG, AND THE CORRECTION MATTERS MORE THAN THE
-    # ENTRY. It said CORS breaks without this variable. **Nothing reads
-    # it.** `main.py` hardcodes its origin list, and a grep of the whole
-    # backend finds this name in exactly one place: here, declaring it
-    # required.
+    # ⚠️ THIS ENTRY WAS WRONG TWICE, AND THE HISTORY IS THE POINT.
     #
-    # The boot check named it missing on the first production deploy, the
+    # v1 said CORS breaks without this variable. Nothing read it. The
+    # boot check named it missing on the first production deploy, the
     # owner set it on the strength of that, and setting it changed
-    # nothing — because the claim it was acting on was mine and it was
-    # false. A manifest that is believed is a manifest that has to be
-    # right.
+    # nothing — because the claim it was acting on was false.
     #
-    # Classified OPTIONAL because that is the truth about its ABSENCE:
-    # nothing changes. It is not deleted, because `render.yaml` declares
-    # it and the two files are checked against each other — and because
-    # the open question is whether `main.py` should read it, which is a
-    # production CORS change and the owner's to rule. See the ledger.
+    # v2 corrected that to "Read by NOTHING today", classified it
+    # OPTIONAL, and left the open question for a ruling. **That
+    # correction was written before the CORS incident and read after
+    # it.** Two more rounds were spent on this variable during a live
+    # outage whose cause was a missing PATCH in `allow_methods`, with the
+    # sentence that would have ended the search sitting in this file.
+    #
+    # A BOOT CHECK VERIFIES PRESENCE, NOT CONSUMPTION. That is the
+    # general shape and it is now in the ledger: a variable can be
+    # declared, classified REQUIRED, set by hand, and reported healthy
+    # while being wired to nothing at all.
+    #
+    # CORS1 resolved it the way the owner ruled — the middleware now
+    # READS it (services/cors_policy.py). Still OPTIONAL, and now that is
+    # a statement about behaviour rather than an admission: absent, the
+    # code's own origin list applies, and that list is correct today.
     EnvVar("ALLOWED_ORIGINS", OPTIONAL,
-           "Read by NOTHING today. `main.py` hardcodes `allow_origins` "
-           "and never consults this name, so its absence changes no "
-           "behaviour and setting it changes none either. Declared here "
-           "and in render.yaml, which is how it came to be set on a "
-           "service that does not consume it. Pending an owner ruling on "
-           "whether CORS should be configured from it."),
+           "Comma-separated extra browser origins, read by "
+           "services/cors_policy.py since CORS1. ADDS to the list in "
+           "code; it cannot remove from it, deliberately — a stale "
+           "single-origin value would otherwise take the real domain "
+           "offline on deploy. Absent, the built-in list applies and "
+           "nothing changes. A `*` entry is IGNORED and named in the "
+           "boot report: with credentials enabled it is invalid per "
+           "spec, and it is what hid a wrong CORS configuration for "
+           "months."),
     EnvVar("SENDGRID_API_KEY", OPTIONAL,
            "No email leaves the building. OPTIONAL and it is a close "
            "call: the product degrades honestly — every sender returns "

--- a/backend/tests/test_cors_contract.py
+++ b/backend/tests/test_cors_contract.py
@@ -1,0 +1,252 @@
+"""The browser-facing surface, checked against the routes it serves.
+
+═══ THE DEFECT ═══
+
+`allow_methods` listed GET, POST, PUT, DELETE, OPTIONS — and not PATCH.
+`profileSave.ts` sends PATCH, and it is the single save path for the
+settings and onboarding screens. Every save died at the preflight:
+OPTIONS with `Access-Control-Request-Method: GET` returned 200, the same
+request with PATCH returned 400. The owner could not set his own
+recording county, and the browser's report — "failed to fetch" — is what
+it says when a preflight is refused, which is indistinguishable from the
+API being down.
+
+═══ WHY NOTHING CAUGHT IT ═══
+
+Two declarations of one contract with nothing comparing them: the route
+table says which methods this API serves, `allow_methods` says which a
+browser may use, and no third thing checked the second against the first.
+That is the same shape as the drifted Shared Deeds row keys, the notary
+package's advertised-but-unrouted links, and the render.yaml/manifest
+split — and it is the reason the FIRST pin below is the one that matters.
+It fails the moment a route is registered with a method a browser cannot
+preflight, which is the event that happened silently when PATCH arrived.
+
+═══ AND WHY IT STAYED INVISIBLE FOR MONTHS ═══
+
+`"*"` was in the origin list. Every origin was already accepted, so no
+CORS experiment could fail on origin grounds and the method list was
+never the suspect. The wildcard did not cause the bug; it removed the
+only signal that would have found it — while being, in combination with
+`allow_credentials=True`, invalid per spec on every credentialed request.
+"""
+from __future__ import annotations
+
+import pytest
+
+from services import cors_policy as policy
+
+
+def _app():
+    import main
+    return main.app
+
+
+def _cors_options(app) -> dict:
+    """The options actually handed to CORSMiddleware.
+
+    Read off the app rather than off the source: a test that greps
+    main.py for the string "PATCH" would pass while the middleware was
+    configured from something else entirely (§14.1.1 — assert the
+    property, not the line that currently expresses it).
+    """
+    for middleware in app.user_middleware:
+        cls = getattr(middleware, "cls", None)
+        if getattr(cls, "__name__", "") == "CORSMiddleware":
+            options = getattr(middleware, "kwargs", None)
+            if options is None:  # older Starlette
+                options = getattr(middleware, "options", {})
+            return dict(options)
+    pytest.fail("no CORSMiddleware is installed on the app")
+
+
+# ═══ THE PIN THIS FILE EXISTS FOR ════════════════════════════════════
+
+def test_every_method_the_app_serves_may_be_preflighted():
+    """The route table is the authority; `allow_methods` follows it.
+
+    Returned `['PATCH']` for the entire life of the settings page.
+    """
+    app = _app()
+    missing = policy.uncovered_methods(app.routes, _cors_options(app)["allow_methods"])
+    assert missing == [], (
+        "these methods are registered on routes but cannot be preflighted "
+        f"by a browser: {missing}. Every request using one of them fails "
+        "before it reaches the API, and the browser reports it as a "
+        "network error."
+    )
+
+
+def test_patch_specifically():
+    """Named on its own, because it is the one that was missing.
+
+    Redundant with the sweep above by design: the sweep states the rule
+    and this states the incident, so a future reader who breaks it sees
+    the story rather than a set difference.
+    """
+    assert "PATCH" in _cors_options(_app())["allow_methods"]
+
+
+def test_the_route_table_actually_has_patch_routes():
+    """Guards the sweep against passing vacuously.
+
+    A sweep over an empty set is green, and an import failure that left
+    `app.routes` unpopulated would make the pin above meaningless while
+    looking healthy (§14.2 — a control is checked before its result is
+    believed).
+    """
+    assert "PATCH" in policy.route_methods(_app().routes)
+
+
+# ═══ ORIGINS ═════════════════════════════════════════════════════════
+
+def test_no_wildcard_origin():
+    """`*` with `allow_credentials=True` is invalid per spec.
+
+    Browsers reject the pair on credentialed requests; ours happened to
+    survive it by authenticating with an `Authorization` header rather
+    than cookies. It is removed as a broken pair, and because it made
+    every origin misconfiguration unfalsifiable.
+    """
+    options = _cors_options(_app())
+    assert options["allow_credentials"] is True
+    assert "*" not in options["allow_origins"]
+
+
+def test_the_real_domains_are_allowed():
+    """Owner-named: the apex and the www host both belong in the list."""
+    origins = _cors_options(_app())["allow_origins"]
+    for origin in ("https://deedpro.io", "https://www.deedpro.io"):
+        assert origin in origins
+
+
+def test_no_glob_is_left_in_the_origin_list():
+    """Starlette compares origins EXACTLY; only `allow_origin_regex` globs.
+
+    `https://deedpro-frontend-new-*.vercel.app` sat in the list as a
+    literal string and matched nothing for its entire life. Previews
+    worked because of the wildcard, so removing the wildcard without
+    noticing this would have broken every preview deployment.
+    """
+    options = _cors_options(_app())
+    assert not [o for o in options["allow_origins"] if "*" in o]
+    assert options.get("allow_origin_regex"), (
+        "preview deployments need a regex — a glob in allow_origins is a "
+        "string that matches nothing"
+    )
+
+
+@pytest.mark.parametrize("origin,expected", [
+    ("https://deedpro-frontend-new-git-main-easydeed.vercel.app", True),
+    ("https://deedpro-frontend-new.vercel.app", False),   # exact-match entry
+    ("https://deedpro-frontend-new-evil.attacker.com", False),
+    ("https://evil.com/deedpro-frontend-new-x.vercel.app", False),
+])
+def test_the_preview_regex_matches_previews_and_nothing_else(origin, expected):
+    """Anchored at both ends, which is the difference between a preview
+    rule and an open door."""
+    import re
+    assert bool(re.match(policy.PREVIEW_ORIGIN_REGEX, origin)) is expected
+
+
+# ═══ THE ENV VARIABLE THAT WAS THEATRE ═══════════════════════════════
+
+def test_allowed_origins_is_read_now():
+    """It was declared, classified REQUIRED, set by hand, reported
+    healthy by the boot check — and consumed by nothing."""
+    assert "https://extra.example.com" in policy.effective_origins(
+        {"ALLOWED_ORIGINS": "https://extra.example.com"})
+
+
+def test_the_env_can_add_but_not_remove():
+    """Deliberate, and flagged rather than decided — see
+    `effective_origins`. A stale single-origin dashboard value would
+    otherwise take the real domain offline on the deploy that fixed
+    CORS."""
+    origins = policy.effective_origins({"ALLOWED_ORIGINS": "https://extra.example.com"})
+    for floor in policy.DEFAULT_ORIGINS:
+        assert floor in origins
+
+
+def test_a_wildcard_in_the_env_is_ignored_and_named():
+    """Ignoring it silently is how a value nobody reads gets set twice."""
+    accepted, refused = policy.parse_origins("*, https://ok.example.com")
+    assert accepted == ["https://ok.example.com"]
+    assert refused == ["*"]
+    assert "*" not in policy.effective_origins({"ALLOWED_ORIGINS": "*"})
+    assert "*" in policy.policy_report({"ALLOWED_ORIGINS": "*"})
+
+
+def test_a_glob_in_the_env_is_ignored_and_named():
+    """Same reason as the list in code: it matches nothing, and looking
+    like a rule is worse than being absent."""
+    accepted, refused = policy.parse_origins("https://*.example.com")
+    assert accepted == []
+    assert refused == ["https://*.example.com"]
+
+
+def test_the_boot_report_states_the_effective_policy():
+    """The origin list has been wrong in production for months and no log
+    line anywhere said what it was. This is that line — and it is the
+    precondition for switching to replace-semantics."""
+    text = policy.policy_report({"ALLOWED_ORIGINS": ""})
+    for origin in policy.DEFAULT_ORIGINS:
+        assert origin in text
+    assert "PATCH" in text
+
+
+# ═══ THE PREFLIGHT ITSELF, THROUGH THE REAL STACK ════════════════════
+#
+# Everything above reads configuration. This sends the request the
+# browser sent — the one that returned 400 — through the actual
+# middleware stack, because a configuration assertion is a claim about
+# what the middleware will do and this is the thing it does (§14.2).
+
+@pytest.mark.parametrize("method", ["GET", "POST", "PUT", "PATCH", "DELETE"])
+def test_a_real_preflight_is_answered_for_every_method(method):
+    from fastapi.testclient import TestClient
+    client = TestClient(_app())
+    response = client.options(
+        "/users/profile",
+        headers={
+            "Origin": "https://deedpro.io",
+            "Access-Control-Request-Method": method,
+            "Access-Control-Request-Headers": "authorization,content-type",
+        },
+    )
+    assert response.status_code == 200, (
+        f"preflight for {method} was refused with {response.status_code} — "
+        "this is the exact failure the settings page hit, and the browser "
+        "reports it as 'failed to fetch'"
+    )
+    assert response.headers["access-control-allow-origin"] == "https://deedpro.io"
+
+
+def test_a_preflight_from_an_unknown_origin_is_refused():
+    """The other half: removing the wildcard has to have MEANT something.
+
+    A test suite that only proves things are allowed cannot tell an
+    open door from a correct list.
+    """
+    from fastapi.testclient import TestClient
+    client = TestClient(_app())
+    response = client.options(
+        "/users/profile",
+        headers={
+            "Origin": "https://not-ours.example.com",
+            "Access-Control-Request-Method": "PATCH",
+        },
+    )
+    assert "access-control-allow-origin" not in response.headers
+
+
+def test_a_preview_deployment_is_allowed_through_the_regex():
+    from fastapi.testclient import TestClient
+    client = TestClient(_app())
+    origin = "https://deedpro-frontend-new-git-main-easydeed.vercel.app"
+    response = client.options(
+        "/users/profile",
+        headers={"Origin": origin, "Access-Control-Request-Method": "PATCH"},
+    )
+    assert response.status_code == 200
+    assert response.headers["access-control-allow-origin"] == origin

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -1131,6 +1131,70 @@ we reach it.
   The lesson transferring is rarer than it should be. Four sightings this
   week of a lesson NOT transferring; this is the one that did.
 
+## Findings that changed how we work
+
+- **CORS1 — A REQUIRED VARIABLE THAT NOTHING READ, SET CORRECTLY, AND
+  IRRELEVANT TO THE FAILURE IT WAS BELIEVED TO CAUSE** (2026-08-18).
+  **DECIDED** 2026-08-18 — the middleware reads `ALLOWED_ORIGINS`; the
+  wildcard and the dead glob go; the method list is pinned against the
+  route table.
+  **BUILT** — yes, CORS1.
+
+  **The defect, in one word.** `allow_methods` omitted `PATCH`.
+  `profileSave.ts` saves by PATCH, so every settings and onboarding save
+  died at the CORS preflight — OPTIONS advertising GET returned 200, the
+  same request advertising PATCH returned 400. The owner could not set
+  his own recording county. The browser's report, "failed to fetch", is
+  what it says when a preflight is refused and is indistinguishable from
+  the API being down, which is how it was read for two rounds.
+
+  **THE PART WORTH KEEPING IS NOT THE BUG.** `ALLOWED_ORIGINS` was:
+  declared in `render.yaml`, classified **REQUIRED** in the environment
+  manifest, named as missing by the boot check on a production deploy,
+  set by hand by the owner on the strength of that report, and then
+  reported healthy — while being **read by nothing at all**. `main.py`
+  hardcoded its own origin list.
+
+  **A boot check verifies PRESENCE, not CONSUMPTION.** It answers "is
+  this variable set", and it cannot answer "does anything use it". Every
+  signal in the loop was green and the loop was closed around nothing.
+  §14's family — a record that states more than it checks — this time in
+  the instrument built to catch exactly that class.
+
+  **AND THE CORRECTION WAS ALREADY WRITTEN.** The manifest entry had
+  been fixed weeks earlier to say "Read by NOTHING today… its absence
+  changes no behaviour and setting it changes none either." That
+  sentence was written before the incident and read after it. A record
+  being correct is not the same as a record being consulted, and this is
+  the second time in two weeks that an accurate entry failed to reach
+  the person who needed it — the first being W0 §3, which is why
+  DECIDED/BUILT became fields.
+
+  **The wildcard is why none of it was falsifiable.** `"*"` sat in the
+  origin list, so every origin was already accepted and no CORS
+  experiment could fail on origin grounds. It also made
+  `allow_credentials=True` invalid per spec — browsers reject that pair
+  on credentialed requests — which happened not to bite only because the
+  app authenticates with an `Authorization` header rather than cookies.
+  A permissive setting that hides the setting that matters is worse than
+  a strict one that breaks loudly.
+
+  **Two more live defects found in the same read:**
+  `"https://deedpro-frontend-new-*.vercel.app"` was a literal string in
+  `allow_origins`, where Starlette compares exactly and never globs — it
+  has never matched a preview deployment, and previews worked only
+  because of the wildcard. And every preflight OPTIONS opens a database
+  connection before CORS answers it, because CORS is the innermost of
+  three middlewares (measured: one connection per preflight, pool of
+  40). The first is fixed via `allow_origin_regex`; the second is
+  reported and held.
+
+  **What now catches it:** `test_cors_contract.py` compares the route
+  table against `allow_methods` — the two declarations that nothing was
+  comparing — and sends real preflights through the middleware stack for
+  every method. Removing PATCH again turns five tests red, including the
+  live preflight.
+
 ## Parked tickets (scoped, not scheduled)
 
 - **W0 §3 — A RULING DECIDED, PARKED, AND NEVER BUILT** (surfaced by

--- a/render.yaml
+++ b/render.yaml
@@ -99,8 +99,23 @@ services:
   - key: DATABASE_URL
     fromDatabase:
       name: deedpro-db
+  # CORS1: this variable is READ now. Until CORS1 it was declared here,
+  # classified in the manifest, set by hand in the dashboard on a boot
+  # report — and consumed by nothing, while `main.py` hardcoded its own
+  # list. Two rounds of a live outage were spent on it.
+  #
+  # It ADDS to the origin list in services/cors_policy.py and cannot
+  # remove from it. The value below is therefore a supplement, not the
+  # policy: `deedpro.io`, `www.deedpro.io`, the Vercel production alias
+  # and localhost are in the code, and preview deployments match a regex
+  # there. Nothing here needs to be set for the site to work.
+  #
+  # ⚠️ AND THE DASHBOARD VALUE GOVERNS, not this line — see the header.
+  # The API prints its effective CORS policy at boot; that log is how the
+  # real value becomes known, and knowing it is the precondition for
+  # switching the code from add-semantics to replace-semantics.
   - key: ALLOWED_ORIGINS
-    value: https://deedpro-frontend-new.vercel.app
+    value: https://deedpro-frontend-new.vercel.app,https://deedpro.io,https://www.deedpro.io
   # ── DECLARED BECAUSE ITS ABSENCE IS SILENT ────────────────────────
   #
   # `sync: false` means: this key is REQUIRED and its value is set in the


### PR DESCRIPTION
Blocking fix. Cursor's diagnosis is confirmed exactly: `allow_methods` omitted `PATCH`, `profileSave.ts` saves by PATCH, and every settings and onboarding save was refused before the request existed as far as the API was concerned.

## 1. The method list, and the pin that will catch the next one

`PATCH` added — but the ticket's real ask was the audit, and it found the surface is exactly `GET, POST, PUT, PATCH, DELETE` (73 gets, 53 posts, 3 puts, 3 patches, 6 deletes across the routers).

**`backend/tests/test_cors_contract.py`** compares the **route table** against `allow_methods` — the two declarations nothing was comparing. It reads the options off `app.user_middleware` rather than grepping `main.py`, so it asserts the property and not the line (§14.1.1), and it carries a vacuity guard: a sweep over an empty set is green, so a separate pin asserts the route table actually contains PATCH routes (§14.2).

It also sends **real preflights through the real middleware stack** for every method, because everything else in the file is a claim about what the middleware will do and this is the thing it does. Mutation probe: removing `PATCH` again turns five tests red, including `test_a_real_preflight_is_answered_for_every_method[PATCH]` — the exact 400 the browser hit.

I kept the method list explicit rather than deriving it from the route table. Deriving would auto-allow any newly registered method including an accidental one; the list plus the pin makes widening the browser-facing surface something a person wrote down, and the pin still fails closed.

## 2. `ALLOWED_ORIGINS` is read now — with one deviation, flagged

The middleware reads it (`services/cors_policy.py`), the manifest entry is rewritten to describe consumption rather than absence, and `render.yaml` carries the full list.

**The deviation: the env ADDS to the list in code rather than replacing it.** Your ruling was that the deploy config should own the list, and replacement is one line from where I stopped (`return accepted or list(DEFAULT_ORIGINS)`). I did not take it because of this specific moment rather than the design: `render.yaml` declared a *single* origin, the dashboard value is not readable from this repo, and the variable has never been consumed — so nobody has ever had a reason to keep it correct. Under replacement, the first deploy of this file hands the middleware whatever that stale value is and could drop `deedpro.io` from the allowed set: a total outage on the real domain, shipped by the ticket that fixed CORS.

So the env can add but not remove, **and the API now prints its effective CORS policy at boot** — which is how that value becomes known good, which is the precondition for flipping to replacement. `deedpro.io` and `www.deedpro.io` are in the code list regardless, per your note.

A `*` or a glob in the env is ignored **and named in the boot report**. Silently dropping a value is how a variable nobody reads gets set twice.

## 3. The wildcard, and why it cost two rounds

`"*"` accepted every origin, so no CORS experiment could fail on origin grounds and the method list was never the suspect. It also made `allow_credentials=True` invalid per spec — browsers reject that pair on credentialed requests — surviving only because the app authenticates with an `Authorization` header rather than cookies. Removed, with a pin that a request from an unknown origin gets no `Access-Control-Allow-Origin` back, so the removal means something.

## 4. The preview glob was never a glob

`"https://deedpro-frontend-new-*.vercel.app"` sat in `allow_origins`, where Starlette compares exactly. It has never matched a preview deployment — previews worked *because of the wildcard*, so removing the wildcard without noticing this would have broken every preview. Now `allow_origin_regex`, anchored at both ends, with a parametrised pin including `https://evil.com/deedpro-frontend-new-x.vercel.app` on the negative side.

## 5. Preflights and the connection pool — reported, held

**Confirmed and measured.** Middleware order, read off `app.user_middleware` rather than reasoned about: `metrics → db_connection → CORS → routes`. CORS is innermost, so a preflight passes through both and **opens exactly one database connection** (instrumented `db.request_connection`, one open per preflight) for a request that never reaches a route. Pool max is 40.

**Cost:** one pool slot per preflight, held for the duration of the CORS response — microseconds, no query, no transaction work. Every non-simple cross-origin request generates one, so it scales with request volume, not user count. Not a live risk at pilot scale; it is pool capacity spent on nothing.

**Is skipping OPTIONS in `db_connection_middleware` safe?** Yes, with one caveat: no route in the app registers OPTIONS, so nothing that needs a connection can be reached by an OPTIONS request today. The caveat is that this becomes false silently the day someone adds one — so if you take this route, it wants a pin (no route registers OPTIONS), not just an early return.

**I'd recommend the other fix instead:** register CORS *last* so it becomes the outermost middleware. Preflights then short-circuit before either middleware runs, which is standard ordering, needs no pin, and costs only that preflights stop being counted in `METRICS` — arguably more correct. One line moved. Held for your ruling either way.

While confirming the order I found the comment above `db_connection_middleware` states it **backwards** ("Registered AFTER the metrics middleware… which means Starlette runs it FIRST"). Corrected in place, with the correction left visible; the claim that mattered — the connection is bound before any handler — is unaffected.

## Self-review

**Premises checked, and what was found**
- *`allow_methods` omits PATCH* — **confirmed**, and it is the whole bug.
- *`ALLOWED_ORIGINS` is unread* — **confirmed**; `main.py` hardcoded the list.
- *The manifest already said so* — **confirmed, and this is the sharpest part.** The entry had been corrected weeks earlier to "Read by NOTHING today… setting it changes none either." Written before the incident, read after it. Ledgered as the second instance in two weeks of an accurate record failing to reach the person who needed it — the first being W0 §3, which is why DECIDED/BUILT became fields.
- *Removing `"*"` is safe* — **not fully verifiable from here.** It is the one change in this PR with outage potential: any browser origin not in the new list breaks. The list covers localhost, the Vercel production alias, previews by regex, the apex and www. If the site is served from a host outside that set, this PR breaks it and the boot report will say so in the first deploy log.

**Pins changed, and in which direction**
All new, all tightening. 22 tests: the method sweep, the incident named on its own, a vacuity guard, origin and regex properties, env parsing, and live preflights in both directions.

**Least sure about**
The add-not-replace semantics. It is the right call today and it is *also* the kind of accommodation that becomes permanent — a floor in code plus a list in config is two declarations again, which is the disease this ticket is about. It should collapse to one once you have read the boot report. Flagging it rather than letting it settle.

**What would be cut if forced**
The boot-time policy report. Everything else either fixes the outage or catches its recurrence.

**Anything decided rather than flagged**
Correcting the reversed ordering comment in `main.py` — outside the ticket's letter, inside a file I was editing, and a record that describes execution backwards is the class of thing §14 exists for.

## Gates

pytest **1502** (was 1480) · jest **1089** / 78 · tsc **88** · banned-claims clean (14 rules, 240 files) · four harnesses green.

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_