### PR TITLE
ESLINT1 — turn the disabled gate back on

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,6 +131,41 @@ jobs:
       working-directory: frontend
       run: npx jest --ci
 
+  eslint-gate:
+    # ESLINT1 — the gate that was turned OFF, not the gate we lacked.
+    #
+    # DASH3's build produced a hooks-after-early-return defect: a render
+    # crash on the one screen every user lands on. Nothing we run caught
+    # it. `tsc` does not model hook ordering, and the frontend suites read
+    # SOURCE TEXT rather than mounting through the state transition — which
+    # is most of our frontend coverage, by design.
+    #
+    # `react-hooks/rules-of-hooks` catches it exactly. It was enabled, at
+    # error severity, in a linter `next build` runs by default, and
+    # `next.config.js` said `eslint.ignoreDuringBuilds: true`.
+    #
+    # A DISABLED GATE IS WORSE THAN A MISSING ONE: the repository looked
+    # equipped. Every part of that control was real except its firing.
+    #
+    # The gate is a ceiling rather than a hard zero because 136 of the
+    # violations pre-date it and 104 are `no-explicit-any` — style debt,
+    # not a defect class. A build that suddenly fails on old style debt is
+    # a gate everyone re-disables, which is how the flag got set. The rules
+    # that catch DEFECTS are pinned at zero separately, so they never
+    # compete with an unescaped apostrophe for the same budget.
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+    - working-directory: frontend
+      run: npm ci
+    - name: eslint ceiling, defect rules at zero, and the floor
+      working-directory: frontend
+      # No `|| true`. The script owns the comparison and exits 1 itself.
+      run: node scripts/eslint-gate.mjs
+
   tsc-baseline:
     # RED-H1.1: was `tsc-report`, `continue-on-error: true`, with a comment
     # claiming "116 known pre-existing errors" against a baseline that has

--- a/docs/DOCTRINE_CONFORMANCE.md
+++ b/docs/DOCTRINE_CONFORMANCE.md
@@ -1250,6 +1250,69 @@ it means *reaches the person who can act*.
 
 ---
 
+### §14.9 — A disabled gate is worse than a missing one (2026-08-20, owner-ruled)
+
+**Statement.** A control that exists, is correctly configured, and is
+switched off is more dangerous than one that was never built. A missing
+control is visible as an absence — someone eventually asks why we do not
+lint. A disabled one answers that question wrongly: the rule is in the
+config, at the right severity, in a tool the build runs. **The repository
+looks equipped.**
+
+**The instance.** DASH3 declared two hooks after an early return, so the
+first paint ran fewer hooks than the second and React tears the component
+down when the profile answers — a render crash on the dashboard, the one
+screen every user lands on. Every gate we run missed it:
+
+  · `tsc` does not model hook ordering. Nothing about the types is wrong.
+  · The frontend suites read SOURCE TEXT rather than mounting through the
+    state transition. That is deliberate and mostly right — it is how one
+    decision avoids being made twice across two languages — and it means
+    the majority of our frontend coverage cannot see a runtime ordering
+    bug at all.
+  · `next build` runs eslint by default, and
+    `react-hooks/rules-of-hooks` was enabled at error severity by
+    `next/core-web-vitals` the whole time.
+
+`next.config.js` said `eslint.ignoreDuringBuilds: true`.
+
+**What the history said, and it matters.** The flag was not set on
+principle after weighing linting. It was born with the file, in a commit
+that also carried `typescript.ignoreBuildErrors: true` and a commented-out
+rewrite labelled *"temporarily disabled to fix build issue"*. **A flag set
+to unblock a deploy and a flag set on principle are different objects, and
+only one of them was ever revisited.** Neither was — but the first has no
+argument behind it to overcome, which is why the history is worth reading
+before the argument is had.
+
+**The general shape.** Ask of any control: *has this ever fired?* A gate
+with no failure in its history is either protecting something nothing
+violates, or is not running. Those look identical from the outside and are
+distinguished only by making it fail on purpose — which is the same
+instrument as the mutation probe, applied to the gate rather than the pin.
+
+**Why the fix is a ceiling and not the flag.** Flipping
+`ignoreDuringBuilds` alone fails every build on 136 pre-existing
+violations, 104 of them `no-explicit-any` — style debt, not a defect
+class. **A build that suddenly fails on old style debt is a gate everyone
+re-disables**, which is precisely how the flag came to be written. So the
+enforcement is `tsc-baseline`'s shape (frozen at N, only goes down) with
+one addition tsc did not need: the rules that catch DEFECTS are pinned at
+ZERO *independently of the ceiling*, because a shared budget between "an
+unescaped apostrophe" and "hooks called conditionally" gets spent on the
+wrong one. Eight such rules were verified at zero before being pinned
+there — the only moment pinning a rule is free.
+
+**And the ceiling needed its own floor**, per §14.4. tsc's version of
+"satisfy the ratchet by breaking the measurement" was a file that failed
+to parse. eslint's is easier: a blanket `/* eslint-disable */` is one
+line, silences a whole file, and the count drops. So the gate refuses
+blanket disables (a disable that NAMES its rules is a scoped decision and
+is allowed), holds a floor on the number of files linted, and fails
+outright on a parse error. All three probed by committing them.
+
+---
+
 ### §14.7 — Knowing a failure mode does not confer immunity from it (2026-08-18)
 
 **Statement.** A shape recognised, named, documented and reasoned about
@@ -1884,6 +1947,7 @@ on.
 |---|---|
 | 2026-08-18 | §14.7 added — knowing a failure mode does not confer immunity from it. Three instances of one shape in a day: a pin quoting an implementation that broke on a correct change; a pin quoting an implementation that WAS the defect and stayed green through it; and the same defect inside the remedy for the first two, where the route-guard sweep — being rewritten because it matched a marker string — was about to match a hook's NAME instead. `useRequireAuth` navigates from an effect, so a page ignoring its `checked` flag still paints content for a frame, and a name-matching sweep would have certified that half-adoption exactly as the old one certified a send-only token read. Caught by reading how `/team` actually used the hook rather than treating the import as the whole pattern. The third instance settles the question the first two raise: it was written the same day the rule was written down, in the remedy for it, by its author. The rate is stated in the entry as evidence the shape is COMMON IN THIS KIND OF WORK rather than accelerating — three in a day reflects a day of unusually dense pin-writing, and a week of building features rather than instruments would show none while the shape stayed exactly as available. Operative consequence — when a shape is identified, ask what MECHANISM can hold it and prefer that to a paragraph, since a note is a thing to remember and remembering is the faculty that just failed. Corollary: a mechanism adopted partially fails in the gap between its halves, and only a sweep can enforce that both arrived. Also recorded in `routeGuards.test.ts` beside its bounded window: it fails CLOSED — an unreadable guard reports an unguarded page — where §14.4's tsc window failed open, so the two must not be made symmetric. And a prediction that missed: three of fourteen pages were passing incidentally, so at least one of the four unverified was expected to fail; none did. A base rate is not evidence about a particular case. |
 | 2026-08-18 | §14.6 added and §15.1 widened, from DASH-SOFTEN. §14.6: when a rule IS the design, the pin covers the domain rather than a point. The setup checklist expands exactly one step and that is not a feature of the card, it is the card — so the pin renders all sixteen arrangements of its four booleans rather than one. A sample would have passed against the obvious wrong implementation: rendering every incomplete step as open is indistinguishable from rendering the first when only the first is incomplete. Probed by making exactly that substitution — four assertions fail. A pin checking an invariant in one arrangement records an observation where a constraint was wanted. §15.1 widened past code: the same shape appeared in a document. DASH-SOFTEN needed to know whether violet — doctrinal, reserved for "proposed legal choice" — could be an ordinary accent on a card with no legal choices in it. BRAND.md answers it in the ADMIN-CONSOLE section, which is not where anyone with a dashboard question would look; the reasoning was never about admin and neither is its scope. General form: an answer filed under the surface it was first needed for is invisible to the next surface that needs it — so when a ruling resolves a question about a doctrinal rule, the instance goes with the surface and the principle goes with the doctrine. Also recorded: "All Good Escow" is absent from the repository, so it is a real row rather than fixture data, and `requestedByDefault.ts` makes `users.company_name` the RECORDING REQUESTED BY default — a typo in a profile field reaches the face of a recorded instrument with no confirmation step between. Correctly not fixed by a gate, since the officer typing her own company name is the authority on it, but it is the shortest path from a keystroke to a recorded document in this product. |
+| 2026-08-20 | §14.9 added (owner-ruled) — a disabled gate is worse than a missing one, because the repository looks equipped. DASH3's hooks-after-early-return defect would have crashed the dashboard for every user, and the tool that catches that class was configured, at error severity, in a linter `next build` runs by default, with `eslint.ignoreDuringBuilds: true` set beside it. The history says the flag was born with `next.config.js` alongside `typescript.ignoreBuildErrors` and a rewrite marked 'temporarily disabled to fix build issue' — a deploy unblock, never a decision about linting, and a flag with no argument behind it is a different object from one set on principle. The general test for any control: has this ever FIRED? A gate with no failure in its history is either guarding something nothing violates or is not running, and those are indistinguishable from outside — the mutation probe, pointed at the gate instead of the pin, is what tells them apart. Fixed as `tsc-baseline`'s shape rather than by flipping the flag: flipping alone fails every build on 136 pre-existing violations, 104 of them `no-explicit-any`, and a build that fails on old style debt is a gate everyone re-disables — which is how the flag got written. Eight defect-catching rules verified at zero and pinned there independently of the ceiling, so they never share a budget with an unescaped apostrophe. Per §14.4 the ceiling got its own floor, and eslint's way of satisfying a ratchet by breaking the measurement is cheaper than tsc's: a blanket `eslint-disable` is one line and silences a file, so blanket disables are refused, the linted-FILE count has a floor, and a parse error fails outright. |
 | 2026-08-20 | DASH3's build. §14.5 gains a FOURTH habitat — a FILE: the redesign removed four modules' render sites and left the modules, so `dashboard/page.tsx` held two dashboards for one build, one unreachable. Nothing failed; tsc does not flag an unreferenced function and the suites assert what renders. `eslint`'s `no-unused-vars` does see it, and `next.config.js` sets `eslint.ignoreDuringBuilds: true`, so it reports into a void. The general shape under all four habitats: what goes unchecked is never the SUBJECT of the change, it is the change's neighbourhood — who arrives at the page now, who called the function you deleted, what was staged alongside your edit, what existed only to serve what you removed. A diff shows the subject and nothing shows the neighbourhood, so it has to be asked for by name. §14.1.1 gains a THIRD symptom: a pin can assert the right property, in the right words, with the ruling named in its docstring, and still pass against a fixture incapable of distinguishing it — the unknown-age ordering pin used `None` against `2` and passed with the rule DELETED, because `-(None or 0)` and `-(2)` differ anyway; only `None` against `0` can separate the rule from the accident. Unlike the first two symptoms this one is invisible to reading — the test means what it says — and is found only by running the code with the rule removed, which is the argument for the mutation probe being a gate. Also found in the build and fixed: the greeting's hooks placed after an early return (a render crash on the one screen everybody lands on, invisible to tsc and to source-reading suites, caught by rules-of-hooks in a linter CI ignores), and F4's ruling one deletion from reversal — the redesign removed the renderer of `deedsError` while the error was still being set, so a failed deed load would have shown the first-run welcome. An error that renders nothing is indistinguishable from having nothing. |
 | 2026-08-18 | §14.4 and §14.5 added, from one bug report. §14.4: a monotonic invariant is satisfied by breaking the thing it measures. A stray `{/* comment */}` in a ternary branch made `dashboard/page.tsx` unparseable, tsc stopped type-checking it and everything depending on it, and the error count fell from 88 to SIX — a gate that fails when the number RISES was delighted, and prints a notice inviting you to lock the improvement in. Jest stayed green at 1084 throughout because no test imports that page, so the frontend suite is fully compatible with the dashboard being unparseable; the only two instruments that could see it were tsc and next build, which is exactly what a shape-based gate rule would have permitted skipping. The fix is a FLOOR that is not a number — an assertion that nothing failed to parse (tsc's TS1xxx family is syntactic) — because no count can express "the measurement happened". General test for any threshold gate: what would happen to this number if the thing it measures stopped existing? §14.5: checking that a change is right is not checking what it exposes. DASH-FIX #1's routing of "Set county" to account-settings was correct on every premise and moved a first-run action onto a page whose save had no retry, while the page it came from had one for exactly this sleeping API — the owner hit it on their first new user. The defect lives entirely in the difference between the page's old population and the one the routing created, which no diff displays. The question it earns for any new route, link, redirect or CTA: who reaches this page now who did not before, and what does that page assume about them? |
 | 2026-08-18 | §14.1.1 gains its second and more dangerous symptom, and §15.1 added. THE SILENT HALF: `StartSomethingNew`'s own test asserted `getByText('grant-deed')`, so the test for a component rendering raw storage slugs was checking that it rendered raw storage slugs — which is why it survived UX2 item 3's sweep across three other surfaces. A pin written against the storage key rather than the product's language does not merely fail to catch the defect, it CERTIFIES it: the sweep had no reason to open a file whose test was green, and the test was green because it asserted the defect. One root, two symptoms — quote an implementation that is later fixed and the pin goes red while the rule is intact (noise); quote an implementation that IS the defect and it stays green forever (a defect with a certificate). The second cannot be found by watching CI, which is why the tell is a review question. §15.1: a rule about how a surface must be ENTERED is invisible where it is written on the surface. Past Deeds' own docstring names the dead-button-defect-wearing-a-URL and the dashboard's "Last 30 days" tile committed it, linking to that page unfiltered — the rule was written in the one place its violators never look. Any invariant of the form "callers must X" is mis-filed if it lives only with the callee: the callee is where the rule is understood, the callers are where it is broken, and documentation follows understanding while defects follow construction. |

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -1407,6 +1407,47 @@ we reach it.
   the convention pays for itself on entries that overstate, and it turned
   out the bigger population was entries that understate.
 
+- **ESLINT1 — turn the disabled gate back on.**
+  **DECIDED** 2026-08-20, owner-ruled: report the count before flipping;
+  if large, a baseline-with-a-ceiling like tsc rather than a hard zero,
+  and `rules-of-hooks` promoted to error regardless of the rest.
+  **BUILT** — yes, 2026-08-20 (`frontend/scripts/eslint-gate.mjs`, and
+  the `eslint-gate` job in `.github/workflows/test.yml`).
+
+  **The count, reported before anything was flipped:** 136 errors and 58
+  warnings across 294 files. **104 of the 136 errors are
+  `no-explicit-any`** — style debt, not a defect class. The remaining 32
+  are 18 `no-require-imports` (test files), 10 `no-unescaped-entities`,
+  3 `no-html-link-for-pages`, 1 `prefer-const`.
+
+  **The decisive number is a zero, not the 136.**
+  `react-hooks/rules-of-hooks` — the rule this whole ticket came from —
+  has **zero violations across the tree**, and so do seven other
+  defect-catching rules, each checked individually rather than assumed.
+  So they are pinned at zero *independently of the ceiling*, at no cost.
+  That is the only moment pinning a rule is free, and it does not recur.
+
+  **Why the flag was off.** `git log -S` puts it in the commit that
+  CREATED `next.config.js`, beside `typescript.ignoreBuildErrors: true`
+  and a commented-out rewrite marked *"temporarily disabled to fix build
+  issue"*. **A deploy unblock, not a decision about linting** — and a flag
+  with no argument behind it is a different object from one set on
+  principle, because there is nothing to overcome, only something to
+  notice.
+
+  **The flag itself STAYS for now, and this is the honest half of the
+  report.** Flipping `ignoreDuringBuilds` alone fails every build on the
+  136 pre-existing violations, and a build that suddenly fails on old
+  style debt is a gate everyone re-disables — which is how the flag came
+  to be written. The enforcement moved to a blocking CI job instead, and
+  `next.config.js` now carries the whole story at the site so the file
+  stops reading as "we do not lint". Remove the flag when the ceiling
+  reaches zero errors; the gate makes that a matter of time.
+
+  Probed by committing all four failures the gate exists to catch: the
+  hooks defect reinstated, a blanket `eslint-disable`, a file that fails
+  to parse, and new violations above the ceiling.
+
 - **DASH3 — the dashboard becomes a worklist. FIVE RULINGS, then build.**
   **DECIDED** 2026-08-19.
   **BUILT** — yes, 2026-08-20. `backend/services/worklist.py` assembles
@@ -1499,6 +1540,24 @@ we reach it.
      dashboard. Nothing failed: tsc does not flag an unreferenced
      function and the suites assert what renders. §14.5's fourth
      instance, in a single file.
+
+  **Both self-review items ruled by the owner 2026-08-20.** The
+  `N recorded` button DOES carry DASH1's every-count ruling adequately — a
+  count with a destination is what that ruling asked for, and the four
+  tiles were four counts *without* destinations until they were made
+  clickable. And `That's everything.` STAYS: the empty state as a result
+  rather than an absence is a ruled behaviour, and that sentence is what
+  makes it one. (I had named it as the thing I would cut first; that was
+  the wrong instinct about which part was load-bearing.)
+
+  **The F4 near-reversal, marked.** The redesign removed the renderer of
+  `deedsError` while the error was still being set, so a failed deed load
+  would have shown the first-run welcome to an officer whose documents
+  merely failed to load. **That is the empty-vs-error collapse this
+  product has ruled twice, one deletion from returning** — and it was
+  found only because I went looking for dead state, not because anything
+  flagged it. Nothing could have: an error that renders nothing is
+  byte-identical, on screen, to having nothing.
 
   Fourteen pins across six suites broke on the removal, each carrying a
   previously-ruled behaviour. **None was deleted.** Each is recorded in

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -41,6 +41,32 @@ const nextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
+  /* ═══ ESLINT1 — READ THIS BEFORE TRUSTING THE LINE BELOW ═══
+   *
+   * `ignoreDuringBuilds: true` was set the day this file was created,
+   * alongside `typescript.ignoreBuildErrors` and a commented-out rewrite
+   * marked "temporarily disabled to fix build issue". It was never a
+   * decision about linting; it was a deploy that needed to go out.
+   *
+   * It cost us a render crash. DASH3 declared two hooks after an early
+   * return — first paint runs fewer hooks than the second and React tears
+   * the component down — on the dashboard, the one screen every user
+   * lands on. `react-hooks/rules-of-hooks` sees that exactly, is enabled
+   * at error severity by `next/core-web-vitals`, and would have run here.
+   *
+   * THE LINTING IS NOT OPTIONAL ANY MORE. It moved to a blocking CI job
+   * (`eslint-gate` in `.github/workflows/test.yml`, running
+   * `scripts/eslint-gate.mjs`) which holds a frozen ceiling that only
+   * goes down, pins the defect-catching rules at zero, and refuses the
+   * three ways an eslint count can improve without anything improving.
+   *
+   * The flag stays HERE, for now, only because flipping it would fail
+   * every build on 136 pre-existing violations — 104 of them
+   * `no-explicit-any` — and a build that fails on old style debt is a
+   * gate everyone re-disables. That is exactly how this line got written.
+   * Remove it when the ceiling reaches zero errors; the gate is what
+   * makes that a matter of time rather than of intent.
+   */
   eslint: {
     ignoreDuringBuilds: true,
   },

--- a/frontend/scripts/eslint-gate.mjs
+++ b/frontend/scripts/eslint-gate.mjs
@@ -1,0 +1,172 @@
+/**
+ * ESLINT1 — the gate that was turned off.
+ *
+ * ═══ WHY THIS EXISTS ═══
+ *
+ * DASH3's build produced a hooks-after-early-return defect: the greeting's
+ * `useState`/`useEffect` were declared after `if (loading) return …`, so
+ * the first paint ran two fewer hooks than the second and React tears the
+ * component down the moment the profile answers. A render crash on the one
+ * screen every user lands on.
+ *
+ * No gate we run catches that class. `tsc` does not model hook ordering.
+ * The frontend suites read SOURCE TEXT rather than mounting through the
+ * state transition, so they cannot see it either — and they are the
+ * majority of our frontend coverage by design.
+ *
+ * `react-hooks/rules-of-hooks` sees it exactly, is enabled at error
+ * severity by `next/core-web-vitals`, and runs during `next build` by
+ * default. `next.config.js` set `eslint.ignoreDuringBuilds: true`.
+ *
+ * **A DISABLED GATE IS WORSE THAN A MISSING ONE, because the repository
+ * looks equipped.** Anyone auditing our controls would find the rule
+ * configured, at the right severity, in a linter the build runs. All of
+ * that was true and none of it fired.
+ *
+ * ═══ WHY A CEILING RATHER THAN A HARD ZERO ═══
+ *
+ * Flipping the flag alone would fail every build on 136 pre-existing
+ * errors, 104 of which are `no-explicit-any` — a style rule, not a defect
+ * class. A build that suddenly fails on old style debt is a gate everyone
+ * re-disables, which is how the flag got set in the first place.
+ *
+ * So the shape is `tsc-baseline`'s, which the repository already trusts:
+ * frozen at N, only goes down. With one addition it needs and tsc did not
+ * — the rules that catch DEFECTS are pinned at zero independently of the
+ * ceiling, because a budget shared between "an unescaped apostrophe" and
+ * "hooks called conditionally" spends itself on the wrong one.
+ *
+ * ═══ WHAT MAKES THIS NUMBER GO DOWN WITHOUT ANYTHING IMPROVING ═══
+ *
+ * §14.4: a monotonic-down invariant is satisfied by breaking the thing it
+ * measures. tsc's version was a file that failed to PARSE. eslint's is
+ * different and easier:
+ *
+ *   1. `/* eslint-disable *​/` at the top of a file silences all of it.
+ *      One line, no diff noise, and the ceiling applauds.
+ *   2. A file leaving the lint set — moved outside `src`, added to an
+ *      ignore list — is not measured, and unmeasured reads as clean.
+ *   3. A parse error stops eslint reading the rest of that file.
+ *
+ * So the floor is not a number either: blanket disables are refused, the
+ * FILE COUNT has its own floor, and a parse error fails outright.
+ */
+import { ESLint } from 'eslint';
+import { readFileSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(HERE, '..');
+
+/** Frozen 2026-08-20. LOWER these when the count drops; never raise them.
+ *  Raising one is a decision to keep a defect, and it should read like
+ *  one in the diff. */
+const CEILING = { errors: 136, warnings: 58 };
+
+/** A file that stops being linted stops being measured, and unmeasured
+ *  reads as clean. This floor is the count of files eslint actually
+ *  reported on — deleting a file legitimately lowers it, so this fails
+ *  loudly and expects a human to lower it deliberately. */
+const FILES_FLOOR = 294;
+
+/**
+ * These catch DEFECTS rather than style, and every one is at zero today —
+ * verified, not assumed, before being written down. They are pinned at
+ * zero independently of the ceiling above.
+ *
+ * `react-hooks/rules-of-hooks` is first because it is the rule this whole
+ * ticket came from. The rest were checked individually and were already
+ * clean, which made pinning them free — the only moment that is ever
+ * true.
+ */
+const MUST_BE_ZERO = [
+  'react-hooks/rules-of-hooks',
+  '@next/next/no-sync-scripts',
+  '@next/next/no-assign-module-variable',
+  'no-cond-assign',
+  'no-dupe-keys',
+  'no-unsafe-negation',
+  'react/jsx-no-undef',
+  'react/jsx-key',
+];
+
+/** A file-level `eslint-disable` with no rule named turns the gate off
+ *  locally. A disable that NAMES its rules is a scoped decision and is
+ *  allowed — this refuses only the blanket form. */
+const BLANKET = /\/\*\s*eslint-disable\s*\*\//;
+
+const eslint = new ESLint({ cwd: ROOT });
+const results = await eslint.lintFiles(['src']);
+
+let errors = 0, warnings = 0, parseErrors = [];
+const byRule = new Map();
+
+for (const file of results) {
+  for (const m of file.messages) {
+    if (m.severity === 2) errors++; else warnings++;
+    if (m.fatal || /^Parsing error/.test(m.message)) {
+      parseErrors.push(`${file.filePath}:${m.line} ${m.message}`);
+    }
+    const id = m.ruleId ?? '(no rule)';
+    byRule.set(id, (byRule.get(id) ?? 0) + 1);
+  }
+}
+
+const blanket = results
+  .map((f) => f.filePath)
+  .filter((p) => BLANKET.test(readFileSync(p, 'utf8')));
+
+const fail = [];
+
+// ── The floor, which is not a number ────────────────────────────────
+if (parseErrors.length) {
+  fail.push(`${parseErrors.length} file(s) failed to PARSE — the counts below `
+          + `are meaningless:\n  ${parseErrors.slice(0, 10).join('\n  ')}`);
+}
+if (blanket.length) {
+  fail.push(`blanket eslint-disable (no rule named) in ${blanket.length} `
+          + `file(s) — that silences the gate rather than passing it:\n  `
+          + blanket.map((p) => p.replace(ROOT, '')).join('\n  '));
+}
+if (results.length < FILES_FLOOR) {
+  fail.push(`only ${results.length} files linted, floor is ${FILES_FLOOR}. `
+          + `A file that stops being linted stops being measured. If files `
+          + `were deleted on purpose, lower FILES_FLOOR deliberately.`);
+}
+
+// ── The defect rules, at zero, independent of the ceiling ────────────
+for (const rule of MUST_BE_ZERO) {
+  const n = byRule.get(rule) ?? 0;
+  if (n > 0) {
+    fail.push(`${rule}: ${n} violation(s). This rule is pinned at ZERO — `
+            + `it catches a defect class, not style, and it was at zero when `
+            + `the gate was written.`);
+  }
+}
+
+// ── The ceiling ─────────────────────────────────────────────────────
+if (errors > CEILING.errors) {
+  fail.push(`eslint errors regressed: ${errors}, ceiling is ${CEILING.errors}`);
+}
+if (warnings > CEILING.warnings) {
+  fail.push(`eslint warnings regressed: ${warnings}, ceiling is ${CEILING.warnings}`);
+}
+
+console.log(`eslint: ${errors} errors (ceiling ${CEILING.errors}), `
+          + `${warnings} warnings (ceiling ${CEILING.warnings}), `
+          + `${results.length} files linted (floor ${FILES_FLOOR})`);
+console.log('\nby rule:');
+for (const [rule, n] of [...byRule].sort((a, b) => b[1] - a[1])) {
+  console.log(`  ${String(n).padStart(5)}  ${rule}`);
+}
+
+if (fail.length) {
+  for (const f of fail) console.error(`::error::${f}`);
+  process.exit(1);
+}
+
+if (errors < CEILING.errors || warnings < CEILING.warnings) {
+  console.log(`\n::notice::eslint improved to ${errors}/${warnings} — lower `
+            + `CEILING in frontend/scripts/eslint-gate.mjs to lock the gain in.`);
+}


### PR DESCRIPTION
## The count, reported before anything was flipped

| | |
|---|---|
| **Errors** | **136** across 61 files |
| **Warnings** | 58 |
| **Files linted** | 294 |

Distribution — the shape matters more than the total:

| n | rule | |
|---:|---|---|
| 104 | `@typescript-eslint/no-explicit-any` | style debt |
| 29 | `@typescript-eslint/no-unused-vars` | warn |
| 19 | unused `eslint-disable` directives | warn |
| 18 | `@typescript-eslint/no-require-imports` | test files |
| 10 | `react-hooks/exhaustive-deps` | warn |
| 10 | `react/no-unescaped-entities` | |
| 3 | `@next/next/no-html-link-for-pages` | real, small |
| 1 | `prefer-const` | |

**The decisive number is a zero, not the 136.** `react-hooks/rules-of-hooks` — the rule this ticket came from — has **no violations anywhere in the tree**. Neither do seven other defect-catching rules, each checked individually rather than assumed. Pinning them costs nothing today, and that is the only moment it is ever free.

## Why the flag was off

`git log -S "ignoreDuringBuilds"` puts it in the commit that **created** `next.config.js`, beside `typescript.ignoreBuildErrors: true` and a commented-out rewrite marked *"temporarily disabled to fix build issue"*.

**A deploy unblock, never a decision about linting.** That distinction matters exactly as you framed it: a flag set on principle has an argument to overcome, and this one has nothing behind it but a deploy that needed to go out eight months ago and nobody's attention since.

## What was built

A blocking `eslint-gate` CI job running `frontend/scripts/eslint-gate.mjs`, in `tsc-baseline`'s shape because the repo already trusts it — frozen at N, only goes down — with one addition tsc did not need:

**The defect rules are pinned at ZERO independently of the ceiling.** A budget shared between "an unescaped apostrophe" and "hooks called conditionally" gets spent on the wrong one.

**Per §14.4, the ceiling needed its own floor** — and eslint's way of satisfying a ratchet by breaking the measurement is *cheaper* than tsc's. tsc's was a file that failed to parse; eslint's is `/* eslint-disable */`, one line, silences a whole file, and the count drops. So:

- blanket disables are **refused** — a disable that *names* its rules is a scoped decision and is allowed;
- the linted-**file count** has its own floor, because a file that stops being linted stops being measured and unmeasured reads as clean;
- a parse error fails outright.

All four guards probed by committing the failure each exists to catch:

| probe | result |
|---|---|
| the hooks defect reinstated | `rules-of-hooks: 3 violations. This rule is pinned at ZERO` |
| blanket `eslint-disable` added | `silences the gate rather than passing it` |
| a file made unparseable | `the counts below are meaningless` |
| new violations added | `errors regressed: 139, ceiling is 136` |

## The flag stays, and that is the honest half

Flipping `ignoreDuringBuilds` alone fails **every build** on 136 pre-existing violations. A build that suddenly fails on old style debt is a gate everyone re-disables — which is how this flag came to be written, and repeating it would be the same mistake with better intentions.

Enforcement moved to CI instead, and `next.config.js` now carries the whole story at the site so the file stops reading as *"we do not lint"*. Remove the flag when the ceiling reaches zero errors; the gate makes that a matter of time rather than of intent.

## Doctrine — §14.9

**A disabled gate is worse than a missing one, because the repository looks equipped.** A missing control is visible as an absence and someone eventually asks. A disabled one answers that question wrongly: the rule is in the config, at the right severity, in a tool the build runs.

The general test: **has this control ever fired?** A gate with no failure in its history is either guarding something nothing violates, or is not running — and those are indistinguishable from outside. What tells them apart is making it fail on purpose, which is the mutation probe pointed at the gate instead of the pin.

## Also in this PR

**The F4 near-reversal, marked** as you asked. The redesign removed the renderer of `deedsError` while the error was still being set — the empty-vs-error collapse this product has ruled twice, one deletion from returning, found only because I went looking for dead state. Nothing could have flagged it: an error that renders nothing is byte-identical on screen to having nothing.

**Both DASH3 self-review items ruled**, recorded in the ledger. The `N recorded` button does carry the every-count ruling — a count with a destination is what it asked for, and the four tiles were counts *without* destinations until they were made clickable. And `That's everything.` stays: the empty state as a result rather than an absence is ruled, and that sentence is what makes it one. I had named it as the first thing I'd cut, which was the wrong read of what was load-bearing.

## Gates

pytest **1581** with DB / **1370 + 211 skipped** without · jest **1139** · tsc **88** · `next build` clean · banned-claims clean · S1, S3, six-flow and API baselines green.

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_