### PR TITLE
The comparison table's checkmark, and the gate that was narrower than it read

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -661,7 +661,19 @@ export default function LandingPage() {
                        nothing behind either number. Deleted rather than
                        hedged: there is no measurement to soften. */
                     { feature: "Recorder formatting checks", deedpro: "Built-in", manual: "Manual tracking" },
-                    { feature: "Multi-user collaboration", deedpro: true, manual: false },
+                    /* DARK1 — this was a CHECKMARK. `deeds` carries one
+                       user_id, every query is scoped to it, and partners are
+                       `user-{id}` scoped, so a second officer in the same
+                       office sees none of her colleague's rolodex. RED-S5
+                       (the org model) is deferred BY DECISION, so this is not
+                       "not yet" either — a soft promise is the same claim
+                       with a delay attached.
+
+                       A checkmark on a comparison table is a capability claim
+                       aimed at somebody choosing between products, which is
+                       the most consequential place to be wrong: a two-person
+                       shop discovers it in week one. */
+                    { feature: "Multi-user collaboration", deedpro: false, manual: false },  // banned-claims: allow the row LABEL names the capability in order to DENY it — the cell renders an X for both columns
                     { feature: "API access", deedpro: true, manual: false },
                     { feature: "SmartReview validation", deedpro: true, manual: false },
                   ].map((row, i) => (
@@ -670,6 +682,13 @@ export default function LandingPage() {
                       <td className="py-5 px-6">
                         {row.deedpro === true ? (
                           <Check className="h-6 w-6 text-[#7C4DFF]" />
+                        ) : row.deedpro === false ? (
+                          /* An honest NO, rendered as legibly as a yes.
+                             `false` used to fall through to `{row.deedpro}`,
+                             which React renders as NOTHING — an empty cell
+                             reads as a layout bug, and a claim we removed
+                             should read as an answer. */
+                          <X className="h-6 w-6 text-gray-400" />
                         ) : (
                           <span className="text-base font-semibold text-[#1F2B37]">{row.deedpro}</span>
                         )}

--- a/scripts/check_banned_claims.py
+++ b/scripts/check_banned_claims.py
@@ -192,7 +192,28 @@ RULES = [
     Rule("custom branding / white-label", r"\b(?:custom branding|white[\s\-]label(?:ed|ing)?)\b",
          "Nothing in the product themes a deed, an email or a portal per "
          "customer. Listed on the Professional tier until TRIAL1."),
-    Rule("team management / seats", r"\b(?:team management|multi[\s\-]user seats?|user seats?)\b",
+    # DARK1 WIDENED THIS, and the reason is the recurring shape rather
+    # than this one miss. The `why` below states the subject plainly —
+    # THERE IS NO TEAM MODEL — and the pattern guarded three spellings of
+    # it: "team management", "multi-user seats", "user seats". The live
+    # comparison table said **"Multi-user collaboration"** with a
+    # checkmark beside it and walked straight past, because the pattern
+    # required the word "seats" to follow "multi-user".
+    #
+    # §14.1: a sweep matches the PROPERTY, not the spelling. A rule whose
+    # stated subject is broader than its regex is a gate narrower than it
+    # reads, and every reader of the `why` will believe the wider thing is
+    # covered. This is the fourth instance of that shape in the ledger.
+    #
+    # So the property is now the claim itself: any assertion of multiple
+    # people sharing this account's work. "Collaboration" is deliberately
+    # required to sit next to a multi-user/team/shared word rather than
+    # being banned alone — the bare noun has honest uses (a signing is a
+    # collaboration between an officer and a notary) and banning it would
+    # trade this narrowness for the opposite error.
+    Rule("team management / seats",
+         r"\b(?:team management|(?:multi[\s\-]?user|team|shared)[\s\-]"
+         r"(?:seats?|collaboration|workspace|access|accounts?)|user seats?)\b",
          "`deeds` carries one user_id and every query is scoped to it. "
          "There is no team model to manage (RED-S5, deferred by decision)."),
 ]


### PR DESCRIPTION
Ruling 1 of two. Ruling 2 (SmartReview) is a report only — below, no code.

## The checkmark

`Multi-user collaboration ✓` on the live comparison table. `deeds` carries one `user_id`, every query is scoped to it, and partners are `user-{id}` scoped — a second officer in the same office sees **none** of her colleague's rolodex.

RED-S5 is deferred **by decision**, so this isn't "not yet" either: a soft promise is the same claim with a delay attached.

**The cell now renders an X**, which needed a small render change. `false` in the DeedPro column fell through to `{row.deedpro}`, and React renders `false` as nothing — an empty cell reads as a layout bug, not an answer. A claim we removed should read as a **no**, as legibly as a yes.

The row label carries the gate's own documented allow-comment — the sanctioned case, not an escape: the label names the capability *in order to deny it*.

## The gate was narrower than its own `why`

| | |
|---|---|
| **Stated subject** | "There is no team model to manage (RED-S5, deferred by decision)" |
| **Actual pattern** | `team management`, `multi-user seats`, `user seats` |
| **What walked past** | **`Multi-user collaboration`** — the pattern required "seats" to follow "multi-user" |

§14.1: a sweep matches the property, not the spelling. **A rule whose stated subject is broader than its regex is a gate narrower than it reads** — and every reader of the `why` believes the wider thing is covered. Fourth instance of that shape.

Widened to the property: any assertion of multiple people sharing this account's work.

**"Collaboration" is deliberately not banned alone.** A signing *is* a collaboration between an officer and a notary; banning the bare noun trades this narrowness for the opposite error. It must sit beside a multi-user/team/shared word.

Probed both directions — 10 cases, 0 mismatches:

```
catches  'Multi-user collaboration'    — the live miss
catches  'multi user collaboration'    — space not hyphen
catches  'Team collaboration'          — other natural spelling
catches  'Shared workspace'            — /team's own words
catches  'Multi-user access'           — different noun
catches  team management / multi-user seats / user seats  — already covered
ignores  'collaboration'               — bare noun, must not fire
ignores  'close collaboration with the county'  — honest prose
```

## Ruling 2 — SmartReview copy, verbatim, as requested

**No code change.** Reporting for your ruling.

**The card** (step 3): badge `SmartReview` beside `✓ Ready`, then:
- "Legal description confirmed" — *"By your officer, against county records"*
- "Formatting checks passed" — *"County recorder formatting rules"*
- "Ready to generate"

**Comparison table:** `SmartReview validation` ✓
**Footer:** *"Create California deeds in minutes with a guided wizard and SmartReview."*

**Your condition is not triggered.** Nothing here claims to catch issues *before recording* or asserts what a recorder will accept:

- "Formatting checks passed — County recorder formatting rules" says *our checks ran against those rules*, not that the recorder will accept it.
- "Ready to **generate**" — about generation, not recording. The one word that could have overclaimed is the one that doesn't.
- "Legal description confirmed — **by your officer**" attributes the confirmation to her, matching doctrine.

The copy is careful, and it describes checks that exist. My recommendation is it stays as written — but it's your ruling, and I've changed nothing pending it.

## Gates

jest **1150** · pytest **1370 + 211 skipped** · tsc **83** · eslint **134/56** (floor 292) · banned-claims **clean**

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_