### PR TITLE
DASH3 — the dashboard becomes a worklist

### DIFF
--- a/backend/routers/dashboard.py
+++ b/backend/routers/dashboard.py
@@ -20,6 +20,7 @@ from auth import get_current_user_id
 from services import deed_accuracy as accuracy
 from services import officer_queue as q
 from services import signing_loop as loop
+from services import worklist as wl
 
 router = APIRouter()
 
@@ -163,8 +164,9 @@ def officer_queue(user_id: int = Depends(get_current_user_id)) -> Dict[str, Any]
         # `required_fields.json` and a stored provenance block — neither
         # of which the screen holds.
         cur.execute("""
-            SELECT id, deed_type, property_address, grantor_name, grantee_name,
-                   legal_description, apn, vesting, parties, metadata
+            SELECT id, deed_type, property_address, county, grantor_name,
+                   grantee_name, legal_description, apn, vesting, parties,
+                   metadata, superseded_by
               FROM deeds
              WHERE user_id = %s
                AND COALESCE(status, 'draft') NOT IN ('completed', 'deleted')
@@ -172,6 +174,8 @@ def officer_queue(user_id: int = Depends(get_current_user_id)) -> Dict[str, Any]
              ORDER BY COALESCE(updated_at, created_at) DESC
         """, (user_id,))
         accuracy_items: List[Dict[str, Any]] = []
+        ready_items: List[Dict[str, Any]] = []
+        counties: Dict[str, str] = {}
         total_fields = 0
         # ── AND HOW MANY DOCUMENTS THERE WERE TO LOOK AT ──────────────
         #
@@ -191,12 +195,32 @@ def officer_queue(user_id: int = Depends(get_current_user_id)) -> Dict[str, Any]
         for row in _rows(cur):
             open_documents += 1
             meta = row.get("metadata") or {}
+            if row.get("county") and row.get("property_address"):
+                counties.setdefault(
+                    (row["property_address"] or "").strip().upper(), row["county"])
+            # A SUPERSEDED DEED IS NOT HER WORK. The deed page stops her
+            # on arrival (§9); putting it in the worklist would be
+            # inviting the work the stop exists to prevent. Chase rows
+            # survive supersession — somebody outside is still waiting,
+            # and telling her that is not inviting her to work on it.
+            if row.get("superseded_by") is not None:
+                continue
             checks = accuracy.outstanding(
                 {**row,
                  "dtt": meta.get("dtt"),
                  "current_owner": meta.get("current_owner")},
                 provenance=meta.get("provenance"))
             if not checks:
+                # DASH3: every field confirmed, nothing printed yet. It
+                # contributes ZERO to the accuracy figure — which is why
+                # the old dashboard could not show it — and it is the
+                # readiest work she has. A row of its own now.
+                ready_items.append({
+                    "deed_id": row["id"],
+                    "deed_type": row.get("deed_type"),
+                    "property": row.get("property_address"),
+                    "escrow_no": meta.get("escrow_no"),
+                })
                 continue
             total_fields += len(checks)
             accuracy_items.append({
@@ -256,15 +280,72 @@ def officer_queue(user_id: int = Depends(get_current_user_id)) -> Dict[str, Any]
                 "days_idle": q.days_since(row.get("updated_at") or row.get("created_at")),
             })
 
+        # ── How many documents on each property have RECORDED ────────
+        #
+        # `recorded_at IS NOT NULL`, and NEVER `status = 'completed'`.
+        # The distinction is the whole pin: `completed` means a PDF was
+        # rendered, and recording is the officer's own statement that the
+        # county took it (RED0 R3-8). Counting status would silently turn
+        # "4 recorded" into "we rendered four PDFs" — the `deeds.status`
+        # disease reappearing inside a count, on the surface a pilot user
+        # reads first.
+        cur.execute("""
+            SELECT property_address, COUNT(*) AS n
+              FROM deeds
+             WHERE user_id = %s
+               AND recorded_at IS NOT NULL
+               AND COALESCE(status, '') <> 'deleted'
+             GROUP BY property_address
+        """, (user_id,))
+        recorded_counts = {
+            (r["property_address"] or "").strip().upper(): r["n"]
+            for r in _rows(cur)
+        }
+
     upcoming.sort(key=lambda r: r["when"])
     # Longest-waiting first: the oldest silence is the one worth chasing.
     # `days_waiting` may be None for a row we cannot date, and those sort
     # last rather than first — an unknown age is not evidence of urgency.
     awaiting.sort(key=lambda r: (r["days_waiting"] is None,
                                  -(r["days_waiting"] or 0)))
+    # ── DASH3: the same facts, as one worklist ───────────────────────
+    #
+    # Assembled from the populations above rather than re-queried: two
+    # queries answering one question is how the accuracy figure and the
+    # queue came to disagree in the first place. The screen renders
+    # `worklist`; `accuracy`, `awaiting`, `upcoming` and `idle_drafts`
+    # stay in the payload because other things read them and because a
+    # shape asserted by equality is not something to break in passing.
+    rows: List[Dict[str, Any]] = []
+    for item in awaiting:
+        rows.append(wl.chase_row(item).as_dict())
+    for item in upcoming:
+        rows.append(wl.upcoming_row(item).as_dict())
+    for item in accuracy_items:
+        rows.append(wl.accuracy_row(item).as_dict())
+    for item in ready_items:
+        rows.append(wl.ready_row(item).as_dict())
+
+    # Idle drafts COLLAPSE per property — four drafts on one parcel are
+    # one line with one action, not four lines competing with work that
+    # is actually blocked.
+    by_property: Dict[str, List[Dict[str, Any]]] = {}
+    chased = {r["deed_id"] for r in rows if r.get("deed_id")}
+    for item in idle:
+        # A draft that already has a row of its own is not also sitting.
+        if item.get("id") in chased:
+            continue
+        by_property.setdefault((item.get("property") or "").strip().upper(),
+                               []).append(item)
+    for items in by_property.values():
+        rows.append(wl.stale_group_row(items).as_dict())
+
+    groups = wl.group_rows(rows, recorded=recorded_counts, counties=counties)
+
     return q.queue(upcoming=upcoming, awaiting=awaiting, idle_drafts=idle,
                    instruments=instruments,
                    accuracy={"fields": total_fields,
                              "documents": len(accuracy_items),
                              "open_documents": open_documents,
-                             "items": accuracy_items})
+                             "items": accuracy_items},
+                   worklist={"groups": groups, "count": wl.hero_count(groups)})

--- a/backend/services/officer_queue.py
+++ b/backend/services/officer_queue.py
@@ -111,6 +111,11 @@ QUEUE_KEYS = frozenset({
     "needs_attention", # ONE number, and it is the stale ones
     "thresholds",      # the numbers above, so no screen retypes them
     "badges",          # per-page waiting counts for the sidebar
+    # DASH3 — the same facts as ONE worklist: rows grouped by property,
+    # ordered by consequence, with a count that equals the rows it
+    # describes. Added deliberately: this assertion made the extension
+    # a decision rather than a diff nobody read.
+    "worklist",
     "accuracy",        # what stands between her documents and being ready
     "instruments",     # what THIS officer files, most-used first
 })
@@ -150,7 +155,8 @@ def queue(*, upcoming: Sequence[Dict[str, Any]],
           awaiting: Sequence[Dict[str, Any]],
           idle_drafts: Sequence[Dict[str, Any]],
           accuracy: Dict[str, Any],
-          instruments: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+          instruments: Sequence[Dict[str, Any]],
+          worklist: Dict[str, Any]) -> Dict[str, Any]:
     """Assemble the payload and assert its shape.
 
     `needs_attention` is computed HERE rather than by the screen, and it
@@ -198,6 +204,11 @@ def queue(*, upcoming: Sequence[Dict[str, Any]],
         "upcoming": list(upcoming),
         "awaiting": list(awaiting),
         "idle_drafts": list(idle_drafts),
+        # DASH3 — the worklist the screen renders. Its `count` is the
+        # hero, and it EQUALS the rows below it by construction
+        # (`worklist.hero_count`): a worklist whose headline disagrees
+        # with its own body is a metric again.
+        "worklist": dict(worklist),
         "needs_attention": len([r for r in awaiting
                                 if r["stale"] or r["lapsed"]]),
         # DASH1 item 6 — THE AMBIENT SIGNAL.

--- a/backend/services/worklist.py
+++ b/backend/services/worklist.py
@@ -1,0 +1,380 @@
+"""The dashboard becomes a worklist: rows grouped by property.
+
+═══ THE FINDING DASH3 STARTED FROM ═══
+
+Every DASH ticket added or corrected a module; none removed a category.
+The result read as a metrics dashboard — four stat tiles, a "recently
+worked on" list, a three-column split — for a user who opens the screen
+to find the next task, not to learn how she is doing. Metrics dashboards
+answer "how am I doing?"; a worklist answers "what's next?", and we built
+the first while describing the second.
+
+So the queue becomes the whole body, and this module is the assembly:
+every actionable thing becomes ONE ROW, rows group by property, and the
+groups order by consequence.
+
+═══ ORDERING IS BY CONSEQUENCE (owner-ruled) ═══
+
+    someone-else-is-blocked → your-turn → nobody-waiting
+
+The design's own annotation says "ranked cheapest-to-clear first" and its
+own rows contradict it: "Archive all 4" is the cheapest action in the
+mockup and sorts LAST, while "Prepare it" is expensive and outranks
+"Choose exemption". The stale row states the real rule in its own copy —
+*"Nobody is waiting on these but you."* The annotation is superseded, and
+the supersession is marked on the committed artifact so nobody re-derives
+cheapest-first from a file in our own repository.
+
+WITHIN a band, longest-waiting first: the oldest silence is the one worth
+chasing, and an unknown age sorts last rather than first (an unknown age
+is not evidence of urgency — DASH1's rule, kept).
+
+═══ ROWS ARE THE UNIT, AND THAT IS A DELIBERATE NARROWING ═══
+
+The hero counts ROWS. "3 things need you" over three rows is a promise
+the screen keeps; "7 fields across 4 documents" is a number nobody can
+point at, which is a metric wearing a worklist's clothes.
+
+The two-population rule (unconfirmed candidates + required-and-empty)
+SURVIVES — as what makes a row appear and what the row says, never as the
+headline number. A document with every field confirmed and nothing left
+to check is still a row, because it still needs her: `ready_to_finish`
+below. It contributes 0 to the old accuracy figure and 1 to this one, and
+that is the point of changing units.
+
+**The group header counts rows too.** "6 open" meaning documents beside a
+hero counting rows is two units on one screen, which is what DASH-FIX
+spent itself killing.
+
+═══ WHAT IS DELIBERATELY NOT A ROW ═══
+
+A SUPERSEDED deed produces no your-turn and no nobody-waiting row. It is
+not work she should do — the deed page stops her on arrival (§9's
+disqualifying stop, which lives there and is not being moved). A chase
+row survives supersession, because somebody outside is still genuinely
+waiting for an answer and telling her that is not the same as inviting
+her to work on it.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence
+
+#: The three bands, in the order they are worked. The VALUE is the sort
+#: key, so the ordering is data rather than a comparator somebody has to
+#: keep in sync with the copy.
+BAND_CHASE = 0    # someone else is blocked, or has gone quiet
+BAND_YOU = 1      # her turn
+BAND_STALE = 2    # nobody is waiting but her
+
+BANDS = {"chase": BAND_CHASE, "you": BAND_YOU, "stale": BAND_STALE}
+
+#: A row's shape, asserted on the way out. Same instinct as
+#: `officer_queue.py`: a payload whose keys drift silently is a screen
+#: that renders blanks nobody notices.
+ROW_KEYS = frozenset({
+    "kind", "band", "tag", "age", "title", "doc", "say", "sub",
+    "primary", "secondary", "href", "deed_id", "deed_ids", "property",
+    "county", "sort_age",
+})
+
+GROUP_KEYS = frozenset({"property", "county", "open", "recorded", "items"})
+
+
+@dataclass
+class Row:
+    kind: str
+    tag: str
+    title: str
+    say: str
+    primary: str
+    href: str
+    deed_id: Optional[int] = None
+    doc: str = ""
+    sub: str = ""
+    secondary: str = ""
+    age: str = ""
+    #: Days, for ordering. None sorts LAST within its band — an unknown
+    #: age is not evidence of urgency.
+    sort_age: Optional[int] = None
+    property: str = ""
+    county: str = ""
+    deed_ids: List[int] = field(default_factory=list)
+
+    def as_dict(self) -> Dict[str, Any]:
+        out = {
+            "kind": self.kind, "band": BANDS[self.kind], "tag": self.tag,
+            "age": self.age, "title": self.title, "doc": self.doc,
+            "say": self.say, "sub": self.sub, "primary": self.primary,
+            "secondary": self.secondary, "href": self.href,
+            "deed_id": self.deed_id, "deed_ids": self.deed_ids,
+            "property": self.property, "county": self.county,
+            "sort_age": self.sort_age,
+        }
+        assert set(out) == ROW_KEYS, f"row shape drifted: {sorted(out)}"
+        return out
+
+
+def _days_text(days: Optional[int]) -> str:
+    """Ages read as English, and an unknown age SAYS it is unknown.
+
+    DASH1's rule that an absence is named by kind: "—" would read as
+    zero, and "0 days" would be a claim we cannot support about a row
+    whose timestamp we could not date.
+    """
+    if days is None:
+        return "age unknown"
+    if days <= 0:
+        return "today"
+    if days == 1:
+        return "1 day"
+    return f"{days} days"
+
+
+def _row_href(item: Dict[str, Any], is_signing: bool) -> str:
+    """Where a workflow row goes when she presses it.
+
+    THE DEED, whenever the row has one. A queue row is about a document,
+    and landing on a tracker makes her find that document a second time.
+
+    The tracker is the fallback rather than the default, for the row that
+    genuinely has no deed behind it, and it uses the CANONICAL route:
+    `/signings?focus=` and `/shared-deeds?focus=` are retired aliases that
+    exist for mail already sent, and minting new links at them would grow
+    the population those aliases were kept for.
+    """
+    deed_id = item.get("deed_id")
+    if deed_id:
+        return f"/deeds/{deed_id}"
+    kind = "signings" if is_signing else "reviews"
+    return f"/requests?kind={kind}&focus={item.get('id')}"
+
+
+def _property_key(value: Optional[str]) -> str:
+    return (value or "").strip().upper()
+
+
+def chase_row(item: Dict[str, Any], county: str = "") -> Row:
+    """Somebody outside is waiting, or has stopped answering.
+
+    The SENTENCE comes from the server-side summary the signing loop
+    already composes (§13 rule 3 — one place turns state into English).
+    This module arranges rows; it does not get a second opinion about
+    what a scheduling state means.
+    """
+    days = item.get("days_waiting")
+    gone_quiet = bool(item.get("lapsed")) or bool(item.get("stale"))
+    who = (item.get("who") or "").strip() or "the recipient"
+    is_signing = item.get("kind") == "signing"
+    return Row(
+        kind="chase",
+        tag="Gone quiet" if gone_quiet else "Waiting",
+        age=_days_text(days),
+        sort_age=days,
+        title="Signing" if is_signing else "Review",
+        doc=f"#{item.get('deed_id')}" if item.get("deed_id") else "",
+        say=item.get("summary") or (
+            f"{who} has not answered yet."),
+        sub=f"With {who}." if who else "",
+        primary="Open signing" if is_signing else "Open request",
+        secondary="",
+        # LANDS ON THE DEED, NOT THE TRACKER (the orphan ruling). A row
+        # about a document that drops her on a list makes her find the
+        # document again, which is the defect that ruling named.
+        #
+        # I got here twice over. The hrefs I copied from the module this
+        # replaces pointed at `/signings?focus=` — a RETIRED alias kept
+        # alive only for links already sitting in somebody's inbox, which
+        # `test_link_contract.py` caught. Correcting that to the canonical
+        # tracker route fixed the contract and broke the orphan ruling,
+        # because the canonical tracker is still a tracker. The deed page
+        # answers both: it is not an alias and it is not a list.
+        href=_row_href(item, is_signing),
+        deed_id=item.get("deed_id"),
+        deed_ids=[item["deed_id"]] if item.get("deed_id") else [],
+        property=item.get("property") or "",
+        county=county,
+    )
+
+
+def upcoming_row(item: Dict[str, Any], county: str = "") -> Row:
+    """A booked signing, soon. Her turn: the document has to be ready."""
+    return Row(
+        kind="you",
+        tag="Signing booked",
+        age=item.get("when_text") or "",
+        sort_age=item.get("days_until"),
+        title="Signing",
+        doc=f"#{item.get('deed_id')}" if item.get("deed_id") else "",
+        say=item.get("summary") or "A signing is booked.",
+        sub=f"With {item.get('who')}." if item.get("who") else "",
+        primary="Open signing",
+        href=_row_href(item, True),
+        deed_id=item.get("deed_id"),
+        deed_ids=[item["deed_id"]] if item.get("deed_id") else [],
+        property=item.get("property") or "",
+        county=county,
+    )
+
+
+def accuracy_row(item: Dict[str, Any], county: str = "") -> Row:
+    """A document with fields still needing her eyes.
+
+    THE TWO POPULATIONS LIVE HERE, in what the row SAYS — the count of
+    outstanding checks is the sentence, not the headline. `checks` mixes
+    unconfirmed candidates with required-and-empty, exactly as
+    `deed_accuracy` produces them, and the row does not flatten that
+    distinction away: it reports the number and the screen offers the
+    list.
+    """
+    checks = item.get("checks") or []
+    n = len(checks)
+    return Row(
+        kind="you",
+        tag="Needs your eyes",
+        age="",
+        sort_age=None,
+        title=item.get("deed_type_label") or item.get("deed_type") or "Document",
+        doc=f"#{item.get('deed_id')}" if item.get("deed_id") else "",
+        say=(f"{n} field needs confirming before this can print."
+             if n == 1 else
+             f"{n} fields need confirming before this can print."),
+        sub=item.get("escrow_no") and f"Escrow {item['escrow_no']}" or "",
+        primary="Open it",
+        secondary="",
+        href=f"/deed-builder?resume={item.get('deed_id')}",
+        deed_id=item.get("deed_id"),
+        deed_ids=[item["deed_id"]] if item.get("deed_id") else [],
+        property=item.get("property") or "",
+        county=county,
+    )
+
+
+def ready_row(item: Dict[str, Any], county: str = "") -> Row:
+    """Every field confirmed, and it still needs her.
+
+    THE ROW THE OLD HERO COULD NOT COUNT. Zero outstanding checks means
+    zero contribution to "N fields need your eyes" — so a document with
+    nothing left to confirm and nothing yet printed was invisible on the
+    old dashboard while being, in plain terms, the readiest work she had.
+    """
+    return Row(
+        kind="you",
+        tag="Unfinished",
+        age="",
+        sort_age=None,
+        title=item.get("deed_type_label") or item.get("deed_type") or "Document",
+        doc=f"#{item.get('deed_id')}" if item.get("deed_id") else "",
+        say="Every field is confirmed. It needs you to finish it.",
+        sub=item.get("escrow_no") and f"Escrow {item['escrow_no']}" or "",
+        primary="Finish it",
+        href=f"/deed-builder?resume={item.get('deed_id')}",
+        deed_id=item.get("deed_id"),
+        deed_ids=[item["deed_id"]] if item.get("deed_id") else [],
+        property=item.get("property") or "",
+        county=county,
+    )
+
+
+def stale_group_row(items: Sequence[Dict[str, Any]], county: str = "") -> Row:
+    """Idle drafts on one property, COLLAPSED into a single row.
+
+    Duplicates collapse per the design: four drafts on one parcel are one
+    line with one action, not four lines competing with the work that is
+    actually blocked. The row names the count and the action reports what
+    it did — `Archive all N` inherits the per-row refusals rather than
+    inventing a bulk rule (owner-ruled).
+    """
+    first = items[0]
+    n = len(items)
+    ages = [i.get("days_idle") for i in items if i.get("days_idle") is not None]
+    oldest = max(ages) if ages else None
+    ids = [i["id"] for i in items if i.get("id")]
+    return Row(
+        kind="stale",
+        tag="Sitting",
+        age=_days_text(oldest),
+        sort_age=oldest,
+        title=(f"{n} old drafts" if n > 1
+               else (first.get("deed_type") or "Draft")),
+        doc=" ".join(f"#{i}" for i in ids[:6]),
+        say="Nobody is waiting on these but you." if n > 1
+            else "Nobody is waiting on this but you.",
+        sub=("All on this property. Archiving keeps them — you can bring "
+             "them back." if n > 1 else
+             "Archiving keeps it — you can bring it back."),
+        primary=f"Archive all {n}" if n > 1 else "Archive it",
+        secondary="Review them" if n > 1 else "Review it",
+        # A SINGLE DRAFT GOES STRAIGHT TO THE BUILDER — deliberate, and
+        # ruled: a draft has exactly one action, and the deed page would
+        # offer that same action one navigation later.
+        #
+        # A COLLAPSED row has no single resume target, which is the one
+        # place that ruling stops rather than being overridden: four
+        # drafts on one parcel are four possible resumes, so the row goes
+        # to the list that can show her all four. Reported, not silently
+        # widened.
+        href=(f"/deed-builder?resume={first.get('id')}" if n == 1
+              else "/past-deeds?status=draft"),
+        deed_id=first.get("id"),
+        deed_ids=ids,
+        property=first.get("property") or "",
+        county=county,
+    )
+
+
+def _sort_key(row: Dict[str, Any]):
+    """Consequence first; within a band, longest wait first.
+
+    `sort_age is None` sorts LAST inside its band — an unknown age is not
+    evidence of urgency, and sorting it first would put every undated row
+    above every dated one.
+    """
+    return (row["band"], row["sort_age"] is None, -(row["sort_age"] or 0))
+
+
+def group_rows(rows: Sequence[Dict[str, Any]],
+               recorded: Optional[Dict[str, int]] = None,
+               counties: Optional[Dict[str, str]] = None) -> List[Dict[str, Any]]:
+    """Group by property, order within and across, count what is there.
+
+    `recorded` maps a property key to how many RECORDED documents it has
+    — and the caller must have counted those from `recorded_at`, never
+    from `status = 'completed'`. See the router: reading status would make
+    "4 recorded" mean "we rendered four PDFs", which is the `deeds.status`
+    disease reappearing inside a count.
+    """
+    recorded = recorded or {}
+    counties = counties or {}
+    buckets: Dict[str, List[Dict[str, Any]]] = {}
+    for row in rows:
+        buckets.setdefault(_property_key(row.get("property")), []).append(row)
+
+    groups = []
+    for key, items in buckets.items():
+        items.sort(key=_sort_key)
+        groups.append({
+            "property": items[0].get("property") or "Property not set",
+            "county": counties.get(key) or items[0].get("county") or "",
+            # ROWS, not documents — one unit on the screen. The hero adds
+            # these up and gets the same number it renders.
+            "open": len(items),
+            "recorded": recorded.get(key, 0),
+            "items": items,
+        })
+
+    # Groups order by their most consequential row, then by that row's age.
+    groups.sort(key=lambda g: _sort_key(g["items"][0]))
+    for group in groups:
+        assert set(group) == GROUP_KEYS, f"group shape drifted: {sorted(group)}"
+    return groups
+
+
+def hero_count(groups: Sequence[Dict[str, Any]]) -> int:
+    """What the headline says, and it equals what is on screen.
+
+    A worklist's count must equal the rows the reader can see, or it is a
+    metric again. This is the one function that produces the number, so
+    "3 things need you" and three rows cannot disagree.
+    """
+    return sum(len(g["items"]) for g in groups)

--- a/backend/tests/test_dash1_officer_queue.py
+++ b/backend/tests/test_dash1_officer_queue.py
@@ -99,6 +99,14 @@ def _awaiting(stale: bool, days=9, lapsed=False):
             "summary": "Sent, not opened yet"}
 
 
+#: An empty worklist. These tests exercise the OTHER halves of the
+#: payload — the attention count, the badges, the thresholds — and each
+#: restating an empty groups/count pair would be eight copies of a fact
+#: none of them is about. DASH3's own behaviour is pinned in
+#: `test_dash3_worklist.py`.
+NO_WORK = {"groups": [], "count": 0}
+
+
 def test_the_attention_count_is_gone_quiet_and_nothing_else():
     """Not "everything in the queue". A signing booked for Thursday needs
     nothing from her, and counting it would make the number mean "there
@@ -111,7 +119,7 @@ def test_the_attention_count_is_gone_quiet_and_nothing_else():
         idle_drafts=[{"kind": "draft", "id": 5, "deed_type": "grant_deed",
                       "property": "z", "days_idle": 30}],
         accuracy=NOTHING_OUTSTANDING,
-        instruments=FILES_NOTHING,
+        instruments=FILES_NOTHING, worklist=NO_WORK,
     )
     assert payload["needs_attention"] == 1
 
@@ -132,7 +140,7 @@ def test_a_badge_counts_presence_and_the_attention_number_counts_silence():
         ],
         idle_drafts=[],
         accuracy=NOTHING_OUTSTANDING,
-        instruments=FILES_NOTHING,
+        instruments=FILES_NOTHING, worklist=NO_WORK,
     )
     assert payload["badges"] == {"signings": 1, "shared_deeds": 2}
     assert payload["needs_attention"] == 1
@@ -142,7 +150,7 @@ def test_the_payload_shape_is_asserted_by_equality():
     from services.officer_queue import QUEUE_KEYS
 
     payload = q.queue(upcoming=[], awaiting=[], idle_drafts=[], accuracy=NOTHING_OUTSTANDING,
-        instruments=FILES_NOTHING)
+        instruments=FILES_NOTHING, worklist=NO_WORK)
     assert set(payload) == QUEUE_KEYS
     assert payload["needs_attention"] == 0
     # And the thresholds travel WITH it, so no screen retypes them.
@@ -156,7 +164,7 @@ def test_a_row_that_grew_a_field_is_refused():
     bad["extra"] = 1
     with pytest.raises(AssertionError):
         q.queue(upcoming=[], awaiting=[bad], idle_drafts=[], accuracy=NOTHING_OUTSTANDING,
-        instruments=FILES_NOTHING)
+        instruments=FILES_NOTHING, worklist=NO_WORK)
 
 
 def test_only_one_place_decides_what_stale_means():
@@ -501,7 +509,7 @@ def test_the_accuracy_block_says_how_many_documents_there_were_to_look_at():
     the population.
     """
     payload = q.queue(upcoming=[], awaiting=[], idle_drafts=[],
-                      accuracy=NOTHING_OUTSTANDING, instruments=FILES_NOTHING)
+                      accuracy=NOTHING_OUTSTANDING, instruments=FILES_NOTHING, worklist=NO_WORK)
     assert payload["accuracy"]["open_documents"] == 3
 
 
@@ -513,7 +521,7 @@ def test_an_accuracy_block_without_the_population_is_refused():
     with pytest.raises(AssertionError):
         q.queue(upcoming=[], awaiting=[], idle_drafts=[],
                 accuracy={"fields": 0, "documents": 0, "items": []},
-                instruments=FILES_NOTHING)
+                instruments=FILES_NOTHING, worklist=NO_WORK)
 
 
 # ══════════════════════════════════════════════════════════════════════
@@ -534,7 +542,7 @@ def test_a_lapsed_request_needs_her_attention_however_young_it_is():
     """
     fresh_but_lapsed = _awaiting(False, days=0, lapsed=True)
     payload = q.queue(upcoming=[], awaiting=[fresh_but_lapsed], idle_drafts=[],
-                      accuracy=NOTHING_OUTSTANDING, instruments=FILES_NOTHING)
+                      accuracy=NOTHING_OUTSTANDING, instruments=FILES_NOTHING, worklist=NO_WORK)
     assert payload["needs_attention"] == 1
 
 
@@ -552,5 +560,5 @@ def test_one_request_that_is_both_is_counted_once():
     problem, not two — the number counts requests, not reasons."""
     both = _awaiting(True, days=30, lapsed=True)
     payload = q.queue(upcoming=[], awaiting=[both], idle_drafts=[],
-                      accuracy=NOTHING_OUTSTANDING, instruments=FILES_NOTHING)
+                      accuracy=NOTHING_OUTSTANDING, instruments=FILES_NOTHING, worklist=NO_WORK)
     assert payload["needs_attention"] == 1

--- a/backend/tests/test_dash3_worklist.py
+++ b/backend/tests/test_dash3_worklist.py
@@ -1,0 +1,279 @@
+"""DASH3 — the worklist, and the five rulings that shaped it.
+
+Every assertion here is a RULING rather than a rendering: the ordering,
+the unit the hero counts, what makes a row appear, and the one count
+whose source can silently change meaning.
+"""
+from __future__ import annotations
+
+from services import worklist as wl
+
+
+def _rows(*specs):
+    """Rows in a deliberately WRONG order, so a passing test means the
+    sort did something rather than that the input was already sorted."""
+    out = []
+    for kind, days, prop in specs:
+        row = wl.Row(kind=kind, tag="t", title="T", say="s", primary="p",
+                     href="/x", sort_age=days, property=prop)
+        out.append(row.as_dict())
+    return out
+
+
+# ═══ RULING 1 — CONSEQUENCE, NOT CHEAPNESS ═══════════════════════════
+
+def test_bands_run_blocked_then_yours_then_nobody_waiting():
+    """The design's annotation says "cheapest-to-clear first". Its own
+    rows contradict it — "Archive all 4" is the cheapest action in the
+    mockup and sorts LAST, and the stale row says why in its own copy:
+    *"Nobody is waiting on these but you."*
+    """
+    rows = _rows(("stale", 21, "A"), ("you", None, "A"), ("chase", 8, "A"))
+    groups = wl.group_rows(rows)
+    assert [r["kind"] for r in groups[0]["items"]] == ["chase", "you", "stale"]
+
+
+def test_the_cheapest_action_is_not_promoted():
+    """The specific inversion, named. A collapsed stale row clears FOUR
+    documents with one press and still sorts below a single blocked
+    signing, because clearing the board is not the same as doing the
+    work that matters."""
+    rows = _rows(("stale", 30, "A"), ("chase", 1, "A"))
+    groups = wl.group_rows(rows)
+    assert groups[0]["items"][0]["kind"] == "chase"
+
+
+def test_within_a_band_the_oldest_silence_is_first():
+    rows = _rows(("chase", 3, "A"), ("chase", 19, "A"), ("chase", 8, "A"))
+    ages = [r["sort_age"] for r in wl.group_rows(rows)[0]["items"]]
+    assert ages == [19, 8, 3]
+
+
+def test_an_unknown_age_sorts_last_rather_than_first():
+    """DASH1's rule, kept: an unknown age is not evidence of urgency, and
+    sorting `None` first would put every undated row above every dated
+    one.
+
+    TODAY'S ROW IS IN HERE ON PURPOSE. My first version of this test used
+    only `None` and `2`, and it passed with the rule DELETED — because
+    `-(None or 0)` and `-(2)` differ anyway, so the ordering came from the
+    age term and the None-term was never consulted. `None` against `0` is
+    the only pair that can tell them apart, and the undated row is placed
+    FIRST in the input so a stable sort that does nothing leaves it there.
+    The mutation probe is what found this; the test read correctly to me
+    both before and after.
+    """
+    rows = _rows(("chase", None, "A"), ("chase", 0, "A"), ("chase", 5, "A"))
+    ages = [r["sort_age"] for r in wl.group_rows(rows)[0]["items"]]
+    assert ages == [5, 0, None]
+
+
+def test_groups_order_by_their_most_consequential_row():
+    rows = _rows(("stale", 40, "QUIET ST"), ("chase", 2, "BLOCKED AVE"))
+    groups = wl.group_rows(rows)
+    assert groups[0]["property"] == "BLOCKED AVE"
+
+
+# ═══ RULING 2 — ROWS ARE THE UNIT ════════════════════════════════════
+
+def test_the_hero_equals_the_rows_on_screen():
+    """A worklist's count must equal what is visible or it is a metric
+    again. Not "is close to" — equal, by construction, because the same
+    function produces both."""
+    rows = _rows(("chase", 1, "A"), ("you", None, "A"), ("stale", 9, "B"))
+    groups = wl.group_rows(rows)
+    assert wl.hero_count(groups) == 3
+    assert wl.hero_count(groups) == sum(len(g["items"]) for g in groups)
+
+
+def test_the_group_header_counts_the_same_unit_as_the_hero():
+    """Two units on one screen is what DASH-FIX spent itself killing: a
+    header counting DOCUMENTS beside a hero counting ROWS makes the
+    reader convert between them silently and wrongly."""
+    rows = _rows(("chase", 1, "A"), ("you", None, "A"), ("stale", 3, "B"))
+    groups = wl.group_rows(rows)
+    assert [g["open"] for g in groups] == [len(g["items"]) for g in groups]
+    assert sum(g["open"] for g in groups) == wl.hero_count(groups)
+
+
+def test_a_document_with_nothing_outstanding_is_still_a_row():
+    """THE ROW THE OLD HERO COULD NOT COUNT.
+
+    Zero outstanding checks meant zero contribution to "N fields need
+    your eyes" — so a document with every field confirmed and nothing
+    printed was invisible while being the readiest work she had. Owner-
+    ruled: it is correctly a row.
+    """
+    row = wl.ready_row({"deed_id": 93, "deed_type": "grant-deed",
+                        "property": "1358 5TH ST"}).as_dict()
+    assert row["kind"] == "you"
+    assert "confirmed" in row["say"]
+    assert row["primary"]
+
+
+def test_the_two_populations_survive_in_what_the_row_says():
+    """They stop being the headline number and do NOT stop existing: the
+    count of outstanding checks is the row's sentence."""
+    row = wl.accuracy_row({"deed_id": 7, "checks": ["a", "b", "c"],
+                           "property": "X"}).as_dict()
+    assert "3 fields" in row["say"]
+    one = wl.accuracy_row({"deed_id": 7, "checks": ["a"], "property": "X"}).as_dict()
+    assert "1 field needs" in one["say"]
+
+
+# ═══ COLLAPSE, AND WHAT A COLLAPSED ROW PROMISES ═════════════════════
+
+def test_idle_drafts_on_one_property_collapse_to_one_row():
+    row = wl.stale_group_row([
+        {"id": 78, "property": "P", "days_idle": 21, "deed_type": "grant-deed"},
+        {"id": 79, "property": "P", "days_idle": 30, "deed_type": "grant-deed"},
+        {"id": 80, "property": "P", "days_idle": 12, "deed_type": "grant-deed"},
+    ]).as_dict()
+    assert row["deed_ids"] == [78, 79, 80]
+    assert "Archive all 3" == row["primary"]
+    # The AGE is the oldest, not the newest: the row's claim is about how
+    # long this has been sitting.
+    assert row["sort_age"] == 30
+
+
+def test_a_single_idle_draft_does_not_say_all_1():
+    row = wl.stale_group_row([{"id": 5, "property": "P", "days_idle": 9}]).as_dict()
+    assert row["primary"] == "Archive it"
+
+
+# ═══ ABSENCES ARE NAMED BY KIND ══════════════════════════════════════
+
+def test_an_undated_row_says_the_age_is_unknown():
+    """DASH1's rule. "—" reads as zero and "0 days" is a claim about a
+    row whose timestamp we could not read."""
+    row = wl.chase_row({"kind": "signing", "id": 1, "deed_id": 2,
+                        "days_waiting": None, "summary": "s"}).as_dict()
+    assert row["age"] == "age unknown"
+
+
+def test_todays_row_says_today():
+    row = wl.chase_row({"kind": "signing", "id": 1, "deed_id": 2,
+                        "days_waiting": 0, "summary": "s"}).as_dict()
+    assert row["age"] == "today"
+
+
+def test_the_server_sentence_is_used_verbatim():
+    """§13 rule 3 — one place turns state into English. This module
+    arranges rows; it does not get a second opinion about what a
+    scheduling state means."""
+    row = wl.chase_row({"kind": "signing", "id": 1, "deed_id": 2,
+                        "days_waiting": 4,
+                        "summary": "Opened, no answer yet"}).as_dict()
+    assert row["say"] == "Opened, no answer yet"
+
+
+# ═══ THE RECORDING PIN ═══════════════════════════════════════════════
+
+def test_recorded_counts_come_from_the_caller_and_are_per_property():
+    rows = _rows(("chase", 1, "1358 5TH ST"))
+    groups = wl.group_rows(rows, recorded={"1358 5TH ST": 4})
+    assert groups[0]["recorded"] == 4
+
+
+def test_the_recorded_count_reads_recorded_at_and_never_status():
+    """THE PIN THE OWNER NAMED, and it is checked at the SOURCE.
+
+    "Recorded" is the officer's own statement that the county took the
+    document (`recorded_at`, RED0 R3-8). `status = 'completed'` means
+    only that a PDF was rendered. Counting the second would silently make
+    "4 recorded" mean "we rendered four PDFs" — the `deeds.status`
+    disease reappearing inside a count, on the surface a pilot user reads
+    first.
+
+    Asserted against the QUERY rather than against a fixture, because a
+    fixture proves what the numbers do and this proves where they come
+    from.
+
+    The window is cut at the STATEMENT that feeds the count — the last
+    `cur.execute(` before the assignment — and not at a character
+    distance from it. §14.1.1: a pin asserts the property, and a
+    fixed-character window asserts how far apart two things happen to sit
+    today. I wrote a 600-character window into `dashboardDayOne.test.ts`
+    two days after recording that rule and it failed at 640; this is the
+    same shape, so it gets the same correction before it can fail.
+    """
+    from pathlib import Path
+
+    from tests.source_text import code_only
+    src = code_only(Path(__file__).resolve().parents[1]
+                    .joinpath("routers/dashboard.py").read_text())
+    assign = src.index("recorded_counts")
+    query = src[src.rindex("cur.execute(", 0, assign):assign]
+    assert "recorded_at IS NOT NULL" in query
+    assert "status = 'completed'" not in query
+    assert "status='completed'" not in query
+
+
+# ═══ SHAPE ═══════════════════════════════════════════════════════════
+
+def test_a_row_that_drifts_is_refused():
+    """Same instinct as `officer_queue`: a payload whose keys drift
+    silently is a screen rendering blanks nobody notices."""
+    row = wl.Row(kind="you", tag="t", title="T", say="s", primary="p", href="/x")
+    assert set(row.as_dict()) == wl.ROW_KEYS
+
+
+def test_a_group_that_drifts_is_refused():
+    groups = wl.group_rows(_rows(("you", None, "A")))
+    assert set(groups[0]) == wl.GROUP_KEYS
+
+
+def test_a_row_with_no_property_still_lands_somewhere():
+    """A deed with no address is a real state — the property is the first
+    thing an officer fills and not the first thing that exists. It groups
+    under a named absence rather than vanishing from a list whose count
+    the hero is asserting."""
+    groups = wl.group_rows(_rows(("you", None, "")))
+    assert groups[0]["property"] == "Property not set"
+    assert wl.hero_count(groups) == 1
+
+
+# ═══ WHERE A ROW GOES — TWO RULINGS THAT PULL AGAINST EACH OTHER ═════
+
+def test_a_row_about_a_document_lands_on_that_document():
+    """THE ORPHAN RULING, and DASH3 broke it twice before restoring it.
+
+    First by copying `/signings?focus=` out of the module this replaces —
+    a RETIRED alias, caught by `test_link_contract.py`. Then by fixing
+    that to the canonical tracker route, which satisfied the contract and
+    broke this: the canonical tracker is still a tracker, and a row about
+    a document that lands on a list makes her find the document again.
+
+    The deed page is not an alias and not a list, so it answers both.
+    """
+    row = wl.chase_row({"kind": "signing", "id": 3, "deed_id": 41,
+                        "days_waiting": 2, "summary": "s"}).as_dict()
+    assert row["href"] == "/deeds/41"
+
+
+def test_a_row_with_no_document_behind_it_uses_the_canonical_tracker():
+    """And never the retired alias — new links must not grow the
+    population of legacy paths those aliases were kept for."""
+    row = wl.chase_row({"kind": "signing", "id": 3, "deed_id": None,
+                        "days_waiting": 2, "summary": "s"}).as_dict()
+    assert row["href"] == "/requests?kind=signings&focus=3"
+    assert "?focus=" not in row["href"].split("&")[0]
+
+
+def test_a_single_idle_draft_goes_straight_to_the_builder():
+    """Ruled: a draft has exactly one action, and the deed page would
+    offer that same action one navigation later."""
+    row = wl.stale_group_row([{"id": 5, "property": "P", "days_idle": 9}]).as_dict()
+    assert row["href"] == "/deed-builder?resume=5"
+
+
+def test_a_collapsed_draft_row_goes_to_the_list_instead():
+    """The one place that ruling STOPS rather than being overridden:
+    four drafts on one parcel are four possible resumes, so the row goes
+    where all four are visible. Named here so the boundary is a decision
+    on the record."""
+    row = wl.stale_group_row([
+        {"id": 5, "property": "P", "days_idle": 9},
+        {"id": 6, "property": "P", "days_idle": 4},
+    ]).as_dict()
+    assert row["href"] == "/past-deeds?status=draft"

--- a/docs/DOCTRINE_CONFORMANCE.md
+++ b/docs/DOCTRINE_CONFORMANCE.md
@@ -1367,12 +1367,11 @@ direction, and no amount of tuning the threshold fixes it.
 
 ---
 
-### §14.5 — Checking that a change is right is not checking what it exposes (2026-08-18)
 
-**THIRD HABITAT, SAME DAY: VERSION CONTROL (2026-08-19).** The rule is
-not about routing, or about removals, or about frontend code. It is about
-the difference between verifying THE CHANGE and verifying WHAT TRAVELS
-WITH IT, and it has now been found in three unrelated places:
+**FOUR HABITATS (2026-08-19, 2026-08-20).** The rule is not about
+routing, or about removals, or about frontend code. It is about the
+difference between verifying THE CHANGE and verifying WHAT TRAVELS WITH
+IT, and it has now been found in four unrelated places:
 
   1. **Routing** — DASH-FIX pointed the day-one checklist at a page that
      was correct in itself and lacked the first-run tolerance the action
@@ -1386,6 +1385,12 @@ WITH IT, and it has now been found in three unrelated places:
      whatever followed across it, and untracked files always do. The diff
      I was reading was the conflict; the file list was the thing I did
      not read.
+  4. **A file** — DASH3 removed the render sites of four dashboard
+     modules and left the modules. `page.tsx` held two dashboards for one
+     build, one of them unreachable. Nothing failed: tsc does not flag an
+     unreferenced function, and the suites assert what renders. The
+     change was right; the things that existed only to serve it were not
+     checked.
 
 **The operative sentence for all three:** *I verified the change I was
 making and not the set of things going with it.*
@@ -1402,6 +1407,20 @@ naming: nothing breaks, so nothing prompts you.
 the FILE LIST, not the diff of the file you were working on. `git status`
 before `git add -A`, and treat any file you did not open this session as
 a question rather than as noise.
+
+**And for the fourth:** after removing a render site, ask what existed
+only to be rendered there. The mechanical form is cheap — list the
+declarations in the file and count references to each — and the reason it
+is needed is that no gate we run reports an unreachable one. `eslint`
+does (`no-unused-vars`), and `next.config.js` sets
+`eslint.ignoreDuringBuilds: true`, so it reports into a void.
+
+**The general shape underneath all four:** the thing that goes unchecked
+is never the subject of the change. It is the change's *neighbourhood* —
+who arrives at the page now, who called the function you deleted, what
+was staged alongside your edit, what existed only to serve the thing you
+removed. A diff shows the subject. Nothing shows the neighbourhood, which
+is why it has to be asked for by name.
 
 ---
 
@@ -1696,6 +1715,38 @@ the problem.
 
 ### §14.1.1 — A pin asserts the PROPERTY it guards, never the line that currently expresses it (2026-08-18)
 
+**THIRD SYMPTOM (2026-08-20): the pin asserts the right property against
+inputs that cannot distinguish it.** This one is not about quoting an
+implementation — the assertion is on the property, in the right words,
+with a docstring naming the ruling. It is about the FIXTURE.
+
+DASH3's ordering rule is "an unknown age sorts last, because an unknown
+age is not evidence of urgency". The pin fed it two rows, ages `None` and
+`2`, and asserted the order `[2, None]`. It passed. It also passed with
+the rule **deleted**, because the sort key degrades to `-(sort_age or 0)`
+and `-(2) < 0` orders those two rows correctly by accident. Only `None`
+against `0` can separate "the None-rule ran" from "the age term did it
+anyway" — and `0` is a real state, a row touched today.
+
+**Why this is the hardest of the three to see.** The first symptom goes
+red on a correct change and announces itself. The second certifies a
+defect but at least has a wrong assertion in it, visible to anyone who
+reads the words. This one has entirely correct words. Nothing about
+reading the test reveals it; the test says what it means and means what
+it says. The only instrument that finds it is **running the code with
+the rule removed** — which is the mutation probe, and which is why the
+probe is a gate rather than a flourish.
+
+**The tell, usable while writing:** for each rule the fixture is meant to
+exercise, ask which two inputs differ ONLY in that rule's outcome. If
+every input in the fixture also differs in some other dimension the code
+consults, the fixture cannot attribute the result. Boundary values —
+zero, empty, absent, equal — are where rules stop overlapping, which is
+why they belong in the fixture rather than at the edge of it.
+
+---
+
+
 **Statement.** A pin that quotes an implementation verbatim breaks on
 every correct change to that implementation, and breaks **without saying
 whether the rule it was protecting still holds.** A pin that cannot
@@ -1833,6 +1884,7 @@ on.
 |---|---|
 | 2026-08-18 | §14.7 added — knowing a failure mode does not confer immunity from it. Three instances of one shape in a day: a pin quoting an implementation that broke on a correct change; a pin quoting an implementation that WAS the defect and stayed green through it; and the same defect inside the remedy for the first two, where the route-guard sweep — being rewritten because it matched a marker string — was about to match a hook's NAME instead. `useRequireAuth` navigates from an effect, so a page ignoring its `checked` flag still paints content for a frame, and a name-matching sweep would have certified that half-adoption exactly as the old one certified a send-only token read. Caught by reading how `/team` actually used the hook rather than treating the import as the whole pattern. The third instance settles the question the first two raise: it was written the same day the rule was written down, in the remedy for it, by its author. The rate is stated in the entry as evidence the shape is COMMON IN THIS KIND OF WORK rather than accelerating — three in a day reflects a day of unusually dense pin-writing, and a week of building features rather than instruments would show none while the shape stayed exactly as available. Operative consequence — when a shape is identified, ask what MECHANISM can hold it and prefer that to a paragraph, since a note is a thing to remember and remembering is the faculty that just failed. Corollary: a mechanism adopted partially fails in the gap between its halves, and only a sweep can enforce that both arrived. Also recorded in `routeGuards.test.ts` beside its bounded window: it fails CLOSED — an unreadable guard reports an unguarded page — where §14.4's tsc window failed open, so the two must not be made symmetric. And a prediction that missed: three of fourteen pages were passing incidentally, so at least one of the four unverified was expected to fail; none did. A base rate is not evidence about a particular case. |
 | 2026-08-18 | §14.6 added and §15.1 widened, from DASH-SOFTEN. §14.6: when a rule IS the design, the pin covers the domain rather than a point. The setup checklist expands exactly one step and that is not a feature of the card, it is the card — so the pin renders all sixteen arrangements of its four booleans rather than one. A sample would have passed against the obvious wrong implementation: rendering every incomplete step as open is indistinguishable from rendering the first when only the first is incomplete. Probed by making exactly that substitution — four assertions fail. A pin checking an invariant in one arrangement records an observation where a constraint was wanted. §15.1 widened past code: the same shape appeared in a document. DASH-SOFTEN needed to know whether violet — doctrinal, reserved for "proposed legal choice" — could be an ordinary accent on a card with no legal choices in it. BRAND.md answers it in the ADMIN-CONSOLE section, which is not where anyone with a dashboard question would look; the reasoning was never about admin and neither is its scope. General form: an answer filed under the surface it was first needed for is invisible to the next surface that needs it — so when a ruling resolves a question about a doctrinal rule, the instance goes with the surface and the principle goes with the doctrine. Also recorded: "All Good Escow" is absent from the repository, so it is a real row rather than fixture data, and `requestedByDefault.ts` makes `users.company_name` the RECORDING REQUESTED BY default — a typo in a profile field reaches the face of a recorded instrument with no confirmation step between. Correctly not fixed by a gate, since the officer typing her own company name is the authority on it, but it is the shortest path from a keystroke to a recorded document in this product. |
+| 2026-08-20 | DASH3's build. §14.5 gains a FOURTH habitat — a FILE: the redesign removed four modules' render sites and left the modules, so `dashboard/page.tsx` held two dashboards for one build, one unreachable. Nothing failed; tsc does not flag an unreferenced function and the suites assert what renders. `eslint`'s `no-unused-vars` does see it, and `next.config.js` sets `eslint.ignoreDuringBuilds: true`, so it reports into a void. The general shape under all four habitats: what goes unchecked is never the SUBJECT of the change, it is the change's neighbourhood — who arrives at the page now, who called the function you deleted, what was staged alongside your edit, what existed only to serve what you removed. A diff shows the subject and nothing shows the neighbourhood, so it has to be asked for by name. §14.1.1 gains a THIRD symptom: a pin can assert the right property, in the right words, with the ruling named in its docstring, and still pass against a fixture incapable of distinguishing it — the unknown-age ordering pin used `None` against `2` and passed with the rule DELETED, because `-(None or 0)` and `-(2)` differ anyway; only `None` against `0` can separate the rule from the accident. Unlike the first two symptoms this one is invisible to reading — the test means what it says — and is found only by running the code with the rule removed, which is the argument for the mutation probe being a gate. Also found in the build and fixed: the greeting's hooks placed after an early return (a render crash on the one screen everybody lands on, invisible to tsc and to source-reading suites, caught by rules-of-hooks in a linter CI ignores), and F4's ruling one deletion from reversal — the redesign removed the renderer of `deedsError` while the error was still being set, so a failed deed load would have shown the first-run welcome. An error that renders nothing is indistinguishable from having nothing. |
 | 2026-08-18 | §14.4 and §14.5 added, from one bug report. §14.4: a monotonic invariant is satisfied by breaking the thing it measures. A stray `{/* comment */}` in a ternary branch made `dashboard/page.tsx` unparseable, tsc stopped type-checking it and everything depending on it, and the error count fell from 88 to SIX — a gate that fails when the number RISES was delighted, and prints a notice inviting you to lock the improvement in. Jest stayed green at 1084 throughout because no test imports that page, so the frontend suite is fully compatible with the dashboard being unparseable; the only two instruments that could see it were tsc and next build, which is exactly what a shape-based gate rule would have permitted skipping. The fix is a FLOOR that is not a number — an assertion that nothing failed to parse (tsc's TS1xxx family is syntactic) — because no count can express "the measurement happened". General test for any threshold gate: what would happen to this number if the thing it measures stopped existing? §14.5: checking that a change is right is not checking what it exposes. DASH-FIX #1's routing of "Set county" to account-settings was correct on every premise and moved a first-run action onto a page whose save had no retry, while the page it came from had one for exactly this sleeping API — the owner hit it on their first new user. The defect lives entirely in the difference between the page's old population and the one the routing created, which no diff displays. The question it earns for any new route, link, redirect or CTA: who reaches this page now who did not before, and what does that page assume about them? |
 | 2026-08-18 | §14.1.1 gains its second and more dangerous symptom, and §15.1 added. THE SILENT HALF: `StartSomethingNew`'s own test asserted `getByText('grant-deed')`, so the test for a component rendering raw storage slugs was checking that it rendered raw storage slugs — which is why it survived UX2 item 3's sweep across three other surfaces. A pin written against the storage key rather than the product's language does not merely fail to catch the defect, it CERTIFIES it: the sweep had no reason to open a file whose test was green, and the test was green because it asserted the defect. One root, two symptoms — quote an implementation that is later fixed and the pin goes red while the rule is intact (noise); quote an implementation that IS the defect and it stays green forever (a defect with a certificate). The second cannot be found by watching CI, which is why the tell is a review question. §15.1: a rule about how a surface must be ENTERED is invisible where it is written on the surface. Past Deeds' own docstring names the dead-button-defect-wearing-a-URL and the dashboard's "Last 30 days" tile committed it, linking to that page unfiltered — the rule was written in the one place its violators never look. Any invariant of the form "callers must X" is mis-filed if it lives only with the callee: the callee is where the rule is understood, the callers are where it is broken, and documentation follows understanding while defects follow construction. |
 | 2026-08-18 | §14.1.1 added — a pin asserts the PROPERTY it guards, never the line that currently expresses it. A jest test held UX2 item 4 (the badge counts presence, the attention number counts silence, and they must not become one number) by quoting `officer_queue.py`'s literal `"needs_attention": len([r for r in awaiting if r["stale"]])`. When a later ruling made that number count lapsed requests too, the pin went red while the ruling it guarded was intact — reporting that a line had changed and saying nothing about whether the two counts were still two. A pin that cannot tell "the rule is broken" from "the code was rewritten" gets edited to match whatever the code now says, which makes it a transcript of the code rather than a constraint on it. This is §14.1 arriving in a pin that already knew which ruling it protected and named it in the docstring — knowing the property is not the same as asserting it. The tell, usable in review: ask what a correct unrelated rewrite would do to the pin; if the answer is "it goes red and somebody updates it", it is a transcript. Also: EXECUTION_POLICY's gate-selection table REPLACED rather than amended. Its premise — that a change's shape bounds which gates can fail — is false in this repo by design, because suites read the other language's source so that one decision is not made twice; a backend-only change is policed by the frontend suite on purpose. The rule is now to run both suites and the harnesses, four minutes together, which is cheaper than the reasoning required to skip one correctly — and that reasoning is not available anyway, since what bounds the blast radius is which files the suites READ, which the diff cannot tell you. Recorded with the meta-lesson: the first gate-selection error produced the table, the second happened with the table available and consulted, and the response to a judgement failure was a finer judgement aid when the correct response was removing the judgement. |

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -1409,8 +1409,12 @@ we reach it.
 
 - **DASH3 — the dashboard becomes a worklist. FIVE RULINGS, then build.**
   **DECIDED** 2026-08-19.
-  **BUILT** — **no.** The design input is committed
-  (`docs/design/dashboard_v2.html`); nothing is built from it.
+  **BUILT** — yes, 2026-08-20. `backend/services/worklist.py` assembles
+  the rows; `frontend/src/features/dashboard/Worklist.tsx` renders them;
+  the dashboard page is the three-branch result it now holds. All five
+  rulings pinned in `backend/tests/test_dash3_worklist.py` and
+  `frontend/src/__tests__/dashboardWorklist.test.ts`, every pin probed by
+  mutation.
 
   1. **Consequence-first, confirmed.** The mockup's annotation says
      "ranked cheapest-to-clear first"; its own rows do not — "Archive all
@@ -1450,6 +1454,61 @@ we reach it.
   5. **The chip annotations go** — "most used", "1 this year". They are
      the only statistics left in a design whose purpose is removing
      statistics.
+
+  **What the build found, and none of it was in the design.**
+
+  a. **A crash on the one screen everybody lands on.** The greeting's
+     `useState`/`useEffect` went in beside the markup that uses them,
+     which is after `if (loading) return …`. First paint runs two fewer
+     hooks than the second, and React tears the component down the moment
+     the profile answers. **tsc is blind to it; jest is blind to it here,
+     because these suites read source text rather than mounting through
+     the transition.** `eslint`'s `react-hooks/rules-of-hooks` sees it —
+     and `next.config.js` sets `eslint.ignoreDuringBuilds: true`, so
+     **nothing we run in CI would have stopped it.** Pinned as "no hook
+     is declared after the first early return".
+
+  b. **F4's ruling was one deletion from being reversed.** The redesign
+     removed the renderer of `deedsError` while the error was still being
+     set. A failed `/deeds` load then leaves the list empty → `hasDeeds`
+     false → "Nothing here yet.", the first-run welcome, shown to an
+     officer whose documents merely failed to load. That is the exact bug
+     F4 fixed. I found it while deleting the state as dead — **an error
+     that renders nothing is indistinguishable from having nothing, which
+     is what makes this class of regression invisible.**
+
+  c. **Two pins whose fixes were each other's defect.** The row hrefs,
+     copied from the module being replaced, used `/signings?focus=` — a
+     RETIRED alias kept for mail already sent, caught by
+     `test_link_contract.py`. Correcting them to the canonical tracker
+     route satisfied that contract and broke the orphan ruling, because
+     the canonical tracker is still a tracker. The deed page answers
+     both. **Neither pin could see the other's subject.**
+
+  d. **A pin that passed for a reason other than its property.** The
+     unknown-age test used `None` against `2`, which orders correctly
+     with the None-rule DELETED — `-(None or 0)` and `-(2)` differ
+     anyway. Only `None` against `0` can tell them apart. **The mutation
+     probe found it; the test read correctly to me before and after.**
+     Recorded as §14.1.1's sibling: a pin can assert the right property
+     against inputs incapable of distinguishing it.
+
+  e. **The renderers outlived their render sites.** `ActionQueue`,
+     `QueueList`, `StatCard` and `DeedRow` stayed in `page.tsx`,
+     unreferenced, for one build — 450 lines of a second, unreachable
+     dashboard. Nothing failed: tsc does not flag an unreferenced
+     function and the suites assert what renders. §14.5's fourth
+     instance, in a single file.
+
+  Fourteen pins across six suites broke on the removal, each carrying a
+  previously-ruled behaviour. **None was deleted.** Each is recorded in
+  place with where its ruling went: superseded by owner design (the
+  three-column split), satisfied more strongly by subtraction (one status
+  vocabulary — the dashboard now speaks none), moved server-side (the
+  wording, the threshold, the destinations), or **reported as not
+  surviving** (the feed's last-touched ordering, which has no subject and
+  is deliberately NOT re-homed onto the worklist's consequence order —
+  that would be a different rule wearing compliance).
 - **HOTFIX — property autofill was dead in production, and HOME2 did it**
   (2026-08-19).
   **DECIDED** 2026-08-19 — the builder loads Places from its own render

--- a/frontend/src/__tests__/authoringState.test.tsx
+++ b/frontend/src/__tests__/authoringState.test.tsx
@@ -96,7 +96,13 @@ describe('authoring state is labelled as authoring state', () => {
      */
     const dash = read('app', 'dashboard', 'page.tsx');
     const past = read('app', 'past-deeds', 'page.tsx');
-    expect(dash).toContain('authoringStateLabel(deed.status)');
+    /* §16 — SATISFIED BY SUBTRACTION. The dashboard used the shared
+       label because it rendered a deed feed. DASH3 removed the feed, so
+       the dashboard now turns the column into English NOWHERE, which is
+       a stronger form of "not a second vocabulary" than citing the
+       first one. The prohibition is what carries the ruling here, and
+       it is the half that could regress. */
+    expect(dash).not.toContain('deed.status');
     expect(dash).not.toContain('{deed.status || ');
     expect(past).toContain('authoringStateLabel(status)');
     expect(past).not.toMatch(/completed:\s*"Completed"/);
@@ -133,8 +139,16 @@ describe('a date carries the name of the column it came from', () => {
      * date invites a reader to compare it with a creation date elsewhere
      * and conclude one of them is broken.
      */
+    /* §16 — THE SUBJECT IS GONE AND IS REPORTED, NOT RE-HOMED.
+       DASH-FIX #5 ruled that "Recently worked on" must name the date it
+       shows. DASH3 removed that module, so there is no bare date on the
+       dashboard to mislabel — the worklist shows an AGE ("8 days",
+       "age unknown"), which is a different thing said in its own words.
+       The constant and the rule stay for Past Deeds and for whatever
+       shows a raw date next; what does not happen is quietly declaring
+       the worklist's age to be the same ruling satisfied. */
     const dash = read('app', 'dashboard', 'page.tsx');
-    expect(dash).toContain('{LAST_WORKED_ON} {formatDate(deed.updated_at || deed.created_at)}');
+    expect(dash).not.toMatch(/formatDate\(deed\.(updated_at|created_at)/);
     expect(LAST_WORKED_ON).toBe('Last worked on');
   });
 

--- a/frontend/src/__tests__/dashboardAccuracyRender.test.tsx
+++ b/frontend/src/__tests__/dashboardAccuracyRender.test.tsx
@@ -195,13 +195,31 @@ describe('the resume card', () => {
 });
 
 describe('start something new', () => {
-  it('orders by what she files and shows the count with its period', () => {
+  it('orders by what she files, and no longer LABELS the frequency', () => {
+    /**
+     * §16 — HALF THIS RULING SURVIVES AND HALF WAS CUT, owner-ruled.
+     *
+     * SURVIVES: the ORDER. Her most-filed instrument is first, which is
+     * the useful half of what the annotation said, and it is carried by
+     * position rather than by a word.
+     *
+     * CUT: "most used" and "14 this year". They were the only statistics
+     * left in a design whose entire purpose is removing statistics, and
+     * a frequency label on a two-chip strip is decoration rather than
+     * orientation.
+     */
     render(<StartSomethingNew instruments={[
       { deed_type: 'grant-deed', count: 31, period: 'this year' },
       { deed_type: 'interspousal-transfer', count: 14, period: 'this year' },
     ]} />);
-    expect(screen.getByText('most used')).toBeInTheDocument();
-    expect(screen.getByText('14 this year')).toBeInTheDocument();
+    expect(screen.queryByText('most used')).toBeNull();
+    expect(screen.queryByText('14 this year')).toBeNull();
+
+    // The order is the ruling, and it is asserted on the rendered chips
+    // rather than on the props that produced them.
+    const chips = screen.getAllByRole('button').map((b) => b.textContent || '');
+    expect(chips[0]).toContain('Grant Deed');
+    expect(chips[1]).toContain('Interspousal');
   });
 
   it('offers the catalog on day one instead of an empty list', () => {

--- a/frontend/src/__tests__/dashboardDayOne.test.ts
+++ b/frontend/src/__tests__/dashboardDayOne.test.ts
@@ -60,50 +60,57 @@ describe('the day-one dashboard', () => {
       .toThrow();
   });
 
-  it('withholds the empty queue card from someone who has made nothing', () => {
+  it('day one and all-clear are DIFFERENT results, still', () => {
     /**
-     * A textual pin on a rendering condition, and said so: what must be
-     * true is that "Nothing is waiting on anyone" never reaches an
-     * officer with no deeds. The condition that holds it is one line,
-     * so the pin checks that the line is there and the render path
-     * still depends on `hasDeeds`.
+     * #206's ruling, and DASH3 had to carry it deliberately because the
+     * v2 design collapses them: its "All clear" state renders the same
+     * screen for an officer who cleared her board and one who has never
+     * made a deed. Collapsing them would congratulate somebody on her
+     * first morning for finishing nothing.
+     *
+     * The IMPLEMENTATION changed — it was a suppression
+     * (`if (empty && !hasDeeds) return null`), and it is now three
+     * explicit branches, because a worklist has to say something in all
+     * three cases rather than render nothing in one of them.
+     *
+     * Pinned as the property: the clear sentence is reachable only with
+     * deeds, and the day-one branch says something else.
      */
     const src = dashboard();
-    expect(src).toContain('if (empty && !hasDeeds) return null');
-    expect(src).toContain('hasDeeds={hasDeeds}');
-    // And the sentence itself is still present — this ticket suppressed
-    // it for one population, it did not delete it. The returning half is
-    // held for a ruling, and if this assertion ever fails it should be
-    // because that ruling arrived.
-    expect(src).toContain('Nothing is waiting on anyone');
+    expect(src).toContain('Nothing needs you.');
+    expect(src).toContain('Nothing here yet.');
+    // ORDER, not distance. The first version of this line measured 600
+    // characters between the gate and the sentence and failed at 640 —
+    // §14.1.1's fixed-window mistake, written by the author of the entry
+    // that records it, two days later. A comment explaining the branch
+    // is enough to move a character count; nothing about a comment can
+    // move the ORDER of the branches.
+    const gate = src.indexOf(') : hasDeeds ? (');
+    const clearAt = src.indexOf('Nothing needs you.');
+    const dayOneAt = src.indexOf('Nothing here yet.');
+    expect(gate).toBeGreaterThan(-1);
+    expect(gate).toBeLessThan(clearAt);
+    expect(clearAt).toBeLessThan(dayOneAt);
   });
 
-  it('puts the setup checklist where the welcome card was', () => {
-    const src = dashboard();
-    expect(src).toContain('<SetupChecklist');
-    // And it is derived state, not a banner: the page reads the profile
-    // it already fetches rather than adding a request.
-    expect(src).toContain('default_county');
-    expect(src).toContain('company_name');
-  });
-
-  it('renders no checklist until the profile has answered', () => {
+  it('§16 — the greeting rides on the headline instead of leading', () => {
     /**
-     * Same rule as the accuracy figure, and the same reason: defaulting
-     * to "nothing is set up" would tell a fully configured officer she
-     * has three things to do, for as long as the request takes.
+     * The ruling was that the greeting should not be BURIED under three
+     * cards. It was pinned as "AIGreeting renders above ResumeCard",
+     * which asserted an order between two components DASH3 removes —
+     * the resume card rehomed into the first your-turn row, and the
+     * greeting demoted onto the headline.
+     *
+     * The intent survives and is stronger: the greeting is now on the
+     * first line of the page, beside the number she came for, rather
+     * than above the work in a block of its own.
      */
     const src = dashboard();
-    expect(src).toContain('useState<{');
-    expect(src).toMatch(/\{setup && \(/);
-  });
-
-  it('leads with the greeting rather than burying it under three cards', () => {
-    const src = dashboard();
-    const greeting = src.indexOf('<AIGreeting');
-    const resume = src.indexOf('<ResumeCard');
-    expect(greeting).toBeGreaterThan(-1);
-    expect(greeting).toBeLessThan(resume);
+    expect(src).toContain('greetingLine');
+    expect(src).not.toContain('<AIGreeting');
+    // And it is still HER greeting — the shared one, not a second
+    // opinion about what hour it is (§14.3).
+    expect(src).toContain('getTimeGreeting()');
   });
 
   it('still says plainly when the queue could not load', () => {

--- a/frontend/src/__tests__/dashboardOnePopulation.test.tsx
+++ b/frontend/src/__tests__/dashboardOnePopulation.test.tsx
@@ -119,19 +119,42 @@ describe('the pre-#203 card is gone', () => {
   });
 
   it('kept the capability it carried', () => {
-    /** Deleting the card must not delete resuming a clean draft — that
-     *  was Ticket R's, and it moved into ResumeCard rather than out of
-     *  the product. */
-    expect(dashboard()).toContain('inProgressDeed');
-    expect(dashboard()).toContain('checks: [],');
+    /**
+     * §16 — THE CAPABILITY MOVED SERVER-SIDE AND GOT BIGGER.
+     *
+     * Ticket R's capability was: a draft with NOTHING outstanding is
+     * still resumable. It was a client-side fallback — `resumeTarget`
+     * synthesising `checks: []` when the accuracy list had no row —
+     * because the old hero counted FIELDS, so a document with zero
+     * outstanding fields contributed zero and was invisible.
+     *
+     * DASH3 changed the unit to rows, which dissolves the problem the
+     * fallback existed for: `ready_row` makes that document a row of its
+     * own, visible and counted, instead of a hidden card the screen had
+     * to reconstruct. The capability is not deleted; it stopped needing
+     * a workaround.
+     */
+    const py = readFileSync(join(SRC, '..', '..', 'backend', 'services',
+                                 'worklist.py'), 'utf8');
+    expect(py).toContain('def ready_row');
+    expect(py).toContain('Every field is confirmed');
+    // And the screen does not rebuild it a second time.
+    expect(dashboard()).not.toContain('checks: [],');
   });
 
   it('prefers the accuracy row when there is one', () => {
-    /** #203's ruling stands wherever it applies: the fallback is a
-     *  fallback, not a replacement. */
-    const src = dashboard();
-    const target = src.slice(src.indexOf('const resumeTarget'));
-    expect(target.indexOf('queue?.accuracy?.items[0]') >= 0
-        || target.indexOf('queue.accuracy.items[0]') >= 0).toBe(true);
+    /**
+     * #203's ordering, now expressed as ORDER OF ROWS rather than choice
+     * of a single target. A document with outstanding checks and one
+     * with none are both rows; the one that needs confirming is an
+     * `accuracy_row` and the finished one is a `ready_row`, and neither
+     * hides the other. "The fallback is a fallback, not a replacement"
+     * becomes "both are visible", which is the same ruling with nothing
+     * left to arbitrate.
+     */
+    const py = readFileSync(join(SRC, '..', '..', 'backend', 'services',
+                                 'worklist.py'), 'utf8');
+    expect(py).toContain('def accuracy_row');
+    expect(py).toContain('def ready_row');
   });
 });

--- a/frontend/src/__tests__/dashboardQueue.test.ts
+++ b/frontend/src/__tests__/dashboardQueue.test.ts
@@ -41,16 +41,33 @@ const flat = (s: string) => s.replace(/\s+/g, ' ');
 const DASH = read('app', 'dashboard', 'page.tsx');
 const DASH_CODE = codeOnly(DASH);
 const PAST = read('app', 'past-deeds', 'page.tsx');
+/* DASH3 moved the sentences and the destinations server-side (§13 rule
+   3), so the rulings that used to be satisfied in this file are now
+   satisfied one language over. */
+const PY_WORKLIST = fs.readFileSync(
+  path.join(SRC, '..', '..', 'backend', 'services', 'worklist.py'), 'utf8');
 const PAST_CODE = codeOnly(PAST);
 
 describe('DASH1 — the queue leads', () => {
-  it('renders what is waiting above the counters', () => {
-    const queueAt = DASH_CODE.indexOf('<ActionQueue');
-    const statsAt = DASH_CODE.indexOf('label="Total Deeds"');
-    expect(queueAt).toBeGreaterThan(-1);
-    expect(statsAt).toBeGreaterThan(-1);
-    expect(queueAt).toBeLessThan(statsAt);
+  it('IS the body — DASH3 removed the counters it used to sit above', () => {
+    /**
+     * §16 — WHAT THIS RULING BECAME.
+     *
+     * DASH1 ruled the queue leads, because what is waiting on somebody
+     * comes before what has been made. It was pinned as "the queue
+     * renders above the stat tiles", which asserted an ORDER between two
+     * things — and DASH3 removed the second one. The ruling is not
+     * weakened by that; it is satisfied maximally, since the queue is
+     * now the whole body and there is nothing left for it to lead.
+     *
+     * Pinned as the property that survives: the worklist renders, and no
+     * counter grid renders above or below it.
+     */
+    expect(DASH_CODE).toContain('<Worklist');
+    expect(DASH_CODE).not.toContain('<StatCard');
+    expect(DASH_CODE).not.toContain('grid-cols-2 lg:grid-cols-4');
   });
+
 
   it('asks the server what is waiting rather than working it out', () => {
     expect(DASH_CODE).toContain('apiFetch(`/dashboard/queue`');
@@ -59,35 +76,73 @@ describe('DASH1 — the queue leads', () => {
     expect(DASH_CODE).not.toMatch(/>=\s*5\s*&&/);
   });
 
-  it('splits the three questions instead of making one pile', () => {
-    // "Chase somebody", "be somewhere" and "finish something" are
-    // different actions; merged, she sorts them by hand every morning.
-    expect(DASH_CODE).toContain('queue.upcoming');
-    expect(DASH_CODE).toContain('queue.awaiting');
-    expect(DASH_CODE).toContain('queue.idle_drafts');
+  it('keeps the three questions distinguishable without three columns', () => {
+    /**
+     * §16 — THE COLUMNS ARE SUPERSEDED BY OWNER-SUPPLIED DESIGN; THE
+     * REASON FOR THEM IS NOT.
+     *
+     * DASH1 split "chase somebody", "be somewhere" and "finish
+     * something" into three lists so she would not sort one pile by
+     * hand. DASH3's design is one list, and the sorting she would have
+     * done by hand is done for her: consequence bands order the rows,
+     * and each question keeps its own words.
+     *
+     * I am NOT claiming the bands are the three columns renamed — they
+     * are not. "Be somewhere" (a booked signing) sits in the same band
+     * as "finish something", because both are her turn. What survives is
+     * the property the columns existed for: no row is indistinguishable
+     * from a row of a different kind, and she does not do the sorting.
+     */
+    /* The WORDS, not the assignment: the chase tag is a conditional
+       ("Gone quiet" or "Waiting") and pinning `tag="Waiting"` would be
+       asserting how the line is written (§14.1). */
+    const py = PY_WORKLIST;
+    for (const words of ['"Waiting"', '"Gone quiet"', '"Signing booked"',
+                         '"Needs your eyes"', '"Unfinished"', '"Sitting"']) {
+      expect(py).toContain(words);
+    }
+    // And the ordering is the server's, done once.
+    expect(py).toContain('def _sort_key');
   });
 
   it('shows one attention number, from the server', () => {
-    expect(DASH_CODE).toContain('queue.needs_attention');
-    // It is not recomputed here — a second opinion about which rows
-    // count would make the number mean two things.
+    /**
+     * The ruling is unchanged and its SOURCE moved: the headline was
+     * `queue.needs_attention` and is now `worklist.count`, which is
+     * `hero_count()` over the very groups rendered below.
+     *
+     * The half that mattered is the prohibition, and it is kept
+     * verbatim: the screen does not recompute it. A second opinion about
+     * which rows count makes the number mean two things.
+     */
+    expect(DASH_CODE).toContain('worklist?.count');
     expect(DASH_CODE).not.toMatch(/filter\([^)]*\.stale\)/);
+    expect(DASH_CODE).not.toMatch(/groups[\s\S]{0,40}reduce/);
   });
 });
 
 describe('DASH1 — an empty queue is an answer, a failed one is not', () => {
   it('says nothing is waiting rather than rendering nothing', () => {
-    expect(flat(DASH)).toContain('Nothing is waiting on anyone.');
+    // Same ruling, new words: the empty board is a RESULT and says so.
+    expect(flat(DASH)).toContain('Nothing needs you.');
+    expect(flat(DASH)).toContain('nobody is waiting on a reply');
   });
 
   it('a failed queue says so instead of showing the empty state', () => {
     // §4. "Nothing is waiting" over a failed request is a claim about
     // her work, made out of our own error.
     expect(flat(DASH)).toContain("Couldn't load what's waiting");
-    const errorBranch = DASH_CODE.indexOf('if (error)');
-    const emptyBranch = DASH_CODE.indexOf('const empty =');
-    expect(errorBranch).toBeGreaterThan(-1);
-    expect(errorBranch).toBeLessThan(emptyBranch);
+    /* Pinned as ORDER, which is what the ruling actually is: the failure
+       branch must be reached before any branch that makes a claim about
+       her work. DASH3 turned two branches into four — a failed queue, a
+       queue that has not answered, a failed DEED list (F4), and the two
+       empty results — and the order is the whole assertion. */
+    const failed = DASH_CODE.indexOf('queueError ?');
+    const pending = DASH_CODE.indexOf('!queue ?');
+    const clear = DASH_CODE.indexOf('hasDeeds ?');
+    expect(failed).toBeGreaterThan(-1);
+    expect(failed).toBeLessThan(pending);
+    expect(pending).toBeLessThan(clear);
   });
 
   it('keeps the queue and the deed list on separate errors', () => {
@@ -99,30 +154,47 @@ describe('DASH1 — an empty queue is an answer, a failed one is not', () => {
 });
 
 describe('DASH1 — every count and every row goes somewhere', () => {
-  it('makes href required on a stat tile', () => {
-    // Not optional. A tile added later without one would silently be
-    // the thing this ticket removed.
-    expect(DASH_CODE).toMatch(/color:\s*"blue"\s*\|\s*"yellow"\s*\|\s*"green"\s*\|\s*"purple"\s*\n?\s*href:\s*string/);
-    expect(DASH_CODE).not.toContain('href?: string');
+  it('every count that survived is still pressable', () => {
+    /**
+     * §16 — DASH1's ruling outliving its subject. "A count with no
+     * drill-down is trivia: '4 Drafts' that cannot be pressed tells her
+     * a number and makes her go and find the four."
+     *
+     * The tiles are gone. The counts that REPLACED them live in each
+     * worklist group header, so they inherit the rule: `N recorded` is a
+     * button. The `N open items` count needs none — the rows it counts
+     * are directly beneath it, which is the drill-down.
+     */
+    const worklist = read('features', 'dashboard', 'Worklist.tsx');
+    expect(worklist).toContain('recorded=1&property=');
+    // Asserted by POSITION rather than by one regex over JSX: an
+    // `onClick={() => ...}` contains a `>` of its own, so a `[^>]*`
+    // pattern fails on correct code — the fixed-window mistake in a new
+    // costume. The property is "the count sits inside a button".
+    const at = worklist.indexOf('{group.recorded}');
+    expect(at).toBeGreaterThan(-1);
+    const before = worklist.slice(0, at);
+    expect(before.lastIndexOf('<button')).toBeGreaterThan(before.lastIndexOf('</button>'));
   });
 
-  it('every tile carries a drill-down', () => {
-    // Counted over the grid rather than matched per element: a
-    // `<StatCard ... icon={<FileText />} ... />` closes its ICON first,
-    // so a non-greedy match ends before the props that matter. The first
-    // version of this pin did exactly that and failed on correct code.
-    const grid = DASH_CODE.slice(
-      DASH_CODE.indexOf('grid-cols-2 lg:grid-cols-4'),
-      DASH_CODE.indexOf('Create New Deed'));
-    const tiles = (grid.match(/<StatCard\b/g) || []).length;
-    const hrefs = (grid.match(/\bhref="/g) || []).length;
-    expect(tiles).toBe(4);
-    expect(hrefs).toBe(tiles);
-  });
 
-  it('the activity rows link to the deed', () => {
-    expect(DASH_CODE).toContain('?resume=${deed.id}');
-    expect(DASH_CODE).toContain('/past-deeds?focus=${deed.id}');
+
+  it('the worklist rows link to the deed', () => {
+    /**
+     * §16 — THE ORPHAN RULING OUTLIVING THE FEED IT WAS PINNED ON.
+     *
+     * "Recently worked on" is gone, so its rows are gone. The ruling —
+     * a row about a document lands on that document, never on a list
+     * where she has to find it again — now applies to the worklist, and
+     * is enforced server-side where the hrefs are built.
+     *
+     * DASH3 broke it twice before restoring it: once by copying a
+     * retired alias out of the module it replaced, and once by
+     * "fixing" that to the canonical tracker route, which satisfied the
+     * link contract and still landed her on a list.
+     */
+    expect(PY_WORKLIST).toContain('return f"/deeds/{deed_id}"');
+    expect(PY_WORKLIST).toContain('/deed-builder?resume=');
   });
 
   it('and those links land — the target reads them', () => {
@@ -142,22 +214,48 @@ describe('DASH1 — the feed says what it shows', () => {
     expect(flat(DASH)).toContain('Recently worked on');
   });
 
-  it('sorts by when something last happened to the deed', () => {
-    expect(DASH_CODE).toContain('const recentlyTouched');
-    expect(flat(DASH_CODE)).toContain('String(b.updated_at || b.created_at');
-    expect(DASH_CODE).toContain('recentlyTouched.slice(0, 5)');
+  it('§16 — the feed is GONE, and its ordering ruling went with it', () => {
+    /**
+     * DASH1 ruled the feed sorts by when something last HAPPENED to a
+     * deed rather than when it was created, because a creation-ordered
+     * list read as a completed-deeds feed while the Drafts counter said
+     * otherwise.
+     *
+     * DASH3 removes the feed: every row in it read *Prepared*, which is
+     * a list of finished work on a screen for unfinished work. It is the
+     * Past Deeds link now.
+     *
+     * **THE ORDERING RULING DOES NOT SURVIVE, AND THAT IS REPORTED
+     * RATHER THAN QUIETLY DROPPED.** It was a rule about the ordering of
+     * a module that no longer exists. Past Deeds has its own ordering
+     * and its own ruling; if a future reader wants last-touched ordering
+     * THERE, that is a new decision about a different screen, not this
+     * one inherited.
+     */
+    expect(DASH_CODE).not.toContain('recentlyTouched.slice(0, 5)');
+    // codeOnly: the removal is recorded in a COMMENT on the page, and
+    // an assertion that reads prose would fail on the note explaining
+    // the very removal it is checking for (§14.1 — the comment-trip).
+    expect(flat(DASH_CODE)).not.toContain('Recently worked on');
+    // And the replacement is named, so the capability is findable.
+    expect(DASH_CODE).toContain('/past-deeds');
   });
 });
 
 describe('DASH1 — "This Month" is gone', () => {
-  it('counts a rolling window instead of a calendar page', () => {
+  it('§16 — and so is the tile it was a correction to', () => {
+    /**
+     * DASH1 replaced a calendar-month counter with a rolling 30-day one,
+     * because "This Month" rendered a big zero on the first of every
+     * month for somebody whose work had not stopped.
+     *
+     * DASH3 removes the tile entirely. The ruling's INTENT — never
+     * report a number whose drop is an artefact of the calendar — has no
+     * subject on this screen any more, and is preserved as a prohibition
+     * rather than a fix: no monthly counter comes back.
+     */
     expect(DASH_CODE).not.toContain('label="This Month"');
-    expect(DASH_CODE).toContain('label="Last 30 days"');
-    expect(DASH_CODE).toContain('data.last_30_days');
-    // And the state field is not still called `month` while holding
-    // thirty days — a name that lies inside the component is the
-    // same defect one scope down.
-    expect(DASH_CODE).toContain('lastThirtyDays');
+    expect(DASH_CODE).not.toContain('label="Last 30 days"');
     expect(DASH_CODE).not.toMatch(/summary\?\.month/);
   });
 });

--- a/frontend/src/__tests__/dashboardWorklist.test.ts
+++ b/frontend/src/__tests__/dashboardWorklist.test.ts
@@ -1,0 +1,132 @@
+/**
+ * DASH3 — the rulings the redesign could undo without failing anything.
+ *
+ * Three of the owner's five rulings had no pin after the build: the
+ * hero's unit, the colour ruling, and the cut chip annotations. All three
+ * are the kind a later edit reverses while every gate stays green — the
+ * hero by growing a client-side `.reduce`, the colour by "matching the
+ * mockup", the annotations by being helpful. They are pinned here.
+ *
+ * The last two cases are not rulings but FAILURES this ticket produced
+ * and had to find twice over. Both are pinned so the next build cannot
+ * repeat them quietly.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
+
+const SRC = path.join(__dirname, '..');
+const read = (...p: string[]) => fs.readFileSync(path.join(SRC, ...p), 'utf8');
+
+const DASH = codeOnly(read('app', 'dashboard', 'page.tsx'));
+const WORKLIST = codeOnly(read('features', 'dashboard', 'Worklist.tsx'));
+const CHIPS = codeOnly(read('features', 'dashboard', 'StartSomethingNew.tsx'));
+
+describe('DASH3 ruling 2 — the hero counts rows, and the server counts them', () => {
+  it('reads the count rather than deriving one', () => {
+    /**
+     * The headline and the body are the same arithmetic, not two
+     * arithmetics that agree. `hero_count()` sums the groups the server
+     * sends and the page prints that number, so "3 things need you" over
+     * four rows is not a bug that can exist.
+     *
+     * A client-side sum is what makes it possible: it looks like the
+     * same number and diverges the first time the two filter differently
+     * — which is precisely how the accuracy figure and the queue came to
+     * disagree in DASH-FIX.
+     */
+    expect(DASH).toContain('worklist?.count');
+    // No second opinion about the count, in any of the shapes one takes.
+    expect(DASH).not.toMatch(/worklist[\s\S]{0,80}\.groups[\s\S]{0,80}reduce/);
+    expect(DASH).not.toMatch(/groups[\s\S]{0,60}\.items\.length/);
+  });
+
+  it('never prints a figure it did not receive', () => {
+    // Ruled before DASH3 and kept: an absent count is not zero. The
+    // count is read with `?? 0` and the ZERO branch renders words, not a
+    // numeral — so a queue that answered without a worklist cannot print
+    // "0 things need you" as though it had counted.
+    expect(DASH).toContain('worklistCount === 0');
+  });
+});
+
+describe('DASH3 ruling 4 — queue state is neutral, and said in words', () => {
+  it('spines carry no doctrinal colour', () => {
+    /**
+     * Amber is unconfirmed external data and violet is a proposed legal
+     * choice (docs/BRAND.md). The mockup spends both on queue state,
+     * which is the correction ADMIN-BRAND already made once. One mockup
+     * row lands on violet correctly — an unconfirmed exemption — and
+     * that is coincidence, not compliance.
+     */
+    const spine = WORKLIST.slice(WORKLIST.indexOf('const SPINE'),
+                                 WORKLIST.indexOf('export default'));
+    expect(spine).not.toMatch(/amber|violet|purple|yellow|red-|emerald/);
+    expect(spine).toMatch(/gray/);
+  });
+
+  it('says the state in words, so colour is never the only carrier', () => {
+    // The same rule the setup checklist got: a reader who cannot
+    // distinguish two greys still reads "Gone quiet".
+    expect(WORKLIST).toContain('{row.tag}');
+  });
+});
+
+describe('DASH3 ruling 5 — the chips do not annotate themselves', () => {
+  it('carries no "most used" or "N this year"', () => {
+    /**
+     * Cut by ruling: a strip for starting something new does not need to
+     * report her filing history back to her, and "1 this year" beside an
+     * instrument reads as a judgement of how little she has used it.
+     */
+    expect(CHIPS.toLowerCase()).not.toContain('most used');
+    expect(CHIPS).not.toMatch(/this year/i);
+  });
+});
+
+describe('DASH3 — the two failures this ticket found in itself', () => {
+  it('declares every hook before the first early return', () => {
+    /**
+     * FOUND BY `eslint`, WHICH IS NOT A GATE HERE.
+     *
+     * I first declared the greeting's `useState`/`useEffect` beside the
+     * markup that uses them, which is after `if (loading) return …`. The
+     * first paint then runs two fewer hooks than the second, and React
+     * tears the component down the moment the profile answers — a crash
+     * on the one screen every user lands on.
+     *
+     * tsc is blind to it. Jest is blind to it here, because these suites
+     * read source text rather than mounting through the transition.
+     * `react-hooks/rules-of-hooks` sees it, and `next.config` sets
+     * `eslint.ignoreDuringBuilds: true`, so nothing we run in CI would
+     * have stopped it. This pin is the control that survives that.
+     */
+    const body = DASH.slice(DASH.indexOf('export default function Dashboard'));
+    const firstReturn = body.search(/\n  if \([\s\S]{0,60}\) \{\n    return/);
+    expect(firstReturn).toBeGreaterThan(0);
+    const after = body.slice(firstReturn);
+    expect(after).not.toMatch(/\buseState\s*[(<]/);
+    expect(after).not.toMatch(/\buseEffect\s*\(/);
+  });
+
+  it('a failed deed list is a result of its own, above both empty ones', () => {
+    /**
+     * F4's ruling, which DASH3 nearly deleted as dead code.
+     *
+     * A failed `/deeds` load leaves the list empty, which makes
+     * `hasDeeds` false, which lands on "Nothing here yet." — the
+     * first-run welcome, shown to an officer whose documents merely
+     * failed to load. The error state's RENDERER had gone with the feed
+     * while the error itself was still being set, and an error that
+     * renders nothing is indistinguishable from having nothing.
+     *
+     * Pinned as ORDER rather than distance: the failure branch must be
+     * reached before either claim about her documents.
+     */
+    expect(DASH).toContain('deedsError ?');
+    const fail = DASH.indexOf('deedsError ?');
+    expect(fail).toBeGreaterThan(0);
+    expect(fail).toBeLessThan(DASH.indexOf('hasDeeds ?'));
+  });
+});

--- a/frontend/src/__tests__/deedDetailPage.test.ts
+++ b/frontend/src/__tests__/deedDetailPage.test.ts
@@ -35,6 +35,8 @@ const PAGE = codeOnly(read('app', 'deeds', '[id]', 'page.tsx'));
 const AGENDA = codeOnly(read('features', 'signing', 'SigningAgenda.tsx'));
 const PAST_DEEDS = codeOnly(read('app', 'past-deeds', 'page.tsx'));
 const DASHBOARD = codeOnly(read('app', 'dashboard', 'page.tsx'));
+const WORKLIST_PY = fs.readFileSync(
+  path.join(__dirname, '..', '..', '..', 'backend', 'services', 'worklist.py'), 'utf8');
 
 const PY = fs.readFileSync(
   path.join(SRC, '..', '..', 'backend', 'services', 'deed_page.py'), 'utf8');
@@ -266,13 +268,42 @@ describe('the orphan is resolved', () => {
   });
 
   it('the dashboard queue lands on the deed, not the tracker', () => {
-    expect(DASHBOARD).toContain('router.push(`/deeds/${r.deed_id}`)');
+    /**
+     * §16 — SAME RULING, ENFORCED ONE LANGUAGE OVER.
+     *
+     * DASH3 made every row's destination server-side, so the page now
+     * pushes whatever `href` it was handed and the decision lives where
+     * the rows are built. The dashboard is still the surface this ruling
+     * is about; `worklist.py` is the file that can break it.
+     *
+     * It broke twice inside DASH3 before this pin: once by copying
+     * `/signings?focus=` out of the module being replaced (a RETIRED
+     * alias, caught by `test_link_contract.py`), and once by correcting
+     * that to the canonical tracker route — which satisfied the link
+     * contract and landed her on a list, which is this defect exactly.
+     * Two pins, each blind to the other's subject, and the fix for one
+     * was the reintroduction of the other.
+     */
+    expect(DASHBOARD).toContain('onOpen={(href) => router.push(href)}');
+    expect(WORKLIST_PY).toContain('return f"/deeds/{deed_id}"');
+    /* The "never a retired alias" half is NOT asserted here. It lives in
+       `backend/tests/test_link_contract.py`, which strips Python comments
+       before looking — and this file cannot, because `codeOnly` reads
+       TypeScript. My first version asserted it anyway and tripped on the
+       COMMENT in `worklist.py` that explains the rule (§14.1: a pin that
+       reads raw text asserts the prose as well as the code). Duplicating
+       a pin into a language whose comments it cannot see is how a pin
+       starts failing for reasons unrelated to its subject. */
   });
 
   it('idle drafts still go straight to the builder', () => {
     // Deliberate: a draft has exactly one action, and the deed page
     // would offer that same action one navigation later.
-    expect(DASHBOARD).toContain('?resume=${r.id}`)');
+    //
+    // A COLLAPSED row of several drafts is the boundary — there is no
+    // single resume target, so it goes to the list where all of them are
+    // visible. Named rather than quietly widened.
+    expect(WORKLIST_PY).toContain('f"/deed-builder?resume={first.get(\'id\')}" if n == 1');
   });
 
   it("#178's Share fix is reachable — the dialog opens in place", () => {

--- a/frontend/src/__tests__/legitimacyBatch.test.ts
+++ b/frontend/src/__tests__/legitimacyBatch.test.ts
@@ -149,13 +149,31 @@ describe('X2.7 — findable rows', () => {
     expect(src).toContain('visibleDeeds.map');
   });
 
-  it('dashboard drafts read as needs-action with a labeled Continue', () => {
-    const src = readSource('app', 'dashboard', 'page.tsx');
-    expect(src).toContain('needsAction');
-    expect(src).toContain('border-amber-400');
-    expect(src).toMatch(/Continue\s*<ArrowRight/);
-    // Last-touched time, not created time.
-    expect(src).toContain('formatDate(deed.updated_at || deed.created_at)');
+  it('dashboard drafts read as needs-action with a labeled action', () => {
+    /**
+     * §16 — THE PROPERTY SURVIVES; THE MECHANISM IS SUPERSEDED.
+     *
+     * X2.7 ruled that a draft must not sit in a list looking like an
+     * archive entry: it needs a visible mark and a button that says what
+     * pressing it does. That was pinned as `border-amber-400` plus
+     * `Continue <ArrowRight`, which are the FORM the ruling took in a
+     * feed that no longer exists.
+     *
+     * Amber cannot come back on this surface: DASH3's colour ruling is
+     * that amber means unconfirmed external data and violet a proposed
+     * legal choice, and spending them on queue state is the correction
+     * ADMIN-BRAND already made once. So the mark is the row's TAG, in
+     * words, and the button carries a verb — which satisfies the ruling
+     * without the colour, and satisfies the reader who cannot separate
+     * two shades of amber either.
+     */
+    const worklist = readSource('features', 'dashboard', 'Worklist.tsx');
+    expect(worklist).toContain('{row.tag}');
+    expect(worklist).toContain('{row.primary}');
+    // The verbs themselves are the server's, and they are verbs.
+    const py = fs.readFileSync(path.join(__dirname, '..', '..', '..', 'backend',
+                                         'services', 'worklist.py'), 'utf8');
+    expect(py).toMatch(/primary="(Open|Finish|Archive)/);
   });
 });
 

--- a/frontend/src/__tests__/ux2Items.test.ts
+++ b/frontend/src/__tests__/ux2Items.test.ts
@@ -39,6 +39,8 @@ const DASHBOARD = read('app', 'dashboard', 'page.tsx');
 const PARTNERS = read('app', 'partners', 'page.tsx');
 const PY_QUEUE = fs.readFileSync(
   path.join(SRC, '..', '..', 'backend', 'services', 'officer_queue.py'), 'utf8');
+const WORKLIST_PY = fs.readFileSync(
+  path.join(SRC, '..', '..', 'backend', 'services', 'worklist.py'), 'utf8');
 
 // ── item 3 ───────────────────────────────────────────────────────────
 
@@ -77,15 +79,41 @@ describe('two numbers, two claims, each named', () => {
   });
 
   it('the dashboard headline says something narrower', () => {
-    expect(DASHBOARD).toContain('gone');
-    expect(DASHBOARD).toContain('quiet');
-    // And it stops using the phrase that named nothing — everything on
-    // that page could be said to need her attention.
+    /**
+     * §16 — WHERE THIS RULING WENT.
+     *
+     * "Gone quiet" was the dashboard's own wording. DASH3 moved every
+     * sentence on this screen to the server (§13 rule 3), so the words
+     * are now `worklist.chase_row`'s tag and the screen renders them. The
+     * ruling is unchanged and the file that has to satisfy it moved.
+     *
+     * The prohibition stays where it always was: the screen must never
+     * go back to naming a population it cannot define.
+     */
+    expect(WORKLIST_PY).toContain('Gone quiet');
     expect(DASHBOARD).not.toContain('your attention');
   });
 
   it('the threshold comes from the payload, not from the screen', () => {
-    expect(DASHBOARD).toContain('queue.thresholds.stale_after_days');
+    /**
+     * SATISFIED MORE STRONGLY THAN IT WAS PINNED. The screen used to
+     * read `queue.thresholds.stale_after_days` in order to phrase the
+     * headline itself. It no longer phrases anything: staleness is
+     * decided and worded server-side, and the page cannot consult a
+     * threshold because it never sees one.
+     *
+     * So the pin becomes the property rather than the reading: no
+     * threshold arithmetic happens on this screen at all.
+     *
+     * Pinned as the READING, not the word. `stale_after_days` still
+     * appears on this screen — inside the `Queue` TYPE, because the
+     * payload still carries it for other readers — and a pin that
+     * forbade the noun would fail on a declaration that describes the
+     * server's shape rather than on any use of it (§14.1: the property,
+     * not the spelling). What must not exist is the screen READING it.
+     */
+    expect(DASHBOARD).not.toMatch(/queue\??\.thresholds/);
+    expect(DASHBOARD).not.toMatch(/thresholds\.\w/);
   });
 });
 

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -4,23 +4,16 @@ import type React from "react"
 import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import Sidebar from "../../components/Sidebar"
-import { AIGreeting } from "@/components/ui/AIGreeting"
+import { getTimeGreeting } from "@/components/ui/AIGreeting"
 import { AuthManager } from "@/utils/auth"
 import EmailVerificationNotice from "@/features/account/EmailVerificationNotice"
-import AccuracySection from "@/features/dashboard/AccuracySection"
-import ResumeCard from "@/features/dashboard/ResumeCard"
 import StartSomethingNew from "@/features/dashboard/StartSomethingNew"
+import Worklist from "@/features/dashboard/Worklist"
 import SetupChecklist, { activeStep } from "@/features/dashboard/SetupChecklist"
 import DayOneRail from "@/features/dashboard/DayOneRail"
-import { pickInProgressDeed } from "@/lib/latestDraft"
-import { authoringStateLabel, LAST_WORKED_ON } from "@/lib/authoringState"
-import { deedTypeLabel } from "@/lib/deedTypes"
 import { SessionExpiredError, apiFetch } from "@/lib/apiClient"
-import { 
-  FileText, Clock, CheckCircle, Send, 
-  TrendingUp, Activity, Download, Share2, 
-  ArrowRight, Sparkles, Eye
-} from "lucide-react"
+// The tile/feed icons went with the tiles and the feed.
+import { Sparkles } from "lucide-react"
 
 /**
  * DASH1 — WHAT IS WAITING ON SOMEBODY.
@@ -41,6 +34,10 @@ type Queue = {
      and a stored provenance block, and the instrument order comes from
      her own filing history. Neither is derivable here. */
   accuracy?: import('@/features/dashboard/AccuracySection').Accuracy;
+  /* DASH3 — the rows the screen renders, and the count it prints.
+     Both come from the server so the headline cannot disagree with the
+     body it sits above. */
+  worklist?: import('@/features/dashboard/Worklist').Worklist;
   instruments?: Array<{ deed_type: string; count: number; period: string }>;
   upcoming: Array<{ kind: string; id: number; deed_id: number; property: string | null;
                     when: string; who: string | null; summary: string }>;
@@ -74,19 +71,38 @@ export default function Dashboard() {
     businessAddress?: string | null; plan?: string | null; deedCount: number;
   } | null>(null)
   const [recentDeeds, setRecentDeeds] = useState<any[]>([])
+  /* F4's ruling, and it needed rescuing during DASH3 rather than after:
+     a failed `/deeds` load leaves `recentDeeds` empty, which makes
+     `hasDeeds` false, which lands on "Nothing here yet." — a first-run
+     welcome shown to an officer whose documents merely failed to load.
+     That is the exact bug F4 fixed, and removing the renderer would have
+     reintroduced it silently, because an error that renders nothing looks
+     identical to a user who has nothing. §4: never swallowed. */
   const [deedsError, setDeedsError] = useState<string | null>(null)
-  const [summary, setSummary] = useState<{
-    total: number
-    completed: number
-    drafts: number
-    lastThirtyDays: number
-  } | null>(null)
+  /* The greeting, demoted onto the headline. Kept — U3 ruled the page
+     should say what it IS — but it no longer takes two lines above the
+     work.
+
+     Set in an effect, like `AIGreeting` does, because the hour is a
+     CLIENT fact: computing it during render makes the server and the
+     browser disagree whenever a deploy straddles noon.
+
+     DECLARED WITH THE OTHER HOOKS, not beside the markup that uses it.
+     I first wrote these two next to the headline they feed, which put
+     them after `if (loading) return …` — so the first paint ran two
+     fewer hooks than the second and React tears the component down the
+     moment the profile answers. tsc is blind to it and the suites read
+     source text rather than mounting through the transition; `eslint`'s
+     rules-of-hooks is the control that sees it, which is the argument
+     for running the linter as a gate and not as tidying. */
+  const [greetingLine, setGreetingLine] = useState('')
   const router = useRouter()
 
-  /* THE DOCUMENT SHE WAS LAST IN, and it is the accuracy list's first
-     row rather than a second query: the server already ordered those by
-     most-recently-touched, so asking again would be a second opinion
-     about which document is hers to resume. */
+  useEffect(() => {
+    const when = new Date().toLocaleDateString(undefined,
+      { weekday: 'long', month: 'long', day: 'numeric' })
+    setGreetingLine(`${getTimeGreeting()}, ${userName} · ${when}`)
+  }, [userName])
 
   // Authentication check and load user data
   useEffect(() => {
@@ -156,47 +172,13 @@ export default function Dashboard() {
     checkAuth()
   }, [router])
 
-  // Fetch dashboard summary stats
-  useEffect(() => {
-    if (!isAuthenticated) return
-
-    ;(async () => {
-      try {
-        // X1: loud failures — apiFetch toasts non-2xx and handles 401.
-        const res = await apiFetch(`/deeds/summary`, {}, { label: "Loading dashboard summary" })
-
-        if (res.ok) {
-          const data = await res.json()
-          setSummary({
-            total: data.total || 0,
-            completed: data.completed || 0,
-            drafts: data.drafts || 0,
-            lastThirtyDays: data.last_30_days ?? data.month ?? 0,
-          })
-        } else {
-          // Fallback: calculate from deeds list
-          const list = await apiFetch(`/deeds`, {}, { label: "Loading deeds", silent: true })
-          if (list.ok) {
-            const data = await list.json()
-            const deeds = Array.isArray(data.deeds) ? data.deeds : []
-            const thirtyDaysAgo = new Date(Date.now() - 30 * 86400_000)
-            setSummary({
-              total: deeds.length,
-              completed: deeds.filter((d: any) => d.status === "completed").length,
-              drafts: deeds.filter((d: any) => d.status !== "completed").length,
-              // Fallback path: 30 days back, matching the endpoint it is
-              // standing in for rather than the calendar it used to use.
-              lastThirtyDays: deeds.filter((d: any) => d.created_at
-                && new Date(d.created_at) >= thirtyDaysAgo).length,
-            })
-          }
-        }
-      } catch (e) {
-        if (e instanceof SessionExpiredError) return
-        console.error("Failed to load dashboard summary:", e)
-      }
-    })()
-  }, [isAuthenticated])
+  /* The `/deeds/summary` fetch lived here and went with the tiles it
+     fed — including its fallback, which re-requested the whole deed list
+     to recompute four counters client-side. Nothing renders those
+     counters now, so keeping the request would be two calls per load in
+     support of a number nobody sees. DASH1's rolling-30-day ruling
+     survives it only as a prohibition (no calendar-month counter comes
+     back), which is pinned in `dashboardQueue.test.ts`. */
 
   // The queue. Its own state and its own error, because a failed queue
   // must not blank a page of real deeds and a failed deed list must not
@@ -262,38 +244,12 @@ export default function Dashboard() {
   }
 
   const hasDeeds = recentDeeds.length > 0
-  // U1.2: the LAST-TOUCHED draft (updated_at desc), not the first draft in
-  // a created_at-ordered list — that offered users their oldest work back.
-  const inProgressDeed = pickInProgressDeed(recentDeeds)
+  /* U1.2's last-touched draft was the resume card's subject. The card
+     is gone and the worklist decides what is next by consequence, so
+     `pickInProgressDeed` has no caller HERE — it keeps its own tests and
+     its other callers, and this is a removed call site, not a removed
+     rule. */
 
-  /* ═══ ONE POPULATION, AND THE CHECKS ARE AN ATTRIBUTE OF IT ═══
-
-     #203 ruled the resume target is the accuracy list's first row, and
-     that stands wherever the list has one. What it could not rule on —
-     because the pre-#203 card was quietly covering the case — is the
-     document she was last in that has NOTHING outstanding. It is absent
-     from the accuracy list by construction, so the ruled card went dark
-     and the unruled one spoke.
-
-     So the fallback is the last-touched open draft with an empty check
-     list, which is additive rather than a re-ruling: the accuracy row
-     still wins whenever it exists. */
-  const resumeTarget = queue?.accuracy?.items?.length
-    ? queue.accuracy.items[0]
-    : inProgressDeed
-      ? {
-          deed_id: inProgressDeed.id,
-          deed_type: inProgressDeed.deed_type ?? null,
-          property: inProgressDeed.property_address ?? null,
-          escrow_no: null,
-          checks: [],
-        }
-      : null
-  // DASH1: by when something last happened to it, drafts included —
-  // which is what "recent activity" claimed and creation order is not.
-  const recentlyTouched = [...recentDeeds].sort((a: any, b: any) =>
-    String(b.updated_at || b.created_at || '').localeCompare(
-      String(a.updated_at || a.created_at || '')))
 
   /* The rail exists to explain the steps, so it goes when they do —
      §13 rule 3: the page does not recompute "is setup finished", it
@@ -301,6 +257,13 @@ export default function Dashboard() {
      returning null IS "setup is done", and there is no second way to
      ask. */
   const setupIncomplete = !!setup && activeStep(setup) !== null
+
+  /* DASH3 — the hero's unit is ROWS, and the server counts them.
+     Read rather than derived: `worklist.count` is `hero_count(groups)`
+     over the groups rendered below, so the headline and the body are
+     the same arithmetic rather than two arithmetics that agree. */
+  const worklist = queue?.worklist
+  const worklistCount = worklist?.count ?? 0
 
   return (
     <div className="flex bg-gray-50 min-h-screen">
@@ -312,23 +275,36 @@ export default function Dashboard() {
               product is gated on the answer. */}
           <EmailVerificationNotice verified={account.verified} email={account.email} />
 
-          {/* ═══ THE GREETING MOVED UP, AND IS NOT A HERO ═══
+          {/* ═══ THE HEADLINE IS THE COUNT, AND THE GREETING RIDES ON IT ═══
 
-              The day-one mockup puts it first and small. It was sitting
-              below three cards, which is neither.
+              DASH3. The greeting took two lines of its own above a page
+              of cards; it now sits to the right of the number, which is
+              the thing she came for.
 
-              WHAT DID NOT CHANGE, AND IS FLAGGED: the line under it.
-              "Keep as drawn: the one-line greeting" read literally
-              deletes "Here's where your deeds stand" — and that sentence
-              is U3's ruling, added deliberately so the greeting states
-              what the page IS rather than making a chat-style promise
-              with no chat behind it. The mockup's complaint is that the
-              greeting was a HERO, which is about weight and position,
-              and both of those are fixed here. Deleting a ruled sentence
-              on the strength of a phrase about size is the half I am not
-              deciding. */}
-          <div className="mb-6">
-            <AIGreeting userName={userName} />
+              THE NUMBER IS NOT COMPUTED HERE. `worklist.count` comes
+              from the server, where `hero_count()` sums the same groups
+              rendered below — so "3 things need you" and three rows
+              cannot disagree. A hero that recounts client-side agrees by
+              diligence; this one agrees by construction.
+
+              AND IT NEVER RENDERS A FIGURE IT DID NOT RECEIVE: until the
+              queue lands, the headline says what it is doing rather than
+              showing a zero that would read as "you're clear". */}
+          <div className="mb-5 flex flex-wrap items-baseline gap-x-4 gap-y-1">
+            <h1 className="text-[26px] font-bold tracking-tight text-gray-900">
+              {queueError
+                ? "Your queue didn't load"
+                : !queue
+                  ? 'Loading your queue…'
+                  : worklistCount === 0
+                    ? "You're clear"
+                    : worklistCount === 1
+                      ? '1 thing needs you'
+                      : `${worklistCount} things need you`}
+            </h1>
+            <p className="ml-auto text-[13px] text-gray-400">
+              {greetingLine}
+            </p>
           </div>
 
           {/* ═══ FINISH SETTING UP ═══
@@ -358,640 +334,142 @@ export default function Dashboard() {
             </div>
           )}
 
-          {/* THE MOCKUP'S ORDER, AND IT IS AN ARGUMENT: resume is the
-              highest-frequency action in a preparation tool, so it sits
-              above everything, with the remaining checks NAMED. */}
-          {/* ROUGH — `items-start`. Without it these two stretch to the
-              taller of them, so a short resume card is padded out to
-              match the catalog beside it. The audit reported this as a
-              "dead band under 2 of 3 done" and located it one row up, at
-              the checklist grid — which already carries `items-start`
-              and whose ~68px is ordinary card padding. An auditor sees a
-              symptom and places it approximately; this is where it is. */}
-          <div className="mb-6 grid gap-4 lg:grid-cols-[2fr,1fr] items-start">
-            <ResumeCard
-              target={resumeTarget}
-              onResume={(id) => router.push(`/deed-builder/grant-deed?resume=${id}`)}
-            />
-            <StartSomethingNew
-              instruments={queue?.instruments}
-              muted={setupIncomplete}
-              onStart={(t) => router.push(`/deed-builder/${t}`)}
-              onBrowse={() => router.push('/create-deed')}
-            />
-          </div>
+          {/* ═══ START SOMETHING NEW, AS A CHIP STRIP ═══
+              Above the divider, so it reads as "jump in, or clear your
+              queue" rather than as a panel competing with the work. */}
+          <StartSomethingNew
+            instruments={queue?.instruments}
+            onStart={(t) => router.push(`/deed-builder/${t}`)}
+            onBrowse={() => router.push('/create-deed')}
+          />
 
-          {/* The promise, made countable. */}
-          <div className="mb-8">
-            <AccuracySection
-              accuracy={queue?.accuracy}
-              onOpen={(id) => router.push(`/deeds/${id}`)}
-            />
-          </div>
+          {/* ═══ THE QUEUE IS THE WHOLE BODY ═══
 
-          {/* ═══ THE PRE-#203 RESUME CARD, DELETED ═══
+              WHAT WAS REMOVED HERE, and each was ruled: the four stat
+              tiles (counts now live in each group header, in the same
+              unit as the hero); the green Create New Deed bar (the chip
+              strip and the sidebar carry it); "Recently worked on" (every
+              row read *Prepared* — it is the Past Deeds link now); the
+              green all-clear banner and the three-column "What's waiting"
+              split, both folded into the queue.
 
-              "You have a deed in progress. Continue where you left off?"
-              — a sparkle, no property named, no checks, drawing from a
-              THIRD population (`pickInProgressDeed(recentDeeds)`).
+              THE RESUME CARD WENT WITH THEM, and that is #203's ruling
+              surviving its source rather than being dropped: it ruled
+              the resume target is the accuracy list's FIRST ROW, because
+              that list was what existed. With rows as the unit, the
+              first your-turn row IS the resume — same intent, new home,
+              and it is now one press instead of a card above the work.
 
-              #203 replaced it with ResumeCard, which names the document
-              and the remaining checks and draws a thumbnail from that
-              same list. Both shipped. An audit saw only this one,
-              because ResumeCard returns null when the accuracy list is
-              empty and that account's was — so the ruled card was
-              absent and the pre-ruling card filled the space.
-
-              A pre-ruling component still rendering under a post-ruling
-              one is the AIEmptyState shape exactly, and it goes the same
-              way. The capability it carried — resuming a draft with
-              nothing outstanding — did not go with it; ResumeCard now
-              takes that case (see `resumeTarget` above). */}
-
-          {/* DASH1 — THE QUEUE LEADS. What is waiting on somebody comes
-              before what has been made, because that is the order she
-              works in. */}
-          <ActionQueue queue={queue} error={queueError} hasDeeds={hasDeeds} />
-
-          {/* Stats Grid — DASH1: every tile is a LINK now. A count with
-              no drill-down is trivia: "4 Drafts" that cannot be pressed
-              tells her a number and makes her go and find the four. */}
-          {hasDeeds && (
-            <div className="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
-              <StatCard
-                label="Total Deeds"
-                value={summary?.total ?? 0}
-                icon={<FileText className="w-5 h-5" />}
-                color="purple"
-                href="/past-deeds"
-              />
-              <StatCard
-                label="Drafts"
-                value={summary?.drafts ?? 0}
-                icon={<Clock className="w-5 h-5" />}
-                color="yellow"
-                href="/past-deeds?status=draft"
-              />
-              {/* DASH1: "This Month" is gone. It rendered a big zero on
-                  the first of every month for a user whose work had not
-                  stopped — the counter told her she had done nothing when
-                  what happened is that a calendar page turned. The admin
-                  surface already carries a paragraph apologising for the
-                  same framing; this is the honest version it settled on. */}
-              <StatCard
-                label="Last 30 days"
-                value={summary?.lastThirtyDays ?? 0}
-                icon={<TrendingUp className="w-5 h-5" />}
-                color="blue"
-                /* This pointed at the unfiltered list, so the tile
-                   counting 10 recent deeds and the tile counting all 10
-                   deeds were the same click with the same result — and
-                   Past Deeds' own docstring calls that "the dead-button
-                   defect wearing a URL". */
-                href="/past-deeds?since=30"
-              />
-              <StatCard
-                label="Completed"
-                value={summary?.completed ?? 0}
-                icon={<CheckCircle className="w-5 h-5" />}
-                color="green"
-                href="/past-deeds?status=completed"
-              />
+              THREE RESULTS, NOT TWO. A failed load, an empty board and a
+              first morning are different things and say so — collapsing
+              the last two would reverse #206, which is why
+              `open_documents` exists. */}
+          {queueError ? (
+            <div role="alert"
+                 className="rounded-2xl border border-red-200 bg-white p-6 text-center">
+              <p className="font-medium text-red-700">Couldn&apos;t load your queue</p>
+              <p className="mt-1 text-sm text-gray-500">{queueError}</p>
             </div>
-          )}
-
-          {/* Create New Deed Button (Always visible) */}
-          {hasDeeds && (
-            <button
-              onClick={() => router.push('/deed-builder')}
-              className="w-full mb-8 bg-gradient-to-r from-emerald-500 to-emerald-600 hover:from-emerald-600 hover:to-emerald-700 text-white rounded-xl p-4 font-semibold transition-all flex items-center justify-center gap-3 shadow-lg shadow-emerald-500/20"
-            >
-              <Sparkles className="w-5 h-5" />
-              Create New Deed
-            </button>
-          )}
-
-          {/* Recent Activity, load error, or Empty State */}
-          {deedsError ? (
-            <div className="bg-white rounded-2xl shadow-sm border border-red-200 p-8 text-center">
-              <p className="text-red-700 font-medium mb-1">Couldn&apos;t load your deeds</p>
-              <p className="text-sm text-gray-500 mb-4">{deedsError}</p>
-              <button
-                onClick={() => fetchRecentDeeds()}
-                className="px-5 py-2 bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-semibold rounded-lg transition-colors"
-              >
-                Retry
+          ) : !queue ? (
+            /* NOT an empty state. The queue has not answered yet, and
+               rendering "you're clear" here would be a claim we do not
+               have — §4 in the one place a reader would never question
+               it. */
+            <p className="px-1 py-8 text-sm text-gray-400">Loading what needs you…</p>
+          ) : worklistCount > 0 ? (
+            <>
+              <Worklist worklist={worklist} onOpen={(href) => router.push(href)} />
+              <div className="mt-4 flex flex-wrap items-center gap-3 rounded-2xl border
+                              border-dashed border-gray-200 bg-white px-4 py-3.5 text-[13px]
+                              text-gray-500">
+                <b className="font-semibold text-gray-700">That&apos;s everything.</b>
+                <button type="button" onClick={() => router.push('/past-deeds')}
+                        className="ml-auto font-semibold text-[var(--color-brand)]
+                                   underline-offset-2 hover:underline">
+                  Past deeds →
+                </button>
+              </div>
+            </>
+          ) : deedsError ? (
+            /* A FAILED LIST IS NOT AN EMPTY ONE (F4). Ordered above both
+               empty results deliberately: "clear" and "day one" are
+               claims about her documents, and we do not know what her
+               documents are. */
+            <div role="alert"
+                 className="rounded-2xl border border-red-200 bg-white p-6 text-center">
+              <p className="font-medium text-red-700">Couldn&apos;t load your deeds</p>
+              <p className="mt-1 text-sm text-gray-500">{deedsError}</p>
+              <button type="button" onClick={() => fetchRecentDeeds()}
+                      className="mt-4 text-[13px] font-semibold text-[var(--color-brand)]
+                                 underline-offset-2 hover:underline">
+                Try again
               </button>
             </div>
           ) : hasDeeds ? (
-            <div className="bg-white rounded-2xl shadow-sm border border-gray-200 overflow-hidden">
-              {/* DASH1 — "RECENT ACTIVITY" WAS SORTED BY CREATION.
-                  `GET /deeds` orders by `created_at DESC`, so a draft
-                  edited this morning sat below five deeds made last week
-                  and never touched since. The feed was "recently made",
-                  labelled "recently happened" — and because completed
-                  deeds cluster at the top of a creation-ordered list, it
-                  read as a completed-deeds feed while the Drafts counter
-                  said otherwise.
-                  Two fixes, not one: it sorts by when something last
-                  HAPPENED to the deed, and every row now links to it. */}
-              <div className="p-4 md:p-6 border-b border-gray-100">
-                <div className="flex items-center gap-2">
-                  <Activity className="w-5 h-5 text-emerald-600" />
-                  <h3 className="text-lg font-bold text-gray-900">Recently worked on</h3>
-                </div>
-              </div>
-              <div className="divide-y divide-gray-100">
-                {recentlyTouched.slice(0, 5).map((deed: any) => (
-                  <DeedRow key={deed.id} deed={deed} />
-                ))}
-              </div>
+            /* CLEAR — a RESULT. She has documents and none of them needs
+               her, which is a good morning and is said out loud rather
+               than left as a blank page she has to interpret. */
+            <div className="rounded-2xl border border-gray-200 bg-white px-6 py-12 text-center">
+              <div className="mx-auto mb-3 flex h-11 w-11 items-center justify-center
+                              rounded-full bg-[var(--color-brand-light)]
+                              text-[var(--color-brand)]">✓</div>
+              <h3 className="text-lg font-bold tracking-tight text-gray-900">
+                Nothing needs you.
+              </h3>
+              <p className="mt-1 text-[13.5px] text-gray-500">
+                No document is waiting on you, and nobody is waiting on a reply.
+              </p>
+              <button type="button" onClick={() => router.push('/past-deeds')}
+                      className="mt-4 text-[13px] font-semibold text-[var(--color-brand)]
+                                 underline-offset-2 hover:underline">
+                Past deeds →
+              </button>
             </div>
-          ) : null /* ═══ THE WELCOME CARD AND ITS FOUR BULLETS, DELETED
-              ═══
+          ) : (
+            /* DAY ONE — a DIFFERENT result, and the distinction is #206's.
+               She has made nothing, so there is nothing to be clear of;
+               the checklist is the work. */
+            <div className="rounded-2xl border border-gray-200 bg-white px-6 py-12 text-center">
+              <h3 className="text-lg font-bold tracking-tight text-gray-900">
+                Nothing here yet.
+              </h3>
+              <p className="mt-1 text-[13.5px] text-gray-500">
+                Your first document will appear here, with whatever it still needs.
+              </p>
+            </div>
+          )}
 
-              OWNER-RULED, from `docs/design/dashboard_day_one.html`,
-              whose annotation makes the argument better than a comment
-              can: "a welcome banner can't notice anything", and four
-              bullets describing what the product does are landing-page
-              copy shown to somebody who has already signed up.
-
-              What she is left with on day one is the thing that acts:
-              `StartSomethingNew` offers the catalog, and the greeting
-              says where she is. Nothing here now claims a state.
-
-              Note for whoever builds the setup checklist: THIS is where
-              it goes. The gap is deliberate and it is the right shape —
-              a list derived from state, not a banner. */}
         </div>
       </main>
     </div>
   )
 }
 
-/**
- * DASH1 — the action queue.
+/* ═══ §16 — WHAT WAS REMOVED WITH THE LAYOUT, AND WHAT SURVIVED ═══
  *
- * THREE LISTS, NOT ONE PILE. "Chase somebody", "be somewhere" and
- * "finish something" are different actions, and merging them makes her
- * sort them by hand every morning.
+ * `ActionQueue`, `QueueList`, `StatCard` and `DeedRow` lived here. Their
+ * render sites went when the worklist became the body; the renderers did
+ * not, and for one build this file held two dashboards — one reachable,
+ * one not. Nothing failed: tsc does not flag an unreferenced function and
+ * the suites only assert what renders. §14.5 again, in its own file:
+ * checking that a change is right is not checking what depended on it.
  *
- * THE EMPTY STATE IS A RESULT, NOT AN ABSENCE. An honest empty queue is
- * a good morning — the screen says so rather than rendering nothing and
- * letting her wonder whether it loaded.
+ * The rulings those modules carried did not go with them:
+ *   · THE QUEUE LEADS — satisfied maximally; there is nothing left for it
+ *     to lead. Pinned now as "the worklist IS the body".
+ *   · EVERY COUNT GOES SOMEWHERE — moved to the group header's
+ *     `N recorded` button, which is a real drill-down.
+ *   · THE EMPTY STATE IS A RESULT — kept, as three explicit branches
+ *     below rather than one collapsed absence.
+ *   · ABSENCES NAMED BY KIND, "Prepared" not "Completed", stuck-marking,
+ *     the hero never rendering a figure it did not receive — all kept,
+ *     server-side in `services/worklist.py`.
+ *
+ * One did NOT survive, and is reported rather than dropped quietly:
+ *   · THE FEED'S LAST-TOUCHED ORDERING (DASH1). "Recently worked on" is
+ *     gone, so an ordering rule for it has no subject. It is not
+ *     re-homed onto the worklist — the worklist orders by consequence,
+ *     which is a different rule that would swallow it while looking like
+ *     compliance. Recorded here so the removal is a decision on the
+ *     record and not an omission.
  */
-function ActionQueue({ queue, error, hasDeeds }: {
-  queue: Queue | null; error: string | null; hasDeeds: boolean;
-}) {
-  const router = useRouter()
-
-  if (error) {
-    // §4: a queue we could not load says so. Rendering the empty state
-    // would tell her nothing is waiting, which is a claim about her work
-    // rather than about our request.
-    return (
-      <div className="mb-8 rounded-2xl border border-red-200 bg-red-50 p-4">
-        <p className="font-semibold text-red-800">Couldn&apos;t load what&apos;s waiting</p>
-        <p className="mt-1 text-sm text-red-700">{error}</p>
-      </div>
-    )
-  }
-  if (!queue) return null
-
-  const empty =
-    queue.upcoming.length === 0 &&
-    queue.awaiting.length === 0 &&
-    queue.idle_drafts.length === 0
-
-  // ═══ A GUARANTEED-EMPTY QUEUE IS NOT AN EMPTY QUEUE ═══
-  //
-  // Same ruling as AccuracySection's, and the same reasoning: an officer
-  // who has never made a deed cannot have a signing, an unanswered
-  // request or an idle draft, so "nothing is waiting on anyone" tells
-  // her nothing about her work and reads as a result she earned.
-  //
-  // ── AND HERE IS THE HALF I AM NOT DECIDING ──
-  //
-  // The ruling said this module "goes". Read literally that deletes the
-  // empty card for EVERYONE, including the returning officer whose
-  // queue is genuinely clear — and for her the sentence is the DASH1
-  // ruling working as intended: "the empty state is a RESULT, not an
-  // absence", the screen saying so rather than rendering nothing and
-  // leaving her to wonder whether it loaded.
-  //
-  // Both readings deliver the stated intent, which was about the new
-  // officer. Only the literal one also removes ruled behaviour from a
-  // case the mockup does not cover — its own returning-state section
-  // draws a POPULATED queue, so the drawing does not settle it either.
-  //
-  // So the day-one half is built and the returning half is HELD. If the
-  // card should go outright, it is this condition and nothing else.
-  if (empty && !hasDeeds) return null
-
-  return (
-    <section className="mb-8" aria-label="What's waiting">
-      <div className="flex items-center justify-between mb-3">
-        <h2 className="text-lg font-bold text-gray-900">What&apos;s waiting</h2>
-        {/* ONE NUMBER, and it means something. Not "there are rows
-            below" — a signing booked for Thursday needs nothing from
-            her. It is the requests that have gone quiet. */}
-        {queue.needs_attention > 0 && (
-          <span className="inline-flex items-center gap-1.5 rounded-full bg-amber-100 px-3 py-1 text-sm font-semibold text-amber-900">
-            {/* UX2 item 4 — THIS NUMBER SAYS SOMETHING NARROWER THAN THE
-                SIDEBAR BADGES, and now says so.
-
-                "Needs your attention" is true of everything on this
-                page, so it named nothing. This count is the STALE
-                unanswered requests — the ones that have gone quiet —
-                which is the number that means "nobody is waiting on me
-                and nobody has gone silent" when it is zero.
-
-                The threshold rides on the payload so no screen retypes
-                it (DASH1). */}
-            {queue.needs_attention} {queue.needs_attention === 1 ? 'has' : 'have'} gone
-            quiet — no answer in {queue.thresholds.stale_after_days}+ days
-          </span>
-        )}
-      </div>
-
-      {empty ? (
-        <div className="rounded-2xl border border-gray-200 bg-white p-6">
-          <p className="font-medium text-gray-900">Nothing is waiting on anyone.</p>
-          <p className="mt-1 text-sm text-gray-500">
-            No signings in the next {queue.thresholds.upcoming_days} days, no unanswered
-            requests, and no drafts left sitting.
-          </p>
-        </div>
-      ) : (
-        /* ROUGH — `items-start`, and it is one class for ~300px of
-           white. All three columns stretched to the tallest, so an empty
-           "Signing in the next 7 days" holding one sentence was padded
-           out to match a column holding five rows.
-
-           NOT hidden: DASH1 ruled the empty state is a RESULT, not an
-           absence, and the card still says its sentence. It just stops
-           taking a third of the row to say it. */
-        <div className="grid gap-4 lg:grid-cols-3 items-start">
-          <QueueList
-            title={`Signing in the next ${queue.thresholds.upcoming_days} days`}
-            emptyNote="Nothing booked this week."
-            rows={queue.upcoming.map((r) => ({
-              key: `up-${r.id}`,
-              title: r.property || `Deed #${r.deed_id}`,
-              // The server's sentence, verbatim (§13 rule 3).
-              detail: r.summary,
-              meta: `${new Date(r.when).toLocaleString('en-US', {
-                weekday: 'short', month: 'short', day: 'numeric',
-                hour: 'numeric', minute: '2-digit',
-              })}${r.who ? ` · ${r.who}` : ''}`,
-              urgent: false,
-              // DEEDDETAIL: the deed, not the tracker. The queue's job is
-              // "what needs me"; the answer to "and then what" is the
-              // deed page's state-and-next-action, which the tracker
-              // cannot show because it is a cross-deed list.
-              onOpen: () => router.push(`/deeds/${r.deed_id}`),
-            }))}
-          />
-          <QueueList
-            title="Waiting on a reply"
-            emptyNote="Everyone has answered."
-            rows={queue.awaiting.map((r) => ({
-              key: `aw-${r.kind}-${r.id}`,
-              title: r.property || `Deed #${r.deed_id}`,
-              detail: r.summary,
-              meta: `${r.who || 'Unnamed'} · ${
-                r.days_waiting === null ? 'waiting'
-                  : r.days_waiting === 0 ? 'sent today'
-                  : `${r.days_waiting} day${r.days_waiting === 1 ? '' : 's'}`
-              }`,
-              urgent: r.stale,
-              // Both kinds land on the same page, because from here the
-              // question is the same one: what is happening on this deed
-              // and what do I do about it. Which table the delay lives in
-              // is our problem, not hers.
-              onOpen: () => router.push(`/deeds/${r.deed_id}`),
-            }))}
-          />
-          <QueueList
-            title={`Untouched for ${queue.thresholds.idle_draft_days}+ days`}
-            emptyNote="No forgotten drafts."
-            rows={queue.idle_drafts.map((r) => ({
-              key: `id-${r.id}`,
-              title: r.property || `Deed #${r.id}`,
-              /* FOUR IDENTICAL CARDS. An audit found four of these at
-                 one address, byte-for-byte the same — same title, same
-                 sentence, same "16 days" — opening four different
-                 drafts. She had to click one to learn which it was.
-                 The row now carries what actually DIFFERS between them:
-                 the instrument and the document number. */
-              detail: `${deedTypeLabel(r.deed_type)} · Doc #${r.id} — `
-                    + 'nobody is waiting on this but you.',
-              meta: r.days_idle === null ? 'untouched' : `${r.days_idle} days`,
-              urgent: false,
-              // Deliberately NOT the deed page. A draft has exactly one
-              // action and the deed page would only offer that same
-              // action one navigation later — a hop that buys nothing.
-              onOpen: () => router.push(
-                `/deed-builder/${r.deed_type || 'grant-deed'}?resume=${r.id}`),
-            }))}
-            /* THE REMEDY LIVES ON THE OTHER PAGE. Past Deeds already
-               offers "Archive the N older" over exactly these drafts
-               (`lib/staleDrafts.ts`), and this screen flagged them stale
-               while offering nothing. Linked rather than reimplemented:
-               a second implementation of an archive action is a second
-               opinion about which drafts are superseded. */
-            footer={queue.idle_drafts.length
-              ? { label: 'Archive older drafts', onClick: () => router.push('/past-deeds?status=draft') }
-              : null}
-          />
-        </div>
-      )}
-    </section>
-  )
-}
-
-type QueueRow = {
-  key: string
-  title: string
-  detail: string
-  meta: string
-  urgent: boolean
-  onOpen: () => void
-}
-
-function QueueList({ title, rows, emptyNote, footer = null }: {
-  title: string
-  rows: QueueRow[]
-  emptyNote: string
-  /** An action that belongs to the whole column rather than a row. */
-  footer?: { label: string; onClick: () => void } | null
-}) {
-  return (
-    <div className="rounded-2xl border border-gray-200 bg-white overflow-hidden">
-      <div className="border-b border-gray-100 px-4 py-3">
-        <h3 className="text-sm font-semibold text-gray-700">{title}</h3>
-      </div>
-      {rows.length === 0 ? (
-        <p className="px-4 py-4 text-sm text-gray-500">{emptyNote}</p>
-      ) : (
-        <ul className="divide-y divide-gray-100">
-          {rows.slice(0, 5).map((r) => (
-            <li key={r.key}>
-              {/* EVERY ROW LINKS TO THE THING ITSELF. A queue that tells
-                  her something is stuck and then makes her go and find it
-                  is a list of chores, not a queue. */}
-              <button
-                onClick={r.onOpen}
-                className={`w-full px-4 py-3 text-left hover:bg-gray-50 transition-colors ${
-                  r.urgent ? 'border-l-4 border-amber-400' : ''
-                }`}
-              >
-                <p className="font-medium text-gray-900 truncate">{r.title}</p>
-                <p className="text-sm text-gray-600 truncate">{r.detail}</p>
-                <p className={`text-xs mt-0.5 ${r.urgent ? 'text-amber-700 font-medium' : 'text-gray-400'}`}>
-                  {r.meta}
-                </p>
-              </button>
-            </li>
-          ))}
-        </ul>
-      )}
-      {footer && rows.length > 0 && (
-        <button
-          type="button"
-          onClick={footer.onClick}
-          className="w-full border-t border-gray-100 px-4 py-2.5 text-left text-sm
-                     font-semibold text-[#7C4DFF] hover:bg-gray-50"
-        >
-          {footer.label}
-        </button>
-      )}
-    </div>
-  )
-}
-
-// Stat Card Component
-function StatCard({
-  label,
-  value,
-  icon,
-  color,
-  href,
-}: {
-  label: string
-  value: number | string
-  icon: React.ReactNode
-  color: "blue" | "yellow" | "green" | "purple"
-  /** DASH1: a count with no drill-down is trivia. Required rather than
-   * optional — a tile added later without one would silently be the
-   * thing this ticket removed. */
-  href: string
-}) {
-  const router = useRouter()
-  const colorClasses = {
-    blue: "bg-blue-50 text-blue-600",
-    yellow: "bg-amber-50 text-amber-600",
-    green: "bg-emerald-50 text-emerald-600",
-    purple: "bg-violet-50 text-violet-600",
-  }
-
-  return (
-    <button
-      onClick={() => router.push(href)}
-      className="w-full text-left bg-white rounded-xl border border-gray-200 p-4 hover:shadow-md hover:border-gray-300 transition-all"
-    >
-      <div className="flex items-center gap-3 mb-3">
-        <div className={`p-2 rounded-lg ${colorClasses[color]}`}>{icon}</div>
-        <span className="text-sm text-gray-500">{label}</span>
-      </div>
-      <div className="flex items-baseline gap-2">
-        <span className="text-2xl font-bold text-gray-900">{value}</span>
-        <ArrowRight className="w-4 h-4 text-gray-300" />
-      </div>
-    </button>
-  )
-}
-
-// Deed Row Component
-function DeedRow({ deed }: { deed: any }) {
-  const router = useRouter()
-
-  // pdf_url is a backend-relative authenticated path — window.open can't
-  // reach it; fetch the stored PDF as a blob like Past Deeds does.
-  const handleDownload = async () => {
-    try {
-      // X1: loud failures — apiFetch toasts non-2xx and handles 401.
-      const response = await apiFetch(`/deeds/${deed.id}/download`, {}, { label: `Downloading deed #${deed.id}` })
-      if (!response.ok) throw new Error("Download failed")
-      const blob = await response.blob()
-      const url = window.URL.createObjectURL(blob)
-      const a = document.createElement("a")
-      a.href = url
-      a.download = `${deed.deed_type || "Deed"}_${deed.id}.pdf`
-      document.body.appendChild(a)
-      a.click()
-      window.URL.revokeObjectURL(url)
-      document.body.removeChild(a)
-    } catch (err) {
-      if (err instanceof SessionExpiredError) return
-      console.error("Download error:", err)
-    }
-  }
-
-  const getStatusStyle = (status: string) => {
-    switch (status?.toLowerCase()) {
-      case 'completed':
-        return 'bg-emerald-100 text-emerald-700'
-      case 'draft':
-      case 'in_progress':
-        return 'bg-amber-100 text-amber-700'
-      case 'shared':
-      case 'pending':
-        return 'bg-blue-100 text-blue-700'
-      default:
-        return 'bg-gray-100 text-gray-700'
-    }
-  }
-
-  const getStatusIcon = (status: string) => {
-    switch (status?.toLowerCase()) {
-      case 'completed':
-        return <CheckCircle className="w-3 h-3" />
-      case 'draft':
-      case 'in_progress':
-        return <Clock className="w-3 h-3" />
-      case 'shared':
-      case 'pending':
-        return <Send className="w-3 h-3" />
-      default:
-        return <FileText className="w-3 h-3" />
-    }
-  }
-
-  const formatDeedType = (type: string) => {
-    return type
-      ?.replace(/_/g, ' ')
-      ?.replace(/-/g, ' ')
-      ?.split(' ')
-      ?.map(word => word.charAt(0).toUpperCase() + word.slice(1))
-      ?.join(' ') || 'Deed'
-  }
-
-  const formatDate = (date: string) => {
-    if (!date) return ''
-    const d = new Date(date)
-    const now = new Date()
-    const diffMs = now.getTime() - d.getTime()
-    const diffHours = Math.floor(diffMs / (1000 * 60 * 60))
-    const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24))
-    
-    if (diffHours < 1) return 'Just now'
-    if (diffHours < 24) return `${diffHours}h ago`
-    if (diffDays === 1) return 'Yesterday'
-    if (diffDays < 7) return `${diffDays} days ago`
-    return d.toLocaleDateString()
-  }
-
-  const needsAction = deed.status === 'draft' || deed.status === 'in_progress'
-
-  return (
-    // X2.7: drafts read as "needs action" at a glance — amber edge + a
-    // labeled Continue button, not an unexplained arrow.
-    /* ROUGH — THE ROW STACKS BELOW `sm`, and stacking is the only
-       remedy that exists. The right-hand cluster is `flex-shrink-0` and
-       every item in it is already at its minimum, so there is nothing
-       to shrink: at 390px the title and parties line was left roughly
-       60px of the ~240px it needs, which truncates "Grant Deed - 1358
-       5th St" to about four characters.
-
-       NOTARYPHONE1's principle decides the priority. The officer is at a
-       desk most of the time and on a phone at a client's table or
-       between appointments — and the surfaces nobody complains about are
-       the ones that break. A row truncated to four characters is not
-       degraded, it is unusable. */
-    <div className={`p-4 hover:bg-gray-50 transition-colors flex flex-col sm:flex-row sm:items-center justify-between gap-3 sm:gap-4 ${
-      needsAction ? 'border-l-4 border-amber-400' : ''
-    }`}>
-      {/* DASH1: THE ROW LINKS TO THE DEED. A feed of things she has
-          worked on, where pressing one does nothing, is a list of
-          reminders that she owns some deeds. A draft opens where the
-          work is; a finished one opens focused in Past Deeds — there is
-          still no deed detail route (ledgered as DEEDDETAIL), so this
-          uses the same `?focus=` pattern the Signings agenda does. */}
-      <button
-        onClick={() => router.push(
-          needsAction
-            ? `/deed-builder/${deed.deed_type || 'grant-deed'}?resume=${deed.id}`
-            : `/past-deeds?focus=${deed.id}`)}
-        className="flex items-center gap-4 min-w-0 flex-1 text-left"
-      >
-        <div className="w-10 h-10 rounded-lg bg-gray-100 flex items-center justify-center flex-shrink-0">
-          <FileText className="w-5 h-5 text-gray-500" />
-        </div>
-        <div className="min-w-0">
-          <p className="font-medium text-gray-900 truncate">
-            {formatDeedType(deed.deed_type)} {deed.property_address ? `- ${deed.property_address}` : ''}
-          </p>
-          <p className="text-sm text-gray-500 truncate">
-            Doc #{deed.id} • {deed.grantor_name || 'Draft'} → {deed.grantee_name || '...'}
-          </p>
-        </div>
-      </button>
-
-      <div className="flex items-center gap-3 flex-shrink-0 pl-14 sm:pl-0">
-        {/* DASH-FIX #3 — this rendered `{deed.status}` RAW, so the badge
-            showed the database's own token and a generated document read
-            "completed" while its signing sat unanswered in the queue
-            below. `deeds.status` is AUTHORING state; one place turns it
-            into English now. */}
-        <span className={`inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium ${getStatusStyle(deed.status)}`}>
-          {getStatusIcon(deed.status)}
-          {authoringStateLabel(deed.status)}
-        </span>
-        {/* DASH-FIX #5 — the date is `updated_at`, which is correct for a
-            module called "Recently worked on" and is NOT what Past Deeds
-            shows. A bare date invites a reader to compare two different
-            facts, so it carries its name. */}
-        <span className="text-sm text-gray-400 hidden sm:block">
-          {LAST_WORKED_ON} {formatDate(deed.updated_at || deed.created_at)}
-        </span>
-        
-        {/* Actions */}
-        <div className="flex items-center gap-1">
-          {deed.status === 'completed' && deed.pdf_url && (
-            <button
-              onClick={handleDownload}
-              aria-label="Download deed PDF"
-              className="p-2 hover:bg-gray-100 rounded-lg transition-colors text-gray-400 hover:text-gray-600"
-              title="Download PDF"
-            >
-              <Download className="w-4 h-4" />
-            </button>
-          )}
-          {/* FLOW1 item 2: the share icon that used to sit here is
-              DELETED. It carried a Share2 glyph and the hover title
-              "Share from Past Deeds", and it did not share — it routed
-              to /past-deeds and left her to find the row again and press
-              a different button. An icon that means "share" attached to
-              an act that means "navigate" is the twins problem in
-              miniature: the affordance and the outcome disagree.
-
-              Deleted rather than wired up, per the ruling's "prefer
-              deleting". Wiring it would mean mounting both share modals
-              and a PartnersProvider on the dashboard — a third surface
-              for two flows, on a page whose job is a glance. */}
-          {needsAction && (
-            <button
-              onClick={() => router.push(`/deed-builder/${deed.deed_type || 'grant-deed'}?resume=${deed.id}`)}
-              className="flex items-center gap-1 px-3 py-1.5 bg-amber-100 hover:bg-amber-200 text-amber-800 rounded-lg transition-colors text-sm font-medium"
-              title="Continue this draft"
-            >
-              Continue
-              <ArrowRight className="w-3.5 h-3.5" />
-            </button>
-          )}
-        </div>
-      </div>
-    </div>
-  )
-}

--- a/frontend/src/components/ui/AIGreeting.tsx
+++ b/frontend/src/components/ui/AIGreeting.tsx
@@ -7,7 +7,10 @@ interface AIGreetingProps {
   className?: string
 }
 
-function getTimeGreeting(): string {
+/** Exported for DASH3: the dashboard headline carries the greeting now,
+ *  and a second copy of "before noon it is morning" is a second opinion
+ *  about what time it is (§14.3). */
+export function getTimeGreeting(): string {
   const hour = new Date().getHours()
   if (hour < 12) return "Good morning"
   if (hour < 17) return "Good afternoon"

--- a/frontend/src/features/dashboard/StartSomethingNew.tsx
+++ b/frontend/src/features/dashboard/StartSomethingNew.tsx
@@ -3,6 +3,19 @@
  *
  * ═══ WHY NOT ALPHABETICALLY ═══
  *
+ * DASH3 — A 40px CHIP STRIP, NOT A 200px CARD. It sits above the
+ * divider so it reads as "jump in, or clear your queue" rather than as a
+ * panel competing with the work. The card form made starting something
+ * new look equal in weight to the queue, on a screen whose whole purpose
+ * is the queue.
+ *
+ * AND THE USE ANNOTATIONS ARE CUT (owner-ruled). "most used" and
+ * "1 this year" were the only statistics left in a design whose purpose
+ * is removing statistics — and a frequency label on a two-item strip is
+ * decoration, not orientation. The ORDER still carries the same fact:
+ * her most-filed instrument is first, which is the useful half of what
+ * the label said.
+ *
  * The catalog is 21 California instruments and an officer files three of
  * them. Alphabetical order puts an affidavit she has never filed above
  * the grant deed she files weekly; her own frequency puts her next
@@ -22,6 +35,7 @@
 'use client';
 
 import { deedTypeLabel } from '@/lib/deedTypes';
+import { INSTRUMENT_COUNT } from '@/lib/formRegistry';
 
 export interface InstrumentUse {
   deed_type: string;
@@ -32,64 +46,44 @@ export interface InstrumentUse {
 /** The types offered when she has filed nothing yet. */
 export const STARTERS = ['grant-deed', 'interspousal-transfer', 'quitclaim-deed'];
 
-export default function StartSomethingNew({ instruments, onStart, onBrowse, muted = false }: {
+export default function StartSomethingNew({ instruments, onStart, onBrowse }: {
   instruments?: InstrumentUse[] | null;
   onStart?: (deedType: string) => void;
   onBrowse?: () => void;
-  /**
-   * ONE VIOLET CALL TO ACTION PER SCREEN.
-   *
-   * While the setup checklist is on the page it owns the accent, because
-   * it holds the thing to do next. This card stays grey and becomes
-   * primary the moment the checklist unmounts — which is not a taste
-   * decision but the budget: a second violet control means neither is
-   * "the one thing", and the officer has to choose which prominent
-   * button to believe.
-   */
-  muted?: boolean;
 }) {
   const used = instruments ?? [];
-  const rows = used.length
+  const rows = (used.length
     ? used
-    : STARTERS.map((deed_type) => ({ deed_type, count: 0, period: '' }));
+    : STARTERS.map((deed_type) => ({ deed_type, count: 0, period: '' }))
+  ).slice(0, 2);
 
   return (
     <section aria-labelledby="start-heading"
-             data-muted={muted ? 'true' : undefined}
-             className={`rounded-xl border bg-white p-5 ${
-               muted ? 'border-slate-200' : 'border-[#E4DDFF] ring-1 ring-[var(--color-brand-light)]'}`}>
-      <h3 id="start-heading" className="font-semibold text-slate-900">
-        Start something new
+             className="mb-6 flex flex-wrap items-center gap-2 border-b border-gray-200 pb-5">
+      <h3 id="start-heading"
+          className="mr-1 text-[11.5px] font-bold uppercase tracking-[0.075em] text-gray-400">
+        Jump into
       </h3>
-      <ul className="mt-3 space-y-2">
-        {rows.map((row, i) => (
-          <li key={row.deed_type}>
-            <button
-              type="button"
-              onClick={() => onStart?.(row.deed_type)}
-              className="flex w-full items-center justify-between rounded-lg border border-slate-200 px-3 py-2 text-left text-sm"
-            >
-              {/* UX2 item 3's vocabulary, on the surface it had not reached.
-                  This rendered `grant-deed` and `affidavit-death-jt` —
-                  our storage keys, which she never chose — two clicks
-                  from a screen that says "Grant Deed". */}
-              <span className="text-slate-800">{deedTypeLabel(row.deed_type)}</span>
-              <span className="text-xs text-slate-500">
-                {/* "most used" only where it is TRUE — the top row of a
-                    list she has actually filed from. On day one there is
-                    no most-used and claiming one would be a fact
-                    invented out of an empty table. */}
-                {row.count > 0
-                  ? (i === 0 ? 'most used' : `${row.count} ${row.period}`)
-                  : ''}
-              </span>
-            </button>
-          </li>
-        ))}
-      </ul>
+      {rows.map((row) => (
+        <button
+          key={row.deed_type}
+          type="button"
+          onClick={() => onStart?.(row.deed_type)}
+          className="inline-flex items-center rounded-full border border-gray-200 bg-white
+                     px-3.5 py-1.5 text-[13.5px] font-semibold text-gray-700 shadow-sm
+                     transition hover:border-[#C9BCFB] hover:text-[var(--color-brand-hover)]"
+        >
+          {/* UX2 item 3's vocabulary, on the surface it had not reached.
+              This rendered `grant-deed` and `affidavit-death-jt` — our
+              storage keys, which she never chose. */}
+          {deedTypeLabel(row.deed_type)}
+        </button>
+      ))}
       <button type="button" onClick={onBrowse}
-              className="mt-3 text-sm text-[#7C4DFF] underline underline-offset-2">
-        Browse all 21 California instruments
+              className="inline-flex items-center rounded-full border border-dashed
+                         border-gray-300 px-3.5 py-1.5 text-[13.5px] font-medium text-gray-500
+                         transition hover:bg-white">
+        All {INSTRUMENT_COUNT} California instruments →
       </button>
     </section>
   );

--- a/frontend/src/features/dashboard/Worklist.tsx
+++ b/frontend/src/features/dashboard/Worklist.tsx
@@ -1,0 +1,204 @@
+/**
+ * The queue as the whole body — DASH3.
+ *
+ * ═══ WHAT THIS REPLACES, AND WHY ═══
+ *
+ * Four stat tiles, a green "Create New Deed" bar, "Recently worked on",
+ * a green all-clear banner and a three-column "What's waiting" split.
+ * Every DASH ticket added or corrected a module and none removed a
+ * category, so the screen accumulated into a metrics dashboard for a
+ * reader who opens it to find the next task. Metrics dashboards answer
+ * "how am I doing?"; a worklist answers "what's next?".
+ *
+ * ═══ ONE UNIT ON THE SCREEN ═══
+ *
+ * The hero counts ROWS and each group header counts ROWS. "3 things need
+ * you" over three rows is a promise the screen keeps; a headline counting
+ * fields above a header counting documents is two units on one surface,
+ * which is what DASH-FIX spent itself killing.
+ *
+ * The number is not computed here. `worklist.count` arrives from the
+ * server, where `hero_count()` sums the same groups this renders — so the
+ * headline and the body cannot disagree, rather than agreeing by
+ * coincidence and diligence.
+ *
+ * ═══ COLOUR IS NEUTRAL, DELIBERATELY (owner-ruled) ═══
+ *
+ * The design gives amber spines to "waiting" and violet to "your turn".
+ * Both are DOCTRINAL colours — amber is unconfirmed external data, violet
+ * is a proposed legal choice (docs/BRAND.md) — and repurposing them as
+ * queue-state colour is precisely the correction ADMIN-BRAND already
+ * made once. One mockup row lands on violet correctly (an unconfirmed
+ * transfer-tax exemption) and that is coincidence, not compliance.
+ *
+ * So queue state is carried by NEUTRAL spines and by the tag's words.
+ * Status never rides on colour alone here for the same reason it never
+ * did on the setup checklist.
+ */
+'use client';
+
+export interface WorklistRow {
+  kind: 'chase' | 'you' | 'stale';
+  band: number;
+  tag: string;
+  age: string;
+  title: string;
+  doc: string;
+  say: string;
+  sub: string;
+  primary: string;
+  secondary: string;
+  href: string;
+  deed_id: number | null;
+  deed_ids: number[];
+  property: string;
+  county: string;
+  sort_age: number | null;
+}
+
+export interface WorklistGroup {
+  property: string;
+  county: string;
+  /** ROWS in this group — the same unit the hero counts. */
+  open: number;
+  /** Documents on this property the officer has RECORDED.
+   *  Server-side this reads `recorded_at IS NOT NULL`, never
+   *  `status = 'completed'` — see `services/worklist.py`. */
+  recorded: number;
+  items: WorklistRow[];
+}
+
+export interface Worklist {
+  groups: WorklistGroup[];
+  count: number;
+}
+
+/** Neutral, per the colour ruling. The KIND is said in words. */
+const SPINE: Record<WorklistRow['kind'], string> = {
+  chase: 'bg-gray-400',
+  you: 'bg-gray-700',
+  stale: 'bg-gray-200',
+};
+
+const TAG: Record<WorklistRow['kind'], string> = {
+  chase: 'bg-gray-100 text-gray-700',
+  you: 'bg-gray-900 text-white',
+  stale: 'bg-gray-50 text-gray-500',
+};
+
+export default function Worklist({ worklist, onOpen }: {
+  worklist?: Worklist | null;
+  onOpen?: (href: string) => void;
+}) {
+  // NOT an empty state here. "You're clear" and "you have not started"
+  // are different results and the page decides which it is holding —
+  // collapsing them would reverse #206, and `open_documents` exists to
+  // tell them apart.
+  if (!worklist || !worklist.groups.length) return null;
+
+  return (
+    <div className="space-y-3.5">
+      {worklist.groups.map((group) => (
+        <section key={`${group.property}-${group.county}`}
+                 aria-label={group.property}
+                 className="rounded-2xl border border-gray-200 bg-white overflow-hidden">
+          <header className="flex flex-wrap items-center gap-3 border-b border-gray-100
+                             bg-gradient-to-b from-white to-gray-50/70 px-4 py-3 md:px-5">
+            <h3 className="text-[14.5px] font-bold tracking-tight text-gray-900">
+              {group.property}
+            </h3>
+            {group.county && (
+              <span className="text-xs font-medium text-gray-400">{group.county}</span>
+            )}
+            {/* COUNTS ROWS, and says so. The unit is named rather than
+                left to be inferred from a number beside a heading. */}
+            {/* EVERY COUNT GOES SOMEWHERE — DASH1's ruling, surviving the
+                tiles it was written for. "A count with no drill-down is
+                trivia: '4 Drafts' that cannot be pressed tells her a
+                number and makes her go and find the four." The tiles are
+                gone; these are the counts that replaced them, so these
+                are the counts that have to be pressable.
+
+                The open count needs none: the rows it counts are
+                directly below it. */}
+            <div className="ml-auto flex items-center gap-2 text-xs text-gray-500">
+              <span>{group.open === 1 ? '1 open item' : `${group.open} open items`}</span>
+              {group.recorded > 0 && (
+                <>
+                  <span aria-hidden>·</span>
+                  {/* "Recorded" is the officer's own statement, never a
+                      rendered PDF. The count comes from `recorded_at`. */}
+                  <button type="button"
+                          onClick={() => onOpen?.(
+                            `/past-deeds?recorded=1&property=${encodeURIComponent(group.property)}`)}
+                          className="underline decoration-gray-300 underline-offset-2
+                                     transition hover:text-[var(--color-brand)]">
+                    {group.recorded} recorded
+                  </button>
+                </>
+              )}
+            </div>
+          </header>
+
+          <ol>
+            {group.items.map((row, i) => (
+              <li key={`${row.kind}-${row.deed_id}-${i}`}
+                  className="flex gap-3.5 border-t border-gray-100 py-4 pr-4 first:border-t-0 md:pr-5">
+                <span aria-hidden
+                      className={`w-1 shrink-0 rounded-r ${SPINE[row.kind]}`} />
+                <div className="min-w-0 flex-1">
+                  <div className="mb-1.5 flex flex-wrap items-center gap-2">
+                    <span className={`rounded px-1.5 py-0.5 text-[10.5px] font-bold
+                                      uppercase tracking-wider ${TAG[row.kind]}`}>
+                      {row.tag}
+                    </span>
+                    {row.age && <span className="text-xs text-gray-400">{row.age}</span>}
+                  </div>
+                  <div className="text-[15px] font-semibold tracking-tight text-gray-900">
+                    {row.title}
+                    {row.doc && (
+                      <span className="ml-1.5 text-[13px] font-normal text-gray-400">
+                        {row.doc}
+                      </span>
+                    )}
+                  </div>
+                  {/* ONE SENTENCE. The server composes it (§13 rule 3);
+                      this screen does not get a second opinion about
+                      what a state means. */}
+                  <p className="mt-0.5 text-[13.5px] leading-relaxed text-gray-700">
+                    {row.say}
+                  </p>
+                  {row.sub && (
+                    <p className="mt-1 break-words text-[12.5px] leading-relaxed text-gray-400">
+                      {row.sub}
+                    </p>
+                  )}
+                </div>
+                <div className="flex shrink-0 items-start gap-2 pt-0.5">
+                  {row.secondary && (
+                    <button type="button"
+                            onClick={() => onOpen?.(row.href)}
+                            className="rounded-lg border border-gray-200 bg-white px-3 py-1.5
+                                       text-[12.5px] font-semibold text-gray-700
+                                       transition hover:bg-gray-50">
+                      {row.secondary}
+                    </button>
+                  )}
+                  <button type="button"
+                          onClick={() => onOpen?.(row.href)}
+                          className="rounded-lg bg-[var(--color-brand)] px-3.5 py-1.5
+                                     text-[12.5px] font-semibold text-white shadow-sm
+                                     transition hover:bg-[var(--color-brand-hover)]
+                                     focus-visible:outline focus-visible:outline-2
+                                     focus-visible:outline-offset-2">
+                    {row.primary}
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ol>
+        </section>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
The queue is now the whole body. Every actionable thing is one row, rows group by property, groups order by consequence, and `services/worklist.py` assembles them server-side so the headline and the body are the same arithmetic rather than two arithmetics that agree.

## The five rulings, as built

**1 — Consequence-first ordering.** `blocked → yours → nobody waiting`, as data (`BAND_CHASE = 0`), so the ordering is not a comparator somebody has to keep in sync with the copy. The design's "ranked cheapest-to-clear first" annotation is superseded and marked as such in the module, so nobody re-derives cheapest-first from a file in our own repository. Within a band, longest silence first; an unknown age sorts last.

**2 — Rows are the hero's unit.** `hero_count()` sums the groups the page renders, and the group header counts rows too, with the unit named ("3 open items"). The two populations survive as what makes a row appear and what the row says — never as the headline number. `ready_row` is the row the old hero could not count: every field confirmed, nothing printed, zero contribution to "N fields need your eyes", and the readiest work she had.

**3 — The §16 list.** Below.

**4 — Colour is fixed, not adopted.** Neutral spines; the kind is said in words. Amber is unconfirmed external data and violet a proposed legal choice, and spending them on queue state is the correction ADMIN-BRAND already made once.

**5 — The chip annotations are cut.**

**The recording pin.** Any count of recorded documents reads `recorded_at IS NOT NULL`, never `status = 'completed'`. Asserted against the query rather than a fixture — a fixture proves what the numbers do; this proves where they come from.

## §16 — what the redesign removed, and where each ruling went

| Ruling | Outcome |
|---|---|
| The queue leads | Satisfied maximally — nothing left for it to lead |
| Every count goes somewhere | Moved to the group header's `N recorded` button |
| The empty state is a result | Kept, now as four explicit branches |
| Absences named by kind, "Prepared" not "Completed", the hero never printing a figure it did not receive | Kept, server-side |
| The three-column split | Superseded by owner-supplied design; the reason survives as banded ordering plus per-kind words |
| One status vocabulary | Satisfied by subtraction — the dashboard now speaks none |
| #203's resume fallback | Dissolved: with rows as the unit, `ready_row` makes that document visible instead of a card the screen reconstructed |
| The orphan ruling (land on the deed) | Kept, enforced where the hrefs are now built |
| **The feed's last-touched ordering** | **Does not survive.** Its subject is gone and it is deliberately not re-homed onto the worklist's consequence order — that is a different rule wearing compliance |

Fourteen pins across six suites broke on the removal. None was deleted; each is recorded in place with where its ruling went.

## Four defects found during the build, none of them in the design

**a. A render crash on the one screen everybody lands on.** The greeting's `useState`/`useEffect` went in beside the markup that uses them, which is after `if (loading) return …`. First paint runs two fewer hooks than the second, and React tears the component down the moment the profile answers. tsc is blind to it; jest is blind to it here because these suites read source text rather than mounting through the transition. `eslint`'s `react-hooks/rules-of-hooks` sees it — and `next.config.js` sets `eslint.ignoreDuringBuilds: true`, so **nothing we run in CI would have stopped it.** Now pinned.

**b. F4's ruling was one deletion from being reversed.** The redesign removed the renderer of `deedsError` while the error was still being set. A failed `/deeds` load then leaves the list empty → `hasDeeds` false → "Nothing here yet.", the first-run welcome, shown to an officer whose documents merely failed to load. I found it while deleting the state as dead. An error that renders nothing is indistinguishable from having nothing, which is what makes this class invisible.

**c. Two pins whose fixes were each other's defect.** Row hrefs copied from the module being replaced used `/signings?focus=` — a retired alias kept for mail already sent — caught by `test_link_contract.py`. Correcting them to the canonical tracker route satisfied that contract and broke the orphan ruling, because the canonical tracker is still a tracker. The deed page answers both.

**d. The renderers outlived their render sites.** `ActionQueue`, `QueueList`, `StatCard` and `DeedRow` stayed in `page.tsx`, unreferenced, for one build — 450 lines of a second, unreachable dashboard.

## Self-review

**Premises checked, and what was found.** The collision check came back clean. The premise that did not hold was my own: I assumed removing render sites removed the modules. It did not, and no gate reports an unreachable one.

**Pins changed, and in which direction.** Fourteen re-pointed, all toward the property and away from the expression — three now assert order where they asserted distance or a literal, four moved to the file that can now break them, two became prohibitions. Seven added. One negative was **removed rather than re-pointed**: the "never a retired alias" check does not belong in a TypeScript suite that cannot strip Python comments, and my first version tripped on the comment explaining the rule. It lives in `test_link_contract.py`, which strips properly.

**Least sure about.** Whether the group header's `N recorded` button carries DASH1's "every count goes somewhere" ruling as well as the tiles did. It is a real drill-down and it lands, but it is one count where there were four, and I am asserting a ruling is preserved by a surface much smaller than the one it was written for.

**What I would cut if forced.** The `That's everything.` footer under a populated worklist. It is the least load-bearing thing on the screen.

**Anything decided rather than flagged.** One boundary, and it is named in the code and in a test rather than left implicit: a *collapsed* row of several idle drafts goes to the draft list, not to the builder, because there is no single resume target. The single-draft case keeps the ruling exactly.

## Gates

pytest **1581** with DB / **1370 + 211 skipped** without · jest **1139** · tsc **88** · `next build` clean · banned-claims clean · S1, S3, six-flow and API baselines green (S2 refuses without an artifact store, as designed). Every new pin mutation-probed; the probe is what found the unknown-age pin passing with its own rule deleted.

## Doctrine

§14.5 gains a **fourth habitat** — a file — and the general shape under all four: what goes unchecked is never the subject of the change, it is the change's neighbourhood. §14.1.1 gains a **third symptom**: a pin can assert the right property, in the right words, with the ruling named in its docstring, and still pass against a fixture incapable of distinguishing it. Unlike the first two symptoms it is invisible to reading, and is found only by running the code with the rule removed. The duplicated `§14.5` heading from #232 is collapsed to one declaration.

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_