### PR TITLE
PILOT1 — cancelling is a control the officer can find

### DIFF
--- a/frontend/src/__tests__/billingCancel.test.tsx
+++ b/frontend/src/__tests__/billingCancel.test.tsx
@@ -1,0 +1,207 @@
+/**
+ * PILOT1 — cancelling is a control the officer can find.
+ *
+ * ═══ THE PREMISE THAT WAS WRONG, AND WHAT WAS ACTUALLY BROKEN ═══
+ *
+ * The ticket said `/payments/create-portal-session` "exists with no UI
+ * entry point anywhere". It has two — "Manage Payment Methods" and "View
+ * Billing History", both in the Billing tab, both calling it. The
+ * endpoint has been reachable the whole time.
+ *
+ * Three real defects sat behind that:
+ *
+ *  1. **Nothing said CANCEL.** The homepage promises "cancel anytime".
+ *     The officer acting on that promise had to already know that
+ *     Stripe's portal is where cancelling happens, and that a button
+ *     labelled "Manage Payment Methods" leads there.
+ *
+ *  2. **Every control was gated on `users.plan`** — a denormalised copy
+ *     of Stripe's state written by the webhook. Stale, and the customer
+ *     with a card on file is shown "No payment method on file" and has
+ *     no exit at all. The cancel control is deliberately ungated: it
+ *     asks Stripe and reports Stripe's answer.
+ *
+ *  3. **The API's reason was thrown away.** `throw new Error("Failed to
+ *     create portal session")` on any non-2xx, so the one informative
+ *     answer — 404, no billing record — arrived as a generic failure
+ *     (§4).
+ *
+ * ═══ WHAT IS PINNED, AND WHAT DELIBERATELY IS NOT ═══
+ *
+ * The PROPERTIES: a control whose accessible name says cancel; that it
+ * renders for a free-plan profile too; that each failure mode produces
+ * its own sentence. NOT the wording of the copy, and NOT any claim about
+ * WHEN access ends after cancelling — that is Stripe portal
+ * configuration this repository cannot see, and a pin asserting it would
+ * be a pin on a guess.
+ */
+import { describe, expect, it, beforeEach, afterEach, jest } from '@jest/globals';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+import { codeOnly } from '../test-support/sourceText';
+import {
+  BillingPortalError, NO_BILLING, PORTAL_PATH, UNREACHABLE, openBillingPortal,
+} from '../lib/billingPortal';
+
+const SRC = join(__dirname, '..');
+const SETTINGS = join(SRC, 'app', 'account-settings', 'page.tsx');
+const read = (p: string) => codeOnly(readFileSync(p, 'utf8'));
+
+jest.mock('sonner', () => ({ toast: { error: jest.fn(), success: jest.fn() } }));
+
+// Typed loosely on purpose: `jest.fn()` from @jest/globals infers a
+// zero-argument mock, so `mockRejectedValue(new TypeError(...))` is a
+// type error rather than a test failure — and the tsc baseline only
+// goes down.
+const fetchMock = jest.fn() as jest.Mock<any>;
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  (global as any).fetch = fetchMock;
+  window.localStorage.setItem('access_token', 'test-token');
+});
+afterEach(() => { jest.clearAllMocks(); });
+
+function answer(status: number, body: unknown) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+    headers: new Headers(),
+  } as unknown as Response);
+}
+
+describe('opening the portal', () => {
+  it('returns the URL Stripe gave us', async () => {
+    fetchMock.mockReturnValue(answer(200, { url: 'https://billing.stripe.com/s/abc' }));
+    await expect(openBillingPortal()).resolves.toBe('https://billing.stripe.com/s/abc');
+    expect(String(fetchMock.mock.calls[0][0])).toContain(PORTAL_PATH);
+    expect((fetchMock.mock.calls[0][1] as RequestInit).method).toBe('POST');
+  });
+
+  it('says there is no billing record, in the API\'s own terms', async () => {
+    /** The 404 is the informative answer, and it was the one being
+     *  flattened into "Failed to create portal session". */
+    fetchMock.mockReturnValue(answer(404, { detail: 'No billing information found' }));
+    await expect(openBillingPortal()).rejects.toMatchObject({
+      message: NO_BILLING, noBilling: true,
+    });
+  });
+
+  it('passes the API\'s reason through on any other refusal', async () => {
+    fetchMock.mockReturnValue(answer(400, { detail: 'Stripe error: no such customer' }));
+    await expect(openBillingPortal()).rejects.toThrow('Stripe error: no such customer');
+  });
+
+  it('names the status when the API gives no reason at all', async () => {
+    fetchMock.mockReturnValue(answer(500, {}));
+    await expect(openBillingPortal()).rejects.toThrow(/500/);
+  });
+
+  it('does not report success it did not get', async () => {
+    /** §4. A 200 carrying no URL is a failure, and navigating to
+     *  `undefined` would be the officer's version of it. */
+    fetchMock.mockReturnValue(answer(200, {}));
+    await expect(openBillingPortal()).rejects.toThrow(/no portal link/);
+  });
+
+  it('says the server was unreachable rather than "failed to fetch"', async () => {
+    fetchMock.mockRejectedValue(new TypeError('Failed to fetch'));
+    await expect(openBillingPortal()).rejects.toThrow(UNREACHABLE);
+  });
+
+  it('lets a session expiry pass through untouched', async () => {
+    /** RED-S3: a 401 is a pause the client already handles — turning it
+     *  into a billing error here would hide the re-auth. */
+    const expired = new Error('Session expired');
+    expired.name = 'SessionExpiredError';
+    fetchMock.mockRejectedValue(expired);
+    await expect(openBillingPortal()).rejects.toThrow('Session expired');
+    await expect(openBillingPortal()).rejects.not.toBeInstanceOf(BillingPortalError);
+  });
+});
+
+describe('the control on the page', () => {
+  /**
+   * Rendered rather than grepped. The defect being fixed is one of
+   * REACHABILITY — a handler existed and the officer could not find the
+   * thing it did — so an assertion that the source mentions "cancel"
+   * would restate the bug rather than catch it (§14.1.1).
+   */
+  async function billingTab(plan: string | undefined) {
+    fetchMock.mockImplementation((url: unknown) => {
+      if (String(url).includes('/users/profile')) {
+        return answer(200, { email: 'officer@example.com', plan });
+      }
+      return answer(404, { detail: 'No billing information found' });
+    });
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const Page = require('../app/account-settings/page').default;
+    render(<Page />);
+    const tab = await screen.findByRole('button', { name: /billing/i });
+    await userEvent.click(tab);
+    return tab;
+  }
+
+  it('offers a cancel control, by that name', async () => {
+    await billingTab('professional');
+    expect(await screen.findByRole('button', { name: /cancel subscription/i }))
+      .toBeInTheDocument();
+  });
+
+  it('offers it to a FREE profile too, because that column can be stale', async () => {
+    /**
+     * THE PIN THAT MATTERS. `users.plan` is written by the webhook; if
+     * it is wrong, every other billing control disappears and the
+     * customer being charged has no way out. This one asks Stripe.
+     */
+    await billingTab('free');
+    expect(await screen.findByRole('button', { name: /cancel subscription/i }))
+      .toBeInTheDocument();
+  });
+
+  it('shows the reason on the page when the portal will not open', async () => {
+    /** A toast that has faded is a failure nobody can re-read. */
+    await billingTab('free');
+    await userEvent.click(await screen.findByRole('button', { name: /cancel subscription/i }));
+    await waitFor(() => {
+      expect(screen.getByTestId('portal-error')).toHaveTextContent(/nothing to cancel/i);
+    });
+  });
+});
+
+describe('one place opens the portal', () => {
+  it('the page holds no second copy of the call (§14.3)', () => {
+    const src = read(SETTINGS);
+    expect(src).toContain('openBillingPortal()');
+    expect(src).not.toContain('create-portal-session');
+  });
+
+  it('and it goes through the client that surfaces failures', () => {
+    expect(read(join(SRC, 'lib', 'billingPortal.ts'))).toContain('apiFetch');
+  });
+});
+
+describe('what the copy does not claim', () => {
+  it('never states when access ends after cancelling', () => {
+    /**
+     * Whether Stripe's portal cancels immediately or at period end is
+     * configuration in the Stripe dashboard, which this repository
+     * cannot read. "You keep access until the end of the period" is the
+     * sentence a customer would rely on and we cannot back — the same
+     * shape as every claim the banned-claims gate exists for.
+     */
+    const src = read(SETTINGS);
+    for (const claim of [
+      /keep access until/i,
+      /end of (the |your )?(current )?(billing )?period/i,
+      /immediately cancel/i,
+      /no further charges/i,
+    ]) {
+      expect(src).not.toMatch(claim);
+    }
+  });
+});

--- a/frontend/src/app/account-settings/page.tsx
+++ b/frontend/src/app/account-settings/page.tsx
@@ -8,6 +8,7 @@ import { toast } from "sonner"
 import { TIERS, priceLabel, priceWithCadence } from "@/lib/pricing"
 import { CA_COUNTY_NAMES } from "@/lib/jurisdictions"
 import { saveProfile } from "@/lib/profileSave"
+import { BillingPortalError, openBillingPortal } from "@/lib/billingPortal"
 import EmailVerificationNotice from "@/features/account/EmailVerificationNotice"
 
 type Tab = "profile" | "billing" | "notifications" | "security"
@@ -67,6 +68,9 @@ function AccountSettingsPage() {
   const [userProfile, setUserProfile] = useState<UserProfile | null>(null)
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
+  // PILOT1: the portal failure is shown ON the page as well as in a
+  // toast — a toast that has faded is a failure nobody can re-read.
+  const [portalError, setPortalError] = useState<string | null>(null)
   // Read by the checkout watcher without re-arming it on every fetch.
   const userProfileRef = useRef<UserProfile | null>(null)
 
@@ -197,29 +201,25 @@ function AccountSettingsPage() {
     }
   }
 
+  // PILOT1. This was a bare `fetch` that threw away the API's own
+  // reason: any non-2xx became "Failed to create portal session", so a
+  // 404 saying "No billing information found" — the one answer that
+  // tells the officer something useful — reached her as a generic
+  // failure (§4). The call, and the sentence for every way it can fail,
+  // now live in `lib/billingPortal.ts`.
   const handleManageSubscription = async () => {
     setSaving(true)
+    setPortalError(null)
     try {
-      const api = process.env.NEXT_PUBLIC_API_URL || "https://deedpro-main-api.onrender.com"
-      const token = localStorage.getItem("access_token")
-
-      const response = await fetch(`${api}/payments/create-portal-session`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      })
-
-      if (!response.ok) {
-        throw new Error("Failed to create portal session")
-      }
-
-      const data = await response.json()
-      if (data.url) {
-        window.location.href = data.url
-      }
+      const url = await openBillingPortal()
+      window.location.href = url
     } catch (err) {
-      toast.error(err instanceof Error ? err.message : "Failed to open billing portal")
+      if (err instanceof Error && err.name === "SessionExpiredError") return
+      const message = err instanceof BillingPortalError
+        ? err.message
+        : "The billing portal could not be opened."
+      setPortalError(message)
+      toast.error(message)
     } finally {
       setSaving(false)
     }
@@ -327,6 +327,7 @@ function AccountSettingsPage() {
                   onUpgrade={handleUpgrade}
                   onManageSubscription={handleManageSubscription}
                   saving={saving}
+                  portalError={portalError}
                 />
               )}
               {activeTab === "notifications" && <NotificationsTab />}
@@ -569,11 +570,13 @@ function BillingTab({
   onUpgrade,
   onManageSubscription,
   saving,
+  portalError,
 }: {
   userProfile: UserProfile | null
   onUpgrade: (plan: string) => void
   onManageSubscription: () => void
   saving: boolean
+  portalError?: string | null
 }) {
   // ONE VOCABULARY (TRIAL1). This read `|| "starter"` while the database
   // stores 'free', so every free user fell through every comparison
@@ -743,6 +746,58 @@ function BillingTab({
             </button>
           </div>
         )}
+      </div>
+
+      {/* ═══ CANCELLING — PILOT1 ═══════════════════════════════════════
+          THE FINDING WAS NOT THE ONE EXPECTED. The portal endpoint was
+          never unreachable: "Manage Payment Methods" and "View Billing
+          History" both call it. What was missing is that **nothing said
+          CANCEL**, while the homepage promises "cancel anytime". An
+          officer acting on that promise had to already know that Stripe's
+          portal is where cancelling lives.
+
+          AND IT IS NOT GATED ON `plan`. Every other control here renders
+          only when `users.plan` says she is paying — a denormalised copy
+          of Stripe's state, written by the webhook. If that column is
+          stale, a customer WITH A CARD ON FILE sees "No payment method on
+          file" and no exit at all. So this section always renders, asks
+          Stripe, and reports Stripe's answer.
+
+          THE COPY CLAIMS NOTHING ABOUT WHAT CANCELLING DOES — whether
+          access ends immediately or at the period end is Stripe portal
+          configuration, and this repository cannot see it. Saying "you
+          keep access until the end of the period" would be a promise made
+          from a guess. */}
+      <div>
+        <h3 className="text-xl font-bold text-slate-800 mb-2">Cancel subscription</h3>
+        <div className="bg-white border border-slate-200 rounded-xl p-6">
+          <p className="text-slate-600 mb-4 max-w-prose">
+            Cancelling happens in Stripe&apos;s billing portal, where you can
+            also see exactly what you will be charged and when. This button
+            opens it.
+          </p>
+          <button
+            onClick={onManageSubscription}
+            disabled={saving}
+            data-testid="cancel-subscription"
+            className="px-6 py-3 border border-slate-300 hover:bg-slate-50 text-slate-700 font-medium rounded-lg transition-colors disabled:opacity-50 flex items-center gap-2"
+          >
+            {saving ? (
+              <>
+                <Loader2 className="w-4 h-4 animate-spin" />
+                Opening the billing portal...
+              </>
+            ) : (
+              "Cancel subscription"
+            )}
+          </button>
+          {portalError && (
+            <p role="alert" data-testid="portal-error"
+               className="mt-4 max-w-prose text-sm text-red-600">
+              {portalError}
+            </p>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/frontend/src/lib/billingPortal.ts
+++ b/frontend/src/lib/billingPortal.ts
@@ -1,0 +1,116 @@
+/**
+ * Opening the billing portal — the one place, and the one place that
+ * turns its failures into English.
+ *
+ * ═══ THE FINDING, WHICH IS NOT THE ONE THE TICKET EXPECTED ═══
+ *
+ * The ticket said `/payments/create-portal-session` "exists with no UI
+ * entry point anywhere". **It has two**, both in the Billing tab:
+ * "Manage Payment Methods" and "View Billing History". The endpoint is
+ * reachable and always has been.
+ *
+ * What is missing is narrower and worse: **nothing anywhere says
+ * CANCEL.** The homepage promises "cancel anytime"; an officer who wants
+ * to act on that promise arrives at a Billing tab offering to manage her
+ * payment methods and view her invoices. She has to know that Stripe's
+ * portal is where cancelling lives, and that one of those two buttons
+ * leads to it. That is not one click, and it is not a claim we can back.
+ *
+ * ═══ THE SECOND DEFECT: A GATE THAT CAN HIDE THE ONLY EXIT ═══
+ *
+ * Both buttons render only when `currentPlan !== 'free'`, i.e. only when
+ * the `users.plan` COLUMN says she is paying. That column is written by
+ * the webhook. If it is stale, or unset, or the pilot subscription is
+ * provisioned in a way that does not update it, then a customer WITH A
+ * CARD ON FILE sees "No payment method on file" and no way out at all —
+ * a cancel path whose visibility depends on the accuracy of a
+ * denormalised copy of Stripe's state.
+ *
+ * So the cancel control is NOT gated on that column. It is always
+ * rendered, it asks Stripe, and Stripe's answer is what the officer is
+ * told — including "no billing information found", which is the honest
+ * answer for an account that genuinely has no subscription.
+ *
+ * ═══ AND THE THIRD: THE REASON WAS BEING THROWN AWAY ═══
+ *
+ * The old handler did `throw new Error("Failed to create portal session")`
+ * on any non-2xx, discarding the API's `detail` — so a 404 saying "No
+ * billing information found" reached the officer as a generic failure.
+ * §4: an error is never swallowed, and the API's own sentence is better
+ * than ours in every case where it exists.
+ */
+import { apiFetch } from './apiClient';
+
+export const PORTAL_PATH = '/payments/create-portal-session';
+
+/** Nothing here asserts what CANCELLING does — see `portalCopy`. */
+export class BillingPortalError extends Error {
+  /** True when the API says this account has no billing relationship. */
+  readonly noBilling: boolean;
+
+  constructor(message: string, noBilling = false) {
+    super(message);
+    this.name = 'BillingPortalError';
+    this.noBilling = noBilling;
+  }
+}
+
+export const UNREACHABLE =
+  'Could not reach the server, so the billing portal did not open. Please try again.';
+
+/**
+ * The sentence shown when the API says there is no billing relationship.
+ *
+ * It states OUR RECORD, not her situation: "we have no subscription on
+ * file for this account" is checkable and true, where "you have no
+ * subscription" would be a claim about the world made from one row.
+ */
+export const NO_BILLING =
+  'Stripe has no billing record for this account, so there is nothing to '
+  + 'cancel. If you believe you are being charged, contact us before '
+  + 'cancelling anywhere else.';
+
+/**
+ * Open Stripe's billing portal for the signed-in officer.
+ *
+ * Returns the URL rather than navigating, so the caller decides — and so
+ * this is testable without a browser that can navigate.
+ */
+export async function openBillingPortal(): Promise<string> {
+  let response: Response;
+  try {
+    response = await apiFetch(PORTAL_PATH, { method: 'POST' },
+      { label: 'Open billing portal', silent: true });
+  } catch (err) {
+    // apiClient rethrows network failures and SessionExpiredError. A
+    // session expiry has already redirected; anything else is the server
+    // not answering, and saying so is better than "failed to fetch".
+    if (err instanceof Error && err.name === 'SessionExpiredError') throw err;
+    throw new BillingPortalError(UNREACHABLE);
+  }
+
+  if (!response.ok) {
+    const detail = await readDetail(response);
+    if (response.status === 404) throw new BillingPortalError(NO_BILLING, true);
+    throw new BillingPortalError(detail
+      || `The billing portal could not be opened (error ${response.status}).`);
+  }
+
+  const data = await response.json().catch(() => ({}));
+  if (!data?.url) {
+    // A 200 with no URL is a success we did not get (§4).
+    throw new BillingPortalError(
+      'The server accepted the request but returned no portal link.');
+  }
+  return data.url as string;
+}
+
+async function readDetail(response: Response): Promise<string> {
+  try {
+    const body = await response.json();
+    const detail = body?.detail;
+    return typeof detail === 'string' ? detail : '';
+  } catch {
+    return '';
+  }
+}


### PR DESCRIPTION
## The premise was partly wrong, and the correction is the finding

`/payments/create-portal-session` was **not** without a UI entry point. It has two — "Manage Payment Methods" and "View Billing History", both in the Billing tab, both calling it, both working. The endpoint has been reachable the whole time.

Three real defects were sitting behind that description, and the ticket's instinct was right even though its premise wasn't.

**1. Nothing said CANCEL.** The homepage promises "cancel anytime" (`page.tsx:875`). An officer acting on that promise arrived at a Billing tab offering to manage her payment methods and view her invoices, and had to already know that Stripe's portal is where cancelling lives and that one of those buttons leads there. That is not one click and it is not a claim we could back. There is now a **Cancel subscription** control, by that name.

**2. Every billing control was gated on `users.plan`** — a denormalised copy of Stripe's state, written by the webhook. If that column is stale, unset, or not updated by however the pilot subscription is provisioned, then a customer **with a card on file** sees "No payment method on file" and has no exit at all. A cancel path whose visibility depends on the accuracy of a cached column is not a cancel path.

So the new control is **deliberately ungated**. It always renders, it asks Stripe, and Stripe's answer is what the officer is told — including "Stripe has no billing record for this account, so there is nothing to cancel", which is the honest answer for an account that genuinely has none. That sentence states *our record*, not her situation, and it tells her to contact us before cancelling elsewhere if she believes she is being charged.

**3. The API's reason was being thrown away.** `throw new Error("Failed to create portal session")` on any non-2xx, so the one informative answer — a 404 saying "No billing information found" — arrived as a generic failure (§4). The call and a sentence for each way it can fail now live in `lib/billingPortal.ts`, routed through `apiClient` so a 401 stays a RED-S3 pause rather than becoming a billing error. The reason renders **on the page** as well as in a toast: a toast that has faded is a failure nobody can re-read.

## What the copy deliberately does not claim

Whether cancelling ends access immediately or at the period end is **Stripe portal configuration**, set in the Stripe dashboard, which this repository cannot read. "You keep access until the end of your billing period" is exactly the sentence a customer would rely on and we could not back, so it is not written — and its absence is pinned, along with three sibling phrasings.

**That is an open question for you, not a gap in this PR:** the copy is honest either way, but the officer would be better served by knowing. Once you confirm the portal's cancellation setting, one sentence gets added and the pin gets narrowed.

## Self-review

**Premises checked, and what was found**
- *No UI entry point anywhere* — **false.** Two, in the Billing tab. Reported rather than quietly built around, because the ticket's justification ("it ships before any external card goes on file") is unaffected but its diagnosis was.
- *The endpoint 404s for accounts with no Stripe customer* — **confirmed**, and that 404 is now the most useful thing the flow can say.
- *`users.plan` is authoritative* — **false**, and it is the sharper of the two findings. It is a webhook-written cache, and every billing control on the page was gated on it.

**Pins changed, and in which direction**
All new (13). The page-level ones are **rendered, not grepped** — the defect is one of reachability, so asserting that the source contains the word "cancel" would restate the bug rather than catch it (§14.1.1). Mutation probe: re-gating the control on `plan !== "free"` turns two red, including the one that represents the stale-column customer.

**Least sure about**
Always rendering the cancel control, including for a free account. It trades a slightly odd Billing tab for a customer being charged always having an exit, and I took that trade because the failure it prevents is one-directional — a free user sees an extra button and a clear answer, while a mis-cached paying user would see nothing at all. If it reads as clutter, the alternative is to render it only when Stripe (not `users.plan`) says there is a subscription, which needs an endpoint that does not exist yet.

**What would be cut if forced**
The on-page error line, keeping just the toast. It is the smallest piece and the toast still names the reason.

**Anything decided rather than flagged**
`tsc` briefly went to 90 from the new test file (`jest.fn()` from `@jest/globals` infers a zero-argument mock, so `mockRejectedValue(new TypeError(...))` is a type error). Fixed in the test rather than reported as a new baseline — the invariant is that the number only goes down.

## Gates

pytest **1480** · jest **1102** / 79 suites · tsc **88** · `next build` clean · banned-claims clean (14 rules, 241 files) · four harnesses green.

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_