### PR TITLE
PILOT2 — nobody is charged without being told first

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -939,6 +939,50 @@ def create_tables():
             "ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS mrr_cents INT",
             "ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS stripe_subscription_id VARCHAR(255)",
             "CREATE INDEX IF NOT EXISTS idx_subscriptions_stripe ON subscriptions(stripe_subscription_id)",
+            # ── PILOT2: what Stripe said, RECORDED ────────────────────
+            #
+            # None of these three decide anything. The notification job
+            # asks Stripe for the upcoming invoice at send time and acts
+            # on THAT; these columns are the record of what it saw, for
+            # the admin view and for a human answering "what did we think
+            # was happening on the 4th".
+            #
+            # That distinction is the whole design (MONEY1's lesson): a
+            # notice that fires off a date we computed can disagree with
+            # the date the card is actually charged on, and the customer
+            # is the one who finds out.
+            "ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS trial_end TIMESTAMP",
+            "ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS renewal_at TIMESTAMP",
+            "ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS renewal_amount_cents INT",
+            "ALTER TABLE subscriptions ADD COLUMN IF NOT EXISTS renewal_seen_at TIMESTAMP",
+            # ── PILOT2: which notices went out, and which did not ─────
+            #
+            # The idempotency record. `charge_date` is part of the
+            # identity on purpose: if the charge date MOVES — a plan
+            # change, a coupon extended — the notices for the new date are
+            # a different set, and the customer should hear about the date
+            # she will actually be charged on rather than be told nothing
+            # because we already wrote to her about a date that no longer
+            # exists.
+            #
+            # A row exists whether or not the mail left the building. `ok`
+            # false with a `reason` is the honest record of a send that
+            # failed, and it is not retried blindly — see the job.
+            """CREATE TABLE IF NOT EXISTS billing_notices (
+                id SERIAL PRIMARY KEY,
+                stripe_subscription_id VARCHAR(255) NOT NULL,
+                user_id INTEGER REFERENCES users(id) ON DELETE CASCADE,
+                notice_kind VARCHAR(32) NOT NULL,
+                charge_date DATE NOT NULL,
+                amount_cents INT,
+                currency VARCHAR(8),
+                sent_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                ok BOOLEAN NOT NULL DEFAULT FALSE,
+                reason TEXT,
+                UNIQUE (stripe_subscription_id, notice_kind, charge_date)
+            )""",
+            "CREATE INDEX IF NOT EXISTS idx_billing_notices_sub "
+            "ON billing_notices(stripe_subscription_id)",
             # Same-invariant gap, declared (not silently absorbed — named
             # in the A1 report): the LIVE verification system and the E1
             # in-app notification writes also depended on hand-run

--- a/backend/phase23_billing/router_webhook.py
+++ b/backend/phase23_billing/router_webhook.py
@@ -39,6 +39,57 @@ def _resolve_user_id(db: Session, customer_id):
     return row[0] if row else None
 
 
+def _run_renewal_notice_for(subscription_id) -> dict:
+    """Evaluate the pre-charge notices for ONE subscription, right now.
+
+    PILOT2 item 3. Called from the `trial_will_end` branch so that a
+    trial ending is heard about even if the daily cron missed a day; it
+    runs the SAME decision against the SAME idempotency table, so it
+    cannot produce a second copy of a notice already sent.
+
+    ═══ IT NEVER FAILS THE WEBHOOK ═══
+
+    Stripe retries a non-2xx, and the subscription upsert has already
+    committed by the time this runs — so an exception here would replay
+    an event whose real work is done, for a notice that is a courtesy.
+    The reason is returned in the response body instead, which is visible
+    in Stripe's own event log.
+    """
+    if not subscription_id:
+        return {"sent": None, "reason": "the event carried no subscription id"}
+    try:
+        import stripe as _stripe
+
+        import db as _dbmod
+        from services import renewal_notice
+
+        conn = getattr(_dbmod, "conn", None)
+        if conn is None:
+            return {"sent": None, "reason": "no database connection on this request"}
+
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT s.stripe_subscription_id, s.user_id, s.status,
+                       u.email, u.full_name
+                FROM subscriptions s JOIN users u ON u.id = s.user_id
+                WHERE s.stripe_subscription_id = %s
+                """,
+                (subscription_id,),
+            )
+            row = cur.fetchone()
+        if not row:
+            return {"sent": None, "reason": "no local subscription row"}
+
+        from datetime import timezone as _tz
+        outcome = renewal_notice.process_subscription(
+            conn, _stripe, dict(row), datetime.now(_tz.utc).date())
+        conn.commit()
+        return outcome
+    except Exception as exc:
+        return {"sent": None, "reason": f"renewal notice not evaluated: {exc}"}
+
+
 def upsert_subscription(db: Session, sub: dict):
     """BILL1 — the write that never existed.
 
@@ -80,11 +131,13 @@ def upsert_subscription(db: Session, sub: dict):
             user_id, stripe_subscription_id, status, plan_name,
             current_period_start, current_period_end,
             current_plan_price_cents, mrr_cents, cancel_at_period_end,
+            trial_end,
             created_at, updated_at
         ) VALUES (
             :uid, :sid, :status, :plan,
             :period_start, :period_end,
             :price_cents, :mrr, :cancel_at_period_end,
+            :trial_end,
             now(), now()
         )
         ON CONFLICT (stripe_subscription_id) DO UPDATE SET
@@ -98,6 +151,12 @@ def upsert_subscription(db: Session, sub: dict):
             current_plan_price_cents = COALESCE(EXCLUDED.current_plan_price_cents, subscriptions.current_plan_price_cents),
             mrr_cents = COALESCE(EXCLUDED.mrr_cents, subscriptions.mrr_cents),
             cancel_at_period_end = COALESCE(EXCLUDED.cancel_at_period_end, subscriptions.cancel_at_period_end),
+            -- PILOT2. NOT COALESCEd, unlike its neighbours: when a trial
+            -- converts, Stripe sends `trial_end: null` and that null is
+            -- the FACT — "there is no longer a trial". COALESCE would
+            -- preserve the old date forever and leave the record saying a
+            -- trial ends on a day that has passed.
+            trial_end = EXCLUDED.trial_end,
             updated_at = now()
         RETURNING id
     """), {
@@ -114,6 +173,11 @@ def upsert_subscription(db: Session, sub: dict):
         "mrr": 0 if sub.get("status") in ("canceled", "incomplete_expired")
                else price.get("unit_amount"),
         "cancel_at_period_end": sub.get("cancel_at_period_end"),
+        # PILOT2 — present on created/updated while the status is
+        # `trialing`, and persisted nowhere until now. It is a RECORD, not
+        # an input: the notification job asks Stripe for the upcoming
+        # invoice rather than reading this column.
+        "trial_end": _ts(sub.get("trial_end")),
     })
     return 1 if result.fetchone() else 0
 
@@ -256,6 +320,30 @@ async def stripe_webhook(request: Request, db: Session = Depends(get_db)):
             ), {"cust": sub.get("customer")})
         db.commit()
         return {"ok": True}
+
+    # --- The trial is ending, and Stripe said so first ---
+    #
+    # PILOT2 item 3. This event used to fall through every branch below
+    # and return a bare 200 — indistinguishable, from Stripe's side, from
+    # being handled.
+    #
+    # THE PILOT PATH DOES NOT EMIT IT. A 100%-off coupon on the standard
+    # price leaves the subscription `active` with a discount, so there is
+    # no trial and no `trial_will_end`. The 14-day path DOES emit it, and
+    # it arrives three days out — inside the 5-day window — which makes it
+    # a free SECOND signal for a job whose first signal is a cron that can
+    # miss a day.
+    #
+    # It is not a second SENDER: it runs the same decision as the daily
+    # job, against the same idempotency table, so a notice already sent
+    # is not sent again. What it adds is that a trial ending is heard
+    # about even if the scheduler is down.
+    if etype == "customer.subscription.trial_will_end":
+        sub = obj
+        upsert_subscription(db, sub)
+        db.commit()
+        outcome = _run_renewal_notice_for(sub.get("id"))
+        return {"ok": True, "renewal_notice": outcome}
 
     # --- Invoice created ---
     #

--- a/backend/scripts/send_renewal_notices.py
+++ b/backend/scripts/send_renewal_notices.py
@@ -1,0 +1,145 @@
+"""PILOT2 — the pre-charge notices, as a standalone daily job.
+
+READY FOR A RENDER CRON JOB, WHICH DOES NOT EXIST YET. Creating that
+service is a deploy-topology change and therefore Tier 3 — the owner's
+call, not this repo's. Unlike the purge, there is no in-request fallback
+carrying this work: **until the cron exists, no notice is sent by this
+path.** The `customer.subscription.trial_will_end` webhook covers the
+14-day trial three days out and nothing covers the pilot's coupon path,
+which emits no trial event at all.
+
+That is stated plainly because the failure is silent by construction: a
+job nobody scheduled produces exactly the same customer experience as the
+gap it was written to close.
+
+Usage:
+    DATABASE_URL=postgresql://... python backend/scripts/send_renewal_notices.py
+    DATABASE_URL=... python backend/scripts/send_renewal_notices.py --dry-run
+    DATABASE_URL=... python backend/scripts/send_renewal_notices.py --verify
+
+Suggested Render Cron Job (owner-side, Tier 3):
+    schedule:      0 15 * * *         # daily, 15:00 UTC — mid-morning in
+                                      # California, so a customer who
+                                      # wants to cancel can do it during
+                                      # a working day rather than finding
+                                      # the mail at 2am.
+    command:       python backend/scripts/send_renewal_notices.py
+    env:           DATABASE_URL from the deedpro-db database
+                   STRIPE_SECRET_KEY   ← the charge date and amount come
+                                         from Stripe; without it this job
+                                         refuses rather than guessing.
+                   FRONTEND_URL        ← the cancel link in the email.
+                   SENDGRID_API_KEY    ← without it every send fails
+                                         HONESTLY: the attempt is
+                                         recorded with its reason and the
+                                         exit code is non-zero.
+                   EXPECTED_DATABASE=deedpro   ← name the database this
+                   job is FOR. Staging carries the same tables, and a
+                   misconfigured cron pointed there would email real
+                   customers about charges from a copy of the data.
+
+WHY `EXPECTED_DATABASE` MATTERS HERE, given nothing is deleted: this job
+is not irreversible against the database, it is irreversible against a
+PERSON. An email cannot be unsent, and the wrong one tells a customer she
+is about to be charged an amount that is not real.
+
+Exit codes: 0 when every notice due was sent, 1 when any send failed or
+the job could not run — so a cron service's own alerting sees a failed
+run rather than a silent one.
+"""
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+
+def main() -> int:
+    url = os.getenv("DATABASE_URL")
+    if not url:
+        print("DATABASE_URL is not set — refusing to guess at a database",
+              file=sys.stderr)
+        return 1
+
+    import psycopg2
+    from db_rows import ROW_FACTORY
+
+    from services import renewal_notice
+    from services.db_identity import (WrongDatabase, assert_tables, describe,
+                                      expected_database)
+
+    dry_run = "--dry-run" in sys.argv
+    verify_only = "--verify" in sys.argv
+
+    # The date and the amount come from Stripe. Without a key there is no
+    # authority to read, and a job that ran anyway would either send
+    # nothing (looking healthy) or send something it made up.
+    if not (os.getenv("STRIPE_SECRET_KEY") or "").strip():
+        print("STRIPE_SECRET_KEY is not set — the charge date and amount come "
+              "from Stripe, and this job will not invent them", file=sys.stderr)
+        return 1
+
+    import stripe
+    stripe.api_key = os.getenv("STRIPE_SECRET_KEY")
+
+    conn = psycopg2.connect(url, cursor_factory=ROW_FACTORY)
+    try:
+        # ── WHICH DATABASE, BEFORE ANYTHING ELSE ──────────────────────
+        #
+        # Same assertion as the purge cron, for a different irreversible
+        # act: that job deletes rows, this one sends mail to customers.
+        # Staging has both tables, so the tables alone would let a
+        # misconfigured cron write to real people about charges recorded
+        # in a copy.
+        try:
+            assert_tables(conn, "subscriptions", "billing_notices", "users",
+                          expect_database=expected_database())
+        except WrongDatabase as wrong:
+            print(str(wrong), file=sys.stderr)
+            return 1
+
+        if verify_only:
+            print(describe(conn))
+            rows = renewal_notice.subscriptions_to_check(conn)
+            print(f"{len(rows)} live subscription(s) would be checked")
+            return 0
+
+        print(f"[renewal-notices] running against {describe(conn)}")
+        today = datetime.now(timezone.utc).date()
+
+        if dry_run:
+            # Asks Stripe and decides, sends nothing, writes nothing. The
+            # question worth asking before the first real run is "who
+            # would this email today", and answering it must not be the
+            # thing that emails them.
+            sent = []
+
+            def refuse(*args, **kwargs):
+                return False, "dry run — not sent"
+
+            report = renewal_notice.run(conn, stripe, today, sender=refuse)
+            conn.rollback()
+            print(json.dumps(report.as_dict(), indent=2, default=str))
+            print("[dry-run] nothing was sent and nothing was recorded")
+            return 0
+
+        report = renewal_notice.run(conn, stripe, today)
+        conn.commit()
+        print(json.dumps(report.as_dict(), indent=2, default=str))
+
+        # A failed send is a failed run. The rows record it either way,
+        # but a cron that exits 0 while nobody was told is the shape this
+        # ticket exists to remove.
+        return 1 if report.failed else 0
+    except Exception as exc:
+        conn.rollback()
+        print(f"renewal notices failed: {exc}", file=sys.stderr)
+        return 1
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/services/renewal_notice.py
+++ b/backend/services/renewal_notice.py
@@ -1,0 +1,432 @@
+"""Telling a customer she is about to be charged, before she is charged.
+
+═══ THE GAP, WHICH IS NOT PILOT-ONLY ═══
+
+The 14-day trial already charges with no warning. `trial_end` is present
+on `customer.subscription.created/.updated` while the status is
+`trialing`; nothing persisted it, `customer.subscription.trial_will_end`
+fell through the webhook chain to a bare 200, and no template existed. So
+the first thing a trialling customer heard from us about money was the
+receipt.
+
+The 90-day pilot runs on a 100%-off coupon against the standard price
+rather than a trial, which produces **no `trial_end` and no
+`trial_will_end` event at all** — the subscription is `active` with a
+discount. The notice is entirely ours to send on that path, and the trial
+path was never covered either.
+
+═══ WHICH DATE IS AUTHORITATIVE — THE PART THAT WAS RULED ═══
+
+Three candidates were on the table and two of them are wrong:
+
+**`current_period_end` is wrong, and wrong in the worst direction.** On a
+3×monthly 100%-off coupon it is the NEXT INVOICE date — one month out —
+and that invoice is **$0**. A notice fired off it says "you will be
+charged on the 4th" three times about invoices that charge nothing,
+before the one time it is true. A notice that cries wolf three times is
+worse than no notice: the fourth is the one that matters and it arrives
+with the credibility of the three that did not.
+
+**`discount.end` is a coupon fact, not a charge date.** Converting one to
+the other means assuming the billing cycle is aligned to the coupon, and
+that assumption is exactly the parallel calculation MONEY1 forbids — a
+date we computed, which can disagree with the date the card is charged
+on, with the customer discovering the disagreement.
+
+**The upcoming invoice is authoritative**, because Stripe computes it
+with the discount already applied: one object carrying the true date and
+the true amount. And the timing works out — by the time the first notice
+is due, the previous $0 invoice has finalised, so the upcoming invoice IS
+the first real charge.
+
+═══ SO THIS MODULE PERSISTS NOTHING THAT DECIDES ANYTHING ═══
+
+The job asks Stripe every day and acts on the answer. `subscriptions.
+trial_end`, `renewal_at` and `renewal_amount_cents` are a RECORD — for
+the admin view, and for a human reconstructing what we believed — never
+an input. `billing_notices` exists for idempotency, which is a fact about
+US (did we already write to her) rather than about the charge.
+
+The cost is one Stripe call per active subscription per day, owner-priced
+and accepted: it is what never computing a charge date ourselves costs.
+
+═══ "AT OR INSIDE", NOT "EXACTLY N DAYS AGO" ═══
+
+A daily job WILL miss a day. If the windows were exact, a missed run
+silently drops a notice, and the failure looks identical to the notice
+never having been due. So a window is open at or inside its threshold,
+and a notice that has not been sent is still due.
+
+The consequence is handled rather than ignored: when a run finds both
+windows open (the job was down through the first one), it sends the
+TIGHTEST one only and records the other as SUPERSEDED. Two emails in one
+minute saying the same thing in different words is not thoroughness.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from datetime import date, datetime, timezone
+from typing import Any, Dict, Optional, Sequence, Tuple
+
+#: (kind, days before the charge the window opens). Order is
+#: widest-first; `decide` picks the tightest OPEN one.
+NOTICE_WINDOWS: Tuple[Tuple[str, int], ...] = (
+    ("renewal_15day", 15),
+    ("renewal_5day", 5),
+)
+
+NOTICE_KINDS = tuple(kind for kind, _ in NOTICE_WINDOWS)
+
+
+@dataclass(frozen=True)
+class UpcomingCharge:
+    """What Stripe says the next real charge is. Never assembled by us."""
+    charge_date: date
+    amount_cents: int
+    currency: str
+    #: Which Stripe object this came from, so the record names its source.
+    source: str = "upcoming_invoice"
+
+
+@dataclass(frozen=True)
+class Decision:
+    """What a run should do about one subscription, and why.
+
+    `reason` is populated even when nothing happens, because "why did she
+    not get a notice" is the question this job will actually be asked.
+    """
+    send: Optional[str] = None
+    supersede: Tuple[str, ...] = ()
+    reason: str = ""
+
+
+def decide(charge: Optional[UpcomingCharge], today: date,
+           recorded: Sequence[str] = ()) -> Decision:
+    """Which notice, if any, is due for this subscription today.
+
+    `recorded` is the notice kinds already written to `billing_notices`
+    FOR THIS CHARGE DATE — sent or superseded alike. A different charge
+    date is a different set, deliberately: if the date moves, she should
+    hear about the one she will actually be charged on.
+    """
+    if charge is None:
+        return Decision(reason="Stripe reports no upcoming invoice")
+    if charge.amount_cents <= 0:
+        # The discounted months. Nothing is owed, so nothing is announced.
+        return Decision(reason="the next invoice is zero — nothing to warn about")
+
+    days_left = (charge.charge_date - today).days
+    if days_left < 0:
+        return Decision(reason="the charge date has passed")
+
+    done = set(recorded)
+    # A WIDER NOTICE NEVER FIRES AFTER A TIGHTER ONE. Caught by this
+    # file's own test: with the 5-day notice already sent and three days
+    # to go, the 15-day window is still technically open (3 <= 15) and
+    # still unsent — so a naive "open and not recorded" rule sends the
+    # 15-day notice AFTER the 5-day one, which reads to the customer as
+    # the date moving further away.
+    tightest_done = min((days for kind, days in NOTICE_WINDOWS if kind in done),
+                        default=None)
+    open_windows = [(kind, days) for kind, days in NOTICE_WINDOWS
+                    if days_left <= days and kind not in done
+                    and (tightest_done is None or days < tightest_done)]
+    if not open_windows:
+        return Decision(reason=f"no window open {days_left} days out, or "
+                               "already recorded")
+
+    # Tightest open window wins; anything wider is superseded rather than
+    # left to fire later as a second email saying the same thing.
+    open_windows.sort(key=lambda pair: pair[1])
+    send, _ = open_windows[0]
+    supersede = tuple(kind for kind, _ in open_windows[1:])
+    return Decision(send=send, supersede=supersede,
+                    reason=f"{days_left} days before the charge")
+
+
+def upcoming_charge(stripe_module, subscription_id: str) -> Tuple[Optional[UpcomingCharge], str]:
+    """Ask Stripe what the next invoice is. Returns (charge, reason).
+
+    ═══ WHY `create_preview` AND NOT `Invoice.upcoming` ═══
+
+    `stripe.Invoice.upcoming` is the method every example on the internet
+    uses and it does not exist in the SDK this service pins (12.3.0) —
+    the operation is `Invoice.create_preview`. Named here because calling
+    the old one raises `AttributeError`, which an `except Exception`
+    around a billing call would turn into "no upcoming invoice" and a
+    customer charged with no warning. Checked against the installed
+    version rather than remembered.
+
+    A failure NEVER becomes a date. It becomes (None, reason), the job
+    records the reason, and nobody is told anything about money on the
+    strength of an exception.
+    """
+    preview_fn = getattr(stripe_module.Invoice, "create_preview", None)
+    if preview_fn is None:  # pragma: no cover - version drift
+        return None, ("this Stripe SDK has no invoice-preview operation "
+                      f"({getattr(stripe_module, 'VERSION', 'unknown')})")
+    try:
+        preview = preview_fn(subscription=subscription_id)
+    except Exception as exc:  # stripe.error.* and transport failures alike
+        return None, f"Stripe would not preview the next invoice: {exc}"
+
+    amount = _as_int(_get(preview, "amount_due"))
+    if amount is None:
+        return None, "the invoice preview carried no amount_due"
+
+    when = _get(preview, "next_payment_attempt") or _get(preview, "period_end")
+    charge_date = _as_date(when)
+    if charge_date is None:
+        return None, "the invoice preview carried no payment date"
+
+    currency = (_get(preview, "currency") or "usd")
+    return UpcomingCharge(charge_date=charge_date, amount_cents=amount,
+                          currency=str(currency).lower()), "ok"
+
+
+# ── Money and dates, in the words a customer reads ───────────────────
+
+def amount_text(amount_cents: int, currency: str = "usd") -> str:
+    """`$249.00`. Not localised, and deliberately not rounded.
+
+    A pre-charge notice quoting `$249` for a `$249.37` charge is a small
+    lie that reaches somebody's bank statement.
+    """
+    symbol = "$" if currency.lower() in ("usd", "cad", "aud") else ""
+    return f"{symbol}{amount_cents / 100:,.2f}" + ("" if symbol else f" {currency.upper()}")
+
+
+def date_text(when: date) -> str:
+    """`4 September 2026` — the date, never a duration.
+
+    Owner-ruled in PILOT1's sibling: trial copy states the date, not the
+    number of days, because a duration has to be counted from something
+    the reader has to remember.
+    """
+    return f"{when.day} {when.strftime('%B %Y')}"
+
+
+def billing_url() -> str:
+    """Where the cancel control lives (PILOT1).
+
+    ═══ WHY NOT A PORTAL SESSION URL, WHICH IS WHAT WAS ASKED ═══
+
+    A Stripe billing-portal session link is short-lived. Embedded in an
+    email that may be opened days later — which is precisely what a
+    15-day notice is — it expires into an error page, and the customer's
+    experience of "cancel before you are charged" becomes a broken link
+    at the moment she trusted it.
+
+    So the link goes to the Billing tab, where PILOT1's ungated "Cancel
+    subscription" control opens a FRESH portal session on click. One
+    extra click, and it works every time instead of most of the time.
+    """
+    base = (os.getenv("FRONTEND_URL") or "").rstrip("/")
+    return f"{base}/account-settings?tab=billing"
+
+
+def _get(obj: Any, key: str):
+    if isinstance(obj, dict):
+        return obj.get(key)
+    return getattr(obj, key, None)
+
+
+def _as_int(value) -> Optional[int]:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_date(value) -> Optional[date]:
+    """Stripe timestamps are UNIX seconds; tests pass dates directly."""
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    seconds = _as_int(value)
+    if seconds is None:
+        return None
+    return datetime.fromtimestamp(seconds, tz=timezone.utc).date()
+
+
+# ── The run itself ───────────────────────────────────────────────────
+#
+# Kept here rather than in the script so it is testable without a cron,
+# and so the webhook can call the same code for one subscription. The
+# script is a thin main() around `run()`; the `trial_will_end` handler is
+# a thin call to `process_subscription()`.
+
+@dataclass
+class RunReport:
+    """What a run did, in the terms somebody debugging it will ask.
+
+    Counted rather than logged-only, because "the job ran" and "the job
+    did anything" are different claims and only one of them is usually
+    true.
+    """
+    considered: int = 0
+    sent: int = 0
+    superseded: int = 0
+    failed: int = 0
+    skipped: list = field(default_factory=list)
+
+    def as_dict(self) -> Dict[str, Any]:
+        return {"considered": self.considered, "sent": self.sent,
+                "superseded": self.superseded, "failed": self.failed,
+                "skipped": self.skipped}
+
+
+#: Statuses worth asking Stripe about. A cancelled or unpaid subscription
+#: has no upcoming charge to warn anybody about, and `trialing`/`active`
+#: are the two the pilot and the 14-day trial live in.
+LIVE_STATUSES = ("active", "trialing", "past_due")
+
+
+def subscriptions_to_check(conn) -> list:
+    """Live subscriptions with a user who can be emailed."""
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT s.stripe_subscription_id, s.user_id, s.status,
+                   u.email, u.full_name
+            FROM subscriptions s
+            JOIN users u ON u.id = s.user_id
+            WHERE s.stripe_subscription_id IS NOT NULL
+              AND s.status = ANY(%s)
+              AND u.email IS NOT NULL
+              AND u.is_active = TRUE
+            ORDER BY s.id
+            """,
+            (list(LIVE_STATUSES),),
+        )
+        return [dict(row) for row in cur.fetchall()]
+
+
+def recorded_kinds(conn, subscription_id: str, charge_date: date) -> list:
+    """Notices already written FOR THIS CHARGE DATE.
+
+    Scoped to the date, deliberately — see the schema comment. A moved
+    charge date is a new conversation.
+    """
+    with conn.cursor() as cur:
+        cur.execute(
+            "SELECT notice_kind FROM billing_notices "
+            "WHERE stripe_subscription_id = %s AND charge_date = %s",
+            (subscription_id, charge_date),
+        )
+        return [dict(row)["notice_kind"] for row in cur.fetchall()]
+
+
+def _record_notice(conn, subscription_id: str, user_id, kind: str,
+                   charge: UpcomingCharge, ok: bool, reason: str) -> None:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO billing_notices (stripe_subscription_id, user_id,
+                notice_kind, charge_date, amount_cents, currency, ok, reason)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (stripe_subscription_id, notice_kind, charge_date)
+            DO UPDATE SET ok = EXCLUDED.ok, reason = EXCLUDED.reason,
+                          sent_at = CURRENT_TIMESTAMP
+            """,
+            (subscription_id, user_id, kind, charge.charge_date,
+             charge.amount_cents, charge.currency, ok, reason),
+        )
+
+
+def _record_what_stripe_said(conn, subscription_id: str,
+                             charge: Optional[UpcomingCharge]) -> None:
+    """The cache, written after the decision and never read by it."""
+    if charge is None:
+        return
+    with conn.cursor() as cur:
+        cur.execute(
+            "UPDATE subscriptions SET renewal_at = %s, renewal_amount_cents = %s, "
+            "renewal_seen_at = CURRENT_TIMESTAMP WHERE stripe_subscription_id = %s",
+            (charge.charge_date, charge.amount_cents, subscription_id),
+        )
+
+
+def process_subscription(conn, stripe_module, row: Dict[str, Any],
+                         today: date, sender=None) -> Dict[str, Any]:
+    """One subscription: ask Stripe, decide, send, record.
+
+    Returns a per-subscription outcome dict rather than raising, so one
+    customer's Stripe hiccup cannot stop the other customers' notices —
+    the failure mode a `for` loop with an exception inside it produces by
+    default.
+    """
+    from utils.notifications import send_renewal_notice_with_reason
+
+    send = sender or send_renewal_notice_with_reason
+    sid = row["stripe_subscription_id"]
+
+    charge, why = upcoming_charge(stripe_module, sid)
+    _record_what_stripe_said(conn, sid, charge)
+
+    decision = decide(charge, today,
+                      recorded_kinds(conn, sid, charge.charge_date) if charge else ())
+    if decision.send is None:
+        # When Stripe would not answer, ITS reason is the useful one:
+        # `decide()` can only say "no upcoming invoice", which is what a
+        # connection reset and a genuinely absent invoice look like from
+        # the inside. Caught by this module's own test, which poisoned
+        # the cached date and made Stripe fail — and got the generic
+        # sentence back instead of the failure (§4).
+        return {"subscription": sid, "sent": None,
+                "reason": why if charge is None else decision.reason}
+
+    assert charge is not None  # decide() returns None to send otherwise
+    days_left = (charge.charge_date - today).days
+    ok, reason = send(
+        row["email"], row.get("full_name") or "", decision.send,
+        date_text(charge.charge_date),
+        amount_text(charge.amount_cents, charge.currency),
+        billing_url(),
+        f"{days_left} days from today" if days_left != 1 else "tomorrow",
+        row.get("user_id"),
+    )
+    _record_notice(conn, sid, row.get("user_id"), decision.send, charge, ok,
+                   reason or "")
+
+    for skipped in decision.supersede:
+        # Recorded as a fact, not silently dropped: "why did the 15-day
+        # notice never go out" has an answer in the table.
+        _record_notice(conn, sid, row.get("user_id"), skipped, charge, False,
+                       f"superseded by {decision.send} — the window had "
+                       "already closed when this run happened")
+
+    return {"subscription": sid, "sent": decision.send, "ok": ok,
+            "reason": reason, "superseded": list(decision.supersede)}
+
+
+def run(conn, stripe_module, today: Optional[date] = None,
+        sender=None) -> RunReport:
+    """Every live subscription, once."""
+    when = today or datetime.now(timezone.utc).date()
+    report = RunReport()
+    for row in subscriptions_to_check(conn):
+        report.considered += 1
+        try:
+            outcome = process_subscription(conn, stripe_module, row, when, sender)
+        except Exception as exc:  # one customer's failure is not everyone's
+            report.failed += 1
+            report.skipped.append({"subscription": row["stripe_subscription_id"],
+                                   "reason": f"unhandled: {exc}"})
+            continue
+        if outcome.get("sent"):
+            if outcome.get("ok"):
+                report.sent += 1
+            else:
+                # The mail did not leave the building. Counted as a
+                # failure even though the row exists (§4).
+                report.failed += 1
+            report.superseded += len(outcome.get("superseded") or ())
+        else:
+            report.skipped.append({"subscription": outcome["subscription"],
+                                   "reason": outcome["reason"]})
+    return report

--- a/backend/tests/test_admin3_email_outcomes.py
+++ b/backend/tests/test_admin3_email_outcomes.py
@@ -87,7 +87,13 @@ def test_every_template_routes_through_send():
     from utils.notifications import TEMPLATES
 
     src = code_only(NOTIFICATIONS)
-    named = set(re.findall(r'_send\(\s*"([a-z_]+)"', src))
+    # `[a-z0-9_]+`, widened in PILOT2. The class was letters-only, so
+    # `renewal_15day` and `renewal_5day` were invisible to this scan and
+    # the pin reported them as declared-but-unused — a false accusation
+    # produced by the pin's SPELLING rather than by the property it
+    # guards (§14.1). A template name with a digit in it is ordinary;
+    # the rule is that every declared name appears at a `_send` call.
+    named = set(re.findall(r'_send\(\s*"([a-z0-9_]+)"', src))
     assert named == set(TEMPLATES), (
         f"declared TEMPLATES and actual _send labels disagree: "
         f"only-declared={set(TEMPLATES) - named}, only-used={named - set(TEMPLATES)}"
@@ -96,7 +102,13 @@ def test_every_template_routes_through_send():
     # NOTARY1's `signing_time_recorded` lost the only handler that sent
     # it, and back UP to 19 with CANCEL1's `signing_cancelled`. The value
     # of the number is that neither direction is silent.
-    assert len(TEMPLATES) == 19
+    #
+    # 21 with PILOT2's two pre-charge notices — `renewal_15day` and
+    # `renewal_5day`. TWO NAMES for one rendering, deliberately: the
+    # question "did the 15-day notice go out" is asked of `email_log` by
+    # a person, and it must be answerable by the template column rather
+    # than by decoding a context blob.
+    assert len(TEMPLATES) == 21
 
 
 # ── The recorder's two constraints ───────────────────────────────────

--- a/backend/tests/test_pilot2_renewal_notices.py
+++ b/backend/tests/test_pilot2_renewal_notices.py
@@ -1,0 +1,488 @@
+"""PILOT2 — nobody is charged without being told first.
+
+═══ WHAT THIS PINS, AND WHY EACH ONE IS HERE ═══
+
+The date. Two of the three candidates were wrong and one of them is
+wrong in a way that would have been WORSE than silence:
+`current_period_end` on a 3×monthly 100%-off coupon is the next invoice
+date, one month out, for a $0 invoice — three "you will be charged"
+notices before the one that is true. So the first group below asserts
+that a zero invoice produces NO notice, which is the property that makes
+the coupon path safe.
+
+The schedule. A daily job misses days, so the windows are AT OR INSIDE
+rather than exactly-N, and a run that finds both windows open sends the
+tightest and records the other as superseded rather than sending two
+emails a minute apart.
+
+The discipline. Nothing persisted is ever read back as an input:
+`renewal_at` is written after the decision, from what Stripe said, and
+the decision is made from the live answer every time.
+"""
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from services import renewal_notice as rn
+
+
+# ── The decision ─────────────────────────────────────────────────────
+
+def charge(days_out: int, amount: int = 24900, today: date = date(2026, 9, 1)):
+    return rn.UpcomingCharge(charge_date=date.fromordinal(today.toordinal() + days_out),
+                             amount_cents=amount, currency="usd")
+
+
+TODAY = date(2026, 9, 1)
+
+
+@pytest.mark.parametrize("days_out,expected", [
+    (40, None),               # nothing is due yet
+    (16, None),               # one day before the first window opens
+    (15, "renewal_15day"),    # AT the threshold, not merely inside it
+    (14, "renewal_15day"),
+    (6, "renewal_15day"),
+    (5, "renewal_5day"),      # the tighter window takes over
+    (1, "renewal_5day"),
+    (0, "renewal_5day"),      # the morning of the charge
+])
+def test_which_notice_is_due(days_out, expected):
+    assert rn.decide(charge(days_out), TODAY).send == expected
+
+
+def test_a_zero_invoice_produces_no_notice():
+    """THE PIN THE COUPON PATH RESTS ON.
+
+    During the discounted months the next invoice is $0. A notice fired
+    off `current_period_end` would announce a charge on each of them —
+    three false alarms before the real one, which is worse than sending
+    nothing, because the fourth arrives with the credibility of the
+    three that did not happen.
+    """
+    decision = rn.decide(charge(3, amount=0), TODAY)
+    assert decision.send is None
+    assert "zero" in decision.reason
+
+
+def test_no_charge_means_no_guess():
+    """Stripe unreachable, no preview, no answer — and no email.
+
+    A failure never becomes a date (MONEY1). The reason is carried so the
+    run report can say why somebody was not written to.
+    """
+    decision = rn.decide(None, TODAY)
+    assert decision.send is None
+    assert decision.reason
+
+
+def test_a_past_charge_date_is_not_announced():
+    assert rn.decide(charge(-1), TODAY).send is None
+
+
+def test_a_notice_already_recorded_is_not_repeated():
+    assert rn.decide(charge(14), TODAY, recorded=["renewal_15day"]).send is None
+    assert rn.decide(charge(3), TODAY, recorded=["renewal_5day"]).send is None
+
+
+def test_a_missed_run_still_sends_the_notice_it_can_still_mean():
+    """A daily job WILL miss a day.
+
+    Exactly-N windows would drop the notice silently and the failure
+    would be indistinguishable from it never being due. At-or-inside
+    means the notice is still owed — and the run sends the TIGHT one,
+    recording the wide one as superseded rather than sending two emails
+    a minute apart that say the same thing.
+    """
+    decision = rn.decide(charge(4), TODAY)   # cron down through day 15..5
+    assert decision.send == "renewal_5day"
+    assert decision.supersede == ("renewal_15day",)
+
+
+def test_the_superseded_notice_is_not_left_to_fire_later():
+    """Once superseded and recorded, it is not due again."""
+    after = rn.decide(charge(3), TODAY, recorded=["renewal_5day", "renewal_15day"])
+    assert after.send is None
+
+
+# ── Reading Stripe ───────────────────────────────────────────────────
+
+class FakeInvoiceAPI:
+    def __init__(self, preview=None, raises=None):
+        self._preview, self._raises = preview, raises
+        self.calls = []
+
+    def create_preview(self, **kwargs):
+        self.calls.append(kwargs)
+        if self._raises:
+            raise self._raises
+        return self._preview
+
+
+class FakeStripe:
+    VERSION = "12.3.0"
+
+    def __init__(self, **kw):
+        self.Invoice = FakeInvoiceAPI(**kw)
+
+
+def test_the_amount_and_date_come_from_the_invoice_preview():
+    """One object, computed by Stripe with the discount applied.
+
+    `next_payment_attempt` is preferred over `period_end`: it is when
+    Stripe will attempt the card, which is the date the customer's
+    statement will show.
+    """
+    stripe = FakeStripe(preview={
+        "amount_due": 24900, "currency": "usd",
+        "next_payment_attempt": 1788480000,  # 2026-09-04Z
+        "period_end": 1790000000,
+    })
+    found, why = rn.upcoming_charge(stripe, "sub_123")
+    assert why == "ok"
+    assert found.amount_cents == 24900
+    assert found.charge_date == date(2026, 9, 4)
+    assert stripe.Invoice.calls == [{"subscription": "sub_123"}]
+
+
+def test_a_stripe_failure_never_becomes_a_date():
+    stripe = FakeStripe(raises=RuntimeError("connection reset"))
+    found, why = rn.upcoming_charge(stripe, "sub_123")
+    assert found is None
+    assert "connection reset" in why
+
+
+def test_the_sdk_operation_is_the_one_this_sdk_actually_has():
+    """`Invoice.upcoming` is the method every example uses, and it does
+    not exist in the pinned SDK — the operation is `create_preview`.
+
+    Pinned against the INSTALLED stripe module rather than a fake,
+    because the failure mode is version drift: calling the absent method
+    raises AttributeError, which an `except Exception` around a billing
+    call would quietly turn into "no upcoming invoice" and a customer
+    charged with no warning.
+    """
+    import stripe as real_stripe
+    assert hasattr(real_stripe.Invoice, "create_preview"), (
+        "the SDK's invoice-preview operation has moved again — "
+        "services/renewal_notice.py must be updated with it"
+    )
+
+
+def test_a_preview_without_a_payment_date_is_refused():
+    stripe = FakeStripe(preview={"amount_due": 24900, "currency": "usd"})
+    found, why = rn.upcoming_charge(stripe, "sub_123")
+    assert found is None
+    assert "payment date" in why
+
+
+# ── What the customer reads ──────────────────────────────────────────
+
+def test_the_amount_is_exact():
+    """A notice quoting $249 for a $249.37 charge is a small lie that
+    arrives on somebody's bank statement."""
+    assert rn.amount_text(24937) == "$249.37"
+    assert rn.amount_text(24900) == "$249.00"
+
+
+def test_the_date_is_a_date_and_not_a_duration():
+    """Owner-ruled: trial copy states the date, not the number of days.
+    A duration has to be counted from something the reader remembers."""
+    assert rn.date_text(date(2026, 9, 4)) == "4 September 2026"
+
+
+def test_the_link_lands_on_the_cancel_control(monkeypatch):
+    """NOT a Stripe portal session URL, and the reason is the ticket's
+    own timescale: those links expire, and a 15-day notice is by
+    definition read late. This lands on PILOT1's ungated cancel control,
+    which mints a fresh session on click."""
+    monkeypatch.setenv("FRONTEND_URL", "https://deedpro.io")
+    assert rn.billing_url() == "https://deedpro.io/account-settings?tab=billing"
+
+
+def test_the_email_says_the_date_the_amount_and_the_way_out():
+    from utils import email_templates
+    subject, html, text = email_templates.renewal_notice(
+        "Dana", "4 September 2026", "$249.00",
+        "https://deedpro.io/account-settings?tab=billing", "5 days from today")
+    for needed in ("4 September 2026", "$249.00", "account-settings?tab=billing"):
+        assert needed in html
+        assert needed in text or needed in subject or needed in text
+    assert "4 September 2026" in subject
+
+
+def test_the_email_does_not_try_to_change_her_mind():
+    """It is not a retention email. A message whose whole purpose is that
+    nobody is surprised must not also be arguing a side."""
+    from utils import email_templates
+    _, html, text = email_templates.renewal_notice(
+        "Dana", "4 September 2026", "$249.00", "https://x/y", "5 days from today")
+    for pitch in ("hate to see you go", "special offer", "discount if you stay",
+                  "are you sure"):
+        assert pitch not in html.lower()
+        assert pitch not in text.lower()
+
+
+def test_the_notice_kinds_are_real_template_names():
+    """§14.3-adjacent: `email_log.template` is the record somebody counts,
+    and a name that is not in the TEMPLATES tuple is vocabulary drift in
+    a log that is supposed to be stable."""
+    from utils.notifications import TEMPLATES
+    for kind in rn.NOTICE_KINDS:
+        assert kind in TEMPLATES
+
+
+def test_an_unknown_notice_kind_is_refused_rather_than_logged():
+    from utils.notifications import send_renewal_notice_with_reason
+    ok, reason = send_renewal_notice_with_reason(
+        "a@b.c", "Dana", "renewal_99day", "4 September 2026", "$249.00",
+        "https://x/y", "99 days")
+    assert ok is False
+    assert "renewal_99day" in reason
+
+
+# ── The webhook's second signal ──────────────────────────────────────
+
+def test_trial_will_end_is_handled_rather_than_silently_accepted():
+    """It used to fall through every branch and return a bare 200 —
+    indistinguishable, from Stripe's side, from being handled."""
+    from tests.source_text import code_only
+    from pathlib import Path
+    src = code_only(Path(__file__).resolve().parents[1]
+                    .joinpath("phase23_billing/router_webhook.py").read_text())
+    assert 'etype == "customer.subscription.trial_will_end"' in src
+    assert "_run_renewal_notice_for" in src
+
+
+def test_trial_end_is_persisted_and_not_coalesced():
+    """When a trial converts, Stripe sends `trial_end: null` and that
+    null IS the fact. COALESCE would keep the old date forever and leave
+    the record claiming a trial ends on a day that has passed — the same
+    shape as every stale-record finding in the ledger."""
+    from tests.source_text import code_only
+    from pathlib import Path
+    src = code_only(Path(__file__).resolve().parents[1]
+                    .joinpath("phase23_billing/router_webhook.py").read_text())
+    assert "trial_end = EXCLUDED.trial_end" in src
+    assert "trial_end = COALESCE" not in src
+
+
+# ── The job ──────────────────────────────────────────────────────────
+
+def test_the_script_asserts_its_database_and_its_stripe_key():
+    """Precedent: `purge_signer_contact.py`. EXPECTED_DATABASE matters
+    here for a different irreversible act — that job deletes rows, this
+    one sends mail to real people about money."""
+    from tests.source_text import code_only
+    from pathlib import Path
+    src = code_only(Path(__file__).resolve().parents[1]
+                    .joinpath("scripts/send_renewal_notices.py").read_text())
+    assert "expected_database()" in src
+    assert "assert_tables(" in src
+    assert "STRIPE_SECRET_KEY" in src
+    assert "--dry-run" in src
+
+
+def test_a_failed_send_is_a_failed_run():
+    """A cron that exits 0 while nobody was told is the shape this ticket
+    exists to remove."""
+    from tests.source_text import code_only
+    from pathlib import Path
+    src = code_only(Path(__file__).resolve().parents[1]
+                    .joinpath("scripts/send_renewal_notices.py").read_text())
+    assert "return 1 if report.failed else 0" in src
+
+
+# ── The run, against a real database ─────────────────────────────────
+#
+# Everything above is the decision in isolation. This is the loop that
+# uses it: who gets asked about, what gets recorded, and — the property
+# the whole design rests on — that the persisted date is written AFTER
+# the decision and never read back into one.
+
+def _db():
+    import os
+    import psycopg2
+    from db_rows import ROW_FACTORY
+    return psycopg2.connect(os.environ["DATABASE_URL"], cursor_factory=ROW_FACTORY)
+
+
+def _make_subscriber(conn, email: str, sid: str, status: str = "active"):
+    with conn.cursor() as cur:
+        cur.execute("DELETE FROM billing_notices WHERE stripe_subscription_id = %s", (sid,))
+        cur.execute("DELETE FROM subscriptions WHERE stripe_subscription_id = %s", (sid,))
+        cur.execute("DELETE FROM users WHERE email = %s", (email,))
+        cur.execute(
+            "INSERT INTO users (email, password_hash, full_name, is_active, plan) "
+            "VALUES (%s, 'x', %s, TRUE, 'professional') RETURNING id",
+            (email, "Dana Officer"))
+        user_id = dict(cur.fetchone())["id"]
+        cur.execute(
+            "INSERT INTO subscriptions (user_id, stripe_subscription_id, status, "
+            "plan_name) VALUES (%s, %s, %s, 'professional')",
+            (user_id, sid, status))
+    conn.commit()
+    return user_id
+
+
+class Recorder:
+    """A sender that records rather than sends."""
+
+    def __init__(self, ok=True, reason=""):
+        self.calls, self.ok, self.reason = [], ok, reason
+
+    def __call__(self, email, name, kind, charge_text, amount, url, days, user_id=None):
+        self.calls.append({"email": email, "kind": kind, "charge_text": charge_text,
+                           "amount": amount, "url": url, "days": days})
+        return self.ok, self.reason
+
+
+def test_the_run_sends_once_and_records_what_it_sent():
+    conn = _db()
+    try:
+        user_id = _make_subscriber(conn, "pilot2.run@example.com", "sub_pilot2_run")
+        stripe = FakeStripe(preview={
+            "amount_due": 24900, "currency": "usd",
+            "next_payment_attempt": int(__import__("datetime").datetime(
+                2026, 9, 10, tzinfo=__import__("datetime").timezone.utc).timestamp()),
+        })
+        sender = Recorder()
+        report = renewal_run(conn, stripe, date(2026, 9, 1), sender)
+        # Asserted against THIS subscriber rather than the run totals:
+        # `run()` sweeps every live subscription in the database, and
+        # other tests leave their own behind.
+        mine = [c for c in sender.calls if c["email"] == "pilot2.run@example.com"]
+        assert report.sent >= 1
+        assert len(mine) == 1
+        assert mine[0]["kind"] == "renewal_15day"
+        assert mine[0]["amount"] == "$249.00"
+        assert mine[0]["charge_text"] == "10 September 2026"
+
+        # SECOND RUN, SAME DAY: idempotent. A cron that runs twice — or a
+        # webhook arriving beside it — must not write to her twice.
+        renewal_run(conn, stripe, date(2026, 9, 1), sender)
+        assert len([c for c in sender.calls
+                    if c["email"] == "pilot2.run@example.com"]) == 1
+
+        with conn.cursor() as cur:
+            cur.execute("SELECT notice_kind, ok, amount_cents, charge_date "
+                        "FROM billing_notices WHERE stripe_subscription_id = %s",
+                        ("sub_pilot2_run",))
+            rows = [dict(r) for r in cur.fetchall()]
+        assert len(rows) == 1
+        assert rows[0]["notice_kind"] == "renewal_15day"
+        assert rows[0]["ok"] is True
+        assert rows[0]["amount_cents"] == 24900
+        assert rows[0]["charge_date"] == date(2026, 9, 10)
+    finally:
+        conn.close()
+
+
+def test_what_stripe_said_is_recorded_but_never_consulted():
+    """THE DISCIPLINE, PINNED.
+
+    `renewal_at` is written from Stripe's answer after the decision is
+    made. To prove it is not an input, the column is poisoned with a
+    date that would trigger a notice, and Stripe is then made to say
+    there is no upcoming invoice: if the column were being read, a
+    notice would go out on a date nobody confirmed.
+    """
+    conn = _db()
+    try:
+        _make_subscriber(conn, "pilot2.record@example.com", "sub_pilot2_record")
+        with conn.cursor() as cur:
+            cur.execute("UPDATE subscriptions SET renewal_at = %s, "
+                        "renewal_amount_cents = 24900 "
+                        "WHERE stripe_subscription_id = %s",
+                        (date(2026, 9, 3), "sub_pilot2_record"))
+        conn.commit()
+
+        silent = FakeStripe(raises=RuntimeError("Stripe is unreachable"))
+        sender = Recorder()
+        outcome = _one(conn, silent, "sub_pilot2_record", date(2026, 9, 1), sender)
+        assert sender.calls == []
+        assert outcome["sent"] is None
+        assert "unreachable" in outcome["reason"]
+    finally:
+        conn.close()
+
+
+def test_a_failed_send_is_recorded_with_its_reason_and_fails_the_run():
+    """§4. The row exists either way; what must not happen is a run that
+    looks successful while nobody was told."""
+    conn = _db()
+    try:
+        _make_subscriber(conn, "pilot2.fail@example.com", "sub_pilot2_fail")
+        stripe = FakeStripe(preview={
+            "amount_due": 24900, "currency": "usd",
+            "next_payment_attempt": int(__import__("datetime").datetime(
+                2026, 9, 4, tzinfo=__import__("datetime").timezone.utc).timestamp()),
+        })
+        sender = Recorder(ok=False, reason="SENDGRID_API_KEY is not set")
+        outcome = _one(conn, stripe, "sub_pilot2_fail", date(2026, 9, 1), sender)
+        assert outcome["sent"] == "renewal_5day"
+        assert outcome["ok"] is False
+
+        with conn.cursor() as cur:
+            cur.execute("SELECT ok, reason FROM billing_notices "
+                        "WHERE stripe_subscription_id = %s", ("sub_pilot2_fail",))
+            row = dict(cur.fetchone())
+        assert row["ok"] is False
+        assert "SENDGRID" in row["reason"]
+    finally:
+        conn.close()
+
+
+def test_a_superseded_notice_is_recorded_rather_than_dropped():
+    """"Why did the 15-day notice never go out" has an answer in the
+    table, rather than being a gap somebody has to infer."""
+    conn = _db()
+    try:
+        _make_subscriber(conn, "pilot2.late@example.com", "sub_pilot2_late")
+        stripe = FakeStripe(preview={
+            "amount_due": 24900, "currency": "usd",
+            "next_payment_attempt": int(__import__("datetime").datetime(
+                2026, 9, 5, tzinfo=__import__("datetime").timezone.utc).timestamp()),
+        })
+        # Four days out and nothing sent: the cron was down through the
+        # whole 15-day window.
+        outcome = _one(conn, stripe, "sub_pilot2_late", date(2026, 9, 1), Recorder())
+        assert outcome["sent"] == "renewal_5day"
+        assert outcome["superseded"] == ["renewal_15day"]
+
+        with conn.cursor() as cur:
+            cur.execute("SELECT notice_kind, ok, reason FROM billing_notices "
+                        "WHERE stripe_subscription_id = %s ORDER BY notice_kind",
+                        ("sub_pilot2_late",))
+            rows = [dict(r) for r in cur.fetchall()]
+        kinds = {r["notice_kind"]: r for r in rows}
+        assert kinds["renewal_5day"]["ok"] is True
+        assert kinds["renewal_15day"]["ok"] is False
+        assert "superseded" in kinds["renewal_15day"]["reason"]
+    finally:
+        conn.close()
+
+
+def test_a_cancelled_subscription_is_not_asked_about():
+    conn = _db()
+    try:
+        _make_subscriber(conn, "pilot2.gone@example.com", "sub_pilot2_gone",
+                         status="canceled")
+        rows = rn.subscriptions_to_check(conn)
+        assert "sub_pilot2_gone" not in [r["stripe_subscription_id"] for r in rows]
+    finally:
+        conn.close()
+
+
+def renewal_run(conn, stripe, today, sender):
+    return rn.run(conn, stripe, today, sender=sender)
+
+
+def _one(conn, stripe, sid, today, sender):
+    """One subscription through the same code the run loop uses."""
+    row = next(r for r in rn.subscriptions_to_check(conn)
+               if r["stripe_subscription_id"] == sid)
+    outcome = rn.process_subscription(conn, stripe, row, today, sender)
+    conn.commit()
+    return outcome

--- a/backend/tests/test_pilot2_renewal_notices.py
+++ b/backend/tests/test_pilot2_renewal_notices.py
@@ -21,9 +21,19 @@ the decision is made from the live answer every time.
 """
 from __future__ import annotations
 
+import os
 from datetime import date
 
 import pytest
+
+#: The suite runs in TWO jobs: one with a Postgres service and one
+#: without. The convention every DB-backed test here follows is to skip
+#: rather than fail when there is no database — the no-Postgres job is a
+#: real gate for everything else, and a test that cannot run must not
+#: turn it red. Caught by CI, which is where it should have been caught,
+#: but it should have been written this way.
+needs_db = pytest.mark.skipif(not os.getenv("DATABASE_URL"),
+                              reason="live test DB required")
 
 from services import renewal_notice as rn
 
@@ -338,6 +348,7 @@ class Recorder:
         return self.ok, self.reason
 
 
+@needs_db
 def test_the_run_sends_once_and_records_what_it_sent():
     conn = _db()
     try:
@@ -379,6 +390,7 @@ def test_the_run_sends_once_and_records_what_it_sent():
         conn.close()
 
 
+@needs_db
 def test_what_stripe_said_is_recorded_but_never_consulted():
     """THE DISCIPLINE, PINNED.
 
@@ -408,6 +420,7 @@ def test_what_stripe_said_is_recorded_but_never_consulted():
         conn.close()
 
 
+@needs_db
 def test_a_failed_send_is_recorded_with_its_reason_and_fails_the_run():
     """§4. The row exists either way; what must not happen is a run that
     looks successful while nobody was told."""
@@ -434,6 +447,7 @@ def test_a_failed_send_is_recorded_with_its_reason_and_fails_the_run():
         conn.close()
 
 
+@needs_db
 def test_a_superseded_notice_is_recorded_rather_than_dropped():
     """"Why did the 15-day notice never go out" has an answer in the
     table, rather than being a gap somebody has to infer."""
@@ -464,6 +478,7 @@ def test_a_superseded_notice_is_recorded_rather_than_dropped():
         conn.close()
 
 
+@needs_db
 def test_a_cancelled_subscription_is_not_asked_about():
     conn = _db()
     try:

--- a/backend/utils/email_templates.py
+++ b/backend/utils/email_templates.py
@@ -307,6 +307,53 @@ def payment_failed(full_name, amount_text, attempt_url) -> Rendered:
     return subject, _base("Payment failed — your account is unaffected", content, False), text
 
 
+def renewal_notice(full_name, charge_text, amount_text_value, billing_url,
+                   days_text) -> Rendered:
+    """PILOT2 — she is about to be charged, and she knows before it happens.
+
+    ═══ WHAT THIS SAYS AND WHY EACH PART IS THERE ═══
+
+    THE DATE, NOT A DURATION. "Your trial ends in 15 days" makes the
+    reader count from a day she has to remember; the date is checkable
+    against her calendar and against her statement.
+
+    THE AMOUNT, from Stripe's own preview of the invoice — not from our
+    price table, and not rounded. A notice quoting $249 for a $249.37
+    charge is a small lie that arrives on a bank statement.
+
+    THE WAY OUT, first-class rather than a footnote. The homepage
+    promises "cancel anytime"; a pre-charge notice that does not link to
+    the cancel control is that promise being made and then withheld at
+    the one moment it is worth something.
+
+    AND NO PERSUASION. This is not a retention email. It carries no offer,
+    no "we would hate to see you go", and no reason to stay — a message
+    whose whole purpose is that nobody is surprised must not also be
+    trying to change the answer.
+    """
+    subject = f"Your DeedPro subscription renews on {charge_text}"
+    content = (
+        _p(f"Hi {_esc(full_name) or 'there'},")
+        + _p(f"This is a reminder that your DeedPro subscription will be "
+             f"charged <strong>{_esc(amount_text_value)}</strong> on "
+             f"<strong>{_esc(charge_text)}</strong> — {_esc(days_text)}.")
+        + _p("No action is needed if you would like to continue. If you would "
+             "rather not be charged, you can cancel before that date.")
+        + _button(billing_url, "Manage or cancel your subscription")
+        + _p('<span style="font-size:13px;color:#8a94a0;">The amount and date '
+             "above come from your Stripe invoice, so they are what will "
+             "actually be charged.</span>")
+    )
+    text = (
+        f"Your DeedPro subscription will be charged {amount_text_value} on "
+        f"{charge_text} ({days_text}).\n\n"
+        "No action is needed to continue. To cancel before then, open your "
+        f"billing settings: {billing_url}"
+    )
+    return subject, _base(f"Your subscription renews on {charge_text}",
+                          content, False), text
+
+
 def welcome(full_name) -> Rendered:
     subject = "Welcome to DeedPro"
     url = _frontend_url()

--- a/backend/utils/notifications.py
+++ b/backend/utils/notifications.py
@@ -44,6 +44,12 @@ TEMPLATES = (
     # hold a link, the link is dead, and discovering that by clicking it
     # is worse than being told.
     "signing_cancelled",
+    # PILOT2 — the pre-charge notices, at 15 and 5 days. TWO NAMES rather
+    # than one template with a parameter, because `email_log.template` is
+    # the record somebody counts: "did the 15-day notice go out" must be
+    # answerable without joining to whatever context column happened to
+    # carry the number.
+    "renewal_15day", "renewal_5day",
 )
 
 
@@ -207,6 +213,39 @@ def send_payment_failed_with_reason(user_email: str, full_name: str,
     return _send("payment_failed", user_email,
                  email_templates.payment_failed(full_name, amount_text, billing_url),
                  user_id=user_id)
+
+
+def send_renewal_notice_with_reason(user_email: str, full_name: str,
+                                    notice_kind: str, charge_text: str,
+                                    amount_text: str, billing_url: str,
+                                    days_text: str,
+                                    user_id: Optional[int] = None) -> SendResult:
+    """PILOT2 — she is told before she is charged, not after.
+
+    `notice_kind` IS the template name (`renewal_15day` / `renewal_5day`),
+    so `email_log` can be counted per notice without decoding a context
+    blob. The rendering is identical for both — the difference is which
+    window fired, and that is a fact about the schedule rather than about
+    the message.
+    """
+    rendered = email_templates.renewal_notice(full_name, charge_text,
+                                              amount_text, billing_url,
+                                              days_text)
+    # DISPATCHED ON LITERALS rather than passing `notice_kind` straight
+    # through, and the reason is the meta-pin in
+    # `test_admin3_email_outcomes.py`: it reads this file and matches
+    # every declared template name against the `_send` calls it can SEE.
+    # A variable label satisfies the runtime and defeats the check —
+    # which is how a template would end up in `email_log` under a name
+    # nothing declared. It caught this on the first run.
+    if notice_kind == "renewal_15day":
+        return _send("renewal_15day", user_email, rendered, user_id=user_id)
+    if notice_kind == "renewal_5day":
+        return _send("renewal_5day", user_email, rendered, user_id=user_id)
+    # Refused rather than coerced: an unknown kind would write a template
+    # name into `email_log` that the TEMPLATES tuple does not know, which
+    # is the vocabulary drift that tuple exists to stop.
+    return False, f"unknown renewal notice kind: {notice_kind}"
 
 
 def send_notary_invited(recipient_email: str, notary_name: str, officer_name: str,

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -1195,6 +1195,39 @@ we reach it.
   every method. Removing PATCH again turns five tests red, including the
   live preflight.
 
+- **PILOT2 — the pre-charge notices exist; THE CRON DOES NOT**
+  (2026-08-18).
+  **DECIDED** 2026-08-18 — two notices, 15 and 5 days before the charge,
+  off the date and amount Stripe computes, via the E1 transport.
+  **BUILT** — the job, the templates, the schema and the webhook signal.
+  **The Render cron service is NOT created: that is deploy topology and
+  therefore the owner's.**
+
+  **Until that service exists, the coupon path sends nothing.** Unlike
+  the purge, there is no in-request fallback carrying this work. The
+  `customer.subscription.trial_will_end` handler covers the 14-day trial
+  three days out, and the pilot's 100%-off coupon emits no trial event at
+  all. Stated loudly because a job nobody scheduled produces exactly the
+  customer experience of the gap it was written to close.
+
+  **The service, when it is created:**
+  `python backend/scripts/send_renewal_notices.py`, daily at 15:00 UTC,
+  with `DATABASE_URL`, `STRIPE_SECRET_KEY`, `FRONTEND_URL`,
+  `SENDGRID_API_KEY` and `EXPECTED_DATABASE=deedpro`. Exit 1 on any
+  failed send, so the cron's own alerting sees it.
+
+  **The date question, ruled.** `current_period_end` and `discount.end`
+  were both wrong; the upcoming invoice is authoritative because Stripe
+  computes it with the discount applied. The design persists nothing that
+  decides anything — `trial_end`, `renewal_at` and `renewal_amount_cents`
+  are a record for the admin view and for reconstructing what we
+  believed, never an input.
+
+  **A gap this closed that was never pilot-only:** the existing 14-day
+  trial charged with no warning. `trial_end` was present on every
+  subscription event and persisted nowhere, `trial_will_end` returned a
+  bare 200, and no template existed.
+
 ## Parked tickets (scoped, not scheduled)
 
 - **W0 §3 — A RULING DECIDED, PARKED, AND NEVER BUILT** (surfaced by

--- a/frontend/src/__tests__/billingCancel.test.tsx
+++ b/frontend/src/__tests__/billingCancel.test.tsx
@@ -205,3 +205,44 @@ describe('what the copy does not claim', () => {
     }
   });
 });
+
+describe('the link the pre-charge email sends her to', () => {
+  /**
+   * PILOT2. The notice's only call to action is "cancel before you are
+   * charged", and the control is one click INSIDE this page. Landing on
+   * Profile and asking her to find Billing is where a promise turns
+   * into a hunt.
+   *
+   * Pinned by rendering with the query parameter rather than by
+   * grepping for it: what matters is that the Billing tab is what she
+   * sees, not that a string appears in the source.
+   */
+  it('opens the Billing tab directly on ?tab=billing', async () => {
+    fetchMock.mockImplementation((url: unknown) => {
+      if (String(url).includes('/users/profile')) {
+        return answer(200, { email: 'officer@example.com', plan: 'professional' });
+      }
+      return answer(404, { detail: 'No billing information found' });
+    });
+    // The suite mocks `next/navigation` globally (jest.setup.js), so the
+    // parameter is supplied by spying on that mock rather than by
+    // re-mocking the module — a `resetModules` here would hand the page
+    // a second copy of React and fail with an invalid-hook error rather
+    // than with anything about tabs.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const nav = require('next/navigation');
+    const spy = jest.spyOn(nav, 'useSearchParams')
+      .mockReturnValue(new URLSearchParams('tab=billing') as any);
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const Page = require('../app/account-settings/page').default;
+      render(<Page />);
+      // No click on the Billing tab anywhere in this test: the control
+      // is on screen because the URL said so.
+      expect(await screen.findByRole('button', { name: /cancel subscription/i }))
+        .toBeInTheDocument();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/frontend/src/app/account-settings/page.tsx
+++ b/frontend/src/app/account-settings/page.tsx
@@ -64,7 +64,28 @@ export default function AccountSettingsPageV0() {
 function AccountSettingsPage() {
   const router = useRouter()
   const params = useSearchParams()
-  const [activeTab, setActiveTab] = useState<Tab>("profile")
+  /**
+   * PILOT2 — `?tab=billing` opens the Billing tab directly.
+   *
+   * The pre-charge email's only call to action is "cancel before you are
+   * charged", and PILOT1's cancel control lives one click inside this
+   * page. Landing on Profile and asking the reader to find Billing is
+   * where a promise turns into a hunt.
+   *
+   * The link is NOT a Stripe portal session URL, which is what a
+   * one-click cancel would ideally be: those expire, and a 15-day notice
+   * is by definition read late. This lands on the control, which mints a
+   * fresh session when she presses it.
+   *
+   * An unknown value falls back to Profile rather than rendering
+   * nothing — a URL somebody edited is not a reason to show an empty
+   * page.
+   */
+  const requestedTab = params?.get("tab")
+  const [activeTab, setActiveTab] = useState<Tab>(
+    (["profile", "billing", "notifications", "security"] as const)
+      .includes(requestedTab as Tab) ? (requestedTab as Tab) : "profile"
+  )
   const [userProfile, setUserProfile] = useState<UserProfile | null>(null)
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)


### PR DESCRIPTION
Built as ruled. All four items.

## 1. The date, and the discipline around it

The **upcoming invoice** is authoritative — `Invoice.create_preview(subscription=...)` — because Stripe computes it with the discount already applied: one object carrying the true date and the true amount.

**Nothing persisted decides anything.** `subscriptions.trial_end`, `renewal_at` and `renewal_amount_cents` are written *after* the decision, from what Stripe said, for the admin view and for reconstructing what we believed. The job asks Stripe every day and acts on the live answer. There is a test that proves it: it poisons `renewal_at` with a date that would trigger a notice, then makes Stripe fail — and asserts nothing is sent.

`billing_notices` is idempotency, which is a fact about *us*. Its identity includes the **charge date**, so a date that moves starts a new conversation rather than being silenced by notices about a date that no longer exists.

**One finding on the SDK worth flagging:** `stripe.Invoice.upcoming` — the method every example uses, and the name in my own report — **does not exist in the pinned SDK** (12.3.0); the operation is `Invoice.create_preview`. Calling the absent one raises `AttributeError`, which an `except Exception` around a billing call would quietly turn into "no upcoming invoice" and a customer charged with no warning. Pinned against the *installed* module, so the next SDK move is loud.

## 2. The notices

15 and 5 days, via the E1 transport, carrying the exact date, the exact amount, and the way out. The template says nothing else — no offer, no "we'd hate to see you go". A message whose whole purpose is that nobody is surprised must not also be arguing a side, and that is pinned too.

**"At or inside", not exactly-N.** A daily job misses days, and exact windows would drop a notice in a way indistinguishable from it never being due. When a run finds both windows open, it sends the tightest and records the other as **superseded, with its reason** — so "why did the 15-day notice never go out" has an answer in the table rather than being a gap somebody infers.

**One deviation, flagged:** the link goes to `/account-settings?tab=billing` — PILOT1's ungated cancel control — rather than embedding a Stripe portal session URL as the ticket asked. Portal session links are short-lived, and a 15-day notice is by definition read late; the ticket's own timescale defeats its letter. The control mints a fresh session on click. One extra click, works every time instead of most of the time. (The `?tab=` deep link is new, and pinned by rendering rather than by grepping.)

## 3. `trial_will_end`

It fell through every branch to a bare 200 — indistinguishable, from Stripe's side, from being handled. It now upserts and runs **the same decision against the same idempotency table**, so it is a second *signal*, not a second sender. It never fails the webhook: the upsert has already committed and the notice is a courtesy, so its reason goes into the response body that Stripe logs.

`trial_end` is persisted and deliberately **not** COALESCEd, unlike its neighbours in that upsert: when a trial converts Stripe sends `trial_end: null`, and that null is the fact. COALESCE would keep the old date forever and leave the record claiming a trial ends on a day that has passed.

## 4. The job — and the service that does not exist

`scripts/send_renewal_notices.py`, shaped like `purge_signer_contact.py`, with `EXPECTED_DATABASE` and the identity assertion. It refuses to run without `STRIPE_SECRET_KEY` rather than inventing a date, has a `--dry-run` that asks Stripe and decides without sending or recording, and **exits 1 on any failed send** — a cron that exits 0 while nobody was told is the shape this ticket removes.

`EXPECTED_DATABASE` earns its place here for a different reason than the purge: nothing is deleted, but **an email cannot be unsent**, and the wrong one tells a real customer she is about to be charged an amount that is not real.

**The Render cron is not created — Tier 3, yours.** And unlike the purge there is *no in-request fallback carrying this work*: until that service exists, the coupon path sends nothing and `trial_will_end` covers only the 14-day trial, three days out. Ledgered loudly, because a job nobody scheduled produces exactly the customer experience of the gap it was written to close.

## Self-review

**Premises checked, and what was found**
- *The 14-day trial already charges without warning* — **confirmed**: `trial_end` present on every subscription event, persisted nowhere; `trial_will_end` unhandled; no template. Not pilot-only, exactly as you said.
- *`Invoice.upcoming` is the API* — **false** for this SDK. See above.
- *A 100%-off coupon leaves the subscription `active`* — consistent with everything in the code; **not verifiable from here** without a Stripe test key. If the pilot is instead provisioned as a trial, the trial path covers it and nothing about this design changes.

**Two defects my own tests caught, not review**
1. A **wider notice could fire after a tighter one**: at 3 days out the 15-day window is still open and still unsent, so a naive "open and not recorded" rule sends the 15-day notice *after* the 5-day one — which reads to the customer as the date moving further away. Fixed by suppressing any window wider than the tightest already recorded.
2. **Stripe's own failure reason was being swallowed** and replaced with the generic "no upcoming invoice" — which is what a connection reset and a genuinely absent invoice look like from the inside (§4).

**The meta-pin fired twice, correctly, and I fixed the property rather than working around it**
`test_admin3_email_outcomes.py` scans this file for `_send("literal")`. Passing `notice_kind` through as a variable satisfies the runtime and defeats the scan — so the sender now dispatches on literals. Then its name regex was `[a-z_]+` and could not see `renewal_15day`, reporting a declared-but-unused template that was neither: a false accusation produced by the pin's spelling rather than the property it guards (§14.1). Widened to `[a-z0-9_]+`. The template trip-wire moves 19 → 21 deliberately, with the reason recorded.

**Least sure about**
15:00 UTC for the cron — mid-morning in California, so someone who wants to cancel can do it during a working day rather than finding the mail at 2am. It is a guess about the audience's day, and it is one line in the service definition.

**What would be cut if forced**
The `?tab=billing` deep link. The email would still name the page; she would land on Profile and click Billing.

**Anything decided rather than flagged**
Two notice *names* (`renewal_15day`, `renewal_5day`) for one rendering. "Did the 15-day notice go out" is a question a person asks of `email_log`, and it should be answerable from the template column rather than by decoding a context blob.

## Gates

pytest **1536** · jest **1103** / 79 · tsc **88** · `next build` clean · banned-claims clean (14 rules, 241 files) · four harnesses green.

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_