### PR TITLE
PILOT2-CRON — the cron's configuration, checked rather than inferred

### DIFF
--- a/backend/scripts/send_renewal_notices.py
+++ b/backend/scripts/send_renewal_notices.py
@@ -17,35 +17,125 @@ Usage:
     DATABASE_URL=... python backend/scripts/send_renewal_notices.py --dry-run
     DATABASE_URL=... python backend/scripts/send_renewal_notices.py --verify
 
-Suggested Render Cron Job (owner-side, Tier 3):
-    schedule:      0 15 * * *         # daily, 15:00 UTC — mid-morning in
-                                      # California, so a customer who
-                                      # wants to cancel can do it during
-                                      # a working day rather than finding
-                                      # the mail at 2am.
-    command:       python backend/scripts/send_renewal_notices.py
-    env:           DATABASE_URL from the deedpro-db database
-                   STRIPE_SECRET_KEY   ← the charge date and amount come
-                                         from Stripe; without it this job
-                                         refuses rather than guessing.
-                   FRONTEND_URL        ← the cancel link in the email.
-                   SENDGRID_API_KEY    ← without it every send fails
-                                         HONESTLY: the attempt is
-                                         recorded with its reason and the
-                                         exit code is non-zero.
-                   EXPECTED_DATABASE=deedpro   ← name the database this
-                   job is FOR. Staging carries the same tables, and a
-                   misconfigured cron pointed there would email real
-                   customers about charges from a copy of the data.
+THE RENDER CRON JOB, EXACTLY (owner-side, Tier 3):
+
+    Name:          renewal_notices
+    Runtime:       Python 3
+    Root Directory: (leave EMPTY — the repository root)
+    Build Command: pip install -r backend/requirements.txt
+    Command:       python backend/scripts/send_renewal_notices.py
+    Schedule:      0 15 * * *        # daily, 15:00 UTC
+
+    ⚠️ THE COMMAND RUNS FROM THE REPOSITORY ROOT, and that is safe here
+    for a reason worth stating rather than assuming: this script puts its
+    own package root on `sys.path` from `__file__`, so the working
+    directory does not matter. `role_census.py` did not, assumed it ran
+    from `backend/`, and died on ModuleNotFoundError in production. If
+    you set Root Directory to `backend`, use
+    `python scripts/send_renewal_notices.py` instead — both work, but the
+    Build Command's path must match the choice.
+
+    ⚠️ 15:00 UTC is mid-morning in California ON PURPOSE. Somebody who
+    reads this mail and wants to cancel can do it during a working day
+    instead of finding it at 2am.
+
+    Environment variables — every one, and where each value comes from:
+
+      PYTHON_VERSION       3.12.7
+                           Pin it. Render's default is a version where
+                           pydantic_core has no wheel and the build dies
+                           compiling Rust. Set it in the DASHBOARD:
+                           declaring it in render.yaml did not apply it
+                           (confirmed the hard way, 2026-08-12).
+
+      DATABASE_URL         The EXTERNAL connection string of the
+                           `deedpro` Postgres. Not the internal one — a
+                           cron job cannot resolve it.
+
+      EXPECTED_DATABASE    deedpro
+                           Names the database this job is FOR. Staging
+                           carries the same tables, so the tables alone
+                           would let a misconfigured cron mail real
+                           customers about charges recorded in a copy.
+
+      STRIPE_SECRET_KEY    Same value as the main API's. The charge date
+                           and amount are READ from Stripe; without it
+                           the job refuses rather than inventing them.
+
+      FRONTEND_URL         https://deedpro.io (whatever the API uses).
+                           The cancel link in every notice. Unset, the
+                           link is RELATIVE — which in an email client is
+                           a dead link — so the job refuses.
+
+      SENDGRID_API_KEY     Same value as the main API's. Without it every
+                           send fails HONESTLY: the attempt is recorded
+                           in `email_log` with its reason and the job
+                           exits 1.
+
+      SENDGRID_FROM_EMAIL  info@deedpro.io — the verified sender. Absent,
+                           mail falls back to a default sender, which is
+                           visible in the message that arrives.
+
+    NOT needed, and deliberately: JWT_SECRET_KEY, ALLOWED_ORIGINS,
+    STRIPE_WEBHOOK_SECRET, the price IDs, ADMIN_EMAIL. This job serves no
+    requests, verifies no sessions and creates no checkouts.
+
+    BEFORE THE FIRST RUN, in this order:
+      1. Deploy the API at least once after PILOT2 merged. The API
+         converges the schema; THIS JOB DOES NOT and must not — a cron
+         issuing `ALTER TABLE users` from a schedule nobody watches is a
+         worse failure than a missing notice. It asserts the tables and
+         refuses when they are absent.
+      2. `--verify` from the Render shell. It needs only DATABASE_URL and
+         EXPECTED_DATABASE, so it can be run before the secrets are in.
+      3. `--dry-run`. Asks Stripe, decides, sends nothing, writes nothing.
+
+    WHAT A SUCCESSFUL RUN PRINTS — so success is distinguishable from
+    silence, which is the whole point of a job like this:
+
+        [renewal-notices] running against deedpro on <host> (as <user>) (PostgreSQL 16.x)
+        {
+          "considered": 3,
+          "sent": 0,
+          "superseded": 0,
+          "failed": 0,
+          "unreachable": 0,
+          "skipped": [
+            {"subscription": "sub_1234", "reason": "the next invoice is zero — nothing to warn about"},
+            {"subscription": "sub_5678", "reason": "no window open 41 days out, or already recorded"}
+          ]
+        }
+
+    `"sent": 0` with a populated `skipped` IS A SUCCESSFUL RUN — during
+    the discounted months of a pilot it is the ONLY correct outcome, and
+    every subscription says why in its own words. An EMPTY report
+    (`"considered": 0`) means the job found no live subscriptions at all,
+    which on a day you expect pilots is the thing to investigate.
+
+    A run that sent something prints `"sent": 1` and the notice is in
+    `billing_notices` with `ok = true`.
+
+    `"unreachable"` MUST BE 0. It counts subscriptions Stripe would not
+    answer about — a wrong API key makes it equal `considered`, and the
+    job exits 1. That case is why the counter exists: before it, a bad
+    key skipped every subscription with an honest reason and exited 0,
+    which is a cron reporting success every day while sending nothing.
 
 WHY `EXPECTED_DATABASE` MATTERS HERE, given nothing is deleted: this job
 is not irreversible against the database, it is irreversible against a
 PERSON. An email cannot be unsent, and the wrong one tells a customer she
 is about to be charged an amount that is not real.
 
-Exit codes: 0 when every notice due was sent, 1 when any send failed or
-the job could not run — so a cron service's own alerting sees a failed
-run rather than a silent one.
+Exit codes:
+    0  every notice due was sent, and Stripe answered about everyone.
+       A run that sent NOTHING exits 0 when that was the right answer —
+       during a pilot's discounted months it is the only right answer.
+    1  a send failed, Stripe would not answer, the database was wrong or
+       unreachable, or a required variable was missing.
+
+So a cron service's own alerting sees a failed run rather than a silent
+one — including the silent failure this job is most likely to have,
+which is a Stripe key that stopped working.
 """
 import json
 import os
@@ -73,13 +163,31 @@ def main() -> int:
     dry_run = "--dry-run" in sys.argv
     verify_only = "--verify" in sys.argv
 
-    # The date and the amount come from Stripe. Without a key there is no
-    # authority to read, and a job that ran anyway would either send
-    # nothing (looking healthy) or send something it made up.
-    if not (os.getenv("STRIPE_SECRET_KEY") or "").strip():
-        print("STRIPE_SECRET_KEY is not set — the charge date and amount come "
-              "from Stripe, and this job will not invent them", file=sys.stderr)
-        return 1
+    # ── What this job refuses to run without ──────────────────────────
+    #
+    # Both checks are BELOW the `--verify` branch's needs on purpose:
+    # `--verify` only reads the database, and demanding a Stripe key to
+    # answer "am I pointed at the right database" makes the first check
+    # an owner runs the hardest one to run.
+    if not verify_only:
+        # The date and the amount come from Stripe. Without a key there
+        # is no authority to read, and a job that ran anyway would either
+        # send nothing (looking healthy) or send something it made up.
+        if not (os.getenv("STRIPE_SECRET_KEY") or "").strip():
+            print("STRIPE_SECRET_KEY is not set — the charge date and amount "
+                  "come from Stripe, and this job will not invent them",
+                  file=sys.stderr)
+            return 1
+
+        # The cancel link. Unset, `billing_url()` produced a RELATIVE
+        # path, which in an email client is a dead link — so the notice
+        # would arrive correct in every detail and fail at the one action
+        # it exists to enable.
+        if not (os.getenv("FRONTEND_URL") or "").strip():
+            print("FRONTEND_URL is not set — every notice would carry a "
+                  "relative cancel link, which is a dead link in an email",
+                  file=sys.stderr)
+            return 1
 
     import stripe
     stripe.api_key = os.getenv("STRIPE_SECRET_KEY")
@@ -123,16 +231,24 @@ def main() -> int:
             conn.rollback()
             print(json.dumps(report.as_dict(), indent=2, default=str))
             print("[dry-run] nothing was sent and nothing was recorded")
-            return 0
+            # A dry run exists to check the configuration BEFORE the
+            # first real one, so a Stripe that will not answer has to
+            # fail it too. Sends are refused by design here, so
+            # `failed` is not consulted — only `unreachable`, which is
+            # the wrong-API-key case this check is for.
+            return 1 if report.unreachable else 0
 
         report = renewal_notice.run(conn, stripe, today)
         conn.commit()
         print(json.dumps(report.as_dict(), indent=2, default=str))
 
-        # A failed send is a failed run. The rows record it either way,
-        # but a cron that exits 0 while nobody was told is the shape this
-        # ticket exists to remove.
-        return 1 if report.failed else 0
+        # A failed send is a failed run — and so is a Stripe that would
+        # not answer. The rows record a failed send either way, but a
+        # cron that exits 0 while nobody was told is the shape this
+        # ticket exists to remove, and a wrong API key produces exactly
+        # that: every subscription skipped with an honest reason, and a
+        # green run every day forever.
+        return 1 if (report.failed or report.unreachable) else 0
     except Exception as exc:
         conn.rollback()
         print(f"renewal notices failed: {exc}", file=sys.stderr)

--- a/backend/services/renewal_notice.py
+++ b/backend/services/renewal_notice.py
@@ -79,6 +79,24 @@ NOTICE_WINDOWS: Tuple[Tuple[str, int], ...] = (
 NOTICE_KINDS = tuple(kind for kind, _ in NOTICE_WINDOWS)
 
 
+class StripeUnavailable(RuntimeError):
+    """Stripe would not answer — distinct from "there is no invoice".
+
+    ═══ WHY THIS IS A TYPE AND NOT A REASON STRING ═══
+
+    Both were reported the same way at first, and the dry-run showed what
+    that costs: with a wrong API key, every subscription was skipped with
+    an honest reason and the job exited **0**. A cron with a bad key
+    would have reported success every day while sending nothing, which is
+    precisely the silence this ticket exists to remove.
+
+    "Stripe has no upcoming invoice for this customer" is an ANSWER.
+    "Stripe would not talk to us" is a FAILURE. They must not exit the
+    same way, and telling them apart by matching on the reason text would
+    be asserting the spelling rather than the property (§14.1).
+    """
+
+
 @dataclass(frozen=True)
 class UpcomingCharge:
     """What Stripe says the next real charge is. Never assembled by us."""
@@ -169,7 +187,8 @@ def upcoming_charge(stripe_module, subscription_id: str) -> Tuple[Optional[Upcom
     try:
         preview = preview_fn(subscription=subscription_id)
     except Exception as exc:  # stripe.error.* and transport failures alike
-        return None, f"Stripe would not preview the next invoice: {exc}"
+        raise StripeUnavailable(
+            f"Stripe would not preview the next invoice: {exc}") from exc
 
     amount = _as_int(_get(preview, "amount_due"))
     if amount is None:
@@ -222,8 +241,17 @@ def billing_url() -> str:
     subscription" control opens a FRESH portal session on click. One
     extra click, and it works every time instead of most of the time.
     """
-    base = (os.getenv("FRONTEND_URL") or "").rstrip("/")
-    return f"{base}/account-settings?tab=billing"
+    # REQUIRED, not defaulted. Unset, this returned
+    # `/account-settings?tab=billing` — a RELATIVE path, which in an
+    # email client resolves against nothing and is simply a dead link.
+    # The notice would still be sent, still say the right date and
+    # amount, and fail at the one action it exists to enable.
+    #
+    # `require()` raises with the manifest's own consequence sentence
+    # (services/environment.py), so a misconfigured cron says which
+    # variable and why rather than mailing a broken link.
+    from services.environment import require
+    return f"{require('FRONTEND_URL').rstrip('/')}/account-settings?tab=billing"
 
 
 def _get(obj: Any, key: str):
@@ -272,12 +300,16 @@ class RunReport:
     sent: int = 0
     superseded: int = 0
     failed: int = 0
+    #: Subscriptions Stripe would not answer about. Counted apart from
+    #: `skipped` because a skip is a decision and this is an absence of
+    #: one.
+    unreachable: int = 0
     skipped: list = field(default_factory=list)
 
     def as_dict(self) -> Dict[str, Any]:
         return {"considered": self.considered, "sent": self.sent,
                 "superseded": self.superseded, "failed": self.failed,
-                "skipped": self.skipped}
+                "unreachable": self.unreachable, "skipped": self.skipped}
 
 
 #: Statuses worth asking Stripe about. A cancelled or unpaid subscription
@@ -365,7 +397,13 @@ def process_subscription(conn, stripe_module, row: Dict[str, Any],
     send = sender or send_renewal_notice_with_reason
     sid = row["stripe_subscription_id"]
 
-    charge, why = upcoming_charge(stripe_module, sid)
+    try:
+        charge, why = upcoming_charge(stripe_module, sid)
+    except StripeUnavailable as unavailable:
+        # NOT a skip. Nothing was learned about this customer, so the run
+        # must not read as healthy — see StripeUnavailable.
+        return {"subscription": sid, "sent": None, "unreachable": True,
+                "reason": str(unavailable)}
     _record_what_stripe_said(conn, sid, charge)
 
     decision = decide(charge, today,
@@ -426,6 +464,10 @@ def run(conn, stripe_module, today: Optional[date] = None,
                 # failure even though the row exists (§4).
                 report.failed += 1
             report.superseded += len(outcome.get("superseded") or ())
+        elif outcome.get("unreachable"):
+            report.unreachable += 1
+            report.skipped.append({"subscription": outcome["subscription"],
+                                   "reason": outcome["reason"]})
         else:
             report.skipped.append({"subscription": outcome["subscription"],
                                    "reason": outcome["reason"]})

--- a/backend/tests/test_pilot2_renewal_notices.py
+++ b/backend/tests/test_pilot2_renewal_notices.py
@@ -35,6 +35,24 @@ import pytest
 needs_db = pytest.mark.skipif(not os.getenv("DATABASE_URL"),
                               reason="live test DB required")
 
+
+@pytest.fixture(autouse=True)
+def _frontend_url():
+    """Every notice carries a cancel link, and the link must be absolute.
+
+    Supplied here rather than per-test because it is a property of the
+    PRODUCT (a relative link is a dead link in an email), not of any one
+    case — and because a test that forgot it would fail with a refusal
+    about configuration rather than about what it was testing.
+    """
+    kept = os.environ.get("FRONTEND_URL")
+    os.environ["FRONTEND_URL"] = "https://deedpro.io"
+    yield
+    if kept is None:
+        os.environ.pop("FRONTEND_URL", None)
+    else:
+        os.environ["FRONTEND_URL"] = kept
+
 from services import renewal_notice as rn
 
 
@@ -157,10 +175,17 @@ def test_the_amount_and_date_come_from_the_invoice_preview():
 
 
 def test_a_stripe_failure_never_becomes_a_date():
+    """And it RAISES rather than returning "no invoice".
+
+    Both were reported identically at first, and a dry-run with a wrong
+    API key exposed the cost: every subscription skipped with an honest
+    reason, and the job exiting 0. A cron with a bad key would have
+    reported success every day while sending nothing.
+    """
     stripe = FakeStripe(raises=RuntimeError("connection reset"))
-    found, why = rn.upcoming_charge(stripe, "sub_123")
-    assert found is None
-    assert "connection reset" in why
+    with pytest.raises(rn.StripeUnavailable) as raised:
+        rn.upcoming_charge(stripe, "sub_123")
+    assert "connection reset" in str(raised.value)
 
 
 def test_the_sdk_operation_is_the_one_this_sdk_actually_has():
@@ -301,7 +326,7 @@ def test_a_failed_send_is_a_failed_run():
     from pathlib import Path
     src = code_only(Path(__file__).resolve().parents[1]
                     .joinpath("scripts/send_renewal_notices.py").read_text())
-    assert "return 1 if report.failed else 0" in src
+    assert "return 1 if (report.failed or report.unreachable) else 0" in src
 
 
 # ── The run, against a real database ─────────────────────────────────
@@ -501,3 +526,104 @@ def _one(conn, stripe, sid, today, sender):
     outcome = rn.process_subscription(conn, stripe, row, today, sender)
     conn.commit()
     return outcome
+
+
+# ── The cron's own configuration ─────────────────────────────────────
+#
+# The purge cron took four failed builds to get right, and every one was
+# a config detail that could have been asked for up front. These pin the
+# details, so the list handed to the owner is checked rather than
+# remembered.
+
+def test_the_cancel_link_is_absolute_or_the_job_refuses():
+    """THE DEFECT THIS PIN EXISTS FOR.
+
+    `billing_url()` used to fall back to an empty base, producing
+    `/account-settings?tab=billing` — a RELATIVE path. In an email client
+    that resolves against nothing: the notice arrives correct in every
+    detail, names the right date and the right amount, and its one
+    call to action is a dead link.
+
+    A missing FRONTEND_URL is now a refusal carrying the manifest's own
+    consequence sentence, not a silently degraded link.
+    """
+    import os
+
+    from services.environment import EnvironmentError_
+
+    kept = os.environ.pop("FRONTEND_URL", None)
+    try:
+        with pytest.raises(EnvironmentError_) as raised:
+            rn.billing_url()
+        assert "FRONTEND_URL" in str(raised.value)
+    finally:
+        if kept is not None:
+            os.environ["FRONTEND_URL"] = kept
+
+
+def test_verify_needs_only_a_database():
+    """`--verify` answers "am I pointed at the right database".
+
+    It used to demand STRIPE_SECRET_KEY as well, which made the FIRST
+    check an owner runs — before any secrets are in place — the hardest
+    one to run.
+    """
+    from tests.source_text import code_only
+    from pathlib import Path
+    src = code_only(Path(__file__).resolve().parents[1]
+                    .joinpath("scripts/send_renewal_notices.py").read_text())
+    guarded = src.index("if not verify_only:")
+    assert guarded < src.index("STRIPE_SECRET_KEY is not set")
+    assert guarded < src.index("FRONTEND_URL is not set")
+
+
+def test_the_script_runs_from_the_repository_root():
+    """Render's working directory, and the shape that broke role_census.
+
+    That script assumed it ran from `backend/` and died on
+    `ModuleNotFoundError` in production. The fix — and the pattern every
+    script here follows — is to put the package root on `sys.path` from
+    the script's OWN location, so the working directory stops mattering.
+    """
+    from pathlib import Path
+    src = Path(__file__).resolve().parents[1].joinpath(
+        "scripts/send_renewal_notices.py").read_text()
+    assert "sys.path.insert(0, str(Path(__file__).resolve().parent.parent))" in src
+
+
+def test_the_job_does_not_converge_the_schema():
+    """A cron that imported `database` would start the convergence
+    thread and issue ALTER TABLE statements from a scheduled job nobody
+    is watching. It asserts the tables instead, and refuses when they are
+    absent — see `assert_tables` in the script."""
+    from tests.source_text import code_only
+    from pathlib import Path
+    src = code_only(Path(__file__).resolve().parents[1]
+                    .joinpath("scripts/send_renewal_notices.py").read_text())
+    assert "import database" not in src
+    assert "create_tables" not in src
+    assert 'assert_tables(conn, "subscriptions", "billing_notices", "users"' in src
+
+
+@needs_db
+def test_a_stripe_that_will_not_answer_fails_the_run():
+    """THE HOLE THE DRY-RUN FOUND.
+
+    With a wrong API key every subscription was skipped with an honest
+    reason and the job exited 0 — a cron reporting success every day
+    while sending nothing, which is the exact silence this ticket exists
+    to remove. An unanswering Stripe is now counted apart from a skip,
+    and it fails the run.
+    """
+    conn = _db()
+    try:
+        _make_subscriber(conn, "pilot2.silent@example.com", "sub_pilot2_silent")
+        silent = FakeStripe(raises=RuntimeError("Invalid API Key provided"))
+        report = renewal_run(conn, silent, date(2026, 9, 1), Recorder())
+        assert report.unreachable >= 1
+        assert report.sent == 0
+        # And the reason survives into the report a human reads.
+        assert any("Invalid API Key" in (s.get("reason") or "")
+                   for s in report.skipped)
+    finally:
+        conn.close()


### PR DESCRIPTION
You asked for the exact configuration before creating the service, because the last cron took four failed builds and every failure was a config detail nobody asked for up front. **Answering it found three defects in the job itself**, which is the argument for having asked.

The full configuration now lives in the script's own docstring, where the next person to touch it will look. It is reproduced in the reply.

## What checking found

**1. `FRONTEND_URL` was optional and should not have been.** Unset, `billing_url()` returned `/account-settings?tab=billing` — a **relative path**, which in an email client resolves against nothing. Every notice would have arrived correct in every detail, named the right date and the right amount, and been a dead link at the one action it exists to enable. It is now a refusal carrying the manifest's own consequence sentence, and the job refuses before sending anything rather than per-subscription.

**2. A Stripe that would not answer looked like success.** The dry run with a bad key skipped every subscription with an honest reason and exited **0**. A cron with a stale key would have reported success every day, forever, while sending nothing — which is precisely the silence this ticket exists to remove. "Stripe has no upcoming invoice" is an *answer*; "Stripe would not talk to us" is a *failure*, and they must not exit the same way. Now a distinct `StripeUnavailable` type (not a string match on the reason — §14.1), counted as `unreachable`, and it fails both the real run and the dry run.

**3. `--verify` demanded a Stripe key it never used.** That made the first check an owner runs — before any secrets are in place — the hardest one to run. It now needs only `DATABASE_URL` and `EXPECTED_DATABASE`.

## Your two constraints, checked

**Working directory:** `send_renewal_notices.py` already carries `sys.path.insert(0, str(Path(__file__).resolve().parent.parent))` — the fix `role_census.py` was given after its `ModuleNotFoundError`. **Verified by running it from the repository root**, not by reading it: `--verify`, `--dry-run` and the refusal paths all work from there. Both root directory choices are documented with the matching command.

**`PYTHON_VERSION=3.12.7`:** in the list, with the note that it must be set in the *dashboard* — declaring it in `render.yaml` did not apply it, confirmed the hard way on 2026-08-12.

**Your inferred list was right, and incomplete by one:** `FRONTEND_URL` is not optional (defect 1), and `SENDGRID_FROM_EMAIL` matters because the fallback sender is visible in the message that arrives. `JWT_SECRET_KEY`, `ALLOWED_ORIGINS`, `STRIPE_WEBHOOK_SECRET`, the price IDs and `ADMIN_EMAIL` are documented as *deliberately not needed* — this job serves no requests, verifies no sessions and creates no checkouts.

## Also confirmed, and worth knowing before you create the service

**The job does not import `database`.** It therefore never starts the schema-convergence thread and never issues `ALTER TABLE` from a schedule nobody watches. It asserts its three tables and refuses when they are absent — so **the API must have deployed once after PILOT2 merged** before the cron's first real run, or it will refuse with a named reason rather than failing obscurely.

## Self-review

**Premises checked** — the working-directory shape (already correct, verified by running); `PYTHON_VERSION` (confirmed, and the dashboard caveat is the part that bit us before); the env list (four of yours confirmed, one added, one promoted from optional to required by defect 1).

**Pins added** — five: the absolute cancel link, `--verify`'s independence from Stripe, the `sys.path` shape that survives any working directory, that the job never converges the schema, and that an unanswering Stripe fails the run. The last one is a `@needs_db` integration test asserting `unreachable >= 1` with the reason surviving into the report.

**Least sure about** — `SENDGRID_FROM_EMAIL`. The code falls back to `FROM_EMAIL` and then to a default sender, so its absence degrades visibly rather than silently. I listed it as required-in-practice because a pre-charge notice arriving from an unexpected sender is the one most likely to be read as a phishing attempt.

**What would be cut if forced** — the `--dry-run` exit-code change. The real run's is the one that matters; the dry run's just means the pre-flight check tells you the truth too.

**Anything decided rather than flagged** — promoting `FRONTEND_URL` to a hard refusal. It is a behaviour change to a merged ticket, made because the alternative is notices whose only call to action is broken.

## Gates

pytest **1543** with a database, **1332 / 211 skipped** without one · banned-claims clean · four harnesses green. Backend-only.

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_