### PR TITLE
Two records, and the notification investigation

### DIFF
--- a/docs/DOCTRINE_CONFORMANCE.md
+++ b/docs/DOCTRINE_CONFORMANCE.md
@@ -1286,6 +1286,77 @@ easiest change to undo silently.
 
 ---
 
+### §14.14 — A threshold must be re-measured when a deletion lowers its subject (2026-08-20)
+
+**Statement.** A ceiling that only moves when somebody decides to move it
+is not a ratchet. When code is deleted, the debt it carried leaves with
+it — and a ceiling left at the old number **silently re-authorises
+exactly that much fresh debt**, with no diff anywhere recording the
+grant.
+
+**The instance.** DARK1's deletions took the eslint count from 134 errors
+to 126 and from 56 warnings to 54. The gate refused the run — but only
+because the FILE FLOOR had its own check. Nothing checked the ceiling,
+because a count going DOWN is what the ceiling exists to reward. Leaving
+it at 134 would have handed the next author eight free errors.
+
+**Why this direction is the invisible one.** Every mechanism we built
+watches the number rising: the ceiling fails on regression, the drawdown
+trigger fires when it reaches zero. **Both watch the number. Neither
+watches the SUBJECT shrinking underneath it.** A threshold is a ratio
+between a count and a corpus, and we had been treating it as a count.
+
+**This generalises to every threshold in the repository**, not just this
+gate: `TSC_BASELINE`, the eslint ceiling, the file floor, any future
+count-based invariant. The question to ask after any deletion is not "did
+this break the gate" but **"did this lower what the gate measures, and is
+the gate still measuring the same thing?"**
+
+**The mechanical form.** Deletions and thresholds are checked together:
+after removing files, re-run every count-based gate and lower each number
+that dropped, in the same commit as the deletion. The improvement notice
+the gate already prints is the prompt — it was printing all along, and
+the ratchet only tightened because somebody read it.
+
+---
+
+### §14.15 — Two modules with near-identical names are one filename check away from the wrong verdict (2026-08-20)
+
+**Statement.** When a check asks "is this module load-bearing?", a name
+is not evidence. Two files can share almost the same path, differ in one
+segment, and sit on opposite sides of the answer — and the reasoning that
+identifies one will read as if it identified the other.
+
+**The instance, and it was a deletion decision.** The owner's carve-out
+before deleting the notifications scaffold: *if the notifications router
+writes the in-app record CANCEL1 depends on, the backend half stays.*
+
+  · `routers/notifications.py` — the flag-gated READ side, off since
+    January. The scaffold.
+  · `utils/notifications.py` — writes the record, NOT flag-gated, called
+    live from `sharing.py`, `signing.py`, `users_auth.py` and
+    `api_key_requests.py`. Its call site carries CANCEL1's rule verbatim:
+    *"the in-app record comes FIRST — an approval must be unlosable
+    regardless of email transport."*
+
+**A check that stopped at the filename would have protected the scaffold
+and deleted the load-bearing module.** Both are `notifications.py`. The
+one named in the carve-out was the wrong one, and only looking at what
+each module DOES separated them.
+
+**This is the DARKSWEEP same-name caveat arriving in the one place it
+mattered.** That caveat was recorded as inert — no basename among the 16
+components was duplicated — and it was inert *for components*. The hazard
+was live one directory over, in Python, in the safety check itself.
+**A limitation recorded as "does not apply here" applies somewhere.**
+
+**The mechanical form.** Any check that decides a module's fate resolves
+it by BEHAVIOUR — what it writes, who calls it, whether a flag gates it —
+never by name, and never by the name a ticket used. When a ticket names a
+file, confirm the file it names is the file it means.
+
+---
+
 ### §14.12 — A removed claim must read as a NO, as legibly as a yes (2026-08-20)
 
 **Statement.** When a capability claim is withdrawn, the surface that

--- a/docs/OWNER_LEDGER.md
+++ b/docs/OWNER_LEDGER.md
@@ -1730,6 +1730,64 @@ we reach it.
 
 ## Parked tickets (scoped, not scheduled)
 
+- **NOTIF1 — the approval record has no reader, and the worklist
+  structurally cannot be one.**
+  **DECIDED** — investigation reported 2026-08-20; the build is NOT ruled.
+  **BUILT** — no.
+
+  **The question asked:** does the worklist already surface approvals
+  through share status? If so the in-app records are redundant and
+  retiring the writer is the honest answer.
+
+  **The answer is no, and the reason is structural rather than
+  incidental.** `routers/dashboard.py`'s awaiting query selects
+  `ds.status IN ('sent', 'viewed')` — the two UNDECIDED statuses — with
+  the comment: *"A share that was approved, rejected, revoked or expired
+  is not waiting on anybody."* That is correct for a worklist. A worklist
+  shows outstanding work, and **an approval is the end of outstanding
+  work**, so the row does not change: it DISAPPEARS.
+
+  **A disappearance is not a notification.** The officer sees a row for a
+  share she is waiting on; when the reviewer approves, the row is simply
+  gone next time she looks. Nothing on any screen says it was approved —
+  swept `features/` and `app/`, and the only approval-aware surfaces are
+  the reviewer's own `/approve/[token]` confirmation, an admin email-log
+  filter, and an account-settings toggle describing the email.
+
+  **So the email is the only channel that tells her**, which is exactly
+  the failure mode E1's comment names: *"Before this, the approval
+  existed only as an email; a transport failure erased the event from the
+  owner's world entirely."* The in-app record was written to survive that
+  failure and currently survives it into a table nobody reads.
+
+  **The records are therefore NOT redundant — they carry the one event
+  this product cannot otherwise show.** Retiring the writer would restore
+  the exact defect E1 was built to fix.
+
+  **What wiring would cost, honestly.** The destination is not a bell.
+  The worklist's unit is a ROW representing outstanding work, and an
+  approval is finished work — so it does not fit the existing bands
+  (chase / you / stale) without changing what a row means. Three shapes,
+  none of them free:
+
+    1. **A fourth band ("resolved since you last looked")** — fits the
+       screen, but the hero counts rows and the hero's promise is "things
+       that need you". An approval needs nothing. It would inflate the
+       count with work that is done, which is the metric-vs-worklist
+       error DASH3 spent itself removing.
+    2. **A separate strip above or below the worklist** — does not touch
+       the count, needs a read endpoint (the router, un-gated), a
+       last-seen marker, and a dismissal rule. Smallest honest version.
+    3. **On the deed's own row/page** — an approval is a fact about a
+       document, and `/deeds/{id}` already tells that story. Cheapest,
+       but only reaches her if she goes looking, which is the thing the
+       record exists to avoid.
+
+  **Recommendation: (2), and it is a real ticket, not a flag flip.** The
+  flag is off, the UI is deleted, and the read API has never served a
+  request. **Not started — this is the report, and the ruling is the
+  owner's.**
+
 - **GUIDE2 — in-product explanation, as static copy.**
   **DECIDED** 2026-08-20, owner-ruled (GUIDE0 ranks 1 and 2).
   **BUILT** — yes, 2026-08-20. `frontend/src/lib/provenanceLabels.ts`,

--- a/frontend/scripts/eslint-gate.mjs
+++ b/frontend/scripts/eslint-gate.mjs
@@ -59,10 +59,26 @@ import { fileURLToPath } from 'url';
 const HERE = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(HERE, '..');
 
-/** Frozen 2026-08-20 at 136/58; 134/56 (GUIDE1), 126/54 (DARK1). Which
- *  deleted three orphaned components. LOWER these when the count drops;
- *  never raise them. Raising one is a decision to keep a defect, and it
- *  should read like one in the diff. */
+/** Frozen 2026-08-20 at 136/58. Lowered to 134/56 by GUIDE1 (three
+ *  orphaned components deleted) and to 126/54 by DARK1 (eleven more).
+ *
+ *  LOWER these when the count drops; never raise them. Raising one is a
+ *  decision to keep a defect and should read like one in the diff.
+ *
+ *  ═══ AND LOWER THEM WHEN A DELETION LOWERS THEM FOR YOU ═══
+ *
+ *  A ceiling left at its old number after files are deleted silently
+ *  re-authorises exactly the debt those files were carrying — DARK1's
+ *  deletions took 8 errors and 2 warnings with them, and leaving 134
+ *  would have granted the next author 8 free errors, invisibly, with no
+ *  diff anywhere recording the grant.
+ *
+ *  The drawdown trigger in OWNER_LEDGER.md watches this number falling
+ *  toward zero. It does not watch the SUBJECT shrinking underneath it.
+ *  A ratchet that tightens only when somebody remembers to tighten it is
+ *  not a ratchet, and this property belongs to every threshold in the
+ *  repo, not just this one: re-measure whenever a deletion lowers what
+ *  the threshold measures. */
 const CEILING = { errors: 126, warnings: 54 };
 
 /** A file that stops being linted stops being measured, and unmeasured


### PR DESCRIPTION
Documentation only. Two doctrine records, one comment repair, and the NOTIF1 investigation — **reported, not built.**

## §14.14 — a threshold must be re-measured when a deletion lowers its subject

DARK1's deletions took the eslint count from 134/56 to 126/54. **The gate refused the run — but only because the file floor had its own check.** Nothing checked the ceiling, because a count going *down* is what the ceiling exists to reward. Leaving it at 134 would have handed the next author eight free errors, with no diff anywhere recording the grant.

**Why this direction is invisible:** every mechanism we built watches the number *rising* — the ceiling fails on regression, the drawdown trigger fires at zero. **Both watch the number. Neither watches the subject shrinking underneath it.** A threshold is a ratio between a count and a corpus, and we were treating it as a count.

Applies to `TSC_BASELINE` and every future count-based invariant. The question after a deletion is not *"did this break the gate"* but ***"did this lower what the gate measures."***

## §14.15 — two modules with near-identical names are one filename check away from the wrong verdict

The carve-out named `routers/notifications.py`. The module that writes CANCEL1's record is `utils/notifications.py` — live, ungated, carrying the rule verbatim at its call site.

**A check stopping at the filename would have protected the scaffold and deleted the load-bearing one.**

This is the DARKSWEEP same-name caveat arriving in the one place it mattered. It was recorded as *inert* — no basename among the 16 components was duplicated — and it was inert **for components**. The hazard was live one directory over, in Python, inside the safety check itself. **A limitation recorded as "does not apply here" applies somewhere.**

Also repairs a comment my own `sed` garbled last commit — *"126/54 (DARK1). Which deleted three orphaned components"* — and states the ceiling rule at the site.

## NOTIF1 — the investigation, and the answer is no

**Does the worklist already surface approvals?** No, and the reason is structural rather than incidental.

`routers/dashboard.py` selects `ds.status IN ('sent', 'viewed')` — the two **undecided** statuses — commented: *"A share that was approved, rejected, revoked or expired is not waiting on anybody."*

That is correct for a worklist. A worklist shows outstanding work, and **an approval is the end of outstanding work.** So the row does not change — **it disappears.**

**A disappearance is not a notification.** I swept `features/` and `app/`: the only approval-aware surfaces are the reviewer's own `/approve/[token]` confirmation, an admin email-log filter, and a settings toggle describing the email. **Nothing tells the officer.**

So the email is the only channel — which is exactly the failure E1's own comment names:

> *"Before this, the approval existed only as an email; a transport failure erased the event from the owner's world entirely."*

**The records are not redundant. They carry the one event this product cannot otherwise show, and retiring the writer would restore the defect E1 was built to fix.**

### What wiring costs — three shapes, none free

| shape | fits? | cost |
|---|---|---|
| **Fourth band** in the worklist | No | Hero counts rows and promises "things that need you". An approval needs nothing — it inflates the count with finished work, the metric-vs-worklist error DASH3 removed |
| **Separate strip** above/below | Yes | Read endpoint (router, ungated), last-seen marker, dismissal rule. Doesn't touch the count |
| **On the deed's own page** | Partly | Cheapest, but only reaches her if she goes looking — the thing the record exists to avoid |

**Recommendation: the separate strip, as a real ticket rather than a flag flip.** The flag is off, the UI is deleted, and the read API has never served a request. Not started — the ruling is yours.

## Gates

jest **1150** · eslint **126/54** (floor 281) · banned-claims **clean**, 231 files · ledger BUILT-path pin green

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_