### PR TITLE
§14.5's third habitat, and the sweep becomes a scheduled item

### DIFF
--- a/docs/DOCTRINE_CONFORMANCE.md
+++ b/docs/DOCTRINE_CONFORMANCE.md
@@ -1369,6 +1369,42 @@ direction, and no amount of tuning the threshold fixes it.
 
 ### §14.5 — Checking that a change is right is not checking what it exposes (2026-08-18)
 
+**THIRD HABITAT, SAME DAY: VERSION CONTROL (2026-08-19).** The rule is
+not about routing, or about removals, or about frontend code. It is about
+the difference between verifying THE CHANGE and verifying WHAT TRAVELS
+WITH IT, and it has now been found in three unrelated places:
+
+  1. **Routing** — DASH-FIX pointed the day-one checklist at a page that
+     was correct in itself and lacked the first-run tolerance the action
+     needed. The destination was right; what depended on the move was not
+     checked.
+  2. **Removal** — HOME2 deleted a script tag, justified against the
+     source of the hook meant to replace it, never against the consumers
+     that were supposed to call it. None did.
+  3. **A commit** — the hotfix for (2) was merged carrying two files its
+     PR body never mentioned. `git add -A` after a branch checkout stages
+     whatever followed across it, and untracked files always do. The diff
+     I was reading was the conflict; the file list was the thing I did
+     not read.
+
+**The operative sentence for all three:** *I verified the change I was
+making and not the set of things going with it.*
+
+**What makes the third worth recording separately** rather than as
+another instance: it is the first where the unchecked set was not part of
+the product at all. The blast radius of a wrong routing or a wrong
+removal is a user; the blast radius here was a RECORD — a merged PR whose
+description understated its own contents. That is the cheapest of the
+three to fix and the easiest to leave, which is precisely why it needs
+naming: nothing breaks, so nothing prompts you.
+
+**The mechanical form, for anyone reviewing:** before committing, read
+the FILE LIST, not the diff of the file you were working on. `git status`
+before `git add -A`, and treat any file you did not open this session as
+a question rather than as noise.
+
+---
+
 **SECOND INSTANCE, AND IT REACHED PRODUCTION (2026-08-19).** Recorded at
 the top of this section because it is the sharper version of the same
 rule, and because it cost the officer her most-used input.

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -1763,6 +1763,38 @@ we reach it.
 
 ## Ledgered triggers (machine-side, fire on condition)
 
+- **THE LEDGER SWEEP RECURS — every wave boundary, or every 10 merged
+  tickets, whichever comes first.**
+  **DECIDED** 2026-08-19, owner-ruled.
+  **BUILT** — the trigger is this entry; the sweep itself is a person
+  reading code, deliberately, and that is the whole point.
+
+  **Why it is a scheduled item and not a habit.** The first sweep found
+  six stale rows in a table whose own header calls itself the authority,
+  "re-ruled, not re-derived". Nobody neglected it; there was simply no
+  moment at which re-ruling was anybody's job. **"Someone will remember"
+  is the mechanism that produced six stale rows**, and §14.7 rejects that
+  trade wherever a mechanism can replace it.
+
+  **What the pin does NOT cover, which is why this exists.**
+  `backend/tests/test_ledger_built_paths.py` catches ROT and
+  OVER-CLAIMING — a `BUILT — yes` citing a module that has since moved.
+  It cannot catch UNDER-claiming, which is what the sweep actually found:
+  nothing mechanical separates "queued, correctly" from "queued, but
+  shipped three weeks ago", because the second requires reading code the
+  row never mentions. The pin holds one direction; this trigger is the
+  only thing holding the other.
+
+  **How to run it, in one line:** for every row and parked entry claiming
+  NOT built, go and look for the module, endpoint or script that would
+  exist if it were — and answer from what you find, never from the
+  entry's own sentence.
+
+  **Last run:** 2026-08-19 (six rows corrected, all under-claiming).
+  **Next due:** at the next wave boundary, or after ten merged tickets.
+
+
+
 - **Verification-at-registration** — ~~stays resend-only for now~~
   **DECIDED** (original) — stay resend-only.
   **BUILT** — resend: **yes** (VERIFY-CHECK). Gating on `verified`:


### PR DESCRIPTION
Two records, both from the same day's mistakes. Docs-only.

## 1. The third habitat

§14.5 is not about routing, or removals, or frontend code. It is the difference between verifying **the change** and verifying **what travels with it**, and it has now been found in three unrelated places:

1. **Routing** — DASH-FIX pointed the day-one checklist at a page that was correct in itself and lacked the first-run tolerance the action needed.
2. **Removal** — HOME2 deleted a script tag, justified against the source of the hook meant to replace it, never against the consumers supposed to call it. None did.
3. **A commit** — the hotfix for (2) merged carrying two files its PR body never mentioned. `git add -A` after a branch checkout stages whatever followed across it, and untracked files always do.

**The operative sentence for all three:** *I verified the change I was making and not the set of things going with it.*

**Why the third is recorded separately** rather than as another instance: it is the first where the unchecked set was not part of the product at all. A wrong routing or a wrong removal costs a user; this cost a **record** — a merged PR whose description understated its own contents. That is the cheapest of the three to fix and the easiest to leave, which is precisely why it needs naming. Nothing breaks, so nothing prompts you.

The entry carries the mechanical form: read the **file list**, not the diff of the file you were working on; `git status` before `git add -A`; treat any file you did not open this session as a question rather than as noise.

(#231's body is corrected [in a comment there](https://github.com/easydeed/new-front/pull/231#issuecomment-5349432207), naming the two files exactly.)

## 2. The sweep recurs, with a trigger

**Every wave boundary, or every ten merged tickets, whichever comes first.**

Nobody neglected the queue table. There was simply no moment at which re-ruling it was anybody's job — and **"someone will remember" is the mechanism that produced six stale rows.**

The entry states plainly **what the pin does not cover, because that is why the trigger exists**: `test_ledger_built_paths.py` catches rot and over-claiming, and cannot catch under-claiming, which is what the sweep actually found. Nothing mechanical separates "queued, correctly" from "queued, but shipped three weeks ago", because the second requires reading code the row never mentions. The pin holds one direction; this trigger is the only thing holding the other.

It carries a **last-run date and a next-due condition**, so "is this overdue" is answerable rather than felt — and a one-line instruction for running it: *for every row claiming not-built, go and look for the module that would exist if it were, and answer from what you find, never from the entry's own sentence.*

## Self-review

**Premises checked** — that the three instances are the same rule and not three rules that rhyme. They are: each one verified an artifact correctly and left unexamined the set of things depending on or travelling with it. If you read them as distinct, the entry is over-generalised and should be split.

**Pins changed** — none. Both items are records, and one of them exists specifically to say that a record is all it is. The sweep is a person reading code, deliberately, and the entry says so rather than implying a mechanism.

**Least sure about** — "every ten merged tickets" as the second trigger arm. Wave boundaries are meaningful; ten is a number I picked because it is roughly the cadence at which this week's staleness accumulated. If it fires too often it will be ignored, which is worse than a longer interval honoured.

**What would be cut if forced** — the mechanical form at the end of the §14.5 entry. The rule is the valuable part; the `git status` advice is the kind of thing people already know and do not do.

**Anything decided rather than flagged** — recording the third instance inside §14.5 rather than opening §14.9. It is the same rule in a new habitat, and a section per habitat would fragment the thing that makes it useful.

## Gates

pytest **1558** with a database, **1347 / 211 skipped** without one · banned-claims clean. Docs-only; frontend untouched.

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_