### PR TITLE
NOTIF1 — the strip that reports what the worklist cannot

### DIFF
--- a/backend/routers/dashboard.py
+++ b/backend/routers/dashboard.py
@@ -20,6 +20,7 @@ from auth import get_current_user_id
 from services import deed_accuracy as accuracy
 from services import officer_queue as q
 from services import signing_loop as loop
+from services import news as nw
 from services import worklist as wl
 
 router = APIRouter()
@@ -302,6 +303,32 @@ def officer_queue(user_id: int = Depends(get_current_user_id)) -> Dict[str, Any]
             for r in _rows(cur)
         }
 
+        # ── NOTIF1: what HAPPENED, which the queries above cannot show ──
+        #
+        # Everything above selects work that is OUTSTANDING. A resolved
+        # share leaves those results by disappearing, so the one event an
+        # officer most needs told — her reviewer answered — is the one
+        # event this screen could not report. The in-app record has been
+        # written since E1 and read by nobody.
+        #
+        # UNREAD only, and joined to the deed so the row can land on the
+        # document rather than a list.
+        cur.execute("""
+            SELECT n.id, n.type, n.message, n.link, n.created_at,
+                   (n.payload->>'deed_id')::int AS deed_id
+              FROM user_notifications un
+              JOIN notifications n ON n.id = un.notification_id
+             WHERE un.user_id = %s
+               AND COALESCE(un.read, false) = false
+             ORDER BY n.created_at DESC
+             LIMIT 25
+        """, (user_id,))
+        news_items = [{
+            "id": r["id"], "type": r["type"], "message": r["message"],
+            "link": r.get("link"), "deed_id": r.get("deed_id"),
+            "days_ago": q.days_since(r.get("created_at")),
+        } for r in _rows(cur)]
+
     upcoming.sort(key=lambda r: r["when"])
     # Longest-waiting first: the oldest silence is the one worth chasing.
     # `days_waiting` may be None for a row we cannot date, and those sort
@@ -348,4 +375,5 @@ def officer_queue(user_id: int = Depends(get_current_user_id)) -> Dict[str, Any]
                              "documents": len(accuracy_items),
                              "open_documents": open_documents,
                              "items": accuracy_items},
-                   worklist={"groups": groups, "count": wl.hero_count(groups)})
+                   worklist={"groups": groups, "count": wl.hero_count(groups)},
+                   news=nw.build(news_items))

--- a/backend/routers/notifications.py
+++ b/backend/routers/notifications.py
@@ -61,8 +61,24 @@ class MarkReadIn(BaseModel):
 
 @router.post("/mark-read")
 def mark_read(body: MarkReadIn, user_id: int = Depends(get_current_user_id)):
-    if not feature_enabled():
-        return {"success": False, "message": "Notifications disabled"}
+    """Dismissal. NOT gated, and that is NOTIF1's one deliberate change here.
+
+    `NOTIFICATIONS_ENABLED` gated a scaffold that never shipped — the bell
+    and its list, deleted by DARK1 after four months unreachable. NOTIF1
+    ships a different, smaller thing: the dashboard's resolved-events
+    strip, whose rows come from `/dashboard/queue` and whose only write is
+    this one.
+
+    So the strip's dismiss cannot sit behind a flag governing a UI that no
+    longer exists. `list_notifications` and the admin broadcast below KEEP
+    the flag, because neither is part of NOTIF1 and turning them on is a
+    decision nobody has made.
+
+    The narrower reason this could not live in `routers/dashboard.py`:
+    that module's docstring declares it READ-ONLY, and an endpoint that
+    writes would make the statement false for every future reader who
+    trusts it.
+    """
     if not body.ids:
         return {"success": True}
     with db_connection() as conn, conn.cursor() as cur:

--- a/backend/services/news.py
+++ b/backend/services/news.py
@@ -1,0 +1,137 @@
+"""NOTIF1 — what happened, as distinct from what needs her.
+
+═══ THE FINDING THIS EXISTS FOR ═══
+
+The worklist selects `ds.status IN ('sent', 'viewed')` — the two
+UNDECIDED statuses — because a worklist shows outstanding work and an
+approval is the END of outstanding work. So when a reviewer approves, the
+row does not change state. **It disappears.**
+
+A DISAPPEARANCE IS NOT A NOTIFICATION. A vanished row is
+indistinguishable from one she handled herself, one that expired, one
+that was revoked, and from nothing at all. Nothing else on any screen
+reports the event: the reviewer's own confirmation page, an admin
+email-log filter and a settings toggle describing the email are the only
+approval-aware surfaces in the product.
+
+So the email was the only channel — which is precisely the failure E1
+named when it added the in-app record: *"Before this, the approval
+existed only as an email; a transport failure erased the event from the
+owner's world entirely."* The record has been written faithfully ever
+since and read by nobody.
+
+═══ WHY THIS IS NOT A WORKLIST BAND (owner-ruled) ═══
+
+The obvious cheap move is a fourth band. It is wrong. The hero counts
+ROWS and promises "things that need you"; an approval needs nothing.
+Adding it inflates that count with finished work, which is the
+metric-vs-worklist error DASH3 spent itself removing.
+
+**An approval is news, not a task, and the two do not share a
+container.** Hence a separate strip: quieter than the queue, dismissible,
+and contributing nothing to the hero.
+
+═══ AND IT MUST NOT BECOME WALLPAPER ═══
+
+A "what happened" line that accumulates forever stops being read. Two
+mechanisms, both owner-ruled: the strip carries only UNREAD items, and
+dismissing is one press. `NEWS_LIMIT` bounds what one render can show —
+not because more cannot be fetched, but because a strip that can grow
+without bound is a feed, and a feed is the thing this is not.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Sequence
+
+#: What one render will show. A strip that can grow without bound is a
+#: feed; the count of anything beyond this is reported rather than
+#: rendered, so "3 more" is a fact she is told rather than a silent trim.
+NEWS_LIMIT = 4
+
+#: Asserted on the way out, same instinct as `officer_queue` and
+#: `worklist`: a payload whose keys drift silently is a screen rendering
+#: blanks nobody notices.
+NEWS_KEYS = frozenset({"id", "kind", "say", "when", "href", "deed_id"})
+
+#: The notification types this strip understands. A type NOT in here is
+#: deliberately NOT rendered — the strip says what it can say, and an
+#: unknown event is left for whatever surface owns it rather than being
+#: given a generic sentence that asserts less than it seems to.
+KNOWN = {
+    "share_approved": "approved",
+    "share_rejected": "declined",
+}
+
+
+@dataclass
+class NewsRow:
+    id: int
+    kind: str
+    say: str
+    when: str
+    href: str
+    deed_id: Optional[int] = None
+
+    def as_dict(self) -> Dict[str, Any]:
+        out = {
+            "id": self.id, "kind": self.kind, "say": self.say,
+            "when": self.when, "href": self.href, "deed_id": self.deed_id,
+        }
+        assert set(out) == NEWS_KEYS, f"news row drifted: {sorted(out)}"
+        return out
+
+
+def _when(days: Optional[int]) -> str:
+    """Ages read as English, and an unknown age SAYS it is unknown.
+
+    DASH1's rule, kept: "—" reads as zero and "0 days" is a claim we
+    cannot support about a row whose timestamp we could not read.
+    """
+    if days is None:
+        return "at an unknown time"
+    if days <= 0:
+        return "today"
+    if days == 1:
+        return "yesterday"
+    return f"{days} days ago"
+
+
+def news_row(item: Dict[str, Any]) -> Optional[NewsRow]:
+    """One resolved event, or None if this is not an event we can name.
+
+    THE SENTENCE IS THE SERVER'S (§13 rule 3). `utils/notifications`
+    composed the message when the event happened, with the facts in hand;
+    this reads it rather than reconstructing a worse one from a type
+    string. A row whose stored message is empty is dropped rather than
+    given a generic line — "something happened" is not news.
+    """
+    ntype = (item.get("type") or "").strip()
+    if ntype not in KNOWN:
+        return None
+    message = (item.get("message") or "").strip()
+    if not message:
+        return None
+    deed_id = item.get("deed_id")
+    return NewsRow(
+        id=item["id"],
+        kind=KNOWN[ntype],
+        say=message,
+        when=_when(item.get("days_ago")),
+        # LANDS ON THE DEED, not a list — the orphan ruling, which the
+        # worklist rows already follow. The stored `link` is used when it
+        # exists because whoever wrote the event knew where it pointed.
+        href=(item.get("link") or (f"/deeds/{deed_id}" if deed_id else "/past-deeds")),
+        deed_id=deed_id,
+    )
+
+
+def build(items: Sequence[Dict[str, Any]]) -> Dict[str, Any]:
+    """The strip's whole payload: what to show, and what is not shown.
+
+    `more` is REPORTED rather than dropped. A strip that silently trims
+    tells her she has seen everything when she has not, which is the
+    same defect as a count that does not match its rows.
+    """
+    rows = [r.as_dict() for r in (news_row(i) for i in items) if r is not None]
+    return {"items": rows[:NEWS_LIMIT], "more": max(0, len(rows) - NEWS_LIMIT)}

--- a/backend/services/officer_queue.py
+++ b/backend/services/officer_queue.py
@@ -116,6 +116,12 @@ QUEUE_KEYS = frozenset({
     # describes. Added deliberately: this assertion made the extension
     # a decision rather than a diff nobody read.
     "worklist",
+    # NOTIF1 — what HAPPENED, which the worklist structurally cannot show:
+    # it selects the undecided statuses, so a resolved share leaves the
+    # queue by DISAPPEARING. News is a separate key because it is a
+    # separate kind of thing — an approval needs nothing done, and folding
+    # it into `worklist` would inflate a hero that counts work.
+    "news",
     "accuracy",        # what stands between her documents and being ready
     "instruments",     # what THIS officer files, most-used first
 })
@@ -156,7 +162,8 @@ def queue(*, upcoming: Sequence[Dict[str, Any]],
           idle_drafts: Sequence[Dict[str, Any]],
           accuracy: Dict[str, Any],
           instruments: Sequence[Dict[str, Any]],
-          worklist: Dict[str, Any]) -> Dict[str, Any]:
+          worklist: Dict[str, Any],
+          news: Dict[str, Any]) -> Dict[str, Any]:
     """Assemble the payload and assert its shape.
 
     `needs_attention` is computed HERE rather than by the screen, and it
@@ -209,6 +216,10 @@ def queue(*, upcoming: Sequence[Dict[str, Any]],
         # (`worklist.hero_count`): a worklist whose headline disagrees
         # with its own body is a metric again.
         "worklist": dict(worklist),
+        # NOTIF1 — the resolved events. Carried on the SAME response as
+        # the worklist, per DASH1's ruling: a second request would let the
+        # page render a partial truth when one of the two failed.
+        "news": dict(news),
         "needs_attention": len([r for r in awaiting
                                 if r["stale"] or r["lapsed"]]),
         # DASH1 item 6 — THE AMBIENT SIGNAL.

--- a/backend/tests/test_dash1_officer_queue.py
+++ b/backend/tests/test_dash1_officer_queue.py
@@ -105,6 +105,11 @@ def _awaiting(stale: bool, days=9, lapsed=False):
 #: none of them is about. DASH3's own behaviour is pinned in
 #: `test_dash3_worklist.py`.
 NO_WORK = {"groups": [], "count": 0}
+#: NOTIF1 — nothing resolved since she last looked. Its own constant
+#: rather than an inline literal, for the same reason NO_WORK is: the
+#: queue's shape is asserted by equality, so a new key has to be supplied
+#: deliberately by every caller rather than defaulted into existence.
+NO_NEWS = {"items": [], "more": 0}
 
 
 def test_the_attention_count_is_gone_quiet_and_nothing_else():
@@ -119,7 +124,7 @@ def test_the_attention_count_is_gone_quiet_and_nothing_else():
         idle_drafts=[{"kind": "draft", "id": 5, "deed_type": "grant_deed",
                       "property": "z", "days_idle": 30}],
         accuracy=NOTHING_OUTSTANDING,
-        instruments=FILES_NOTHING, worklist=NO_WORK,
+        instruments=FILES_NOTHING, worklist=NO_WORK, news=NO_NEWS,
     )
     assert payload["needs_attention"] == 1
 
@@ -140,7 +145,7 @@ def test_a_badge_counts_presence_and_the_attention_number_counts_silence():
         ],
         idle_drafts=[],
         accuracy=NOTHING_OUTSTANDING,
-        instruments=FILES_NOTHING, worklist=NO_WORK,
+        instruments=FILES_NOTHING, worklist=NO_WORK, news=NO_NEWS,
     )
     assert payload["badges"] == {"signings": 1, "shared_deeds": 2}
     assert payload["needs_attention"] == 1
@@ -150,7 +155,7 @@ def test_the_payload_shape_is_asserted_by_equality():
     from services.officer_queue import QUEUE_KEYS
 
     payload = q.queue(upcoming=[], awaiting=[], idle_drafts=[], accuracy=NOTHING_OUTSTANDING,
-        instruments=FILES_NOTHING, worklist=NO_WORK)
+        instruments=FILES_NOTHING, worklist=NO_WORK, news=NO_NEWS)
     assert set(payload) == QUEUE_KEYS
     assert payload["needs_attention"] == 0
     # And the thresholds travel WITH it, so no screen retypes them.
@@ -164,7 +169,7 @@ def test_a_row_that_grew_a_field_is_refused():
     bad["extra"] = 1
     with pytest.raises(AssertionError):
         q.queue(upcoming=[], awaiting=[bad], idle_drafts=[], accuracy=NOTHING_OUTSTANDING,
-        instruments=FILES_NOTHING, worklist=NO_WORK)
+        instruments=FILES_NOTHING, worklist=NO_WORK, news=NO_NEWS)
 
 
 def test_only_one_place_decides_what_stale_means():
@@ -509,7 +514,7 @@ def test_the_accuracy_block_says_how_many_documents_there_were_to_look_at():
     the population.
     """
     payload = q.queue(upcoming=[], awaiting=[], idle_drafts=[],
-                      accuracy=NOTHING_OUTSTANDING, instruments=FILES_NOTHING, worklist=NO_WORK)
+                      accuracy=NOTHING_OUTSTANDING, instruments=FILES_NOTHING, worklist=NO_WORK, news=NO_NEWS)
     assert payload["accuracy"]["open_documents"] == 3
 
 
@@ -521,7 +526,7 @@ def test_an_accuracy_block_without_the_population_is_refused():
     with pytest.raises(AssertionError):
         q.queue(upcoming=[], awaiting=[], idle_drafts=[],
                 accuracy={"fields": 0, "documents": 0, "items": []},
-                instruments=FILES_NOTHING, worklist=NO_WORK)
+                instruments=FILES_NOTHING, worklist=NO_WORK, news=NO_NEWS)
 
 
 # ══════════════════════════════════════════════════════════════════════
@@ -542,7 +547,7 @@ def test_a_lapsed_request_needs_her_attention_however_young_it_is():
     """
     fresh_but_lapsed = _awaiting(False, days=0, lapsed=True)
     payload = q.queue(upcoming=[], awaiting=[fresh_but_lapsed], idle_drafts=[],
-                      accuracy=NOTHING_OUTSTANDING, instruments=FILES_NOTHING, worklist=NO_WORK)
+                      accuracy=NOTHING_OUTSTANDING, instruments=FILES_NOTHING, worklist=NO_WORK, news=NO_NEWS)
     assert payload["needs_attention"] == 1
 
 
@@ -560,5 +565,5 @@ def test_one_request_that_is_both_is_counted_once():
     problem, not two — the number counts requests, not reasons."""
     both = _awaiting(True, days=30, lapsed=True)
     payload = q.queue(upcoming=[], awaiting=[both], idle_drafts=[],
-                      accuracy=NOTHING_OUTSTANDING, instruments=FILES_NOTHING, worklist=NO_WORK)
+                      accuracy=NOTHING_OUTSTANDING, instruments=FILES_NOTHING, worklist=NO_WORK, news=NO_NEWS)
     assert payload["needs_attention"] == 1

--- a/backend/tests/test_notif1_news.py
+++ b/backend/tests/test_notif1_news.py
@@ -1,0 +1,149 @@
+"""NOTIF1 — the strip that reports what the worklist cannot.
+
+The rule this whole ticket rests on: **a disappearance is not a
+notification.** The worklist selects the UNDECIDED share statuses, so an
+approval removes the row rather than changing it, and a vanished row is
+indistinguishable from one she handled, one that expired, or nothing.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from services import news as nw
+from tests.source_text import code_only
+
+
+def _item(**kw):
+    base = {"id": 1, "type": "share_approved", "message": "Reviewer approved 12 Oak St",
+            "link": None, "deed_id": 7, "days_ago": 1}
+    base.update(kw)
+    return base
+
+
+# ═══ THE SEPARATION THAT IS THE WHOLE DESIGN ═════════════════════════
+
+def test_news_is_not_carried_inside_the_worklist():
+    """OWNER-RULED, and the reason is DASH3's.
+
+    A fourth band would put an approval into a container whose hero
+    counts rows and promises "things that need you". An approval needs
+    nothing. Counting it inflates the number with finished work, which is
+    the metric-vs-worklist error DASH3 spent itself removing.
+
+    Pinned at the CONTRACT rather than the screen: `news` is its own key,
+    so folding it into `worklist` fails an equality assertion rather than
+    a review.
+    """
+    from services.officer_queue import QUEUE_KEYS
+    assert "news" in QUEUE_KEYS
+    assert "worklist" in QUEUE_KEYS
+
+
+def test_the_hero_cannot_see_news_at_all():
+    """The count is `hero_count(groups)` over worklist groups. News rows
+    are not groups and never reach it — asserted by construction rather
+    than by hoping nobody adds them."""
+    from services import worklist as wl
+    built = nw.build([_item(), _item(id=2)])
+    assert built["items"]
+    # The hero's input is groups; news is a sibling key with no path in.
+    assert wl.hero_count([]) == 0
+    assert "count" not in built
+
+
+# ═══ THE SENTENCE IS THE SERVER'S ════════════════════════════════════
+
+def test_the_stored_message_is_used_verbatim():
+    """§13 rule 3 — one place turns state into English, and it is the one
+    that had the facts. `utils/notifications` composed this message when
+    the event happened; reconstructing a worse one from a type string
+    here would be a second opinion about what occurred."""
+    row = nw.news_row(_item(message="Dana approved 1358 5TH ST")).as_dict()
+    assert row["say"] == "Dana approved 1358 5TH ST"
+
+
+def test_an_event_with_no_message_is_dropped_rather_than_narrated():
+    """"Something happened" is not news. A row we cannot describe is
+    withheld rather than given a generic line that asserts less than it
+    appears to."""
+    assert nw.news_row(_item(message="")) is None
+    assert nw.news_row(_item(message=None)) is None
+
+
+def test_an_unknown_event_type_is_not_rendered():
+    """The strip says what it can say. A type it does not understand is
+    left to whatever surface owns it."""
+    assert nw.news_row(_item(type="api_key_requested")) is None
+    assert nw.news_row(_item(type="share_rejected")) is not None
+
+
+# ═══ ABSENCES NAMED BY KIND ══════════════════════════════════════════
+
+def test_an_undated_event_says_so():
+    """DASH1's rule, kept: "—" reads as zero and "0 days" is a claim
+    about a row whose timestamp we could not read."""
+    assert nw.news_row(_item(days_ago=None)).as_dict()["when"] == "at an unknown time"
+
+
+def test_todays_event_says_today():
+    assert nw.news_row(_item(days_ago=0)).as_dict()["when"] == "today"
+    assert nw.news_row(_item(days_ago=1)).as_dict()["when"] == "yesterday"
+
+
+# ═══ IT MUST NOT BECOME WALLPAPER ════════════════════════════════════
+
+def test_what_is_not_shown_is_reported_rather_than_trimmed():
+    """A strip that silently truncates tells her she has seen everything
+    when she has not — the same defect as a count that disagrees with its
+    rows."""
+    built = nw.build([_item(id=i) for i in range(1, 8)])
+    assert len(built["items"]) == nw.NEWS_LIMIT
+    assert built["more"] == 7 - nw.NEWS_LIMIT
+
+
+def test_nothing_to_report_is_an_empty_strip_not_a_zero():
+    built = nw.build([])
+    assert built["items"] == []
+    assert built["more"] == 0
+
+
+# ═══ WHERE A ROW GOES ════════════════════════════════════════════════
+
+def test_a_news_row_lands_on_the_document():
+    """The orphan ruling, which the worklist rows already follow: a row
+    about a document that drops her on a list makes her find the document
+    again."""
+    assert nw.news_row(_item(deed_id=41, link=None)).as_dict()["href"] == "/deeds/41"
+
+
+def test_a_stored_link_wins_because_the_writer_knew_where_it_pointed():
+    row = nw.news_row(_item(link="/requests?kind=reviews&focus=9")).as_dict()
+    assert row["href"] == "/requests?kind=reviews&focus=9"
+
+
+def test_a_row_that_drifts_is_refused():
+    row = nw.NewsRow(id=1, kind="approved", say="s", when="today", href="/x")
+    assert set(row.as_dict()) == nw.NEWS_KEYS
+
+
+# ═══ THE QUERY, PINNED AT ITS SOURCE ═════════════════════════════════
+
+def test_the_strip_reads_unread_events_and_never_the_undecided_query():
+    """THE FINDING, PINNED.
+
+    The worklist's `awaiting` query selects `status IN ('sent','viewed')`
+    — undecided — which is why a resolved share leaves by disappearing.
+    The strip must therefore read the NOTIFICATION record, not that
+    query, or it would inherit the blindness it exists to fix.
+
+    Asserted against the source, cut at the statement that feeds the
+    strip rather than at a character distance from it (§14.1.1).
+    """
+    src = code_only(Path(__file__).resolve().parents[1]
+                    .joinpath("routers/dashboard.py").read_text())
+    assign = src.index("news_items = ")
+    query = src[src.rindex("cur.execute(", 0, assign):assign]
+    assert "user_notifications" in query
+    assert "COALESCE(un.read, false) = false" in query
+    # The undecided-status filter belongs to the worklist, not here.
+    assert "'sent', 'viewed'" not in query

--- a/frontend/scripts/eslint-gate.mjs
+++ b/frontend/scripts/eslint-gate.mjs
@@ -99,15 +99,20 @@ const CEILING = { errors: 126, warnings: 54 };
  *  deleted — the rickroll a green pin had been certifying the absence of),
  *  then 285 (the DARKSWEEP cleanup: seven unruled, unimported, unpinned
  *  components), then 281 (the four notification/partner scaffold
- *  components, owner-ruled). Six deliberate moves now, and the gate has
- *  refused a run for every one of them — which is the only evidence that
- *  it is doing anything at all (§14.9).
+ *  components, owner-ruled). NOTIF1 raised it to 283 by adding two — the
+ *  strip and its pins. Seven deliberate moves now, and the gate has
+ *  refused a run for every DOWNWARD one — which is the only evidence
+ *  that it is doing anything at all (§14.9).
+ *
+ *  Raising it after an addition is the same discipline as lowering it
+ *  after a deletion (§14.14): a floor left below the real count silently
+ *  tolerates that many files going dark later.
  *
  *  The last move lowered the CEILING too: deleting dead files took 8
  *  errors and 2 warnings with them, and a ceiling left at the old number
  *  would quietly re-authorise that much new debt. Cleanup that does not
  *  move the ceiling is cleanup the gate forgets. */
-const FILES_FLOOR = 281;
+const FILES_FLOOR = 283;
 
 /**
  * These catch DEFECTS rather than style, and every one is at zero today —

--- a/frontend/src/__tests__/dashboardNews.test.ts
+++ b/frontend/src/__tests__/dashboardNews.test.ts
@@ -1,0 +1,102 @@
+/**
+ * NOTIF1 — the rulings a later edit could reverse while every gate stays
+ * green.
+ *
+ * The finding underneath all of them: the worklist selects the UNDECIDED
+ * share statuses, so an approval removes its row rather than changing it,
+ * and **a disappearance is not a notification**.
+ */
+import { describe, expect, it } from '@jest/globals';
+import * as fs from 'fs';
+import * as path from 'path';
+import { codeOnly } from '../test-support/sourceText';
+
+const SRC = path.join(__dirname, '..');
+const read = (...p: string[]) => fs.readFileSync(path.join(SRC, ...p), 'utf8');
+
+const DASH = codeOnly(read('app', 'dashboard', 'page.tsx'));
+const STRIP = codeOnly(read('features', 'dashboard', 'RecentlyResolved.tsx'));
+
+describe('NOTIF1 — news is not a task, and does not share the queue container', () => {
+  it('the strip renders outside the worklist and above it', () => {
+    /**
+     * OWNER-RULED. A fourth band would put an approval inside a container
+     * whose hero counts rows and promises "things that need you" — the
+     * metric-vs-worklist error DASH3 spent itself removing.
+     */
+    expect(DASH).toContain('<RecentlyResolved');
+    expect(DASH.indexOf('<RecentlyResolved')).toBeLessThan(DASH.indexOf('<Worklist'));
+    // And the strip is its own component, not a Worklist band.
+    expect(codeOnly(read('features', 'dashboard', 'Worklist.tsx')))
+      .not.toContain('news');
+  });
+
+  it('the headline count still reads only the worklist', () => {
+    // The one number on this screen promises "things that need you". An
+    // approval needs nothing, so it must not reach the count.
+    expect(DASH).toContain('worklist?.count');
+    expect(DASH).not.toMatch(/news[\s\S]{0,40}count/);
+  });
+});
+
+describe('NOTIF1 — quieter than the queue, and it does not become wallpaper', () => {
+  it('carries no card, border or spine — the worklist owns those', () => {
+    expect(STRIP).not.toMatch(/rounded-2xl|border-gray-200|shadow/);
+  });
+
+  it('is dismissible in one press', () => {
+    expect(STRIP).toContain('onDismiss');
+    expect(STRIP).toContain('Dismiss');
+  });
+
+  it('says what it cannot fit rather than trimming it', () => {
+    // A strip that silently truncates tells her she has seen everything
+    // when she has not — the same defect as a count disagreeing with its
+    // rows.
+    /* PINNED AS THE GUARD, not the mention. My first version asserted
+       that `news.more` appears — and it passed with the render disabled,
+       because the count is ALSO mentioned inside the block it guards.
+       The mutation probe found it; reading the test did not. Same shape
+       as §14.1.1's third symptom: the right property, asserted against
+       something incapable of distinguishing it. */
+    expect(STRIP).toMatch(/\{news\.more > 0 && \(/);
+    expect(STRIP).toContain('{news.more} more');
+  });
+
+  it('renders nothing when there is no news, and that is NOT the empty-state rule', () => {
+    /* The worklist's empty state is a RESULT she needs told ("Nothing
+       needs you"). An absence of news is not a result — "nothing happened
+       since you last looked" is the ordinary case, and saying it every
+       morning is how a strip becomes wallpaper. The distinction is
+       deliberate and is why this file pins both halves. */
+    expect(STRIP).toContain('return null');
+    expect(DASH).toContain('Nothing needs you.');
+  });
+});
+
+describe('NOTIF1 — the sentence and the write', () => {
+  it('renders the server sentence verbatim', () => {
+    // §13 rule 3 — one place turns state into English, and it is the one
+    // that had the facts when the event happened.
+    expect(STRIP).toContain('{row.say}');
+  });
+
+  it('dismissal does not write through the read-only queue endpoint', () => {
+    /* `routers/dashboard.py` declares itself READ-ONLY in its own
+       docstring. An endpoint that writes would make that statement false
+       for every future reader who trusts it, so the dismiss goes to the
+       notifications router instead. */
+    expect(DASH).toContain('/notifications/mark-read');
+    expect(DASH).not.toMatch(/dashboard\/queue[\s\S]{0,80}method:\s*'POST'/);
+  });
+
+  it('a failed dismissal leaves the strip up', () => {
+    // §4 — the error is not swallowed into a UI that looks like it
+    // worked. The local clear happens only after a successful response.
+    const fn = DASH.slice(DASH.indexOf('const dismissNews'));
+    const clearAt = fn.indexOf('setQueue');
+    const guardAt = fn.indexOf('if (!res.ok) return');
+    expect(guardAt).toBeGreaterThan(-1);
+    expect(guardAt).toBeLessThan(clearAt);
+  });
+});

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -9,6 +9,7 @@ import { AuthManager } from "@/utils/auth"
 import EmailVerificationNotice from "@/features/account/EmailVerificationNotice"
 import StartSomethingNew from "@/features/dashboard/StartSomethingNew"
 import Worklist from "@/features/dashboard/Worklist"
+import RecentlyResolved from "@/features/dashboard/RecentlyResolved"
 import SetupChecklist, { activeStep } from "@/features/dashboard/SetupChecklist"
 import DayOneRail from "@/features/dashboard/DayOneRail"
 import { SessionExpiredError, apiFetch } from "@/lib/apiClient"
@@ -38,6 +39,10 @@ type Queue = {
      Both come from the server so the headline cannot disagree with the
      body it sits above. */
   worklist?: import('@/features/dashboard/Worklist').Worklist;
+  /* NOTIF1 — resolved events. On the SAME response as the worklist, per
+     DASH1: a second request would let the page render a partial truth
+     when one of the two failed. */
+  news?: import('@/features/dashboard/RecentlyResolved').News;
   instruments?: Array<{ deed_type: string; count: number; period: string }>;
   upcoming: Array<{ kind: string; id: number; deed_id: number; property: string | null;
                     when: string; who: string | null; summary: string }>;
@@ -262,6 +267,31 @@ export default function Dashboard() {
      Read rather than derived: `worklist.count` is `hero_count(groups)`
      over the groups rendered below, so the headline and the body are
      the same arithmetic rather than two arithmetics that agree. */
+  /* NOTIF1's one write from this screen, and it goes to the
+     notifications router rather than `/dashboard/queue` — that endpoint
+     declares itself READ-ONLY in its own docstring, and an endpoint that
+     writes would make the statement false for every future reader.
+
+     The strip is cleared locally on success rather than re-fetching the
+     queue: a dismissal she pressed is not a fact the server needs to
+     re-tell her, and a full re-fetch would flash the worklist for a
+     change that does not touch it. On failure the strip STAYS — §4, the
+     error is not swallowed into a UI that looks like it worked. */
+  const dismissNews = async (ids: number[]) => {
+    if (!ids.length) return
+    try {
+      const res = await apiFetch(`/notifications/mark-read`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ids }),
+      }, { label: "Dismissing" })
+      if (!res.ok) return
+      setQueue((prev) => prev ? { ...prev, news: { items: [], more: 0 } } : prev)
+    } catch (e) {
+      if (e instanceof SessionExpiredError) return
+    }
+  }
+
   const worklist = queue?.worklist
   const worklistCount = worklist?.count ?? 0
 
@@ -364,6 +394,15 @@ export default function Dashboard() {
               first morning are different things and say so — collapsing
               the last two would reverse #206, which is why
               `open_documents` exists. */}
+          {/* NOTIF1 — what happened, above what needs her. Quieter than
+              the queue and contributing nothing to the headline count:
+              an approval is news, not a task. */}
+          <RecentlyResolved
+            news={queue?.news}
+            onOpen={(href) => router.push(href)}
+            onDismiss={dismissNews}
+          />
+
           {queueError ? (
             <div role="alert"
                  className="rounded-2xl border border-red-200 bg-white p-6 text-center">

--- a/frontend/src/features/dashboard/RecentlyResolved.tsx
+++ b/frontend/src/features/dashboard/RecentlyResolved.tsx
@@ -1,0 +1,98 @@
+/**
+ * NOTIF1 — what happened, kept out of the queue that says what needs her.
+ *
+ * ═══ THE FINDING ═══
+ *
+ * The worklist selects the two UNDECIDED share statuses, because a
+ * worklist shows outstanding work and an approval is the END of
+ * outstanding work. So when a reviewer approves, the row does not change
+ * state — it DISAPPEARS.
+ *
+ * **A disappearance is not a notification.** A vanished row is
+ * indistinguishable from one she handled herself, one that expired, one
+ * that was revoked, and from nothing at all. Until this strip, the email
+ * was the only thing that told her — which is exactly the failure E1
+ * named when it started writing the in-app record: *"a transport failure
+ * erased the event from the owner's world entirely."*
+ *
+ * ═══ WHY IT IS NOT A WORKLIST BAND (owner-ruled) ═══
+ *
+ * The hero counts ROWS and promises "things that need you". An approval
+ * needs nothing. A fourth band would inflate that number with finished
+ * work — the metric-vs-worklist error DASH3 spent itself removing.
+ *
+ * An approval is NEWS, not a task, and the two do not share a container.
+ *
+ * ═══ QUIETER THAN THE QUEUE, AND DISMISSIBLE (owner-ruled) ═══
+ *
+ * No card, no border, no spine — the worklist owns those. This is a line
+ * of text with a dismiss. A "what happened" strip that accumulates
+ * forever becomes wallpaper, so it shows only UNREAD items, dismissing
+ * is one press, and what it cannot fit it SAYS rather than trimming.
+ */
+'use client';
+
+export interface NewsRow {
+  id: number;
+  kind: string;
+  say: string;
+  when: string;
+  href: string;
+  deed_id: number | null;
+}
+
+export interface News {
+  items: NewsRow[];
+  /** Unread events beyond what one render shows. NAMED, not trimmed. */
+  more: number;
+}
+
+export default function RecentlyResolved({ news, onOpen, onDismiss }: {
+  news?: News | null;
+  onOpen?: (href: string) => void;
+  onDismiss?: (ids: number[]) => void;
+}) {
+  // Nothing to report renders NOTHING — and that is right here, unlike
+  // the worklist below it. An empty queue is a RESULT she needs told
+  // ("Nothing needs you"); an absence of news is not a result, because
+  // "nothing happened since you last looked" is the ordinary case and
+  // saying it every morning is how a strip becomes wallpaper.
+  if (!news || !news.items.length) return null;
+
+  return (
+    <section aria-label="Recently resolved"
+             className="mb-5 flex flex-wrap items-center gap-x-3 gap-y-1.5 px-1">
+      <span className="text-[11px] font-semibold uppercase tracking-wider text-gray-400">
+        Since you last looked
+      </span>
+      <ul className="flex flex-wrap items-center gap-x-3 gap-y-1.5">
+        {news.items.map((row) => (
+          <li key={row.id} className="flex items-center gap-1.5">
+            <button type="button"
+                    onClick={() => onOpen?.(row.href)}
+                    className="text-[13px] text-gray-600 underline decoration-gray-300
+                               underline-offset-2 transition hover:text-[var(--color-brand)]">
+              {/* THE SERVER'S SENTENCE, verbatim (§13 rule 3). This screen
+                  does not get a second opinion about what happened. */}
+              {row.say}
+            </button>
+            <span className="text-[11.5px] text-gray-400">{row.when}</span>
+          </li>
+        ))}
+      </ul>
+      {news.more > 0 && (
+        /* WHAT IS NOT SHOWN IS SAID. A strip that silently truncates
+           tells her she has seen everything when she has not. */
+        <span className="text-[11.5px] text-gray-400">
+          +{news.more} more
+        </span>
+      )}
+      <button type="button"
+              onClick={() => onDismiss?.(news.items.map((r) => r.id))}
+              className="ml-auto text-[11.5px] font-medium text-gray-400
+                         transition hover:text-gray-700">
+        Dismiss
+      </button>
+    </section>
+  );
+}


### PR DESCRIPTION
Built as the separate strip, per your ruling.

## What it fixes

The worklist selects the two **undecided** share statuses, because a worklist shows outstanding work and an approval is the *end* of outstanding work. So a resolved share doesn't change its row — **it removes it.**

A vanished row is indistinguishable from one she handled, one that expired, one that was revoked, and from nothing at all. The email was the only thing telling her, which is the failure E1 named when it began writing the record: *"a transport failure erased the event from the owner's world entirely."* That record has been written faithfully since and read by nobody.

## Not a fourth band

The hero counts rows and promises "things that need you". An approval needs nothing — counting it inflates the number with finished work, the metric-vs-worklist error DASH3 removed. **News is its own key in the asserted contract**, so folding it into `worklist` fails an equality assertion rather than a review.

## Not wallpaper

Unread items only · dismissible in one press · **what it can't fit it says** (`+N more`) rather than trimming · no card, border or spine — the worklist owns those.

**Nothing to report renders nothing**, deliberately unlike the worklist below it. The worklist's empty state is a result she needs told; *"nothing happened since you last looked"* is the ordinary case, and saying it every morning is how a strip becomes wallpaper. Both halves are pinned so the distinction survives.

## Where the write goes

`routers/dashboard.py` declares itself **READ-ONLY** in its own docstring, so the dismiss goes to the notifications router instead — an endpoint that writes would make that statement false for every future reader who trusts it.

`mark_read` loses its feature flag and says why: `NOTIFICATIONS_ENABLED` gated a scaffold DARK1 deleted, and the strip can't sit behind a flag governing a UI that no longer exists. The list endpoint and admin broadcast **keep** theirs — neither is part of this ticket, and turning them on is a decision nobody has made.

## Two defects found while building, both mine

**The news query landed inside the idle-drafts loop.** `news_items` was unbound whenever a user had no idle drafts, and `cur` was a closed cursor even when they did. An anchor-based insert placed code in a block I hadn't checked it was in. Caught by the suite — 7 failures — not by reading.

**A pin passed with the feature disabled.** It asserted `news.more` appears; the count is *also* mentioned inside the block it guards, so disabling the overflow render left the assertion satisfied. The mutation probe found it; reading the test did not. Now pinned as the guard — §14.1.1's third symptom, one ticket after recording it.

## Probes

Backend, 5/5 bite: generic sentence for an unnamed event · silent overflow trim · unknown time as a dash · unknown type narrated · unread filter removed.
Frontend, 4/4 bite: strip below the worklist · strip grows a card · overflow hidden · dismiss clears on failure.

## Gates

pytest **1594** with DB / **1383 + 211 skipped** without · jest **1159** · tsc **83** · `next build` clean · eslint **126/54** (floor 281 → 283) · banned-claims clean · S1, S3, six-flow, API baselines green

---
_Generated by [Claude Code](https://claude.ai/code/session_0142a62hx91zHieSoUZrJ51h)_